### PR TITLE
Update files per dependency level and create prerelease

### DIFF
--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor
@@ -127,7 +127,7 @@
                                                                        ColSpan="@TableColSpan"
                                                                        Group="@group"
                                                                        OnSyncToDefault="() => ShowConfirmSyncToDefaultLevel(group.Select(wr => wr.RepositoryId).ToList())"
-                                                                       OnSyncCommits="() => ShowConfirmSyncCommitsLevel(group.Select(wr => wr.RepositoryId).ToList())"
+                                                                       OnSyncCommits="() => CommitSyncLevelAsync(group.Select(wr => wr.RepositoryId).ToList())"
                                                                        OnOpenPr="() => ShowConfirmOpenPr(group)"
                                                                        OnSyncLevel="() => ShowConfirmSyncLevel(group.Select(wr => wr.RepositoryId).ToList())"
                                                                        />

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor
@@ -211,12 +211,6 @@
                           OnProceed="@OnUpdateSingleRepositoryDependenciesProceedAsync"
                           OnCancel="@CloseUpdateSingleRepositoryDependenciesModal" />
 
-<VersionFilesCommitModal IsVisible="@_versionFilesCommitModal.IsVisible"
-                         Message="@_versionFilesCommitModal.Message"
-                         Files="@_versionFilesCommitModal.Files"
-                         OnProceed="@OnVersionFilesCommitProceedAsync"
-                         OnCancel="@CloseVersionFilesCommitModal" />
-
 <PushWithDependenciesModal IsVisible="@_pushWithDependenciesModal.IsVisible"
           Info="@_pushWithDependenciesModal.Info"
           RepoName="@_pushWithDependenciesModal.RepoName"

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
@@ -87,7 +87,6 @@ public sealed partial class WorkspaceRepositories : IDisposable
     private IReadOnlyList<(int RepoId, int? DefaultAhead, bool? HasUpstream)>? _syncToDefaultCheckResults = null;
     private UpdateModalState _updateModal = new();
     private UpdateSingleRepoDependenciesModalState _updateSingleRepoModal = new();
-    private VersionFilesCommitModalState _versionFilesCommitModal = new();
     private PushWithDependenciesModalState _pushWithDependenciesModal = new();
     private ConfirmModalState _confirmModal = new();
     private string searchTerm = string.Empty;
@@ -479,30 +478,6 @@ public sealed partial class WorkspaceRepositories : IDisposable
             : $"Waiting for the agent to complete {AgentTasksPendingCount} tasks";
     }
 
-    /// <summary>
-    /// Called by the dependency update orchestrator when version-file updates have been applied but not yet committed.
-    /// Groups files by repo and opens the version-files commit modal so the user can confirm and commit via CommitFileVersionUpdatesAsync.
-    /// </summary>
-    private void HandleVersionFilesUpdated(IReadOnlyList<(int RepoId, string RepoName, IReadOnlyList<string> FilePaths)> byRepo)
-    {
-        if (byRepo == null || byRepo.Count == 0)
-            return;
-
-        var repoCount = byRepo.Count;
-        var distinctFiles = byRepo
-            .SelectMany(r => r.FilePaths)
-            .Distinct()
-            .ToList();
-        var filesForDisplay = distinctFiles.Count <= 5
-            ? distinctFiles
-            : distinctFiles.Take(5).Concat(new[] { $"... and {distinctFiles.Count - 5} more" }).ToList();
-        var prefix = repoCount == 1
-            ? "Commit the updated version files in this repository?"
-            : $"Commit all updated version files in all {repoCount} repositories?";
-
-        OpenVersionFilesCommitModal(prefix, byRepo, filesForDisplay);
-    }
-
     private void AbortPushAsync()
     {
         _pushCts?.Cancel();
@@ -738,11 +713,6 @@ public sealed partial class WorkspaceRepositories : IDisposable
         _updateSingleRepoModal = _updateSingleRepoModal with { IsVisible = false, Payload = null };
     }
 
