### PR TITLE
Add Switch Branch across multiple repositories

### DIFF
--- a/src/GrayMoon.Abstractions/Notifications/RepositorySyncNotification.cs
+++ b/src/GrayMoon.Abstractions/Notifications/RepositorySyncNotification.cs
@@ -15,5 +15,22 @@ public sealed class RepositorySyncNotification
     public bool? HasUpstream { get; init; }
     public int? DefaultBranchBehind { get; init; }
     public int? DefaultBranchAhead { get; init; }
+    public List<RepositorySyncProjectNotification>? Projects { get; init; }
     public string? ErrorMessage { get; init; }
+}
+
+public sealed class RepositorySyncProjectNotification
+{
+    public string Name { get; init; } = "";
+    public int ProjectType { get; init; }
+    public string? ProjectPath { get; init; }
+    public string? TargetFramework { get; init; }
+    public string? PackageId { get; init; }
+    public List<RepositorySyncPackageReferenceNotification>? PackageReferences { get; init; }
+}
+
+public sealed class RepositorySyncPackageReferenceNotification
+{
+    public string Name { get; init; } = "";
+    public string? Version { get; init; }
 }

--- a/src/GrayMoon.Agent/Commands/CheckoutHookSyncCommand.cs
+++ b/src/GrayMoon.Agent/Commands/CheckoutHookSyncCommand.cs
@@ -12,7 +12,7 @@ namespace GrayMoon.Agent.Commands;
 /// upstream/default comparisons correct without paying the cost of a full fetch of all branches
 /// and tags (full fetch is done by Sync and branch list flows).
 /// </summary>
