### PR TITLE
Improve product docs and README onboarding for multi-repo workflows

### DIFF
--- a/LICENSE-COMMERCIAL.txt
+++ b/LICENSE-COMMERCIAL.txt
@@ -1,0 +1,64 @@
+﻿GrayMoon Commercial License
+
+Copyright (c) 2026 GrayMoon
+
+Website: https://graymoon.io/
+
+This Commercial License grants the right to use GrayMoon in a commercial environment, subject to the terms below.
+
+1. Grant of License
+
+Upon purchase of a valid license, GrayMoon grants you a non-exclusive, non-transferable, revocable license to use the software for commercial purposes.
+
+2. Definition of Commercial Use
+
+Commercial Use includes any use:
+- by a for-profit organization
+- for internal business operations
+- within CI/CD pipelines or automated systems
+- in connection with revenue-generating activities
+- as part of a paid product or service
+
+3. License Model
+
+Licenses are typically issued on a per-user basis.
+
+Each individual who installs, uses, or interacts with GrayMoon within an organization must have a valid license.
+
+4. Restrictions
+
+You may NOT:
+- redistribute the software as a standalone product
+- sublicense or resell the software without explicit permission
+- provide GrayMoon as a hosted or SaaS offering without a separate agreement
+- remove or alter copyright or licensing notices
+
+5. Updates and Support
+
+Unless explicitly stated, this license does not guarantee:
+- ongoing updates
+- support or maintenance
+- service-level agreements
+
+Such services may be offered separately.
+
+6. Termination
+
+This license is valid for the duration of the purchased subscription.
+
+Failure to comply with these terms may result in termination of the license.
+
+7. No Warranty
+
+The software is provided "AS IS", without warranty of any kind.
+
+8. Limitation of Liability
+
+In no event shall GrayMoon be liable for any damages arising from the use of the software.
+
+9. Governing Terms
+
+Use of the software constitutes acceptance of these terms.
+
+For licensing inquiries or enterprise agreements, contact:
+https://graymoon.io/

--- a/LICENSE-NON-COMMERCIAL.txt
+++ b/LICENSE-NON-COMMERCIAL.txt
@@ -1,0 +1,51 @@
+﻿GrayMoon Non-Commercial License
+
+Copyright (c) 2026 GrayMoon
+
+Website: https://graymoon.io/
+
+Permission is hereby granted, free of charge, to any individual or organization to use, copy, modify, and run this software for non-commercial purposes, subject to the conditions below.
+
+1. Definition of Non-Commercial Use
+
+Non-Commercial Use means use of the software solely for:
+- personal use
+- educational purposes
+- academic research
+- evaluation or testing
+- non-profit activities
+
+Non-Commercial Use explicitly excludes any use:
+- by or within a for-profit organization
+- in connection with revenue-generating activities
+- for internal business operations
+- within CI/CD pipelines or production environments of a business
+
+2. Restrictions
+
+You may NOT:
+- use this software for Commercial Use (see Commercial License)
+- sell, sublicense, or distribute the software as a paid product
+- provide the software as part of a hosted or SaaS offering for a fee
+- remove or alter copyright notices
+
+3. Distribution
+
+You may distribute unmodified copies of this software for non-commercial purposes only, provided this license is included.
+
+4. No Warranty
+
+This software is provided "AS IS", without warranty of any kind, express or implied, including but not limited to fitness for a particular purpose.
+
+5. Limitation of Liability
+
+In no event shall the author be liable for any claim, damages, or other liability arising from the use of the software.
+
+6. Commercial Use
+
+Any use that does not qualify as Non-Commercial Use requires a valid Commercial License.
+
+Commercial licenses can be obtained from:
+https://graymoon.io/
+
+By using this software, you agree to the terms of this license.

