### PR TITLE
Fix dependency update sequencing and skip empty commits

### DIFF
--- a/src/GrayMoon.Agent/Services/GitService.cs
+++ b/src/GrayMoon.Agent/Services/GitService.cs
@@ -971,6 +971,20 @@ public sealed class GitService(IOptions<AgentOptions> options, ILogger<GitServic
             return (false, err);
         }
 
+        // Skip commit when staging resulted in no index changes.
+        var (stagedExit, _, stagedErr) = await RunProcessAsync("git", "diff --cached --quiet", repoPath, ct);
+        if (stagedExit == 0)
+        {
+            logger.LogInformation("Git stage and commit skipped for {RepoPath}: nothing staged to commit", repoPath);
+            return (true, null);
+        }
+        if (stagedExit != 1)
+        {
+            var err = (stagedErr ?? "").Trim();
+            logger.LogError("Git staged diff check failed for {RepoPath}. ExitCode={ExitCode}, Stderr={Stderr}", repoPath, stagedExit, err);
+            return (false, string.IsNullOrWhiteSpace(err) ? "Failed to verify staged changes before commit." : err);
+        }
+
         var messageNormalized = commitMessage.Replace("\r\n", "\n").Replace("\r", "\n").TrimEnd();
         var (commitExit, commitOut, commitErr) = await RunProcessWithStdinAsync("git", "commit -F -", repoPath, messageNormalized, ct);
         if (commitExit != 0)

--- a/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor.css
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor.css
@@ -28,6 +28,10 @@
     text-overflow: ellipsis;
 }
 
