### PR TITLE
Fix connector health problem

### DIFF
--- a/src/GrayMoon.App/Components/Pages/Connectors.razor
+++ b/src/GrayMoon.App/Components/Pages/Connectors.razor
@@ -175,6 +175,16 @@
             ?? Configuration["GitHub::PersonalAccessToken"]
             ?? string.Empty;
         await LoadConnectorsAsync();
+        await TestAllConnectorsAsync();
+    }
+
+    private async Task TestAllConnectorsAsync()
+    {
+        if (connectors == null || connectors.Count == 0)
+            return;
+
+        foreach (var connector in connectors.ToList())
+            await TestConnectorAsync(connector);
     }
 
     private async Task LoadConnectorsAsync()

--- a/src/GrayMoon.App/Repositories/ConnectorRepository.cs
+++ b/src/GrayMoon.App/Repositories/ConnectorRepository.cs
@@ -113,6 +113,7 @@ public class ConnectorRepository(AppDbContext dbContext, ILogger<ConnectorReposi
 
         connector.Status = status;
         connector.LastError = string.IsNullOrWhiteSpace(errorMessage) ? null : errorMessage;
+        connector.IsHealthy = status == "Ok";
         await dbContext.SaveChangesAsync();
         logger.LogInformation("Persistence: saved Connector. Action=UpdateStatus, ConnectorId={ConnectorId}, Status={Status}", connectorId, status);
     }


### PR DESCRIPTION
Two changes made:

- **`ConnectorRepository.UpdateStatusAsync`** — now also sets `IsHealthy = true` when status is `"Ok"`, and `false` for any other status (Error, Testing, Unknown).
- **`Connectors.razor` `OnInitializedAsync`** — calls the new `TestAllConnectorsAsync` after loading, which runs `TestConnectorAsync` for every connector. This means each time the user navigates to the Connectors page, all connectors are re-tested and their `IsHealthy` flag is updated accordingly.