--- a/README.md
+++ b/README.md
@@ -2,33 +2,57 @@
 
 [![Docker Build](https://github.com/Jandini/GrayMoon/actions/workflows/docker-build.yml/badge.svg)](https://github.com/Jandini/GrayMoon/actions/workflows/docker-build.yml)
 
-.NET dependency orchestrator: connector management, repository visibility, workspace grouping, and sync with GitVersion.
+.NET multi-repository orchestration tool for teams building with microservices and shared packages.
 
-## Features
+GrayMoon helps you work across many repositories as one coordinated workspace:
 
-- GitHub connector management and status checks
-- Repository discovery and workspace grouping (with default workspace)
-- Actions overview for selected repositories
-- Background sync queue (concurrency, deduplication)
+- clone and organize multiple repositories under one workspace
+- create/switch feature branches across repositories
+- keep repository status and activity up to date while you work in your IDE (checkout/commit/push/merge events are tracked)
+- track versions and dependency drift
+- update `PackageReference` versions automatically
+- synchronize pushes to reduce CI failures caused by missing dependency versions
+- when version alignment is required, GrayMoon can update the impacted `PackageReference` versions and commit those changes as part of the same coordinated workflow
+
+If a shared package changes and dozens of repositories need updates, GrayMoon can handle the rollout flow in one place.
+
+## Who GrayMoon is for
+
+GrayMoon is useful for:
+
+- .NET teams with multiple services and shared libraries/packages
+- teams that use semantic versioning with GitVersion
+- developers doing cross-repository feature work
+- teams using AI IDEs (VS Code/Cursor) where cross-repo context improves productivity
+
+## Why teams use GrayMoon
+
+- You get one view of branch/version/PR/action status across repositories.
+- You can run coordinated dependency updates instead of editing each repo manually.
+- You can create one feature branch (for example `feature/dependency-update`) across repos, auto-update package refs, auto-commit, and push together.
+- When rolling out changes, GrayMoon can push multiple repositories in parallel so the full workflow finishes faster than pushing repo-by-repo manually.
+
+## Quick Start
+
+GrayMoon runs as two parts:
+
+- **GrayMoon App** in Docker (web UI + orchestration API)
+- **GrayMoon Agent** on your host machine as a service/process (executes git and filesystem operations in your repositories)
+
+Keep both running for full functionality.
 
 ## Docker
 
-Build (use WSL on Windows if Docker isn’t available from PowerShell):
+Run on port `8384`; optional volume to persist the SQLite database:
 
 ```bash
-docker build -t jandini/graymoon:latest .
-```
-
-Run on port 8384; optional volume to persist the SQLite database:
-
-```bash
-docker run -p 8384:8384 -v ./db:/app/db jandini/graymoon:latest
+docker run -d -p 8384:8384 -v ./db:/app/db jandini/graymoon:latest
 ```
 
 To override the default token encryption key (recommended for non-dev use), set `TokenKey` to any password-like value (it will be hashed into a key automatically). Advanced users can also pass a Base64-encoded key if they prefer:
 
 ```bash
-docker run -p 8384:8384 -v ./db:/app/db -e TokenKey="my strong password here" jandini/graymoon:latest
+docker run -d -p 8384:8384 -v ./db:/app/db -e TokenKey="my strong password here" jandini/graymoon:latest
 ```
 
 Open http://localhost:8384 in your browser.
@@ -40,5 +64,20 @@ The app runs in a container and does not run git or access your workspace filesy
 1. **Download** — On the home page, use **Download Agent**. The correct executable (Windows or Linux) is chosen from your browser.
 2. **Run on the host** — Run the agent on the same machine (or network) as your repositories, e.g. as a console app or Windows/Linux service.
 
-When the agent is connected, the app shows an **online** badge; sync and repo operations use the agent. When it’s offline, sync fails with a clear message. 
+When the agent is connected, the app shows an **online** badge; sync and repository operations use the agent.
+
+On the **Agent** page, GrayMoon provides an **Install/Upgrade** command you can run on the host (PowerShell), for example:
+
+```powershell
+Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('http://localhost:8384/api/agent/install'))
+```
+
+## Typical workflow
+
+1. Configure connectors and fetch repositories.
+2. Create a workspace and select the repositories needed for a feature.
+3. Clone/check out repositories into the workspace.
+4. Create or switch a branch across selected repositories.
+5. Run dependency/version updates (GrayMoon updates the impacted `PackageReference` versions for you when needed).
+6. Continue working in your IDE while GrayMoon tracks changes in the background; GrayMoon UI does not need to stay open as long as the Docker app and agent services are running.
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ GrayMoon helps you work across many repositories as one coordinated workspace:
 - keep repository status and activity up to date while you work in your IDE (checkout/commit/push/merge events are tracked)
 - track versions and dependency drift
 - update `PackageReference` versions automatically
+- one-click sync back to default branch after merge (single repo or multiple repos by dependency level)
 - synchronize pushes to reduce CI failures caused by missing dependency versions
+- group repositories by dependency levels and type (services vs packages/libraries) for easier dependency visualization
 - when version alignment is required, GrayMoon can update the impacted `PackageReference` versions and commit those changes as part of the same coordinated workflow
 
 If a shared package changes and dozens of repositories need updates, GrayMoon can handle the rollout flow in one place.
@@ -28,9 +30,12 @@ GrayMoon is useful for:
 ## Why teams use GrayMoon
 
 - You get one view of branch/version/PR/action status across repositories.
+- You can see GitHub Actions results for the current branch across all repositories in a workspace.
+- You can open multiple repositories (and multiple new PR pages by dependency level) in GitHub with one action.
 - You can run coordinated dependency updates instead of editing each repo manually.
 - You can create one feature branch (for example `feature/dependency-update`) across repos, auto-update package refs, auto-commit, and push together.
 - When rolling out changes, GrayMoon can push multiple repositories in parallel so the full workflow finishes faster than pushing repo-by-repo manually.
+- GrayMoon tracks changed files across repositories so you can avoid unnecessary PRs when changes are only dependency-version updates.
 
 ## Quick Start
 

--- a/docs/GrayMoon-Software-Overview.md
+++ b/docs/GrayMoon-Software-Overview.md
@@ -1,0 +1,326 @@
+# GrayMoon: Software Overview
+
+## What GrayMoon is
+
+GrayMoon is a **workspace orchestration tool for multi-repository .NET development**.
+
+It is built for teams working across many repositories (for example microservices, shared libraries, and NuGet packages) where one feature often requires coordinated changes in multiple places.
+
+GrayMoon provides:
+
+- a web app to manage workspaces, repositories, dependencies, branches, and automation status
+- a host-side agent that runs on your machine and executes Git/file operations safely on local repositories
+
+In short: GrayMoon helps you treat many repositories like one coordinated system during feature development.
+
+## The main problem it solves
+
+When you change one service or package, other repositories often need updates too:
+
+- dependency versions drift
+- branches are inconsistent across repos
+- pushes happen in the wrong order
+- CI fails because a dependent package/version is not available yet
+- developers spend time manually checking statuses, PRs, actions, and branch divergence repo-by-repo
+
+GrayMoon centralizes this workflow so these steps are visible, repeatable, and much less error-prone.
+
+## Core capabilities
+
+### 1) Workspace-based multi-repo management
+
+- Create workspaces and assign repositories to each workspace.
+- Set a default workspace for fast navigation.
+- Import repository assignments based on repositories already present on disk.
+- Manage workspace root path centrally.
+
+### 2) Connector management (GitHub and NuGet)
+
+- Add/edit/delete connectors.
+- Test connector health and automatically mark failed connectors.
+- Fetch repositories from GitHub connectors and persist them.
+- Use NuGet connector metadata for package-registry synchronization.
+
+### 3) Agent-powered local execution
+
+- GrayMoon App does not directly touch local git repos in a containerized setup.
+- GrayMoon Agent performs local git and filesystem actions and communicates with the app over SignalR.
+- Includes install/uninstall support and host prerequisite checks (.NET, Git, GitVersion).
+
+### 4) Workspace repository control panel
+
+For each repository in a workspace, GrayMoon tracks and displays:
+
+- current version
+- current branch
+- incoming/outgoing commits
+- divergence from default branch (ahead/behind)
+- pull request status
+- CI action status
+- dependency mismatch indicators
+- sync state/errors
+
+This gives one operational view instead of opening each repository separately.
+
+### 5) Branch orchestration across repositories
+
+- Create branches (single repo or workspace-wide patterns).
+- Checkout/switch branches.
+- Refresh local and remote branch lists.
+- Set upstream tracking.
+- Delete local/remote branches safely.
+- Sync repository back to default branch with cleanup behavior.
+- Detect common branches across workspace repositories.
+
+### 6) Sync and commit synchronization
+
+- Sync installs repository hooks (checkout/commit/push/merge) so GrayMoon can keep the workspace state updated even while developers keep working normally in their IDE.
+- When the workspace needs version/dependency alignment, GrayMoon can automatically run the dependency update flow (updating `PackageReference` versions and committing those changes as part of the coordinated workflow).
+- Commit synchronization endpoint for repository-level commit state refresh.
+- Agent queue visibility and progress overlays in UI.
+- Real-time UI updates through SignalR workspace sync events.
+
+### 7) Dependency-aware updates for .NET repositories
+
+- Reads project data from `.csproj` files.
+- Builds dependency update plans and executes them in dependency-level order.
+- Performs sync -> commit -> version refresh flow level-by-level to reduce breakage.
+- Recomputes dependency mismatch stats after operations.
+
+### 8) Synchronized push workflow (important differentiator)
+
+GrayMoon supports **dependency-synchronized pushes**:
+
+- computes push plan by dependency levels
+- can sync package registries first
+- waits for required package versions to appear in registries (when mappings exist)
+- pushes repositories in level order
+- supports parallel push mode when synchronization is not required
+- can push multiple repositories simultaneously (up to configured concurrency), which is faster than pushing one repository at a time from an IDE
+
+This directly addresses CI failures caused by missing dependency versions at push time.
+
+### 9) Files and version-pattern automation
+
+- Add workspace files to track.
+- Search files via agent in workspace repositories.
+- View file content from the UI.
+- Configure version replacement patterns using tokens like `{RepositoryName}`.
+- Bulk-update configured files with latest repository versions from workspace state.
+- Optional commit flow for version-file updates.
+
+### 10) Dependency graph, projects, and packages visibility
+
+- Workspace dependency graph visualization with filtering by repo or dependency level.
+- Project inventory view (type/framework/path).
+- Package inventory view and registry mapping checks.
+- Package registry sync actions for workspace packages.
+
+### 11) PR and GitHub Actions awareness
+
+- Pull request state persistence and refresh per repository branch.
+- GitHub Actions aggregate status visibility per repository/branch.
+- Re-run failed workflows from the actions workspace view.
+
+### 12) GitVersion compatibility per repository
+
+- GrayMoon can use globally installed GitVersion.
+- If a repository contains a .NET tool manifest for GitVersion, GrayMoon can use the version required by that repository.
+- This supports mixed environments where some repositories need GitVersion 5.x and others require 6.x.
+
+## Typical feature-development workflow with GrayMoon
+
+1. Configure connectors (GitHub/NuGet) and fetch repositories.
+2. Create a workspace and add all repositories involved in your feature.
+3. Create/switch to a feature branch across required repositories.
+4. Implement changes (including with AI IDE tooling across all repos).
+5. Run GrayMoon sync/update to align dependency versions and project state.
+6. Use dependency-aware push (or synchronized push) so package and repo ordering is safe.
+7. Monitor PR status, CI actions, branch divergence, and commit flow from one UI.
+8. Sync repositories back to default branch after merge.
+
+## Benefits
+
+- **Fewer integration surprises**: dependency and push order awareness reduces avoidable CI failures.
+- **Faster multi-repo delivery**: one coordinated workflow replaces many manual per-repo steps.
+- **Better visibility**: branch/version/PR/action/commit health in one place.
+- **Safer automation**: concurrency control, queueing, and explicit progress for long operations.
+- **Good fit for AI-assisted development**: workspaces map naturally to cross-repo feature work where AI needs context from many codebases.
+- **Bulk dependency rollout**: when a shared package changes, GrayMoon can create a feature branch across required repositories, update package references automatically, commit changes, and let you push and test all updates in one coordinated flow.
+
+## Who this helps most
+
+GrayMoon is especially useful for:
+
+- teams maintaining microservices plus shared libraries
+- organizations publishing internal/shared NuGet packages
+- platform teams that coordinate version bumps and dependency rollouts
+- developers doing frequent cross-repository feature branches and synchronized releases
+
+## Positioning statement
+
+GrayMoon is a multi-repository orchestration layer for .NET teams that coordinates branches, dependency updates, and pushes across workspaces so cross-repo feature delivery becomes faster, safer, and easier to operate.
+
+## Stack and versioning model
+
+GrayMoon is designed around a .NET stack:
+
+- .NET / C#
+- semantic versioning with GitVersion
+- repository-level versions captured in workspace state
+- cross-repository dependency updates based on current branch versions
+
+In practical terms, teams often run a model where each feature-branch commit advances package/service versions. GrayMoon helps keep those versions aligned across dependent repositories and updates references so builds stay consistent both inside and outside developer machines.
+
+## How the dual-reference `.csproj` pattern works
+
+The common pattern is:
+
+1. Define a `UseProjectRefs` switch based on `$(SolutionFileName)`.
+2. Define `*ProjectPath` properties for dependency projects in sibling repositories.
+3. Add `PackageReference` entries when `UseProjectRefs` is `false`.
+4. Add `ProjectReference` entries when `UseProjectRefs` is not `false` and project files exist.
+5. Use `Exists(...)` guards for optional dependencies or partial checkouts.
+
+Result:
+
+- building from the service's own solution (or no solution, e.g., Docker) uses NuGet packages
+- building from the sibling solution context can use project references automatically
+- fallback package references still work if a dependency repository is missing locally
+
+## New example
+
+### Example system shape
+
+- Workspace root: `C:\Workspace\Platform`
+- Sibling repository for cross-repo development: `platform-workspace\Platform.sln`
+- Service repository: `platform-orders-service`
+- Shared dependency repos:
+  - `Platform.Contracts`
+  - `Platform.Messaging`
+  - `Platform.Persistence`
+
+In this document, a **sibling repository** means a repository that lives next to another repository under the same workspace root, so projects can be referenced through relative paths during integrated development.
+
+### Recommended setup (what is developer convenience vs what GrayMoon manages)
+
+In this setup:
+
+- `ProjectReference` switching is **developer convenience only** (it makes IDE “open the solution” experience nicer by enabling source-level references in the sibling solution).
+- `PackageReference` versions are the **canonical dependency contract** that GrayMoon manages.
+
+GrayMoon updates `PackageReference` entries by the `Include` name, so keep explicit `PackageReference Include="..."` lines in the `.csproj`.
+
+### Service `.csproj` (project refs for sibling-solution dev, packages as the managed baseline)
+
+`platform-orders-service\src\Platform.Orders.Service\Platform.Orders.Service.csproj`
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <!-- Default: package mode -->
+    <UseProjectRefs>false</UseProjectRefs>
+    <!-- Sibling solution context: project-reference mode -->
+    <UseProjectRefs Condition="'$(SolutionFileName)' == 'Platform.sln'">true</UseProjectRefs>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <ContractsProjectPath>..\..\..\Platform.Contracts\src\Platform.Contracts\Platform.Contracts.csproj</ContractsProjectPath>
+    <MessagingProjectPath>..\..\..\Platform.Messaging\src\Platform.Messaging\Platform.Messaging.csproj</MessagingProjectPath>
+    <PersistenceProjectPath>..\..\..\Platform.Persistence\src\Platform.Persistence\Platform.Persistence.csproj</PersistenceProjectPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Package mode, plus fallback when sibling project is missing -->
+    <PackageReference Include="Platform.Contracts"
+                      Version="1.2.0-feature-x.4"
+                      Condition="'$(UseProjectRefs)' == 'false' OR !Exists('$(ContractsProjectPath)')" />
+    <PackageReference Include="Platform.Messaging"
+                      Version="2.3.1-feature-x.7"
+                      Condition="'$(UseProjectRefs)' == 'false' OR !Exists('$(MessagingProjectPath)')" />
+    <PackageReference Include="Platform.Persistence"
+                      Version="3.1.0-feature-x.2"
+                      Condition="'$(UseProjectRefs)' == 'false' OR !Exists('$(PersistenceProjectPath)')" />
+
+    <!-- Project mode when sibling project exists -->
+    <ProjectReference Include="$(ContractsProjectPath)"
+                      Condition="'$(UseProjectRefs)' != 'false' AND Exists('$(ContractsProjectPath)')" />
+    <ProjectReference Include="$(MessagingProjectPath)"
+                      Condition="'$(UseProjectRefs)' != 'false' AND Exists('$(MessagingProjectPath)')" />
+    <ProjectReference Include="$(PersistenceProjectPath)"
+                      Condition="'$(UseProjectRefs)' != 'false' AND Exists('$(PersistenceProjectPath)')" />
+  </ItemGroup>
+</Project>
+```
+
+## How GrayMoon organizes repositories in one Workspace
+
+GrayMoon is designed to bring many existing repositories together under one Workspace folder so cross-repository development becomes a single flow instead of a repeated manual process.
+
+### Workspace-first repository organization
+
+- Choose a Workspace root path (for example, `C:\Workspace\Platform`).
+- Create a workspace in GrayMoon (for example, `PlatformFeatureA`).
+- Select multiple repositories from your connector list and assign them to that workspace.
+- GrayMoon keeps those repositories grouped as one working set for branch, sync, update, push, and status operations.
+
+### Multi-repository clone and checkout workflow
+
+- In one workspace operation, select many repositories and clone them into the same workspace folder structure.
+- Create or checkout a branch across selected repositories in one action.
+- Keep branch names aligned (for example, `feature/dependency-update`) across all selected repositories.
+- Continue with synchronized updates, commits, and pushes from the same workspace context.
+
+### Why this matters
+
+- You avoid repetitive per-repo clone and checkout commands.
+- You can start feature work across many repositories much faster.
+- You keep repositories organized by feature/workstream, not just by individual repo ownership.
+- You reduce mistakes caused by one repository being on a different branch than the others.
+
+## Version files: why they matter and how GrayMoon helps
+
+GrayMoon can update version tokens not only inside `.csproj`, but also in any configured file where service/package versions are required for runtime or deployment consistency.
+
+Examples:
+
+- `docker-compose.yml` image tags
+- `.env` values
+- deployment manifests (Helm values, Kubernetes YAML)
+- pipeline YAML files
+- app config files (`appsettings.*.json`, custom config)
+
+Using version-file patterns, GrayMoon can:
+
+- map placeholders to repository names/tokens
+- replace values with current tracked versions from workspace repositories
+- update many files in one operation
+- optionally commit those file changes as part of orchestration flow
+
+This is especially valuable when teams need reproducible builds and deployments outside local IDE scenarios, because the same version alignment is carried into configuration artifacts.
+
+## Package references: the GrayMoon-managed dependency contract
+
+GrayMoon’s dependency engine is built around `PackageReference` versions:
+
+- when you create a workspace and work on a feature branch, GrayMoon tracks the versions it detects for each repository in that workspace
+- when you run dependency updates, GrayMoon updates `PackageReference` versions (by `Include` name) across all impacted repositories
+- it can commit those `.csproj` version changes for you, so you can push them together and test as one coordinated release unit
+
+This is what enables the “shared library/package changed once, everything else updates automatically” workflow:
+
+- create a feature branch for a dependency rollout (for example `feature/dependency-update`)
+- let GrayMoon update `PackageReference` versions across the required repositories
+- automatically commit the changes
+- push all updates in one go, then run your normal build/test/CI validation
+
+### Why the centralized solution + package refs help AI tools
+
+When developers open the sibling solution in editors like VS Code or Cursor, `ProjectReference`-based source wiring improves navigation and understanding for code-aware AI tooling.
+
+At the same time, keeping `PackageReference` versions aligned ensures those edits compile consistently and remain correct for CI and for isolated builds that use packages.
+
+

--- a/docs/GrayMoon-Software-Overview.md
+++ b/docs/GrayMoon-Software-Overview.md
@@ -69,7 +69,8 @@ This gives one operational view instead of opening each repository separately.
 - Refresh local and remote branch lists.
 - Set upstream tracking.
 - Delete local/remote branches safely.
-- Sync repository back to default branch with cleanup behavior.
+- One-click sync back to default branch (single repo or multiple repos in a dependency level).
+- After a PR is merged, GrayMoon can sync back to default by checking out the default branch, pruning the local feature branch when there is no commit drift, and pulling the latest changes.
 - Detect common branches across workspace repositories.
 
 ### 6) Sync and commit synchronization
@@ -112,6 +113,8 @@ This directly addresses CI failures caused by missing dependency versions at pus
 ### 10) Dependency graph, projects, and packages visibility
 
 - Workspace dependency graph visualization with filtering by repo or dependency level.
+- Automatic repository grouping by dependency levels based on dependency hierarchy.
+- Grouped visualization by repository type (services and packages/libraries) to make dependency flow easier to understand.
 - Project inventory view (type/framework/path).
 - Package inventory view and registry mapping checks.
 - Package registry sync actions for workspace packages.
@@ -120,6 +123,10 @@ This directly addresses CI failures caused by missing dependency versions at pus
 
 - Pull request state persistence and refresh per repository branch.
 - GitHub Actions aggregate status visibility per repository/branch.
+- Workspace-level view of GitHub Actions results for the current branch across all repositories in the workspace.
+- Open multiple repositories in GitHub from GrayMoon in one action.
+- Open new pull request pages in GitHub for multiple repositories in a selected dependency level.
+- Track changed files across repositories so you can verify whether feature-branch commits actually produce PR-worthy changes; if only dependency-version updates exist, you can skip creating unnecessary PRs.
 - Re-run failed workflows from the actions workspace view.
 
 ### 12) GitVersion compatibility per repository


### PR DESCRIPTION
### Summary
- Reworked `README.md` into a fast, approachable introduction that explains GrayMoon’s core value in ~5 minutes.
- Expanded `docs/GrayMoon-Software-Overview.md` with concrete multi-repository workflows and feature explanations, including:
  - workspace-based multi-repo clone/branch operations
  - hook-based background tracking while developers work in IDEs
  - dependency-level grouping and visualization (services vs packages/libraries)
  - one-click sync to default branch after PR merge (single repo or dependency level)
  - GitHub Actions branch-level visibility across workspace repositories
  - multi-repo GitHub navigation and multi-PR opening by dependency level
  - changed-file awareness to avoid unnecessary PRs when only dependency-version updates exist
- Added dual-license files:
  - `LICENSE-NON-COMMERCIAL.txt`
  - `LICENSE-COMMERCIAL.txt`
