### PR TITLE
Switch branch UX improvements

### DIFF
--- a/src/GrayMoon.App/Components/Modals/BranchModal.razor
+++ b/src/GrayMoon.App/Components/Modals/BranchModal.razor
@@ -148,15 +148,17 @@
                                                        checked="@(selectedSwitchBranchKey == branch.Key)"
                                                        @onchange='() => SelectSwitchBranch(branch.Key)' />
                                                 <span class="ms-2 text-truncate">@branch.BranchName</span>
-                                                <span class="badge bg-secondary ms-2">@(branch.IsRemote ? "Remote" : "Local")</span>
                                             </div>
-                                            <button type="button"
-                                                    class="btn btn-link p-0 branch-delete-link branch-delete-link-disabled"
-                                                    title="Delete is not implemented yet"
-                                                    aria-label="Delete branch (not implemented)"
-                                                    disabled>
-                                                <i class="bi bi-trash" aria-hidden="true"></i>
-                                            </button>
+                                            <div class="d-flex align-items-center flex-shrink-0 ms-2 branch-item-actions">
+                                                <span class="badge bg-secondary">@(branch.IsRemote ? "Remote" : "Local")</span>
+                                                <button type="button"
+                                                        class="btn btn-link p-0 branch-delete-link branch-delete-link-disabled ms-2"
+                                                        title="Delete is not implemented yet"
+                                                        aria-label="Delete branch (not implemented)"
+                                                        disabled>
+                                                    <i class="bi bi-trash" aria-hidden="true"></i>
+                                                </button>
+                                            </div>
                                         </div>
                                     </div>
                                 }
@@ -246,7 +248,14 @@
 
         var remoteBranches = CommonRemoteBranchNames
             .Where(b => !string.IsNullOrWhiteSpace(b))
-            .Select(b => new SwitchBranchOption($"remote:{b}", b, true));
+            .Select(b =>
+            {
+                var branchName = b.Trim();
+                var remoteName = branchName.StartsWith("origin/", StringComparison.OrdinalIgnoreCase)
+                    ? branchName
+                    : $"origin/{branchName}";
+                return new SwitchBranchOption($"remote:{remoteName}", remoteName, true);
+            });
 
         return localBranches.Concat(remoteBranches).ToList();
     }

--- a/src/GrayMoon.App/Components/Modals/BranchModal.razor.css
+++ b/src/GrayMoon.App/Components/Modals/BranchModal.razor.css
@@ -152,6 +152,10 @@
     background-color: var(--bg-active) !important;
 }
 
+.branch-item-actions {
+    justify-content: flex-end;
+}
+
 .branch-delete-link,
 .branch-delete-link i {
     color: #505050 !important;

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
@@ -1780,7 +1780,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
                 {
                     workspaceBranchesCheckoutProgressMessage = completed <= 0
                         ? "Checking out..."
-                        : $"Checked out {branchName} in {completed} of {total} repositories";
+                        : $"Checked out {completed} of {total} branches";
                     _ = InvokeAsync(StateHasChanged);
                 },
                 _workspaceBranchesCheckoutCts.Token);


### PR DESCRIPTION
## Summary

Adds a workspace-wide **Switch Branch** flow in the branch modal (common local + remote branches, multi-repo **Fetch** and **Check out** with progress overlays), refines list UX (badges, alignment, `origin/...` remote labels), and ensures **checkout hook** notifications carry **project/package** data so dependency state updates without a manual Sync.

## Switch Branch (workspace)

- New **Switch Branch** tab on `BranchModal`: searchable list of branches **common to every repo** in the workspace; locals and remotes kept as separate rows (remotes shown as `origin/...`).
- **Fetch** runs refresh across all workspace repos with a full-page overlay; progress text starts as “Fetching branches…” then reports per-repo completion.
- **Check out** runs checkout across repos with overlay; progress uses “Checking out…” then **“Checked out x of y branches”**.
- Shared **default** branch (e.g. `main`) stays in the list with a **Default** badge; API no longer hides it only from the common-local list without a UI replacement (modal injects default local row when needed).
- **Current** (when all repos report the same `BranchName`): blue **`bg-primary`** badge, **local row only**, **left-aligned** next to the name; **Check out** disabled for that selection. **Default** badge is also **left-aligned**; **Remote** stays on the right. Delete/trash UI **hidden** for now.

## API / backend

- Common branches endpoint returns **`commonLocalBranchNames`** and **`commonRemoteBranchNames`** (legacy `commonBranchNames` still populated from locals).
- `WorkspaceBranchHandler` fans out single-repo **refresh** and **checkout** calls for bulk workspace operations.

## Agent / sync (no fallback)

- **`RepositorySyncNotification`** extended with **`Projects`** (project + package refs).
- **`CheckoutHookSyncCommand`** scans `.csproj` and sends that payload.
- **`SyncCommandHandler`** merges projects/dependencies when `Projects` is present so **UnmatchedDeps** / badges stay correct immediately after checkout.

## Testing

- Open workspace branch modal → **Switch Branch** → **Fetch** / **Check out**; confirm overlays, badges, and disabled checkout on unified current local branch.
- Change branch via hook → confirm dependency indicators match without running **Sync** (with agent connected).
- *(Optional)* `dotnet build` with app/agent not locking output assemblies.