-    private void OnCommitDependencyProgress(int current, int total, int unused)
-    {
-        SetUpdateProgress($"Committed {current} of {total}");
-    }
-
     private async Task OnUpdateSingleRepositoryDependenciesProceedAsync()
     {
         if (_updateSingleRepoModal.Payload == null)
@@ -768,8 +738,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
                     SetUpdateProgress,
                     (repoId, msg) => { repositoryErrors[repoId] = msg; _ = InvokeAsync(StateHasChanged); },
                     onAppSideComplete: () => _updateAwaitingAgentTasks = true,
-                    repoIdsToUpdate: new HashSet<int> { repositoryId },
-                    onVersionFilesUpdated: HandleVersionFilesUpdated);
+                    repoIdsToUpdate: new HashSet<int> { repositoryId });
             }
             await RefreshFromSync();
         }
@@ -1102,8 +1071,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
                     _ = InvokeAsync(StateHasChanged);
                 },
                 onAppSideComplete: () => _updateAwaitingAgentTasks = true,
-                repoIdsToUpdate: null,
-                onVersionFilesUpdated: HandleVersionFilesUpdated);
+                repoIdsToUpdate: null);
 
             isUpdating = false;
             await InvokeAsync(StateHasChanged);
@@ -1125,79 +1093,6 @@ public sealed partial class WorkspaceRepositories : IDisposable
             isUpdating = false;
             await InvokeAsync(StateHasChanged);
         }
-    }
-
-    /// <summary>Commit file-version updates (no dependency updates path). Stages and commits the given paths per repo via agent StageAndCommit.</summary>
-    private async Task CommitFileVersionUpdatesAsync(IReadOnlyList<(int RepoId, string RepoName, IReadOnlyList<string> FilePaths)> byRepo)
-    {
-        if (byRepo == null || byRepo.Count == 0)
-            return;
-
-        _updateCts?.Cancel();
-        _updateCts?.Dispose();
-        _updateCts = new CancellationTokenSource();
-        isUpdating = true;
-        SetUpdateProgress("Committing updated versions...");
-        try
-        {
-            await InvokeAsync(StateHasChanged);
-            await using (var scope = ServiceScopeFactory.CreateAsyncScope())
-            {
-                var workspaceGitService = scope.ServiceProvider.GetRequiredService<WorkspaceGitService>();
-                var commitResults = await workspaceGitService.CommitFilePathsAsync(
-                    WorkspaceId,
-                    byRepo,
-                    onProgress: OnCommitDependencyProgress,
-                    cancellationToken: _updateCts.Token);
-                foreach (var (repoId, errMsg) in commitResults)
-                {
-                    if (!string.IsNullOrEmpty(errMsg))
-                        repositoryErrors[repoId] = errMsg;
-                }
-            }
-            await RefreshFromSync();
-        }
-        finally
-        {
-            isUpdating = false;
-            await InvokeAsync(StateHasChanged);
-        }
-    }
-
-    /// <summary>Opens the dedicated version-files commit modal with message and file list.</summary>
-    private void OpenVersionFilesCommitModal(
-        string message,
-        IReadOnlyList<(int RepoId, string RepoName, IReadOnlyList<string> FilePaths)> byRepo,
-        IReadOnlyList<string> filesForDisplay)
-    {
-        _versionFilesCommitModal = _versionFilesCommitModal with
-        {
-            IsVisible = true,
-            Message = message,
-            ByRepoToCommit = byRepo,
-            Files = filesForDisplay
-        };
-        StateHasChanged();
-    }
-
-    private void CloseVersionFilesCommitModal()
-    {
-        _versionFilesCommitModal = _versionFilesCommitModal with
-        {
-            IsVisible = false,
-            ByRepoToCommit = null,
-            Files = Array.Empty<string>()
-        };
-        StateHasChanged();
-    }
-
-    private async Task OnVersionFilesCommitProceedAsync()
-    {
-        var byRepo = _versionFilesCommitModal.ByRepoToCommit;
-        CloseVersionFilesCommitModal();
-        if (byRepo == null || byRepo.Count == 0)
-            return;
-        await CommitFileVersionUpdatesAsync(byRepo);
     }
 
     private async Task HandleDependencyBadgeKeydown(KeyboardEventArgs e, int repositoryId, int unmatchedDeps)