-public sealed class CheckoutHookSyncCommand(IGitService git, IAgentTokenProvider tokenProvider, IHubConnectionProvider hubProvider, ILogger<CheckoutHookSyncCommand> logger)
+public sealed class CheckoutHookSyncCommand(IGitService git, ICsProjFileService csProjFileService, IAgentTokenProvider tokenProvider, IHubConnectionProvider hubProvider, ILogger<CheckoutHookSyncCommand> logger)
 {
     public async Task ExecuteAsync(INotifyJob payload, CancellationToken cancellationToken = default)
     {
@@ -24,6 +24,7 @@ public sealed class CheckoutHookSyncCommand(IGitService git, IAgentTokenProvider
 
         // Resolve default origin ref once so minimal fetch and commit-count calls share it.
         var defaultRef = await git.GetDefaultBranchOriginRefAsync(payload.RepositoryPath, cancellationToken);
+        var findProjectsTask = csProjFileService.FindAsync(payload.RepositoryPath, cancellationToken);
 
         // Minimal fetch: only current branch and default branch, not all branches/tags.
         string? token = await tokenProvider.GetTokenForRepositoryAsync(payload.RepositoryId, cancellationToken);
@@ -66,6 +67,27 @@ public sealed class CheckoutHookSyncCommand(IGitService git, IAgentTokenProvider
             hasUpstream = remoteBranches.Any(r => string.Equals(r, branch, StringComparison.OrdinalIgnoreCase));
         }
 
+        var projects = await findProjectsTask;
+        var syncProjects = projects?
+            .Where(p => !string.IsNullOrWhiteSpace(p.Name))
+            .Select(p => new RepositorySyncProjectNotification
+            {
+                Name = p.Name.Trim(),
+                ProjectType = (int)p.ProjectType,
+                ProjectPath = p.ProjectPath ?? "",
+                TargetFramework = p.TargetFramework ?? "",
+                PackageId = p.PackageId,
+                PackageReferences = p.PackageReferences
+                    .Where(pr => !string.IsNullOrWhiteSpace(pr.Name))
+                    .Select(pr => new RepositorySyncPackageReferenceNotification
+                    {
+                        Name = pr.Name.Trim(),
+                        Version = pr.Version ?? ""
+                    })
+                    .ToList()
+            })
+            .ToList();
+
         var connection = hubProvider.Connection;
         if (connection?.State == HubConnectionState.Connected)
         {
@@ -80,6 +102,7 @@ public sealed class CheckoutHookSyncCommand(IGitService git, IAgentTokenProvider
                 HasUpstream = hasUpstream,
                 DefaultBranchBehind = defaultBehind,
                 DefaultBranchAhead = defaultAhead,
+                Projects = syncProjects,
                 ErrorMessage = fetchError
             };
             await connection.InvokeAsync(AgentHubMethods.SyncCommand, notification, cancellationToken);

--- a/src/GrayMoon.App/Api/Endpoints/BranchEndpoints.cs
+++ b/src/GrayMoon.App/Api/Endpoints/BranchEndpoints.cs
@@ -684,31 +684,51 @@ public static class BranchEndpoints
             return Results.Ok(new
             {
                 commonBranchNames = Array.Empty<string>(),
+                commonLocalBranchNames = Array.Empty<string>(),
+                commonRemoteBranchNames = Array.Empty<string>(),
                 defaultDisplayText = "multiple"
             });
         }
 
-        // Local branch names per repo (so we can intersect for "common")
-        var branchSets = new List<HashSet<string>>();
+        // Branch names per repo (local and remote separately so UI can combine without collapsing).
+        var localBranchSets = new List<HashSet<string>>();
+        var remoteBranchSets = new List<HashSet<string>>();
         var defaultBranchNames = new List<string>();
         foreach (var wr in links)
         {
             var branches = await dbContext.RepositoryBranches
-                .Where(rb => rb.WorkspaceRepositoryId == wr.WorkspaceRepositoryId && !rb.IsRemote)
-                .Select(rb => rb.BranchName)
+                .Where(rb => rb.WorkspaceRepositoryId == wr.WorkspaceRepositoryId)
+                .Select(rb => new { rb.BranchName, rb.IsRemote, rb.IsDefault })
                 .ToListAsync();
-            branchSets.Add(branches.ToHashSet(StringComparer.OrdinalIgnoreCase));
-            var defaultRow = await dbContext.RepositoryBranches
-                .Where(rb => rb.WorkspaceRepositoryId == wr.WorkspaceRepositoryId && rb.IsDefault)
-                .Select(rb => rb.BranchName)
-                .FirstOrDefaultAsync();
+
+            localBranchSets.Add(
+                branches
+                    .Where(b => !b.IsRemote)
+                    .Select(b => b.BranchName)
+                    .Where(b => !string.IsNullOrWhiteSpace(b))
+                    .ToHashSet(StringComparer.OrdinalIgnoreCase));
+
+            remoteBranchSets.Add(
+                branches
+                    .Where(b => b.IsRemote)
+                    .Select(b => b.BranchName)
+                    .Where(b => !string.IsNullOrWhiteSpace(b))
+                    .ToHashSet(StringComparer.OrdinalIgnoreCase));
+
+            var defaultRow = branches.FirstOrDefault(b => b.IsDefault)?.BranchName;
             defaultBranchNames.Add(defaultRow ?? "");
         }
 
-        var common = branchSets[0];
-        for (var i = 1; i < branchSets.Count; i++)
+        var commonLocal = localBranchSets[0];
+        for (var i = 1; i < localBranchSets.Count; i++)
         {
-            common.IntersectWith(branchSets[i]);
+            commonLocal.IntersectWith(localBranchSets[i]);
+        }
+
+        var commonRemote = remoteBranchSets[0];
+        for (var i = 1; i < remoteBranchSets.Count; i++)
+        {
+            commonRemote.IntersectWith(remoteBranchSets[i]);
         }
 
         // Default option: one common default (e.g. main [default]) or "multiple [default]" when repos have different defaults
@@ -717,12 +737,17 @@ public static class BranchEndpoints
 
         // All other branches common across every repo go in the list; exclude the single default so it appears only as the first option
         if (distinctDefaults.Count == 1)
-            common.Remove(distinctDefaults[0]);
-        var commonBranchNames = common.OrderBy(b => b, StringComparer.OrdinalIgnoreCase).ToList();
+            commonLocal.Remove(distinctDefaults[0]);
+
+        var commonLocalBranchNames = commonLocal.OrderBy(b => b, StringComparer.OrdinalIgnoreCase).ToList();
+        var commonRemoteBranchNames = commonRemote.OrderBy(b => b, StringComparer.OrdinalIgnoreCase).ToList();
 
         return Results.Ok(new
         {
-            commonBranchNames,
+            // Keep legacy field populated with local common branches for backwards compatibility.
+            commonBranchNames = commonLocalBranchNames,
+            commonLocalBranchNames,
+            commonRemoteBranchNames,
             defaultDisplayText
         });
     }

--- a/src/GrayMoon.App/Components/Modals/BranchModal.razor
+++ b/src/GrayMoon.App/Components/Modals/BranchModal.razor
@@ -24,6 +24,14 @@
                                 New Branch
                             </button>
                         </li>
+                        <li class="nav-item" role="presentation">
+                            <button class="nav-link @(activeTab == "switchbranch" ? "active" : "")"
+                                    type="button"
+                                    role="tab"
+                                    @onclick='() => SetActiveTab("switchbranch")'>
+                                Switch Branch
+                            </button>
+                        </li>
                     </ul>
 
                     @if (activeTab == "newbranch")
@@ -104,12 +112,79 @@
                             </div>
                         </div>
                     }
+                    else
+                    {
+                        <div class="mb-3 switch-branch-field-block">
+                            <div class="d-flex align-items-center justify-content-between switch-branch-label-row">
+                                <label class="form-label mb-0" for="switch-branch-filter">Branch name</label>
+                                <span class="switch-branch-tab-count">@GetBranchCountText(GetFilteredSwitchBranches().Count(), !string.IsNullOrWhiteSpace(switchBranchFilter))</span>
+                            </div>
+                            <input id="switch-branch-filter"
+                                   type="text"
+                                   class="form-control"
+                                   placeholder="search branch..."
+                                   @bind="switchBranchFilter"
+                                   @bind:event="oninput"
+                                   @bind:after="SelectClosestSwitchBranch"
+                                   @ref="switchBranchFilterInput" />
+                        </div>
+                        <div class="branch-list border rounded">
+                            @if (GetFilteredSwitchBranches().Count() == 0)
+                            {
+                                <div class="text-muted p-3">@(GetSwitchBranchOptions().Count == 0 ? "No common branches across all repositories." : "No branches match the filter.")</div>
+                            }
+                            else
+                            {
+                                @foreach (var branch in GetFilteredSwitchBranches())
+                                {
+                                    <div class="branch-item p-2 @(selectedSwitchBranchKey == branch.Key ? "bg-light" : "")"
+                                         style="cursor: pointer;"
+                                         @onclick='() => SelectSwitchBranch(branch.Key)'>
+                                        <div class="d-flex align-items-center justify-content-between">
+                                            <div class="d-flex align-items-center flex-grow-1 min-w-0">
+                                                <input type="radio"
+                                                       name="switchBranchSelection"
+                                                       class="switch-branch-radio"
+                                                       checked="@(selectedSwitchBranchKey == branch.Key)"
+                                                       @onchange='() => SelectSwitchBranch(branch.Key)' />
+                                                <span class="ms-2 text-truncate">@branch.BranchName</span>
+                                                <span class="badge bg-secondary ms-2">@(branch.IsRemote ? "Remote" : "Local")</span>
+                                            </div>
+                                            <button type="button"
+                                                    class="btn btn-link p-0 branch-delete-link branch-delete-link-disabled"
+                                                    title="Delete is not implemented yet"
+                                                    aria-label="Delete branch (not implemented)"
+                                                    disabled>
+                                                <i class="bi bi-trash" aria-hidden="true"></i>
+                                            </button>
+                                        </div>
+                                    </div>
+                                }
+                            }
+                        </div>
+                    }
                 </div>
                 <div class="modal-footer">
+                    <div class="d-flex gap-2 align-items-center me-auto">
+                        @if (activeTab == "switchbranch")
+                        {
+                            <button type="button"
+                                    class="btn btn-outline-secondary"
+                                    @onclick="FetchAcrossWorkspaceAsync">
+                                Fetch
+                            </button>
+                        }
+                    </div>
                     @if (activeTab == "newbranch" && !showBranchExistsConfirmation)
                     {
                         <button type="button" class="btn btn-primary" @onclick="CreateAsync" disabled="@(string.IsNullOrWhiteSpace(newBranchName) || isCreating)">
                             Create
+                        </button>
+                    }
+                    else if (activeTab == "switchbranch")
+                    {
+                        <button type="button" class="btn btn-primary" @onclick="CheckoutSelectedBranchAsync" disabled="@(SelectedSwitchBranch == null || isCreating)">
+                            Check out
                         </button>
                     }
                     <button type="button" class="btn btn-secondary" @onclick="OnCancel" disabled="@isCreating">Cancel</button>
@@ -124,10 +199,14 @@
     [Parameter] public string? WorkspaceName { get; set; }
     [Parameter] public int WorkspaceId { get; set; }
     [Parameter] public IReadOnlyList<string> CommonBranchNames { get; set; } = Array.Empty<string>();
+    [Parameter] public IReadOnlyList<string> CommonLocalBranchNames { get; set; } = Array.Empty<string>();
+    [Parameter] public IReadOnlyList<string> CommonRemoteBranchNames { get; set; } = Array.Empty<string>();
     /// <summary>Display text for the default option: e.g. "main" when all repos same default, or "multiple" when different.</summary>
     [Parameter] public string DefaultDisplayText { get; set; } = "multiple";
     [Parameter] public EventCallback OnCancel { get; set; }
     [Parameter] public EventCallback<(string NewBranchName, string BaseBranch)> OnCreateBranch { get; set; }
+    [Parameter] public EventCallback OnFetchBranches { get; set; }
+    [Parameter] public EventCallback<string> OnCheckoutBranch { get; set; }
 
     private string activeTab = "newbranch";
     private string newBranchName = "";
@@ -141,11 +220,92 @@
     private bool showBasedOnDropdown = false;
     private ElementReference modalElement;
     private ElementReference newBranchNameInput;
+    private ElementReference switchBranchFilterInput;
     private bool _wasVisible;
+    private bool _focusSwitchFilterOnNextRender;
+    private string switchBranchFilter = "";
+    private string? selectedSwitchBranchKey;
+
+    private sealed record SwitchBranchOption(string Key, string BranchName, bool IsRemote);
 
     private void SetActiveTab(string tab)
     {
         activeTab = tab;
+        if (tab == "switchbranch")
+        {
+            SelectClosestSwitchBranch();
+            _focusSwitchFilterOnNextRender = true;
+        }
+    }
+
+    private List<SwitchBranchOption> GetSwitchBranchOptions()
+    {
+        var localBranches = (CommonLocalBranchNames.Count > 0 ? CommonLocalBranchNames : CommonBranchNames)
+            .Where(b => !string.IsNullOrWhiteSpace(b))
+            .Select(b => new SwitchBranchOption($"local:{b}", b, false));
+
+        var remoteBranches = CommonRemoteBranchNames
+            .Where(b => !string.IsNullOrWhiteSpace(b))
+            .Select(b => new SwitchBranchOption($"remote:{b}", b, true));
+
+        return localBranches.Concat(remoteBranches).ToList();
+    }
+
+    private IEnumerable<SwitchBranchOption> GetFilteredSwitchBranches()
+    {
+        var all = GetSwitchBranchOptions();
+        if (string.IsNullOrWhiteSpace(switchBranchFilter))
+            return all;
+
+        var term = switchBranchFilter.Trim();
+        return all.Where(b => b.BranchName.Contains(term, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private void SelectClosestSwitchBranch()
+    {
+        var filtered = GetFilteredSwitchBranches().ToList();
+        if (filtered.Count == 0)
+        {
+            selectedSwitchBranchKey = null;
+            StateHasChanged();
+            return;
+        }
+
+        if (selectedSwitchBranchKey == null || filtered.All(b => b.Key != selectedSwitchBranchKey))
+            selectedSwitchBranchKey = filtered[0].Key;
+
+        StateHasChanged();
+    }
+
+    private void SelectSwitchBranch(string key)
+    {
+        selectedSwitchBranchKey = key;
+        StateHasChanged();
+    }
+
+    private SwitchBranchOption? SelectedSwitchBranch =>
+        GetSwitchBranchOptions().FirstOrDefault(b => b.Key == selectedSwitchBranchKey);
+
+    private string GetBranchCountText(int count, bool isFiltered = false)
+    {
+        if (isFiltered)
+            return count == 1 ? "1 branch matched" : $"{count} branches matched";
+        return count == 1 ? "1 branch" : $"{count} branches";
+    }
+
+    private async Task FetchAcrossWorkspaceAsync()
+    {
+        await OnFetchBranches.InvokeAsync();
+    }
+
+    private async Task CheckoutSelectedBranchAsync()
+    {
+        var selected = SelectedSwitchBranch;
+        if (selected == null)
+            return;
+
+        await OnCancel.InvokeAsync();
+        await OnCheckoutBranch.InvokeAsync(selected.BranchName);
     }
 
     private string GetSelectedBaseDisplayText()
@@ -175,6 +335,9 @@
             errorMessage = null;
             showBranchExistsConfirmation = false;
             activeTab = "newbranch";
+            switchBranchFilter = "";
+            selectedSwitchBranchKey = null;
+            _focusSwitchFilterOnNextRender = false;
         }
     }
 
@@ -194,6 +357,16 @@
         {
             _wasVisible = false;
             showBasedOnDropdown = false;
+        }
+
+        if (IsVisible && activeTab == "switchbranch" && _focusSwitchFilterOnNextRender)
+        {
+            _focusSwitchFilterOnNextRender = false;
+            try
+            {
+                await switchBranchFilterInput.FocusAsync();
+            }
+            catch { }
         }
     }
 
@@ -305,6 +478,10 @@
                 await ProceedWithCreateAsync();
             else if (!string.IsNullOrWhiteSpace(newBranchName?.Trim()))
                 await CreateAsync();
+        }
+        else if (e.Key == "Enter" && activeTab == "switchbranch" && !isCreating)
+        {
+            await CheckoutSelectedBranchAsync();
         }
     }
 

