### PR TITLE
Dynamic wait timer for synchronized push

### DIFF
--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
@@ -474,8 +474,8 @@ public sealed partial class WorkspaceRepositories : IDisposable
         if (!awaitingAgentTasks) return progressMessage;
         if (AgentTasksPendingCount == 0) return progressMessage;
         return AgentTasksPendingCount == 1
-            ? "Waiting for the agent to complete 1 task"
-            : $"Waiting for the agent to complete {AgentTasksPendingCount} tasks";
+            ? "Waiting for the agent to complete 1 task..."
+            : $"Waiting for the agent to complete {AgentTasksPendingCount} tasks...";
     }
 
     private void AbortPushAsync()

--- a/src/GrayMoon.App/Models/WorkspaceOptions.cs
+++ b/src/GrayMoon.App/Models/WorkspaceOptions.cs
@@ -11,6 +11,6 @@ public class WorkspaceOptions
     /// <summary>Port only for post-commit hook URL. When set (and PostCommitHookBaseUrl is empty), hooks use http://127.0.0.1:{port}. Typical value: 8384.</summary>
     public int? PostCommitHookPort { get; set; }
 
-    /// <summary>Expected time per dependency build in minutes, used to compute push wait timeout. Timeout = (number of dependencies) × this value. Default 1.</summary>
-    public double PushWaitDependencyTimeoutMinutesPerDependency { get; set; } = 1.0;
+    /// <summary>Expected time per dependency build in minutes, used to compute push wait timeout. Timeout = (number of dependencies) × this value. Default 2.</summary>
+    public double PushWaitDependencyTimeoutMinutesPerDependency { get; set; } = 2.0;
 }

--- a/src/GrayMoon.App/Services/WorkspacePushService.cs
+++ b/src/GrayMoon.App/Services/WorkspacePushService.cs
@@ -181,7 +181,7 @@ public sealed class WorkspacePushService(
                     }
                     var found = getFoundCount();
                     var line1 = found == 0
-                        ? $"Waiting for {totalDeps} {(totalDeps == 1 ? "package" : "packages")}"
+                        ? $"Waiting for {totalDeps} {(totalDeps == 1 ? "package" : "packages")}..."
                         : $"Found {found} of {totalDeps} {(totalDeps == 1 ? "package" : "packages")}";
                     var totalSec = (int)remaining.TotalSeconds;
                     var mm = totalSec / 60;

--- a/src/GrayMoon.App/Services/WorkspacePushService.cs
+++ b/src/GrayMoon.App/Services/WorkspacePushService.cs
@@ -154,7 +154,8 @@ public sealed class WorkspacePushService(
                     totalDeps,
                     string.Join(", ", requiredForLevel.Select(r => r.PackageId + "@" + r.Version + " (connector " + r.MatchedConnectorId + ")")));
 
-                var timeoutMinutes = totalDeps * Math.Max(0.1, workspaceOptions.Value.PushWaitDependencyTimeoutMinutesPerDependency);
+                var minutesPerDep = Math.Max(0.1, workspaceOptions.Value.PushWaitDependencyTimeoutMinutesPerDependency);
+                var timeoutMinutes = totalDeps * minutesPerDep;
                 var totalTimeout = TimeSpan.FromMinutes(timeoutMinutes);
                 using var timeoutCts = new CancellationTokenSource(totalTimeout);
                 using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
@@ -197,6 +198,7 @@ public sealed class WorkspacePushService(
                         }
                         if (toCheck.Length > 0)
                         {
+                            var prevFound = getFoundCount();
                             foreach (var chunk in toCheck.Chunk(_maxConcurrent))
                             {
                                 await Task.WhenAll(chunk.Select(async i =>
@@ -218,7 +220,14 @@ public sealed class WorkspacePushService(
                                     }
                                 }));
                             }
