### PR TITLE
Include project metadata in merge sync notifications

### DIFF
--- a/src/GrayMoon.Agent/Commands/MergeHookSyncCommand.cs
+++ b/src/GrayMoon.Agent/Commands/MergeHookSyncCommand.cs
@@ -10,7 +10,7 @@ namespace GrayMoon.Agent.Commands;
 /// Handles post-merge hooks: re-runs GitVersion and gets commit counts.
 /// No git fetch — the merge already brought remote changes in; existing remote tracking refs are current enough.
 /// </summary>
-public sealed class MergeHookSyncCommand(IGitService git, IAgentTokenProvider tokenProvider, IHubConnectionProvider hubProvider, ILogger<MergeHookSyncCommand> logger)
+public sealed class MergeHookSyncCommand(IGitService git, ICsProjFileService csProjFileService, IAgentTokenProvider tokenProvider, IHubConnectionProvider hubProvider, ILogger<MergeHookSyncCommand> logger)
 {
     public async Task ExecuteAsync(INotifyJob payload, CancellationToken cancellationToken = default)
     {
@@ -23,6 +23,7 @@ public sealed class MergeHookSyncCommand(IGitService git, IAgentTokenProvider to
         var (versionResult, _) = await git.GetVersionAsync(payload.RepositoryPath, cancellationToken);
         var version = versionResult?.InformationalVersion ?? "-";
         var branch = versionResult?.BranchName ?? versionResult?.EscapedBranchName ?? "-";
+        var findProjectsTask = csProjFileService.FindAsync(payload.RepositoryPath, cancellationToken);
 
         int? outgoing = null;
         int? incoming = null;
@@ -53,6 +54,27 @@ public sealed class MergeHookSyncCommand(IGitService git, IAgentTokenProvider to
             }
         }
 
+        var projects = await findProjectsTask;
+        var syncProjects = projects?
+            .Where(p => !string.IsNullOrWhiteSpace(p.Name))
+            .Select(p => new RepositorySyncProjectNotification
+            {
+                Name = p.Name.Trim(),
+                ProjectType = (int)p.ProjectType,
+                ProjectPath = p.ProjectPath ?? "",
+                TargetFramework = p.TargetFramework ?? "",
+                PackageId = p.PackageId,
+                PackageReferences = p.PackageReferences
+                    .Where(pr => !string.IsNullOrWhiteSpace(pr.Name))
+                    .Select(pr => new RepositorySyncPackageReferenceNotification
+                    {
+                        Name = pr.Name.Trim(),
+                        Version = pr.Version ?? ""
+                    })
+                    .ToList()
+            })
+            .ToList();
+
         var connection = hubProvider.Connection;
         if (connection?.State == HubConnectionState.Connected)
         {
@@ -67,6 +89,7 @@ public sealed class MergeHookSyncCommand(IGitService git, IAgentTokenProvider to
                 HasUpstream = hasUpstream,
                 DefaultBranchBehind = defaultBehind,
                 DefaultBranchAhead = defaultAhead,
+                Projects = syncProjects,
                 ErrorMessage = null
             };
             await connection.InvokeAsync(AgentHubMethods.SyncCommand, notification, cancellationToken);

--- a/src/GrayMoon.App/Api/Endpoints/BranchEndpoints.cs
+++ b/src/GrayMoon.App/Api/Endpoints/BranchEndpoints.cs
@@ -224,6 +224,7 @@ public static class BranchEndpoints
         GitHubRepositoryRepository repoRepository,
         WorkspacePullRequestRepository workspacePullRequestRepository,
         AppDbContext dbContext,
+        WorkspaceGitService workspaceGitService,
         IHubContext<WorkspaceSyncHub> hubContext,
         ConnectorHealthService connectorHealthService,
         ILoggerFactory loggerFactory)
@@ -282,6 +283,9 @@ public static class BranchEndpoints
             if (!commandSuccess)
                 return Results.Problem(errorMessage, statusCode: 500);
 
+            if (!string.IsNullOrWhiteSpace(syncResponse?.CurrentBranch))
+                wr.BranchName = syncResponse.CurrentBranch;
+
             // Sync prunes the previous local branch; remove it from persistence
             var toRemove = await dbContext.RepositoryBranches
                 .Where(rb => rb.WorkspaceRepositoryId == wr.WorkspaceRepositoryId && !rb.IsRemote && rb.BranchName == currentBranchName)
@@ -290,6 +294,25 @@ public static class BranchEndpoints
             {
                 dbContext.RepositoryBranches.RemoveRange(toRemove);
                 await dbContext.SaveChangesAsync(CancellationToken.None);
+            }
+
+            // Sync-to-default performs checkout + pull, which can change project files.
+            // Refresh project/dependency data now so UnmatchedDeps is current without requiring a follow-up Sync.
+            try
+            {
+                var projectRefreshOk = await workspaceGitService.RefreshSingleRepositoryProjectsAsync(
+                    workspaceId,
+                    repositoryId,
+                    onRepoError: (_, msg) => logger.LogWarning("Sync-to-default project refresh reported an issue for repo {RepositoryId}: {Message}", repositoryId, msg),
+                    cancellationToken: CancellationToken.None);
+                if (!projectRefreshOk)
+                {
+                    logger.LogWarning("Sync-to-default project refresh failed for repo {RepositoryId}", repositoryId);
+                }
+            }
+            catch (Exception refreshEx)
+            {
+                logger.LogWarning(refreshEx, "Sync-to-default project refresh threw for repo {RepositoryId}", repositoryId);
             }
 
             // Broadcast update to refresh UI

--- a/src/GrayMoon.App/Api/Endpoints/BranchEndpoints.cs
+++ b/src/GrayMoon.App/Api/Endpoints/BranchEndpoints.cs
@@ -224,7 +224,6 @@ public static class BranchEndpoints
         GitHubRepositoryRepository repoRepository,
         WorkspacePullRequestRepository workspacePullRequestRepository,
         AppDbContext dbContext,
-        WorkspaceGitService workspaceGitService,
         IHubContext<WorkspaceSyncHub> hubContext,
         ConnectorHealthService connectorHealthService,
         ILoggerFactory loggerFactory)
@@ -283,9 +282,6 @@ public static class BranchEndpoints
             if (!commandSuccess)
                 return Results.Problem(errorMessage, statusCode: 500);
 
-            if (!string.IsNullOrWhiteSpace(syncResponse?.CurrentBranch))
-                wr.BranchName = syncResponse.CurrentBranch;
-
             // Sync prunes the previous local branch; remove it from persistence
             var toRemove = await dbContext.RepositoryBranches
                 .Where(rb => rb.WorkspaceRepositoryId == wr.WorkspaceRepositoryId && !rb.IsRemote && rb.BranchName == currentBranchName)
@@ -294,25 +290,6 @@ public static class BranchEndpoints
             {
                 dbContext.RepositoryBranches.RemoveRange(toRemove);
                 await dbContext.SaveChangesAsync(CancellationToken.None);
-            }
-
-            // Sync-to-default performs checkout + pull, which can change project files.
-            // Refresh project/dependency data now so UnmatchedDeps is current without requiring a follow-up Sync.
-            try
-            {
-                var projectRefreshOk = await workspaceGitService.RefreshSingleRepositoryProjectsAsync(
-                    workspaceId,
-                    repositoryId,
-                    onRepoError: (_, msg) => logger.LogWarning("Sync-to-default project refresh reported an issue for repo {RepositoryId}: {Message}", repositoryId, msg),
-                    cancellationToken: CancellationToken.None);
-                if (!projectRefreshOk)
-                {
-                    logger.LogWarning("Sync-to-default project refresh failed for repo {RepositoryId}", repositoryId);
-                }
-            }
-            catch (Exception refreshEx)
-            {
-                logger.LogWarning(refreshEx, "Sync-to-default project refresh threw for repo {RepositoryId}", repositoryId);
             }
 
             // Broadcast update to refresh UI


### PR DESCRIPTION
## Summary
- Updates `MergeHookSyncCommand` to include `ICsProjFileService` and gather `.csproj` project metadata during sync.
- Adds `Projects` payload data (project name/type/path/framework/package details) to the sync notification sent to the hub.
- Starts project discovery early in command execution so it can run in parallel with other sync checks.

## Why
The sync event previously reported branch/version status only. This change ensures clients also receive up-to-date project/package metadata after merge, keeping workspace state accurate without requiring a separate refresh.

## Test plan
- [ ] Trigger merge sync flow for a repo with one or more `.csproj` files.
- [ ] Verify the `SyncCommand` hub payload includes populated `Projects` data.
- [ ] Confirm package references are present with expected `Name` and `Version` values.
- [ ] Confirm behavior remains stable when project/package fields are missing (no null/format errors).
- [ ] Confirm existing sync fields (`OutgoingChanges`, `IncomingChanges`, `Version`, branch/default-branch fields) are unchanged.