--- a/src/GrayMoon.App/Components/Modals/BranchModal.razor.css
+++ b/src/GrayMoon.App/Components/Modals/BranchModal.razor.css
@@ -61,6 +61,26 @@
     color: var(--text-primary);
     border: 1px solid var(--border-input) !important;
     box-shadow: none !important;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: auto;
+    scrollbar-color: #5a5a5a var(--bg-input, #252526);
+}
+
+.new-branch-based-on-list::-webkit-scrollbar {
+    width: 8px;
+}
+
+.new-branch-based-on-list::-webkit-scrollbar-track {
+    background: var(--bg-input, #252526);
+}
+
+.new-branch-based-on-list::-webkit-scrollbar-thumb {
+    background: #5a5a5a;
+    border-radius: 4px;
+}
+
+.new-branch-based-on-list::-webkit-scrollbar-thumb:hover {
+    background: #6a6a6a;
 }
 
 .new-branch-based-on-item {
@@ -93,6 +113,26 @@
     border-color: var(--border-color) !important;
     max-height: 10.3rem;
     overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: auto;
+    scrollbar-color: #5a5a5a var(--bg-card, #252526);
+}
+
+.branch-list::-webkit-scrollbar {
+    width: 8px;
+}
+
+.branch-list::-webkit-scrollbar-track {
+    background: var(--bg-card, #252526);
+}
+
+.branch-list::-webkit-scrollbar-thumb {
+    background: #5a5a5a;
+    border-radius: 4px;
+}
+
+.branch-list::-webkit-scrollbar-thumb:hover {
+    background: #6a6a6a;
 }
 
 .branch-item {

--- a/src/GrayMoon.App/Components/Modals/BranchModal.razor.css
+++ b/src/GrayMoon.App/Components/Modals/BranchModal.razor.css
@@ -74,3 +74,76 @@
 .new-branch-based-on-item:hover {
     background-color: var(--bg-hover);
 }
+
+.switch-branch-tab-count {
+    font-size: 0.8em;
+    color: #5a5a5a;
+}
+
+.switch-branch-field-block .form-label {
+    margin-bottom: 0.5rem;
+}
+
+.switch-branch-label-row {
+    margin-bottom: 0.5rem;
+}
+
+.branch-list {
+    background-color: var(--bg-card);
+    border-color: var(--border-color) !important;
+    max-height: 10.3rem;
+    overflow-y: auto;
+}
+
+.branch-item {
+    border-bottom: 1px solid var(--border-color);
+    transition: background-color 0.15s ease;
+}
+
+.branch-item:last-child {
+    border-bottom: none;
+}
+
+.branch-item:hover {
+    background-color: var(--bg-hover) !important;
+}
+
+.branch-item.bg-light {
+    background-color: var(--bg-active) !important;
+}
+
+.branch-delete-link,
+.branch-delete-link i {
+    color: #505050 !important;
+    text-decoration: none;
+    display: inline-flex;
+    align-items: center;
+}
+
+.branch-delete-link:hover,
+.branch-delete-link:hover i {
+    color: #707070 !important;
+}
+
+.branch-delete-link-disabled,
+.branch-delete-link-disabled i {
+    color: #6a6a6a !important;
+    opacity: 0.6;
+    cursor: not-allowed;
+}
+
+.switch-branch-radio {
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+    background-image: none !important;
+    background-color: var(--bg-input) !important;
+    border-color: var(--border-light) !important;
+    border-radius: 50%;
+}
+
+.switch-branch-radio:checked {
+    background-color: var(--accent-blue) !important;
+    border-color: var(--accent-blue) !important;
+    box-shadow: inset 0 0 0 2px var(--bg-input);
+}

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor
@@ -43,7 +43,7 @@
                                     IsPushing="@isPushing"
                                     IsCommitSyncing="@isCommitSyncing"
                                     AgentTasksPendingCount="@AgentTasksPendingCount"
-                                    IsOverlayVisible="@(isLoading || isSyncing || isPushing || isUpdating || isCommitSyncing || isCheckingOut || isCreatingBranches || isCreatingBranch || isSyncingToDefault || ShowRepositoriesFetchOverlay)"
+                                    IsOverlayVisible="@(isLoading || isSyncing || isPushing || isUpdating || isCommitSyncing || isCheckingOut || isCreatingBranches || isCreatingBranch || isSyncingToDefault || isWorkspaceBranchesFetching || isWorkspaceBranchesCheckingOut || ShowRepositoriesFetchOverlay)"
                                     OnShowRepositories="ShowRepositoriesModalAsync"
                                     OnShowBranch="ShowBranchModalAsync"
                                     OnUpdate="OnUpdateClickAsync"
@@ -184,9 +184,13 @@
                    WorkspaceName="@(workspace?.Name)"
                    WorkspaceId="@WorkspaceId"
                    CommonBranchNames="@_branchModal.CommonBranchNames"
+                   CommonLocalBranchNames="@_branchModal.CommonLocalBranchNames"
+                   CommonRemoteBranchNames="@_branchModal.CommonRemoteBranchNames"
                    DefaultDisplayText="@_branchModal.DefaultDisplayText"
                    OnCancel="@CloseBranchModal"
-                   OnCreateBranch="@CreateBranchesAsync" />
+                   OnCreateBranch="@CreateBranchesAsync"
+                   OnFetchBranches="@FetchCommonBranchesAcrossWorkspaceAsync"
+                   OnCheckoutBranch="@CheckoutCommonBranchAcrossWorkspaceAsync" />
 
 <SwitchBranchModal IsVisible="@_switchBranchModal.IsVisible"
                    WorkspaceId="@WorkspaceId"
@@ -252,3 +256,9 @@
 <LoadingOverlay IsVisible="@isSyncingToDefault"
                 Message="@GetOverlayMessage(syncToDefaultMessage, isSyncingToDefault, _syncToDefaultAwaitingAgentTasks)"
                 PendingAgentTasksCount="@AgentTasksPendingCount" />
+<LoadingOverlay IsVisible="@isWorkspaceBranchesFetching"
+                Message="@workspaceBranchesFetchProgressMessage"
+                OnAbort="AbortWorkspaceBranchesFetchAsync" />
+<LoadingOverlay IsVisible="@isWorkspaceBranchesCheckingOut"
+                Message="@workspaceBranchesCheckoutProgressMessage"
+                OnAbort="AbortWorkspaceBranchesCheckoutAsync" />

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
@@ -1721,7 +1721,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
                 {
                     workspaceBranchesFetchProgressMessage = completed <= 0
                         ? "Fetching branches..."
-                        : $"Fetched {completed} of {total} branches...";
+                        : $"Fetched branches in {completed} of {total} repositories...";
                     _ = InvokeAsync(StateHasChanged);
                 },
                 _workspaceBranchesFetchCts.Token);

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
@@ -85,6 +85,12 @@ public sealed partial class WorkspaceRepositories : IDisposable
     private bool isSyncingToDefault = false;
     private string syncToDefaultMessage = "";
     private IReadOnlyList<(int RepoId, int? DefaultAhead, bool? HasUpstream)>? _syncToDefaultCheckResults = null;
+    private bool isWorkspaceBranchesFetching = false;
+    private string workspaceBranchesFetchProgressMessage = "Fetching branches across workspace...";
+    private CancellationTokenSource? _workspaceBranchesFetchCts;
+    private bool isWorkspaceBranchesCheckingOut = false;
+    private string workspaceBranchesCheckoutProgressMessage = "Checking out branch across workspace...";
+    private CancellationTokenSource? _workspaceBranchesCheckoutCts;
     private UpdateModalState _updateModal = new();
     private UpdateSingleRepoDependenciesModalState _updateSingleRepoModal = new();
     private PushWithDependenciesModalState _pushWithDependenciesModal = new();
@@ -192,6 +198,10 @@ public sealed partial class WorkspaceRepositories : IDisposable
         _fetchRepositoriesCts?.Dispose();
         _createBranchesCts?.Cancel();
         _createBranchesCts?.Dispose();
+        _workspaceBranchesFetchCts?.Cancel();
+        _workspaceBranchesFetchCts?.Dispose();
+        _workspaceBranchesCheckoutCts?.Cancel();
+        _workspaceBranchesCheckoutCts?.Dispose();
     }
 
     /// <summary>Called when WorkspaceSynced is received (or after Update): reload from a fresh scope so the grid gets current DB values (no stale DbContext).</summary>
@@ -1635,18 +1645,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
             return;
         try
         {
-            var data = await WorkspaceBranchHandler.GetCommonBranchesAsync(
-                WorkspaceId,
-                ApiBaseUrl,
-                CancellationToken.None);
-            if (data != null)
-            {
-                _branchModal = _branchModal with
-                {
-                    CommonBranchNames = data.CommonBranchNames ?? new List<string>(),
-                    DefaultDisplayText = data.DefaultDisplayText ?? "multiple"
-                };
-            }
+            await LoadCommonBranchesForBranchModalAsync(CancellationToken.None);
         }
         catch (Exception ex)
         {
@@ -1659,6 +1658,157 @@ public sealed partial class WorkspaceRepositories : IDisposable
     private void CloseBranchModal()
     {
         _branchModal = _branchModal with { IsVisible = false };
+    }
+
+    private async Task LoadCommonBranchesForBranchModalAsync(CancellationToken cancellationToken)
+    {
+        var data = await WorkspaceBranchHandler.GetCommonBranchesAsync(
+            WorkspaceId,
+            ApiBaseUrl,
+            cancellationToken);
+
+        if (data == null)
+            return;
+
+        var commonLocal = data.CommonLocalBranchNames ?? data.CommonBranchNames ?? new List<string>();
+        var commonRemote = data.CommonRemoteBranchNames ?? new List<string>();
+        _branchModal = _branchModal with
+        {
+            CommonBranchNames = commonLocal,
+            CommonLocalBranchNames = commonLocal,
+            CommonRemoteBranchNames = commonRemote,
+            DefaultDisplayText = data.DefaultDisplayText ?? "multiple"
+        };
+    }
+
+    private void AbortWorkspaceBranchesFetchAsync()
+    {
+        _workspaceBranchesFetchCts?.Cancel();
+    }
+
+    private void AbortWorkspaceBranchesCheckoutAsync()
+    {
+        _workspaceBranchesCheckoutCts?.Cancel();
+    }
+
+    private async Task FetchCommonBranchesAcrossWorkspaceAsync()
+    {
+        if (workspace == null || isWorkspaceBranchesFetching || isSyncing || isUpdating || isCommitSyncing || isCheckingOut)
+            return;
+
+        var repoIds = workspaceRepositories
+            .Select(wr => wr.RepositoryId)
+            .Distinct()
+            .ToList();
+        if (repoIds.Count == 0)
+            return;
+
+        _workspaceBranchesFetchCts?.Cancel();
+        _workspaceBranchesFetchCts?.Dispose();
+        _workspaceBranchesFetchCts = new CancellationTokenSource();
+
+        isWorkspaceBranchesFetching = true;
+        workspaceBranchesFetchProgressMessage = "Fetching branches...";
+        await InvokeAsync(StateHasChanged);
+
+        try
+        {
+            var result = await WorkspaceBranchHandler.FetchBranchesForWorkspaceAsync(
+                WorkspaceId,
+                repoIds,
+                ApiBaseUrl,
+                (completed, total) =>
+                {
+                    workspaceBranchesFetchProgressMessage = completed <= 0
+                        ? "Fetching branches..."
+                        : $"Fetched {completed} of {total} branches...";
+                    _ = InvokeAsync(StateHasChanged);
+                },
+                _workspaceBranchesFetchCts.Token);
+
+            await RefreshFromSync();
+            await LoadCommonBranchesForBranchModalAsync(CancellationToken.None);
+            await InvokeAsync(StateHasChanged);
+
+            if (result.FailureCount > 0)
+                ToastService.Show($"Fetched branches for {result.SuccessCount} repositories. {result.FailureCount} failed.");
+        }
+        catch (OperationCanceledException)
+        {
+            ToastService.Show("Fetch branches cancelled.");
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error fetching branches across workspace {WorkspaceId}", WorkspaceId);
+            ToastService.Show("Failed to fetch branches across workspace.");
+        }
+        finally
+        {
+            isWorkspaceBranchesFetching = false;
+            await InvokeAsync(StateHasChanged);
+        }
+    }
+
+    private async Task CheckoutCommonBranchAcrossWorkspaceAsync(string branchName)
+    {
+        if (workspace == null || string.IsNullOrWhiteSpace(branchName) || isWorkspaceBranchesCheckingOut || isSyncing || isUpdating || isCommitSyncing || isCheckingOut)
+            return;
+
+        var repoIds = workspaceRepositories
+            .Select(wr => wr.RepositoryId)
+            .Distinct()
+            .ToList();
+        if (repoIds.Count == 0)
+            return;
+
+        _workspaceBranchesCheckoutCts?.Cancel();
+        _workspaceBranchesCheckoutCts?.Dispose();
+        _workspaceBranchesCheckoutCts = new CancellationTokenSource();
+
+        isWorkspaceBranchesCheckingOut = true;
+        workspaceBranchesCheckoutProgressMessage = $"Checking out '{branchName}' 0 of {repoIds.Count}";
+        await InvokeAsync(StateHasChanged);
+
+        try
+        {
+            var result = await WorkspaceBranchHandler.CheckoutBranchForWorkspaceAsync(
+                WorkspaceId,
+                repoIds,
+                branchName,
+                ApiBaseUrl,
+                (completed, total) =>
+                {
+                    workspaceBranchesCheckoutProgressMessage = $"Checking out '{branchName}' {completed} of {total}";
+                    _ = InvokeAsync(StateHasChanged);
+                },
+                _workspaceBranchesCheckoutCts.Token);
+
+            foreach (var repoId in repoIds)
+            {
+                if (result.ErrorsByRepositoryId.TryGetValue(repoId, out var error))
+                    repositoryErrors[repoId] = error;
+                else
+                    repositoryErrors.Remove(repoId);
+            }
+
+            await RefreshFromSync();
+            if (result.FailureCount > 0)
+                ToastService.Show($"Checked out branch in {result.SuccessCount} repositories. {result.FailureCount} failed.");
+        }
+        catch (OperationCanceledException)
+        {
+            ToastService.Show("Checkout cancelled.");
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error checking out branch {BranchName} across workspace {WorkspaceId}", branchName, WorkspaceId);
+            ToastService.Show("Failed to check out branch across workspace.");
+        }
+        finally
+        {
+            isWorkspaceBranchesCheckingOut = false;
+            await InvokeAsync(StateHasChanged);
+        }
     }
 
     private async Task CreateBranchesAsync((string NewBranchName, string BaseBranch) args)
@@ -2128,6 +2278,8 @@ public sealed partial class WorkspaceRepositories : IDisposable
     {
         public bool IsVisible { get; init; }
         public IReadOnlyList<string> CommonBranchNames { get; init; } = Array.Empty<string>();
+        public IReadOnlyList<string> CommonLocalBranchNames { get; init; } = Array.Empty<string>();
+        public IReadOnlyList<string> CommonRemoteBranchNames { get; init; } = Array.Empty<string>();
         public string DefaultDisplayText { get; init; } = "multiple";
     }
 

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
@@ -1766,7 +1766,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
         _workspaceBranchesCheckoutCts = new CancellationTokenSource();
 
         isWorkspaceBranchesCheckingOut = true;
-        workspaceBranchesCheckoutProgressMessage = $"Checking out '{branchName}' 0 of {repoIds.Count}";
+        workspaceBranchesCheckoutProgressMessage = "Checking out...";
         await InvokeAsync(StateHasChanged);
 
         try
@@ -1778,7 +1778,9 @@ public sealed partial class WorkspaceRepositories : IDisposable
                 ApiBaseUrl,
                 (completed, total) =>
                 {
-                    workspaceBranchesCheckoutProgressMessage = $"Checking out '{branchName}' {completed} of {total}";
+                    workspaceBranchesCheckoutProgressMessage = completed <= 0
+                        ? "Checking out..."
+                        : $"Checked out {completed} of {total}";
                     _ = InvokeAsync(StateHasChanged);
                 },
                 _workspaceBranchesCheckoutCts.Token);

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
@@ -1780,7 +1780,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
                 {
                     workspaceBranchesCheckoutProgressMessage = completed <= 0
                         ? "Checking out..."
-                        : $"Checked out {completed} of {total}";
+                        : $"Checked out {branchName} in {completed} of {total} repositories";
                     _ = InvokeAsync(StateHasChanged);
                 },
                 _workspaceBranchesCheckoutCts.Token);