-                            if (getFoundCount() >= totalDeps)
+                            var nowFound = getFoundCount();
+                            if (nowFound > prevFound)
+                            {
+                                var stillWaiting = totalDeps - nowFound;
+                                if (stillWaiting > 0)
+                                    deadline = DateTime.UtcNow + TimeSpan.FromMinutes(stillWaiting * minutesPerDep);
+                            }
+                            if (nowFound >= totalDeps)
                                 _logger.LogInformation("Push wait: all {Total} package(s) found for level {Level}, proceeding.", totalDeps, level);
                         }
                     }


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><h2 style="line-height: normal; font-size: 16.003px; font-weight: 600; margin: 1.5em 0px 0.875em; font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; color: rgb(191, 191, 191); font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Dynamic wait timer for synchronized push</h2><h3 style="line-height: normal; font-size: 13px; font-weight: 600; margin: 1.5em 0px 0.875em; font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; color: rgb(191, 191, 191); font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Summary</h3><p style="margin: 0px 0px 16px; color: rgb(191, 191, 191); font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Improves the push overlay experience when waiting for NuGet package dependencies by making the countdown timer reflect the number of packages still pending, rather than the original total.</p><h3 style="line-height: normal; font-size: 13px; font-weight: 600; margin: 1.5em 0px 0.875em; font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; color: rgb(191, 191, 191); font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Changes</h3><p style="margin: 0px 0px 16px; color: rgb(191, 191, 191); font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong style="font-weight: 600;">Dynamic deadline adjustment (<a href="vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/41dd792b5e/resources/app/out/vs/code/electron-browser/workbench/workbench.html" title="" draggable="true" data-href="file:///c%3A/Users/matth/source/repos/GrayMoon/src/GrayMoon.App/Services/WorkspacePushService.cs#17%2C21" custom-hover="true" class="chat-inline-anchor-widget show-file-icons" style="border-color: rgba(255, 255, 255, 0.1); border-style: solid; border-width: 0.5px; border-image: none 100% / 1 / 0 stretch; border-radius: 4px; margin: 0px 1px; padding: 1px 3px; text-wrap: nowrap; width: fit-content; font-weight: 400; text-decoration: none; font-size: 11.999px; color: inherit; user-select: text;"><span class="icon-label" style="padding: 0px 3px;">WorkspacePushService</span></a>)</strong></p><ul style="padding-inline-start: 24px; color: rgb(191, 191, 191); font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li style="margin: 4px 0px;">Extracted<span> </span><a href="vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/41dd792b5e/resources/app/out/vs/code/electron-browser/workbench/workbench.html" title="" draggable="true" data-href="file:///c%3A/Users/matth/source/repos/GrayMoon/src/GrayMoon.App/Services/WorkspacePushService.cs#157%2C21" custom-hover="true" class="chat-inline-anchor-widget show-file-icons" style="border-color: rgba(255, 255, 255, 0.1); border-style: solid; border-width: 0.5px; border-image: none 100% / 1 / 0 stretch; border-radius: 4px; margin: 0px 1px; padding: 1px 3px; text-wrap: nowrap; width: fit-content; font-weight: 400; text-decoration: none; font-size: 11.999px; color: inherit; user-select: text;"><span class="icon-label" style="padding: 0px 3px;">minutesPerDep</span></a><span> </span>as a named variable so it can be reused after packages are found.</li><li style="margin: 4px 0px;">After each poll cycle, if one or more packages were newly found, the deadline is recalculated as<span> </span><a href="vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/41dd792b5e/resources/app/out/vs/code/electron-browser/workbench/workbench.html" title="" draggable="true" data-href="file:///c%3A/Users/matth/source/repos/GrayMoon/src/GrayMoon.App/Services/WorkspacePushService.cs#471%2C13" custom-hover="true" class="chat-inline-anchor-widget show-file-icons" style="border-color: rgba(255, 255, 255, 0.1); border-style: solid; border-width: 0.5px; border-image: none 100% / 1 / 0 stretch; border-radius: 4px; margin: 0px 1px; padding: 1px 3px; text-wrap: nowrap; width: fit-content; font-weight: 400; text-decoration: none; font-size: 11.999px; color: inherit; user-select: text;"><span class="icon-label" style="padding: 0px 3px;">now + (remaining packages × minutesPerDep)</span></a>. This means the timer counts down from the correct remaining budget rather than continuing from the original over-estimated total.</li></ul><p style="margin: 0px 0px 16px; color: rgb(191, 191, 191); font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong style="font-weight: 600;">Increased default timeout (<a href="vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/41dd792b5e/resources/app/out/vs/code/electron-browser/workbench/workbench.html" title="" draggable="true" data-href="file:///c%3A/Users/matth/source/repos/GrayMoon/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor#18%2C85" custom-hover="true" class="chat-inline-anchor-widget show-file-icons" style="border-color: rgba(255, 255, 255, 0.1); border-style: solid; border-width: 0.5px; border-image: none 100% / 1 / 0 stretch; border-radius: 4px; margin: 0px 1px; padding: 1px 3px; text-wrap: nowrap; width: fit-content; font-weight: 400; text-decoration: none; font-size: 11.999px; color: inherit; user-select: text;"><span class="icon-label" style="padding: 0px 3px;">WorkspaceOptions</span></a>)</strong></p><ul style="padding-inline-start: 24px; color: rgb(191, 191, 191); font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li style="margin: 4px 0px;"><a href="vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/41dd792b5e/resources/app/out/vs/code/electron-browser/workbench/workbench.html" title="" draggable="true" data-href="file:///c%3A/Users/matth/source/repos/GrayMoon/src/GrayMoon.App/Models/WorkspaceOptions.cs#15%2C19" custom-hover="true" class="chat-inline-anchor-widget show-file-icons" style="border-color: rgba(255, 255, 255, 0.1); border-style: solid; border-width: 0.5px; border-image: none 100% / 1 / 0 stretch; border-radius: 4px; margin: 0px 1px; padding: 1px 3px; text-wrap: nowrap; width: fit-content; font-weight: 400; text-decoration: none; font-size: 11.999px; color: inherit; user-select: text;"><span class="icon-label" style="padding: 0px 3px;">PushWaitDependencyTimeoutMinutesPerDependency</span></a><span> </span>default raised from<span> </span><strong style="font-weight: 600;">1.0 → 2.0 minutes</strong><span> </span>per package to give builds more headroom.</li></ul><p style="margin: 0px 0px 16px; color: rgb(191, 191, 191); font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong style="font-weight: 600;">Overlay copy tweaks</strong></p><ul style="padding-inline-start: 24px; color: rgb(191, 191, 191); font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li style="margin: 4px 0px;">"Waiting for N package(s)" and "Waiting for the agent to complete N task(s)" messages now end with<span> </span><code style="font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 10.998px; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 1px 3px; border-radius: 4px; border-color: rgb(140, 140, 140); border-style: none; border-width: 0px; border-image: none 100% / 1 / 0 stretch; white-space: pre-wrap;">...</code><span> </span>for a more natural in-progress feel.</li></ul><h3 style="line-height: normal; font-size: 13px; font-weight: 600; margin: 1.5em 0px 0.875em; font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; color: rgb(191, 191, 191); font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Behaviour example</h3><div class="monaco-scrollable-element rendered-markdown-table-scroll-wrapper" role="presentation" style="width: 557px; margin-bottom: 0px; color: rgb(191, 191, 191); font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial; position: relative; overflow: hidden;"><div style="overflow: hidden;">
Packages at start | Initial timer | After 1 found | After 2 found
-- | -- | -- | --
3 | 6:00 | 4:00 | 2:00
2 | 4:00 | 2:00 | —