@@ -2256,14 +2151,6 @@ public sealed partial class WorkspaceRepositories : IDisposable
         public SyncDependenciesRepoPayload? Payload { get; init; }
         public int RepositoryId { get; init; }
         public string? RepoName { get; init; }
-    }
-
-    private sealed record VersionFilesCommitModalState
-    {
-        public bool IsVisible { get; init; }
-        public string Message { get; init; } = "";
-        public IReadOnlyList<string> Files { get; init; } = Array.Empty<string>();
-        public IReadOnlyList<(int RepoId, string RepoName, IReadOnlyList<string> FilePaths)>? ByRepoToCommit { get; init; }
     }
 
     private sealed record PushWithDependenciesModalState

--- a/src/GrayMoon.App/Services/DependencyUpdateOrchestrator.cs
+++ b/src/GrayMoon.App/Services/DependencyUpdateOrchestrator.cs
@@ -21,20 +21,13 @@ public sealed class DependencyUpdateOrchestrator(
     /// Stops on first error and reports it via <paramref name="onRepoError"/>.
     /// </summary>
     /// <param name="repoIdsToUpdate">Optional. When set, only these repositories are considered for the update plan and all steps.</param>
-    /// <param name="onVersionFilesUpdated">
-    /// Optional. When set and version files are updated, the orchestrator does not commit them but instead
-    /// groups updated file paths per repo and invokes this callback so the caller (typically UI) can confirm
-    /// and commit via <see cref="WorkspaceGitService.CommitFilePathsAsync"/>.
-    /// When null, version-file commits are performed automatically.
-    /// </param>
     public async Task RunAsync(
         int workspaceId,
         CancellationToken cancellationToken,
         Action<string> setProgress,
         Action<int, string> onRepoError,
         Action? onAppSideComplete = null,
-        IReadOnlySet<int>? repoIdsToUpdate = null,
-        Action<IReadOnlyList<(int RepoId, string RepoName, IReadOnlyList<string> FilePaths)>>? onVersionFilesUpdated = null)
+        IReadOnlySet<int>? repoIdsToUpdate = null)
     {
         var hadError = false;
         void OnRepoError(int repoId, string msg)
@@ -54,107 +47,36 @@ public sealed class DependencyUpdateOrchestrator(
         if (hadError)
             return;
 
-        // Step 2: Build update plan (repos with mismatched deps, by level).
-        var (payload, isMultiLevel) = await workspaceGitService.GetUpdatePlanAsync(workspaceId, repoIdsToUpdate, cancellationToken);
-
-        if (payload.Count > 0 && isMultiLevel)
+        // Step 2+: Rebuild plan before each level and process the current lowest level atomically.
+        while (!hadError)
         {
-            // Multi-level: for each level, sync → commit → refresh version (commits required before next level).
-            var levelsAsc = payload.Select(p => p.DependencyLevel ?? 0).Distinct().OrderBy(x => x).ToList();
-            foreach (var level in levelsAsc)
-            {
-                if (hadError)
-                    break;
+            var (payload, _) = await workspaceGitService.GetUpdatePlanAsync(workspaceId, repoIdsToUpdate, cancellationToken);
+            if (payload.Count == 0)
+                break;
 
-                var reposAtLevel = payload.Where(p => (p.DependencyLevel ?? 0) == level).ToList();
-                if (reposAtLevel.Count == 0)
-                    continue;
+            var level = payload.Min(p => p.DependencyLevel ?? 0);
+            var reposAtLevel = payload
+                .Where(p => (p.DependencyLevel ?? 0) == level)
+                .ToList();
+            if (reposAtLevel.Count == 0)
+                break;
 
-                var repoIds = reposAtLevel.Select(r => r.RepoId).ToHashSet();
+            var repoIds = reposAtLevel.Select(r => r.RepoId).ToHashSet();
 
-                // Step 3a: Sync .csproj files for this level.
-                setProgress($"Updating {reposAtLevel.Count} {(reposAtLevel.Count == 1 ? "repository" : "repositories")}...");
-                await workspaceGitService.SyncDependenciesAsync(
-                    workspaceId,
-                    onProgress: (c, t, _) => setProgress($"Syncing {c} of {t}"),
-                    onRepoError: OnRepoError,
-                    repoIdsToSync: repoIds,
-                    cancellationToken);
-                if (hadError)
-                    break;
-
-                // Step 4a: Commit .csproj changes for this level (required before next level).
-                setProgress("Committing...");
-                var commitResults = await workspaceGitService.CommitDependencyUpdatesAsync(
-                    workspaceId,
-                    reposAtLevel,
-                    onProgress: (c, t, _) =>
-                    {
-                        setProgress($"Committed {c} of {t}");
-                        if (c == t)
-                            onAppSideComplete?.Invoke();
-                    },
-                    cancellationToken);
-                foreach (var (repoId, errMsg) in commitResults)
-                {
-                    if (!string.IsNullOrEmpty(errMsg))
-                    {
-                        OnRepoError(repoId, errMsg);
-                        break;
-                    }
-                }
-                if (hadError)
-                    break;
-
-                // Step 5a: Refresh repo version so grid is up to date for this level.
-                var totalRefresh = reposAtLevel.Count;
-                var completedRefresh = 0;
-                using var refreshSemaphore = new SemaphoreSlim(_maxConcurrent);
-                var refreshTasks = reposAtLevel.Select(async repo =>
-                {
-                    await refreshSemaphore.WaitAsync(cancellationToken);
-                    try
-                    {
-                        var (refreshSuccess, refreshError) = await workspaceGitService.SyncSingleRepositoryAsync(repo.RepoId, workspaceId, cancellationToken);
-                        var c = Interlocked.Increment(ref completedRefresh);
-                        setProgress($"Updating version {c} of {totalRefresh}...");
-                        if (c == totalRefresh)
-                            onAppSideComplete?.Invoke();
-                        return (repo.RepoId, refreshSuccess, refreshError);
-                    }
-                    finally
-                    {
-                        refreshSemaphore.Release();
-                    }
-                });
-                var refreshResults = await Task.WhenAll(refreshTasks);
-                foreach (var (repoId, success, err) in refreshResults)
-                {
-                    if (!success)
-                        OnRepoError(repoId, err ?? "Refresh version failed.");
-                }
-
-                if (hadError)
-                    break;
-            }
-        }
-        else if (payload.Count > 0)
-        {
-            // Single-level: sync all → commit all → refresh version for all.
-            setProgress("Syncing dependencies...");
+            setProgress($"Updating {reposAtLevel.Count} {(reposAtLevel.Count == 1 ? "repository" : "repositories")}...");
             await workspaceGitService.SyncDependenciesAsync(
                 workspaceId,
-                onProgress: (c, t, _) => setProgress($"Synced dependencies {c} of {t}"),
+                onProgress: (c, t, _) => setProgress($"Syncing {c} of {t}"),
                 onRepoError: OnRepoError,
-                repoIdsToSync: repoIdsToUpdate,
+                repoIdsToSync: repoIds,
                 cancellationToken);
             if (hadError)
-                return;
+                break;
 
-            setProgress("Committing updates...");
+            setProgress("Committing...");
             var commitResults = await workspaceGitService.CommitDependencyUpdatesAsync(
                 workspaceId,
-                payload,
+                reposAtLevel,
                 onProgress: (c, t, _) =>
                 {
                     setProgress($"Committed {c} of {t}");
@@ -167,87 +89,76 @@ public sealed class DependencyUpdateOrchestrator(
                 if (!string.IsNullOrEmpty(errMsg))
                 {
                     OnRepoError(repoId, errMsg);
-                    return;
+                    break;
                 }
             }
+            if (hadError)
+                break;
 
-            if (payload.Count > 0)
+            if (!await RefreshRepositoryVersionsAsync(
+                    reposAtLevel.Select(r => r.RepoId).ToList(),
+                    workspaceId,
+                    cancellationToken,
+                    setProgress,
+                    onAppSideComplete,
+                    OnRepoError))
             {
-                var totalRefresh = payload.Count;
-                var completedRefresh = 0;
-                using var refreshSemaphore = new SemaphoreSlim(_maxConcurrent);
-                var refreshTasks = payload.Select(async repo =>
-                {
-                    await refreshSemaphore.WaitAsync(cancellationToken);
-                    try
-                    {
-                        var (refreshSuccess, refreshError) = await workspaceGitService.SyncSingleRepositoryAsync(repo.RepoId, workspaceId, cancellationToken);
-                        var c = Interlocked.Increment(ref completedRefresh);
-                        setProgress($"Updating version {c} of {totalRefresh}...");
-                        if (c == totalRefresh)
-                            onAppSideComplete?.Invoke();
-                        return (repo.RepoId, refreshSuccess, refreshError);
-                    }
-                    finally
-                    {
-                        refreshSemaphore.Release();
-                    }
-                });
-                var refreshResults = await Task.WhenAll(refreshTasks);
-                foreach (var (repoId, success, err) in refreshResults)
-                {
-                    if (!success)
-                        OnRepoError(repoId, err ?? "Refresh version failed.");
-                }
+                hadError = true;
+                break;
             }
-        }
 
-        // Step 3+: Always update configured version files after dependency updates.
-        // This ensures version files aren't skipped when a dependency level has no csproj mismatches,
-        // or when the update plan is empty (payload.Count == 0).
-        if (!hadError)
-        {
             setProgress("Updating version files...");
-            HashSet<int>? selectedRepoIds = null;
-            if (repoIdsToUpdate != null && repoIdsToUpdate.Count > 0)
-                selectedRepoIds = new HashSet<int>(repoIdsToUpdate);
-
             var (_, _, fileError, updatedFiles) = await fileVersionService.UpdateAllVersionsAsync(
                 workspaceId,
-                selectedRepositoryIds: selectedRepoIds,
+                selectedRepositoryIds: repoIds,
                 onFileUpdated: null,
                 cancellationToken: cancellationToken);
 
             if (fileError != null && !fileError.Contains("No version configurations", StringComparison.OrdinalIgnoreCase))
             {
                 OnRepoError(0, fileError);
+                break;
             }
 
-            if (!hadError && updatedFiles is { Count: > 0 })
+            if (updatedFiles is { Count: > 0 })
             {
                 var byRepo = updatedFiles
                     .GroupBy(x => (x.RepositoryId, x.RepoName))
                     .Select(g => (g.Key.RepositoryId, g.Key.RepoName, (IReadOnlyList<string>)g.Select(x => x.FilePath).Distinct().ToList()))
                     .ToList();
 
-                if (onVersionFilesUpdated != null)
-                {
-                    onVersionFilesUpdated(byRepo);
-                }
-                else
-                {
-                    setProgress("Committing updated versions...");
-                    var vfCommitResults = await workspaceGitService.CommitFilePathsAsync(
-                        workspaceId,
-                        byRepo,
-                        onProgress: (c, t, _) => setProgress($"Committed version files {c} of {t}"),
-                        cancellationToken: cancellationToken);
+                setProgress("Committing updated versions...");
+                var vfCommitResults = await workspaceGitService.CommitFilePathsAsync(
+                    workspaceId,
+                    byRepo,
+                    onProgress: (c, t, _) => setProgress($"Committed version files {c} of {t}"),
+                    cancellationToken: cancellationToken);
 
-                    foreach (var (repoId, errMsg) in vfCommitResults)
+                var committedVersionRepoIds = new List<int>();
+                foreach (var (repoId, errMsg) in vfCommitResults)
+                {
+                    if (!string.IsNullOrEmpty(errMsg))
                     {
-                        if (!string.IsNullOrEmpty(errMsg))
-                            OnRepoError(repoId, errMsg);
+                        OnRepoError(repoId, errMsg);
+                        break;
                     }
+                    committedVersionRepoIds.Add(repoId);
+                }
+                if (hadError)
+                    break;
+
+                // Version-file commits must also refresh GitVersion before planning next higher level.
+                if (committedVersionRepoIds.Count > 0
+                    && !await RefreshRepositoryVersionsAsync(
+                        committedVersionRepoIds,
+                        workspaceId,
+                        cancellationToken,
+                        setProgress,
+                        onAppSideComplete,
+                        OnRepoError))
+                {
+                    hadError = true;
+                    break;
                 }
             }
         }
@@ -258,5 +169,50 @@ public sealed class DependencyUpdateOrchestrator(
             onAppSideComplete?.Invoke();
             await workspaceGitService.RecomputeAndBroadcastWorkspaceSyncedAsync(workspaceId, cancellationToken);
         }
+    }
+
+    private async Task<bool> RefreshRepositoryVersionsAsync(
+        IReadOnlyList<int> repositoryIds,
+        int workspaceId,
+        CancellationToken cancellationToken,
+        Action<string> setProgress,
+        Action? onAppSideComplete,
+        Action<int, string> onRepoError)
+    {
+        if (repositoryIds.Count == 0)
+            return true;
+
+        var totalRefresh = repositoryIds.Count;
+        var completedRefresh = 0;
+        using var refreshSemaphore = new SemaphoreSlim(_maxConcurrent);
+        var refreshTasks = repositoryIds.Select(async repoId =>
+        {
+            await refreshSemaphore.WaitAsync(cancellationToken);
+            try
+            {
+                var (refreshSuccess, refreshError) = await workspaceGitService.SyncSingleRepositoryAsync(repoId, workspaceId, cancellationToken);
+                var c = Interlocked.Increment(ref completedRefresh);
+                setProgress($"Updating version {c} of {totalRefresh}...");
+                if (c == totalRefresh)
+                    onAppSideComplete?.Invoke();
+                return (RepoId: repoId, Success: refreshSuccess, Error: refreshError);
+            }
+            finally
+            {
+                refreshSemaphore.Release();
+            }
+        });
+
+        var refreshResults = await Task.WhenAll(refreshTasks);
+        foreach (var (repoId, success, err) in refreshResults)
+        {
+            if (!success)
+            {
+                onRepoError(repoId, err ?? "Refresh version failed.");
+                return false;
+            }
+        }
+
+        return true;
     }
 }

--- a/src/GrayMoon.App/Services/WorkspaceUpdateHandler.cs
+++ b/src/GrayMoon.App/Services/WorkspaceUpdateHandler.cs
@@ -17,8 +17,7 @@ public sealed class WorkspaceUpdateHandler(
         Action<string> setProgress,
         Action<int, string> setRepositoryError,
         Action? onAppSideComplete = null,
-        IReadOnlySet<int>? repoIdsToUpdate = null,
-        Action<IReadOnlyList<(int RepoId, string RepoName, IReadOnlyList<string> FilePaths)>>? onVersionFilesUpdated = null)
+        IReadOnlySet<int>? repoIdsToUpdate = null)
     {
         try
         {
@@ -28,8 +27,7 @@ public sealed class WorkspaceUpdateHandler(
                 setProgress,
                 setRepositoryError,
                 onAppSideComplete,
-                repoIdsToUpdate,
-                onVersionFilesUpdated);
+                repoIdsToUpdate);
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {


### PR DESCRIPTION
Implemented the per-level update fix so each dependency level is now processed atomically before moving up: re-plan level-by-level, sync + commit dependency updates, refresh repo versions, update + commit configured version files for that same level, then refresh versions again so higher levels use final Git versions. I also removed the version-file confirmation dialog path from update flow (`WorkspaceRepositories`) so version-file commits happen automatically.

Validation passed: lints are clean for edited files, and `dotnet build GrayMoon.sln` succeeds (there is one pre-existing warning in `GitVersionCommandService.cs`, unrelated to this change).