+.actions-table td.col-action-status {
+    text-overflow: clip;
+}
+
 .actions-table {
     table-layout: fixed;
     width: 100%;

--- a/src/GrayMoon.App/Services/DependencyUpdateOrchestrator.cs
+++ b/src/GrayMoon.App/Services/DependencyUpdateOrchestrator.cs
@@ -224,6 +224,7 @@ public sealed class DependencyUpdateOrchestrator(
         var (_, _, fileError, updatedFiles) = await fileVersionService.UpdateAllVersionsAsync(
             workspaceId,
             selectedRepositoryIds: selectedRepositoryIds,
+            filterPatternTokensToSelectedRepositories: false,
             onFileUpdated: null,
             cancellationToken: cancellationToken);
 

--- a/src/GrayMoon.App/Services/DependencyUpdateOrchestrator.cs
+++ b/src/GrayMoon.App/Services/DependencyUpdateOrchestrator.cs
@@ -1,4 +1,5 @@
 using GrayMoon.App.Models;
+using GrayMoon.App.Repositories;
 using Microsoft.Extensions.Options;
 
 namespace GrayMoon.App.Services;
@@ -11,13 +12,14 @@ namespace GrayMoon.App.Services;
 public sealed class DependencyUpdateOrchestrator(
     WorkspaceGitService workspaceGitService,
     WorkspaceFileVersionService fileVersionService,
+    WorkspaceRepository workspaceRepository,
     IOptions<WorkspaceOptions> workspaceOptions)
 {
     private readonly int _maxConcurrent = Math.Max(1, workspaceOptions?.Value?.MaxParallelOperations ?? 8);
 
     /// <summary>
-    /// Runs the full update flow: refresh projects, sync and commit csproj deps (per level or single-level),
-    /// refresh repo versions, then run version-file updates and optionally commit them.
+    /// Runs the full update flow per dependency level:
+    /// refresh projects, update+commit version files, sync+commit csproj deps, refresh repo versions.
     /// Stops on first error and reports it via <paramref name="onRepoError"/>.
     /// </summary>
     /// <param name="repoIdsToUpdate">Optional. When set, only these repositories are considered for the update plan and all steps.</param>
@@ -47,21 +49,40 @@ public sealed class DependencyUpdateOrchestrator(
         if (hadError)
             return;
 
-        // Step 2+: Rebuild plan before each level and process the current lowest level atomically.
-        while (!hadError)
+        // Step 2+: Process repositories by dependency level.
+        var levelRepoIds = await GetRepositoryIdsByDependencyLevelAsync(workspaceId, repoIdsToUpdate, OnRepoError);
+        if (levelRepoIds.Count == 0)
+            hadError = true;
+
+        foreach (var (level, repoIds) in levelRepoIds)
         {
-            var (payload, _) = await workspaceGitService.GetUpdatePlanAsync(workspaceId, repoIdsToUpdate, cancellationToken);
-            if (payload.Count == 0)
+            if (hadError)
                 break;
 
-            var level = payload.Min(p => p.DependencyLevel ?? 0);
+            if (repoIds.Count == 0)
+                break;
+
+            // Version files must be committed first because those commits can change
+            // versions consumed by dependency updates at this and higher levels.
+            if (!await UpdateAndCommitVersionFilesAsync(
+                    workspaceId,
+                    repoIds,
+                    level,
+                    cancellationToken,
+                    setProgress,
+                    onAppSideComplete,
+                    OnRepoError))
+            {
+                hadError = true;
+                break;
+            }
+
+            var (payload, _) = await workspaceGitService.GetUpdatePlanAsync(workspaceId, repoIds, cancellationToken);
             var reposAtLevel = payload
-                .Where(p => (p.DependencyLevel ?? 0) == level)
+                .Where(p => repoIds.Contains(p.RepoId))
                 .ToList();
             if (reposAtLevel.Count == 0)
-                break;
-
-            var repoIds = reposAtLevel.Select(r => r.RepoId).ToHashSet();
+                continue;
 
             setProgress($"Updating {reposAtLevel.Count} {(reposAtLevel.Count == 1 ? "repository" : "repositories")}...");
             await workspaceGitService.SyncDependenciesAsync(
@@ -108,28 +129,42 @@ public sealed class DependencyUpdateOrchestrator(
             }
         }
 
-        // Always run version-file updates after dependency-level processing so files are
-        // written from the final versions produced by this orchestration.
-        if (!hadError)
-        {
-            if (!await UpdateAndCommitVersionFilesAsync(
-                    workspaceId,
-                    repoIdsToUpdate,
-                    cancellationToken,
-                    setProgress,
-                    onAppSideComplete,
-                    OnRepoError))
-            {
-                hadError = true;
-            }
-        }
-
         // Finalize: broadcast so grid refreshes.
         if (!hadError)
         {
             onAppSideComplete?.Invoke();
             await workspaceGitService.RecomputeAndBroadcastWorkspaceSyncedAsync(workspaceId, cancellationToken);
         }
+    }
+
+    private async Task<IReadOnlyList<(int Level, IReadOnlySet<int> RepoIds)>> GetRepositoryIdsByDependencyLevelAsync(
+        int workspaceId,
+        IReadOnlySet<int>? selectedRepositoryIds,
+        Action<int, string> onRepoError)
+    {
+        var workspace = await workspaceRepository.GetByIdAsync(workspaceId);
+        if (workspace == null)
+        {
+            onRepoError(0, $"Workspace {workspaceId} not found.");
+            return [];
+        }
+
+        var levelRepoIds = workspace.Repositories
+            .Where(link => link.Repository != null)
+            .Where(link => selectedRepositoryIds == null || selectedRepositoryIds.Count == 0 || selectedRepositoryIds.Contains(link.RepositoryId))
+            .GroupBy(link => link.DependencyLevel ?? 0)
+            .OrderBy(g => g.Key)
+            .Select(g => (Level: g.Key, RepoIds: (IReadOnlySet<int>)g.Select(x => x.RepositoryId).ToHashSet()))
+            .ToList();
+
+        if (levelRepoIds.Count > 0)
+            return levelRepoIds;
+
+        if (selectedRepositoryIds is { Count: > 0 })
+            return [(0, selectedRepositoryIds)];
+
+        onRepoError(0, "No repositories found for update.");
+        return [];
     }
 
     private async Task<bool> RefreshRepositoryVersionsAsync(
@@ -178,68 +213,64 @@ public sealed class DependencyUpdateOrchestrator(
 
     private async Task<bool> UpdateAndCommitVersionFilesAsync(
         int workspaceId,
-        IReadOnlySet<int>? selectedRepositoryIds,
+        IReadOnlySet<int> selectedRepositoryIds,
+        int level,
         CancellationToken cancellationToken,
         Action<string> setProgress,
         Action? onAppSideComplete,
         Action<int, string> onRepoError)
     {
-        const int maxVersionFilePasses = 6;
-        for (var pass = 1; pass <= maxVersionFilePasses; pass++)
+        setProgress($"Updating version files (level {level})...");
+        var (_, _, fileError, updatedFiles) = await fileVersionService.UpdateAllVersionsAsync(
+            workspaceId,
+            selectedRepositoryIds: selectedRepositoryIds,
+            onFileUpdated: null,
+            cancellationToken: cancellationToken);
+
+        if (fileError != null && !fileError.Contains("No version configurations", StringComparison.OrdinalIgnoreCase))
         {
-            setProgress(pass == 1 ? "Updating version files..." : $"Updating version files (pass {pass})...");
-            var (_, _, fileError, updatedFiles) = await fileVersionService.UpdateAllVersionsAsync(
-                workspaceId,
-                selectedRepositoryIds: selectedRepositoryIds,
-                onFileUpdated: null,
-                cancellationToken: cancellationToken);
-
-            if (fileError != null && !fileError.Contains("No version configurations", StringComparison.OrdinalIgnoreCase))
-            {
-                onRepoError(0, fileError);
-                return false;
-            }
-
-            if (updatedFiles is not { Count: > 0 })
-                return true;
-
-            var byRepo = updatedFiles
-                .GroupBy(x => (x.RepositoryId, x.RepoName))
-                .Select(g => (g.Key.RepositoryId, g.Key.RepoName, (IReadOnlyList<string>)g.Select(x => x.FilePath).Distinct().ToList()))
-                .ToList();
-
-            setProgress(pass == 1 ? "Committing updated versions..." : $"Committing updated versions (pass {pass})...");
-            var vfCommitResults = await workspaceGitService.CommitFilePathsAsync(
-                workspaceId,
-                byRepo,
-                onProgress: (c, t, _) => setProgress($"Committed version files {c} of {t}"),
-                cancellationToken: cancellationToken);
-
-            var committedVersionRepoIds = new List<int>();
-            foreach (var (repoId, errMsg) in vfCommitResults)
-            {
-                if (!string.IsNullOrEmpty(errMsg))
-                {
-                    onRepoError(repoId, errMsg);
-                    return false;
-                }
-                committedVersionRepoIds.Add(repoId);
-            }
-
-            if (committedVersionRepoIds.Count > 0
-                && !await RefreshRepositoryVersionsAsync(
-                    committedVersionRepoIds,
-                    workspaceId,
-                    cancellationToken,
-                    setProgress,
-                    onAppSideComplete,
-                    onRepoError))
-                return false;
+            onRepoError(0, fileError);
+            return false;
         }
 
+        if (updatedFiles is not { Count: > 0 })
+            return true;
 
-        onRepoError(0, $"Version-file updates did not converge after {maxVersionFilePasses} passes.");
-        return false;
+        var byRepo = updatedFiles
+            .GroupBy(x => (x.RepositoryId, x.RepoName))
+            .Select(g => (g.Key.RepositoryId, g.Key.RepoName, (IReadOnlyList<string>)g.Select(x => x.FilePath).Distinct().ToList()))
+            .ToList();
+
+        setProgress($"Committing updated versions (level {level})...");
+        var vfCommitResults = await workspaceGitService.CommitFilePathsAsync(
+            workspaceId,
+            byRepo,
+            onProgress: (c, t, _) => setProgress($"Committed version files {c} of {t}"),
+            cancellationToken: cancellationToken);
+
+        var committedVersionRepoIds = new List<int>();
+        foreach (var (repoId, errMsg) in vfCommitResults)
+        {
+            if (!string.IsNullOrEmpty(errMsg))
+            {
+                onRepoError(repoId, errMsg);
+                return false;
+            }
+            committedVersionRepoIds.Add(repoId);
+        }
+
+        if (committedVersionRepoIds.Count > 0
+            && !await RefreshRepositoryVersionsAsync(
+                committedVersionRepoIds,
+                workspaceId,
+                cancellationToken,
+                setProgress,
+                onAppSideComplete,
+                onRepoError))
+            return false;
+
+
+        return true;
     }
 
 }

--- a/src/GrayMoon.App/Services/DependencyUpdateOrchestrator.cs
+++ b/src/GrayMoon.App/Services/DependencyUpdateOrchestrator.cs
@@ -237,6 +237,7 @@ public sealed class DependencyUpdateOrchestrator(
                 return false;
         }
 
+
         onRepoError(0, $"Version-file updates did not converge after {maxVersionFilePasses} passes.");
         return false;
     }

--- a/src/GrayMoon.App/Services/DependencyUpdateOrchestrator.cs
+++ b/src/GrayMoon.App/Services/DependencyUpdateOrchestrator.cs
@@ -30,7 +30,6 @@ public sealed class DependencyUpdateOrchestrator(
         IReadOnlySet<int>? repoIdsToUpdate = null)
     {
         var hadError = false;
-        var processedAnyDependencyLevel = false;
         void OnRepoError(int repoId, string msg)
         {
             hadError = true;
@@ -63,7 +62,6 @@ public sealed class DependencyUpdateOrchestrator(
                 break;
 
             var repoIds = reposAtLevel.Select(r => r.RepoId).ToHashSet();
-            processedAnyDependencyLevel = true;
 
             setProgress($"Updating {reposAtLevel.Count} {(reposAtLevel.Count == 1 ? "repository" : "repositories")}...");
             await workspaceGitService.SyncDependenciesAsync(
@@ -108,23 +106,11 @@ public sealed class DependencyUpdateOrchestrator(
                 hadError = true;
                 break;
             }
-
-            if (!await UpdateAndCommitVersionFilesAsync(
-                    workspaceId,
-                    repoIds,
-                    cancellationToken,
-                    setProgress,
-                    onAppSideComplete,
-                    OnRepoError))
-            {
-                hadError = true;
-                break;
-            }
         }
 
-        // Even when there are no dependency changes for the selected scope, we still must
-        // run version-file update because this flow does not pre-check whether files need changes.
-        if (!hadError && !processedAnyDependencyLevel)
+        // Always run version-file updates after dependency-level processing so files are
+        // written from the final versions produced by this orchestration.
+        if (!hadError)
         {
             if (!await UpdateAndCommitVersionFilesAsync(
                     workspaceId,

--- a/src/GrayMoon.App/Services/DependencyUpdateOrchestrator.cs
+++ b/src/GrayMoon.App/Services/DependencyUpdateOrchestrator.cs
@@ -1,5 +1,4 @@
 using GrayMoon.App.Models;
-using Microsoft.Extensions.Options;
 
 namespace GrayMoon.App.Services;
 
@@ -10,11 +9,8 @@ namespace GrayMoon.App.Services;
 /// </summary>
 public sealed class DependencyUpdateOrchestrator(
     WorkspaceGitService workspaceGitService,
-    WorkspaceFileVersionService fileVersionService,
-    IOptions<WorkspaceOptions> workspaceOptions)
+    WorkspaceFileVersionService fileVersionService)
 {
-    private readonly int _maxConcurrent = Math.Max(1, workspaceOptions?.Value?.MaxParallelOperations ?? 8);
-
     /// <summary>
     /// Runs the full update flow: refresh projects, sync and commit csproj deps (per level or single-level),
     /// refresh repo versions, then run version-file updates and optionally commit them.
@@ -144,36 +140,20 @@ public sealed class DependencyUpdateOrchestrator(
             return true;
 
         var totalRefresh = repositoryIds.Count;
-        var completedRefresh = 0;
-        using var refreshSemaphore = new SemaphoreSlim(_maxConcurrent);
-        var refreshTasks = repositoryIds.Select(async repoId =>
+        for (var i = 0; i < repositoryIds.Count; i++)
         {
-            await refreshSemaphore.WaitAsync(cancellationToken);
-            try
+            var repoId = repositoryIds[i];
+            var (refreshSuccess, refreshError) = await workspaceGitService.SyncSingleRepositoryAsync(repoId, workspaceId, cancellationToken);
+            var completed = i + 1;
+            setProgress($"Updating version {completed} of {totalRefresh}...");
+            if (!refreshSuccess)
             {
-                var (refreshSuccess, refreshError) = await workspaceGitService.SyncSingleRepositoryAsync(repoId, workspaceId, cancellationToken);
-                var c = Interlocked.Increment(ref completedRefresh);
-                setProgress($"Updating version {c} of {totalRefresh}...");
-                if (c == totalRefresh)
-                    onAppSideComplete?.Invoke();
-                return (RepoId: repoId, Success: refreshSuccess, Error: refreshError);
-            }
-            finally
-            {
-                refreshSemaphore.Release();
-            }
-        });
-
-        var refreshResults = await Task.WhenAll(refreshTasks);
-        foreach (var (repoId, success, err) in refreshResults)
-        {
-            if (!success)
-            {
-                onRepoError(repoId, err ?? "Refresh version failed.");
+                onRepoError(repoId, refreshError ?? "Refresh version failed.");
                 return false;
             }
         }
 
+        onAppSideComplete?.Invoke();
         return true;
     }
 

--- a/src/GrayMoon.App/Services/DependencyUpdateOrchestrator.cs
+++ b/src/GrayMoon.App/Services/DependencyUpdateOrchestrator.cs
@@ -1,4 +1,5 @@
 using GrayMoon.App.Models;
+using Microsoft.Extensions.Options;
 
 namespace GrayMoon.App.Services;
 
@@ -9,8 +10,11 @@ namespace GrayMoon.App.Services;
 /// </summary>
 public sealed class DependencyUpdateOrchestrator(
     WorkspaceGitService workspaceGitService,
-    WorkspaceFileVersionService fileVersionService)
+    WorkspaceFileVersionService fileVersionService,
+    IOptions<WorkspaceOptions> workspaceOptions)
 {
+    private readonly int _maxConcurrent = Math.Max(1, workspaceOptions?.Value?.MaxParallelOperations ?? 8);
+
     /// <summary>
     /// Runs the full update flow: refresh projects, sync and commit csproj deps (per level or single-level),
     /// refresh repo versions, then run version-file updates and optionally commit them.
@@ -140,15 +144,30 @@ public sealed class DependencyUpdateOrchestrator(
             return true;
 
         var totalRefresh = repositoryIds.Count;
-        for (var i = 0; i < repositoryIds.Count; i++)
+        var completedRefresh = 0;
+        using var refreshSemaphore = new SemaphoreSlim(_maxConcurrent);
+        var refreshTasks = repositoryIds.Select(async repoId =>
         {
-            var repoId = repositoryIds[i];
-            var (refreshSuccess, refreshError) = await workspaceGitService.SyncSingleRepositoryAsync(repoId, workspaceId, cancellationToken);
-            var completed = i + 1;
-            setProgress($"Updating version {completed} of {totalRefresh}...");
-            if (!refreshSuccess)
+            await refreshSemaphore.WaitAsync(cancellationToken);
+            try
             {
-                onRepoError(repoId, refreshError ?? "Refresh version failed.");
+                var (refreshSuccess, refreshError) = await workspaceGitService.SyncSingleRepositoryAsync(repoId, workspaceId, cancellationToken);
+                var c = Interlocked.Increment(ref completedRefresh);
+                setProgress($"Updating version {c} of {totalRefresh}...");
+                return (RepoId: repoId, Success: refreshSuccess, Error: refreshError);
+            }
+            finally
+            {
+                refreshSemaphore.Release();
+            }
+        });
+
+        var refreshResults = await Task.WhenAll(refreshTasks);
+        foreach (var (repoId, success, err) in refreshResults)
+        {
+            if (!success)
+            {
+                onRepoError(repoId, err ?? "Refresh version failed.");
                 return false;
             }
         }
@@ -165,56 +184,61 @@ public sealed class DependencyUpdateOrchestrator(
         Action? onAppSideComplete,
         Action<int, string> onRepoError)
     {
-        setProgress("Updating version files...");
-        var (_, _, fileError, updatedFiles) = await fileVersionService.UpdateAllVersionsAsync(
-            workspaceId,
-            selectedRepositoryIds: selectedRepositoryIds,
-            onFileUpdated: null,
-            cancellationToken: cancellationToken);
-
-        if (fileError != null && !fileError.Contains("No version configurations", StringComparison.OrdinalIgnoreCase))
+        const int maxVersionFilePasses = 6;
+        for (var pass = 1; pass <= maxVersionFilePasses; pass++)
         {
-            onRepoError(0, fileError);
-            return false;
-        }
+            setProgress(pass == 1 ? "Updating version files..." : $"Updating version files (pass {pass})...");
+            var (_, _, fileError, updatedFiles) = await fileVersionService.UpdateAllVersionsAsync(
+                workspaceId,
+                selectedRepositoryIds: selectedRepositoryIds,
+                onFileUpdated: null,
+                cancellationToken: cancellationToken);
 
-        if (updatedFiles is not { Count: > 0 })
-            return true;
-
-        var byRepo = updatedFiles
-            .GroupBy(x => (x.RepositoryId, x.RepoName))
-            .Select(g => (g.Key.RepositoryId, g.Key.RepoName, (IReadOnlyList<string>)g.Select(x => x.FilePath).Distinct().ToList()))
-            .ToList();
-
-        setProgress("Committing updated versions...");
-        var vfCommitResults = await workspaceGitService.CommitFilePathsAsync(
-            workspaceId,
-            byRepo,
-            onProgress: (c, t, _) => setProgress($"Committed version files {c} of {t}"),
-            cancellationToken: cancellationToken);
-
-        var committedVersionRepoIds = new List<int>();
-        foreach (var (repoId, errMsg) in vfCommitResults)
-        {
-            if (!string.IsNullOrEmpty(errMsg))
+            if (fileError != null && !fileError.Contains("No version configurations", StringComparison.OrdinalIgnoreCase))
             {
-                onRepoError(repoId, errMsg);
+                onRepoError(0, fileError);
                 return false;
             }
-            committedVersionRepoIds.Add(repoId);
+
+            if (updatedFiles is not { Count: > 0 })
+                return true;
+
+            var byRepo = updatedFiles
+                .GroupBy(x => (x.RepositoryId, x.RepoName))
+                .Select(g => (g.Key.RepositoryId, g.Key.RepoName, (IReadOnlyList<string>)g.Select(x => x.FilePath).Distinct().ToList()))
+                .ToList();
+
+            setProgress(pass == 1 ? "Committing updated versions..." : $"Committing updated versions (pass {pass})...");
+            var vfCommitResults = await workspaceGitService.CommitFilePathsAsync(
+                workspaceId,
+                byRepo,
+                onProgress: (c, t, _) => setProgress($"Committed version files {c} of {t}"),
+                cancellationToken: cancellationToken);
+
+            var committedVersionRepoIds = new List<int>();
+            foreach (var (repoId, errMsg) in vfCommitResults)
+            {
+                if (!string.IsNullOrEmpty(errMsg))
+                {
+                    onRepoError(repoId, errMsg);
+                    return false;
+                }
+                committedVersionRepoIds.Add(repoId);
+            }
+
+            if (committedVersionRepoIds.Count > 0
+                && !await RefreshRepositoryVersionsAsync(
+                    committedVersionRepoIds,
+                    workspaceId,
+                    cancellationToken,
+                    setProgress,
+                    onAppSideComplete,
+                    onRepoError))
+                return false;
         }
 
-        // Version-file commits must also refresh GitVersion before planning next higher level.
-        if (committedVersionRepoIds.Count > 0
-            && !await RefreshRepositoryVersionsAsync(
-                committedVersionRepoIds,
-                workspaceId,
-                cancellationToken,
-                setProgress,
-                onAppSideComplete,
-                onRepoError))
-            return false;
-
-        return true;
+        onRepoError(0, $"Version-file updates did not converge after {maxVersionFilePasses} passes.");
+        return false;
     }
+
 }

--- a/src/GrayMoon.App/Services/DependencyUpdateOrchestrator.cs
+++ b/src/GrayMoon.App/Services/DependencyUpdateOrchestrator.cs
@@ -220,7 +220,7 @@ public sealed class DependencyUpdateOrchestrator(
         Action? onAppSideComplete,
         Action<int, string> onRepoError)
     {
-        setProgress($"Updating version files (level {level})...");
+        setProgress($"Updating version files in level {level}...");
         var (_, _, fileError, updatedFiles) = await fileVersionService.UpdateAllVersionsAsync(
             workspaceId,
             selectedRepositoryIds: selectedRepositoryIds,
@@ -242,7 +242,7 @@ public sealed class DependencyUpdateOrchestrator(
             .Select(g => (g.Key.RepositoryId, g.Key.RepoName, (IReadOnlyList<string>)g.Select(x => x.FilePath).Distinct().ToList()))
             .ToList();
 
-        setProgress($"Committing updated versions (level {level})...");
+        setProgress($"Committing updated versions in level {level}...");
         var vfCommitResults = await workspaceGitService.CommitFilePathsAsync(
             workspaceId,
             byRepo,

--- a/src/GrayMoon.App/Services/WorkspaceFileVersionService.cs
+++ b/src/GrayMoon.App/Services/WorkspaceFileVersionService.cs
@@ -14,12 +14,16 @@ public sealed class WorkspaceFileVersionService(
     /// For every file in the workspace that has a version pattern configured:
     ///   1. Resolves the current version for each repo from the workspace's repository links (DB state); no GitVersion is run.
     ///   2. Calls UpdateFileVersions on the agent with those versions in the request to perform the in-place substitution.
-    /// When <paramref name="selectedRepositoryIds"/> is set, only repositories in that set are included: pattern lines are filtered to tokens matching selected repo names, and only files in selected repos are updated.
+    /// When <paramref name="selectedRepositoryIds"/> is set, only files in those repositories are updated.
+    /// By default, version-pattern token lines are also filtered to selected repo names; set
+    /// <paramref name="filterPatternTokensToSelectedRepositories"/> to false to keep all token lines
+    /// while still limiting which files are updated.
     /// Returns (updatedLineCount, failedFileCount, fatalError, list of (RepositoryId, RepoName, FilePath) for each file that was updated).
     /// </summary>
     public async Task<(int Updated, int Failed, string? Error, IReadOnlyList<(int RepositoryId, string RepoName, string FilePath)> UpdatedFiles)> UpdateAllVersionsAsync(
         int workspaceId,
         IReadOnlySet<int>? selectedRepositoryIds = null,
+        bool filterPatternTokensToSelectedRepositories = true,
         Action<string>? onFileUpdated = null,
         CancellationToken cancellationToken = default)
     {
@@ -49,7 +53,7 @@ public sealed class WorkspaceFileVersionService(
             foreach (var token in ExtractTokens(cfg.VersionPattern))
                 repoNamesInUse.Add(token);
         }
-        if (selectedRepoNames != null)
+        if (selectedRepoNames != null && filterPatternTokensToSelectedRepositories)
             repoNamesInUse.IntersectWith(selectedRepoNames);
 
         // Build repo name -> version from workspace links (DB state). No GitVersion is run.
@@ -82,7 +86,7 @@ public sealed class WorkspaceFileVersionService(
                 continue;
 
             var versionPatternToSend = cfg.VersionPattern;
-            if (selectedRepoNames != null)
+            if (selectedRepoNames != null && filterPatternTokensToSelectedRepositories)
             {
                 versionPatternToSend = FilterPatternLinesToRepos(cfg.VersionPattern, selectedRepoNames);
                 if (string.IsNullOrWhiteSpace(versionPatternToSend)) continue;


### PR DESCRIPTION
## Summary
- Reworks dependency update orchestration to process repositories by dependency level and run version-file updates/commits before dependency sync at each level.
- Prevents false failures when there is nothing to commit by checking staged changes before running `git commit`.
- Adds a `WorkspaceFileVersionService` option to avoid filtering version-pattern tokens to selected repos, while still limiting which files are updated.
- Fixes `WorkspaceActions` status column rendering so narrow columns no longer show ellipsis next to the status badge.

## Why
- Version-file commits can change inputs needed by dependency updates in higher levels, so ordering by level with per-level version commits keeps updates consistent.
- Empty staged changes should be treated as a no-op rather than an error path.
- Status badges should stay visually clean in constrained table widths.

## Test Plan
- [ ] Run update flow on a workspace with multiple dependency levels and verify each level completes in order.
- [ ] Verify version-file updates are committed per level and repository versions are refreshed after those commits.
- [ ] Run update flow where no files change and confirm no commit failure is reported.
- [ ] Run selective repository updates and verify only selected repo files are updated while token lines remain intact when expected.
- [ ] Open Workspace Actions page and confirm status badge cell does not show `...` when column is narrow.