--- a/src/GrayMoon.App/Models/Api/BranchesApiModels.cs
+++ b/src/GrayMoon.App/Models/Api/BranchesApiModels.cs
@@ -133,6 +133,12 @@ public sealed class CommonBranchesApiResult
     [JsonPropertyName("commonBranchNames")]
     public List<string>? CommonBranchNames { get; set; }
 
+    [JsonPropertyName("commonLocalBranchNames")]
+    public List<string>? CommonLocalBranchNames { get; set; }
+
+    [JsonPropertyName("commonRemoteBranchNames")]
+    public List<string>? CommonRemoteBranchNames { get; set; }
+
     /// <summary>Display text for the default option: branch name when all repos share same default (e.g. "main"), or "multiple" when they differ.</summary>
     [JsonPropertyName("defaultDisplayText")]
     public string? DefaultDisplayText { get; set; }

--- a/src/GrayMoon.App/Services/SyncCommandHandler.cs
+++ b/src/GrayMoon.App/Services/SyncCommandHandler.cs
@@ -51,6 +51,29 @@ public sealed class SyncCommandHandler(
 
         await dbContext.SaveChangesAsync();
 
+        if (n.Projects is { Count: > 0 })
+        {
+            var syncProjects = n.Projects
+                .Where(p => !string.IsNullOrWhiteSpace(p.Name))
+                .Select(p => new SyncProjectInfo(
+                    p.Name.Trim(),
+                    p.ProjectType >= 0 && p.ProjectType <= 4 ? (ProjectType)p.ProjectType : ProjectType.Library,
+                    p.ProjectPath ?? "",
+                    p.TargetFramework ?? "",
+                    p.PackageId,
+                    (p.PackageReferences ?? new List<RepositorySyncPackageReferenceNotification>())
+                        .Where(pr => !string.IsNullOrWhiteSpace(pr.Name))
+                        .Select(pr => new SyncPackageReference(pr.Name.Trim(), pr.Version ?? ""))
+                        .ToList()))
+                .ToList();
+
+            await workspaceProjectRepository.MergeWorkspaceProjectsAsync(n.WorkspaceId, n.RepositoryId, syncProjects);
+            await workspaceProjectRepository.MergeWorkspaceProjectDependenciesAsync(
+                n.WorkspaceId,
+                [(n.RepositoryId, (IReadOnlyList<SyncProjectInfo>?)syncProjects)],
+                persistDependencyLevel: false);
+        }
+
         var allLinks = await dbContext.WorkspaceRepositories
             .Where(w => w.WorkspaceId == n.WorkspaceId)
             .Select(w => w.SyncStatus)

--- a/src/GrayMoon.App/Services/WorkspaceBranchHandler.cs
+++ b/src/GrayMoon.App/Services/WorkspaceBranchHandler.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Text.Json;
 using GrayMoon.App.Models.Api;
 
@@ -12,6 +13,8 @@ public sealed class WorkspaceBranchHandler(
     IHttpClientFactory httpClientFactory,
     ILogger<WorkspaceBranchHandler> logger)
 {
+    private const int DefaultMaxParallelOperations = 16;
+
     public async Task<CommonBranchesApiResult?> GetCommonBranchesAsync(int workspaceId, string apiBaseUrl, CancellationToken cancellationToken)
     {
         var httpClient = httpClientFactory.CreateClient();
@@ -192,5 +195,134 @@ public sealed class WorkspaceBranchHandler(
         logger.LogError("SyncToDefault failed for repo {RepositoryId}: {StatusCode}, {Error}", repositoryId, response.StatusCode, errorText2);
         return (false, errMsg);
     }
+
+    public async Task<WorkspaceBranchBulkResult> FetchBranchesForWorkspaceAsync(
+        int workspaceId,
+        IReadOnlyCollection<int> repositoryIds,
+        string apiBaseUrl,
+        Action<int, int>? reportProgress,
+        CancellationToken cancellationToken)
+    {
+        if (repositoryIds.Count == 0)
+            return WorkspaceBranchBulkResult.Empty;
+
+        var total = repositoryIds.Count;
+        var completed = 0;
+        var errors = new ConcurrentDictionary<int, string>();
+        using var semaphore = new SemaphoreSlim(DefaultMaxParallelOperations, DefaultMaxParallelOperations);
+        var httpClient = httpClientFactory.CreateClient();
+
+        var tasks = repositoryIds.Select(async repositoryId =>
+        {
+            await semaphore.WaitAsync(cancellationToken);
+            try
+            {
+                var apiRequest = new { workspaceId, repositoryId };
+                var json = JsonSerializer.Serialize(apiRequest);
+                using var content = new StringContent(json, System.Text.Encoding.UTF8, "application/json");
+                using var response = await httpClient.PostAsync($"{apiBaseUrl}/api/branches/refresh", content, cancellationToken);
+                if (!response.IsSuccessStatusCode)
+                {
+                    var errorText = await response.Content.ReadAsStringAsync(cancellationToken);
+                    errors[repositoryId] = ApiErrorHelper.TryGetErrorMessageFromResponseBody(errorText)
+                        ?? $"Failed to fetch branches: {response.StatusCode}";
+                    return;
+                }
+
+                var responseContent = await response.Content.ReadAsStringAsync(cancellationToken);
+                var result = JsonSerializer.Deserialize<BranchesResponse>(responseContent, AgentResponseJson.Options);
+                if (result?.Success == false)
+                    errors[repositoryId] = result.ErrorMessage ?? "Failed to fetch branches.";
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Fetch branches failed for repository {RepositoryId}", repositoryId);
+                errors[repositoryId] = "Failed to fetch branches.";
+            }
+            finally
+            {
+                semaphore.Release();
+                var done = Interlocked.Increment(ref completed);
+                reportProgress?.Invoke(done, total);
+            }
+        });
+
+        await Task.WhenAll(tasks);
+        var failureCount = errors.Count;
+        return new WorkspaceBranchBulkResult(total - failureCount, failureCount, new Dictionary<int, string>(errors));
+    }
+
+    public async Task<WorkspaceBranchBulkResult> CheckoutBranchForWorkspaceAsync(
+        int workspaceId,
+        IReadOnlyCollection<int> repositoryIds,
+        string branchName,
+        string apiBaseUrl,
+        Action<int, int>? reportProgress,
+        CancellationToken cancellationToken)
+    {
+        if (repositoryIds.Count == 0)
+            return WorkspaceBranchBulkResult.Empty;
+
+        var total = repositoryIds.Count;
+        var completed = 0;
+        var errors = new ConcurrentDictionary<int, string>();
+        using var semaphore = new SemaphoreSlim(DefaultMaxParallelOperations, DefaultMaxParallelOperations);
+        var httpClient = httpClientFactory.CreateClient();
+
+        var tasks = repositoryIds.Select(async repositoryId =>
+        {
+            await semaphore.WaitAsync(cancellationToken);
+            try
+            {
+                var apiRequest = new { workspaceId, repositoryId, branchName };
+                var json = JsonSerializer.Serialize(apiRequest);
+                using var content = new StringContent(json, System.Text.Encoding.UTF8, "application/json");
+                using var response = await httpClient.PostAsync($"{apiBaseUrl}/api/branches/checkout", content, cancellationToken);
+                if (!response.IsSuccessStatusCode)
+                {
+                    var errorText = await response.Content.ReadAsStringAsync(cancellationToken);
+                    errors[repositoryId] = ApiErrorHelper.TryGetErrorMessageFromResponseBody(errorText)
+                        ?? $"Failed to checkout branch: {response.StatusCode}";
+                    return;
+                }
+
+                var responseContent = await response.Content.ReadAsStringAsync(cancellationToken);
+                var result = JsonSerializer.Deserialize<CheckoutBranchResponse>(responseContent, AgentResponseJson.Options);
+                if (result is { Success: false })
+                    errors[repositoryId] = result.ErrorMessage ?? "Failed to checkout branch.";
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Checkout failed for repository {RepositoryId}", repositoryId);
+                errors[repositoryId] = "Failed to checkout branch.";
+            }
+            finally
+            {
+                semaphore.Release();
+                var done = Interlocked.Increment(ref completed);
+                reportProgress?.Invoke(done, total);
+            }
+        });
+
+        await Task.WhenAll(tasks);
+        var failureCount = errors.Count;
+        return new WorkspaceBranchBulkResult(total - failureCount, failureCount, new Dictionary<int, string>(errors));
+    }
+}
+
+public sealed record WorkspaceBranchBulkResult(
+    int SuccessCount,
+    int FailureCount,
+    IReadOnlyDictionary<int, string> ErrorsByRepositoryId)
+{
+    public static WorkspaceBranchBulkResult Empty { get; } = new(0, 0, new Dictionary<int, string>());
 }
 


### PR DESCRIPTION
Implemented the new workspace-level **Switch Branch** feature in `BranchModal` with common local + remote branch support, fetch-across-repositories, and checkout-across-repositories using page overlays.

- Added `Switch Branch` tab UI in `src/GrayMoon.App/Components/Modals/BranchModal.razor` with: branch count, search box, unified list (local + remote kept separate), disabled delete icon (not implemented), `Fetch`, and `Check out` primary action.
- Extended common branch payloads in `src/GrayMoon.App/Models/Api/BranchesApiModels.cs` and `src/GrayMoon.App/Api/Endpoints/BranchEndpoints.cs` to return `commonLocalBranchNames` and `commonRemoteBranchNames` (while keeping legacy `commonBranchNames`).
- Added workspace fan-out operations in `src/GrayMoon.App/Services/WorkspaceBranchHandler.cs` for multi-repo fetch and multi-repo checkout, with progress + per-repo error collection.
- Wired callbacks/state/overlays in `src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor` and `src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs`, including branch-modal data refresh after fetch and workspace-wide checkout execution.
- Added scoped styling for the new tab/list UX in `src/GrayMoon.App/Components/Modals/BranchModal.razor.css`.

Validation: `dotnet build` succeeds; one pre-existing warning remains in `src/GrayMoon.App/Services/GitVersionCommandService.cs` (`CS8604`).