</div></div><!--EndFragment-->
</body>
</html>Dynamic wait timer for synchronized push
Summary
Improves the push overlay experience when waiting for NuGet package dependencies by making the countdown timer reflect the number of packages still pending, rather than the original total.

Changes
Dynamic deadline adjustment ([WorkspacePushService](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/41dd792b5e/resources/app/out/vs/code/electron-browser/workbench/workbench.html))

Extracted [minutesPerDep](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/41dd792b5e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) as a named variable so it can be reused after packages are found.
After each poll cycle, if one or more packages were newly found, the deadline is recalculated as [now + (remaining packages × minutesPerDep)](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/41dd792b5e/resources/app/out/vs/code/electron-browser/workbench/workbench.html). This means the timer counts down from the correct remaining budget rather than continuing from the original over-estimated total.
Increased default timeout ([WorkspaceOptions](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/41dd792b5e/resources/app/out/vs/code/electron-browser/workbench/workbench.html))

[PushWaitDependencyTimeoutMinutesPerDependency](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/41dd792b5e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) default raised from 1.0 → 2.0 minutes per package to give builds more headroom.
Overlay copy tweaks

"Waiting for N package(s)" and "Waiting for the agent to complete N task(s)" messages now end with ... for a more natural in-progress feel.
Behaviour example
Packages at start	Initial timer	After 1 found	After 2 found
3	6:00	4:00	2:00
2	4:00	2:00	—