### PR TITLE
Connector improvements: fault detection, test controls, and workspace repo rename fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,13 +51,13 @@ Keep both running for full functionality.
 Run on port `8384`; optional volume to persist the SQLite database:
 
 ```bash
-docker run -d -p 8384:8384 -v ./db:/app/db jandini/graymoon:latest
+docker run -d --name graymoon -p 8384:8384 -v graymoon:/app/db jandini/graymoon:latest
 ```
 
 To override the default token encryption key (recommended for non-dev use), set `TokenKey` to any password-like value (it will be hashed into a key automatically). Advanced users can also pass a Base64-encoded key if they prefer:
 
 ```bash
-docker run -d -p 8384:8384 -v ./db:/app/db -e TokenKey="my strong password here" jandini/graymoon:latest
+docker run -d --name graymoon -p 8384:8384 -v graymoon:/app/db -e TokenKey="my strong password here" jandini/graymoon:latest
 ```
 
 Open http://localhost:8384 in your browser.

--- a/README.md
+++ b/README.md
@@ -51,13 +51,13 @@ Keep both running for full functionality.
 Run on port `8384`; optional volume to persist the SQLite database:
 
 ```bash
-docker run -d --name graymoon -p 8384:8384 -v graymoon:/app/db jandini/graymoon:latest
+docker run -d --restart unless-stopped --name graymoon -p 8384:8384 -v graymoon:/app/db jandini/graymoon:latest
 ```
 
 To override the default token encryption key (recommended for non-dev use), set `TokenKey` to any password-like value (it will be hashed into a key automatically). Advanced users can also pass a Base64-encoded key if they prefer:
 
 ```bash
-docker run -d --name graymoon -p 8384:8384 -v graymoon:/app/db -e TokenKey="my strong password here" jandini/graymoon:latest
+docker run -d --restart unless-stopped --name graymoon -p 8384:8384 -v graymoon:/app/db -e TokenKey="my strong password here" jandini/graymoon:latest
 ```
 
 Open http://localhost:8384 in your browser.
@@ -67,13 +67,13 @@ Open http://localhost:8384 in your browser.
 Update running container:
 
 ```sh
-docker pull jandini/graymoon:latest && docker stop graymoon && docker rm graymoon && docker run -d --name graymoon -p 8384:8384 -v graymoon:/app/db jandini/graymoon:latest
+docker pull jandini/graymoon:latest && docker stop graymoon && docker rm graymoon && docker run -d --restart unless-stopped --name graymoon -p 8384:8384 -v graymoon:/app/db jandini/graymoon:latest
 ```
 
 Update running container with token encryption key:
 
 ```sh
-docker pull jandini/graymoon:latest && docker stop graymoon && docker rm graymoon && docker run -d --name graymoon -p 8384:8384 -v graymoon:/app/db -e TokenKey="my strong password here" jandini/graymoon:latest
+docker pull jandini/graymoon:latest && docker stop graymoon || true && docker rm graymoon || true && docker run -d --restart unless-stopped --name graymoon -p 8384:8384 -v graymoon:/app/db -e TokenKey="my strong password here" jandini/graymoon:latest
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,22 @@ docker run -d --name graymoon -p 8384:8384 -v graymoon:/app/db -e TokenKey="my s
 
 Open http://localhost:8384 in your browser.
 
+
+
+Update running container:
+
+```sh
+docker pull jandini/graymoon:latest && docker stop graymoon && docker rm graymoon && docker run -d --name graymoon -p 8384:8384 -v graymoon:/app/db jandini/graymoon:latest
+```
+
+Update running container with token encryption key:
+
+```sh
+docker pull jandini/graymoon:latest && docker stop graymoon && docker rm graymoon && docker run -d --name graymoon -p 8384:8384 -v graymoon:/app/db -e TokenKey="my strong password here" jandini/graymoon:latest
+```
+
+
+
 ## Agent
 
 The app runs in a container and does not run git or access your workspace filesystem. A **host-side agent** does that: it runs on the machine where your repos live, connects to the app via SignalR, and runs git, GitVersion, and workspace I/O.

--- a/src/GrayMoon.Abstractions/Models/ConnectorTestResult.cs
+++ b/src/GrayMoon.Abstractions/Models/ConnectorTestResult.cs
@@ -4,8 +4,18 @@ namespace GrayMoon.Abstractions.Models;
 /// Result of a connector connection test. Carries success state and a human-readable error
 /// message when the test fails, suitable for display in the UI.
 /// </summary>
-public sealed record ConnectorTestResult(bool Success, string? ErrorMessage = null)
+public sealed record ConnectorTestResult(bool Success, string? ErrorMessage = null, bool IsConnectorFault = false)
 {
     public static ConnectorTestResult Ok() => new(true);
+
+    /// <summary>
+    /// Transient failure (network outage, rate limit, server down). The connector stays active.
+    /// </summary>
     public static ConnectorTestResult Fail(string error) => new(false, error);
+
+    /// <summary>
+    /// Configuration fault (invalid/expired token, missing token, wrong API base URL).
+    /// The connector should be deactivated until the user corrects the configuration.
+    /// </summary>
+    public static ConnectorTestResult Fault(string error) => new(false, error, IsConnectorFault: true);
 }

--- a/src/GrayMoon.Agent/Services/GitService.cs
+++ b/src/GrayMoon.Agent/Services/GitService.cs
@@ -15,7 +15,6 @@ public sealed class GitService(IOptions<AgentOptions> options, ILogger<GitServic
 {
     private readonly int _listenPort = options.Value.ListenPort;
     private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
-    private readonly HashSet<string> _toolRestoreAttempted = new(StringComparer.OrdinalIgnoreCase);
 
     public string GetWorkspacePath(string root, string workspaceName)
     {
@@ -128,11 +127,11 @@ public sealed class GitService(IOptions<AgentOptions> options, ILogger<GitServic
         sw.Stop();
         if (exitCode != 0)
         {
-            var combinedOutput = (!string.IsNullOrWhiteSpace(stderr) ? stderr : stdout)?.Trim() ?? string.Empty;
-            if (combinedOutput.Contains("dotnet tool restore", StringComparison.OrdinalIgnoreCase)
-                && _toolRestoreAttempted.Add(repoPath))
+            var manifestExists = File.Exists(Path.Combine(repoPath, "dotnet-tools.json"))
+                || File.Exists(Path.Combine(repoPath, ".config", "dotnet-tools.json"));
+            if (manifestExists)
             {
-                logger.LogWarning("{ToolName} requires tool restore. Running 'dotnet tool restore' in {RepoPath}", toolName, repoPath);
+                logger.LogWarning("{ToolName} failed and tool manifest found. Running 'dotnet tool restore' in {RepoPath}", toolName, repoPath);
                 var (restoreExitCode, _, restoreStderr) = await RunProcessAsync("dotnet", "tool restore", repoPath, ct);
                 if (restoreExitCode != 0)
                 {
@@ -152,7 +151,8 @@ public sealed class GitService(IOptions<AgentOptions> options, ILogger<GitServic
             }
             else
             {
-                var error = combinedOutput.Length > 0 ? combinedOutput : $"{toolName} exited with code {exitCode}";
+                var error = (!string.IsNullOrWhiteSpace(stderr) ? stderr : stdout)?.Trim()
+                            ?? $"{toolName} exited with code {exitCode}";
                 logger.LogError("{ToolName} failed in {ElapsedMs}ms. ExitCode={ExitCode}, Stdout={Stdout}, Stderr={Stderr}", toolName, sw.ElapsedMilliseconds, exitCode, stdout, stderr);
                 return (null, error);
             }

--- a/src/GrayMoon.Agent/Services/GitService.cs
+++ b/src/GrayMoon.Agent/Services/GitService.cs
@@ -15,6 +15,7 @@ public sealed class GitService(IOptions<AgentOptions> options, ILogger<GitServic
 {
     private readonly int _listenPort = options.Value.ListenPort;
     private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
+    private readonly HashSet<string> _toolRestoreAttempted = new(StringComparer.OrdinalIgnoreCase);
 
     public string GetWorkspacePath(string root, string workspaceName)
     {
@@ -127,10 +128,34 @@ public sealed class GitService(IOptions<AgentOptions> options, ILogger<GitServic
         sw.Stop();
         if (exitCode != 0)
         {
-            var error = (!string.IsNullOrWhiteSpace(stderr) ? stderr : stdout)?.Trim()
-                        ?? $"{toolName} exited with code {exitCode}";
-            logger.LogError("{ToolName} failed in {ElapsedMs}ms. ExitCode={ExitCode}, Stdout={Stdout}, Stderr={Stderr}", toolName, sw.ElapsedMilliseconds, exitCode, stdout, stderr);
-            return (null, error);
+            var combinedOutput = (!string.IsNullOrWhiteSpace(stderr) ? stderr : stdout)?.Trim() ?? string.Empty;
+            if (combinedOutput.Contains("dotnet tool restore", StringComparison.OrdinalIgnoreCase)
+                && _toolRestoreAttempted.Add(repoPath))
+            {
+                logger.LogWarning("{ToolName} requires tool restore. Running 'dotnet tool restore' in {RepoPath}", toolName, repoPath);
+                var (restoreExitCode, _, restoreStderr) = await RunProcessAsync("dotnet", "tool restore", repoPath, ct);
+                if (restoreExitCode != 0)
+                {
+                    logger.LogError("dotnet tool restore failed. ExitCode={ExitCode}, Stderr={Stderr}", restoreExitCode, restoreStderr);
+                    return (null, $"dotnet tool restore failed: {restoreStderr?.Trim()}");
+                }
+                logger.LogInformation("dotnet tool restore succeeded in {RepoPath}. Retrying {ToolName}", repoPath, toolName);
+                var (retryExitCode, retryStdout, retryStderr) = await RunProcessAsync(fileName, arguments, repoPath, ct);
+                if (retryExitCode != 0)
+                {
+                    var retryError = (!string.IsNullOrWhiteSpace(retryStderr) ? retryStderr : retryStdout)?.Trim()
+                                    ?? $"{toolName} exited with code {retryExitCode}";
+                    logger.LogError("{ToolName} failed after tool restore. ExitCode={ExitCode}, Stdout={Stdout}, Stderr={Stderr}", toolName, retryExitCode, retryStdout, retryStderr);
+                    return (null, retryError);
+                }
+                stdout = retryStdout;
+            }
+            else
+            {
+                var error = combinedOutput.Length > 0 ? combinedOutput : $"{toolName} exited with code {exitCode}";
+                logger.LogError("{ToolName} failed in {ElapsedMs}ms. ExitCode={ExitCode}, Stdout={Stdout}, Stderr={Stderr}", toolName, sw.ElapsedMilliseconds, exitCode, stdout, stderr);
+                return (null, error);
+            }
         }
         logger.LogDebug("{ToolName} completed in {ElapsedMs}ms for {RepoPath}", toolName, sw.ElapsedMilliseconds, repoPath);
 

--- a/src/GrayMoon.App/Components/Modals/ConnectorModal.razor
+++ b/src/GrayMoon.App/Components/Modals/ConnectorModal.razor
@@ -105,7 +105,7 @@
                                                 @if (Model.ConnectorType == ConnectorType.GitHub)
                                                 {
                                                     <a class="btn btn-outline-secondary"
-                                                       href="https://github.com/settings/tokens/new"
+                                                       href="https://github.com/settings/tokens/new?scopes=repo,workflow,read:packages&amp;description=GrayMoon%20Token"
                                                        target="_blank"
                                                        rel="noopener noreferrer"
                                                        title="Create a classic personal access token on GitHub"

--- a/src/GrayMoon.App/Components/Pages/Agent.razor
+++ b/src/GrayMoon.App/Components/Pages/Agent.razor
@@ -41,6 +41,10 @@
                             {
                                 <p class="mb-3 small text-muted">The agent is running version <strong class="text-muted">@(AgentConnectionTracker.AgentSemVer ?? "unknown")</strong>, which is not compatible with this application. Run the command below to update.</p>
                             }
+                            <p class="mb-2 small text-muted">
+                                The Windows service requires the .NET 8 (x64) runtime on the host.
+                                <a href="@AgentDotnet8RuntimeUrl" target="_blank" rel="noopener noreferrer">Download the .NET 8 runtime</a>
+                            </p>
                             <p class="mb-3">Run this PowerShell command as Administrator to install the GrayMoon Agent as a Windows service:</p>
                             <div class="input-group">
                                 <input type="text" class="form-control font-monospace bg-dark" id="installCommand" readonly
@@ -102,6 +106,8 @@
         </div>
     </div>
 @code {
+    private const string AgentDotnet8RuntimeUrl = "https://aka.ms/dotnet-core-applaunch?framework=Microsoft.NETCore.App&framework_version=8.0.0&arch=x64&rid=win-x64&os=win10";
+
     private sealed record HostInfoDto(string? DotnetVersion, string? GitVersion, string? GitVersionToolVersion);
 
     private string installCommand = string.Empty;
@@ -195,10 +201,10 @@
             return;
         }
         builder.OpenElement(0, "a");
-        builder.AddAttribute(1, "href", "https://dotnet.microsoft.com/en-us/download");
+        builder.AddAttribute(1, "href", AgentDotnet8RuntimeUrl);
         builder.AddAttribute(2, "target", "_blank");
         builder.AddAttribute(3, "rel", "noopener noreferrer");
-        builder.AddContent(4, "Download .NET");
+        builder.AddContent(4, "Download .NET 8 runtime");
         builder.CloseElement();
     };
 

--- a/src/GrayMoon.App/Components/Pages/Agent.razor
+++ b/src/GrayMoon.App/Components/Pages/Agent.razor
@@ -41,10 +41,6 @@
                             {
                                 <p class="mb-3 small text-muted">The agent is running version <strong class="text-muted">@(AgentConnectionTracker.AgentSemVer ?? "unknown")</strong>, which is not compatible with this application. Run the command below to update.</p>
                             }
-                            <p class="mb-2 small text-muted">
-                                The Windows service requires the .NET 8 (x64) runtime on the host.
-                                <a href="@AgentDotnet8RuntimeUrl" target="_blank" rel="noopener noreferrer">Download the .NET 8 runtime</a>
-                            </p>
                             <p class="mb-3">Run this PowerShell command as Administrator to install the GrayMoon Agent as a Windows service:</p>
                             <div class="input-group">
                                 <input type="text" class="form-control font-monospace bg-dark" id="installCommand" readonly
@@ -54,6 +50,10 @@
                             <small class="text-muted mt-2 d-block">
                                 The script will download, install, and start the agent service automatically.
                             </small>
+                            <p class="mb-0 small text-muted mt-2 d-block">
+                                The Windows service requires the .NET 8 (x64) runtime on the host.
+                                <a href="@AgentDotnet8RuntimeUrl" target="_blank" rel="noopener noreferrer">Download the .NET 8 runtime</a>
+                            </p>
                         </div>
                         <div class="tab-pane @(ActiveTab == "uninstall" ? "show active" : "")" role="tabpanel">
                             <p class="mb-3">Run this PowerShell command as Administrator to uninstall the GrayMoon Agent Windows service:</p>

--- a/src/GrayMoon.App/Components/Pages/Connectors.razor
+++ b/src/GrayMoon.App/Components/Pages/Connectors.razor
@@ -481,7 +481,8 @@
             {
                 var errorMsg = result.ErrorMessage ?? "Connection test failed.";
                 await ConnectorRepository.UpdateStatusAsync(connector.ConnectorId, "Error", errorMsg);
-                await ConnectorRepository.UpdateIsActiveAsync(connector.ConnectorId, false);
+                if (result.IsConnectorFault)
+                    await ConnectorRepository.UpdateIsActiveAsync(connector.ConnectorId, false);
             }
 
             return result.Success;
@@ -489,8 +490,9 @@
         catch (Exception ex)
         {
             Logger.LogError(ex, "Error testing connector.");
-            await ConnectorRepository.UpdateStatusAsync(connector.ConnectorId, "Error", ex.Message);
-            await ConnectorRepository.UpdateIsActiveAsync(connector.ConnectorId, false);
+            // Unexpected app exception — not a connector fault; do not deactivate
+            await ConnectorRepository.UpdateStatusAsync(connector.ConnectorId, "Error",
+                "An unexpected error occurred while testing the connector.");
             return false;
         }
     }

--- a/src/GrayMoon.App/Components/Pages/Connectors.razor
+++ b/src/GrayMoon.App/Components/Pages/Connectors.razor
@@ -23,9 +23,16 @@
                     &nbsp;
                 </p>
             </div>
-            <button class="btn btn-primary" @onclick="ShowCreateModal">
-                Add Connector
-            </button>
+            <div class="d-flex align-items-center gap-2">
+                <button class="btn btn-outline-primary"
+                        @onclick="TestAllConnectorsAsync"
+                        disabled="@(connectors == null || connectors.Count == 0 || isTestingAll)">
+                    @(isTestingAll ? "Testing..." : "Test Connectors")
+                </button>
+                <button class="btn btn-primary" @onclick="ShowCreateModal">
+                    Add Connector
+                </button>
+            </div>
         </div>
         @if (errorMessage != null)
         {
@@ -89,7 +96,7 @@
                                                        role="switch"
                                                        checked="@connector.IsActive"
                                                        aria-label="Toggle connector active"
-                                                       disabled="@(testingConnectorId == connector.ConnectorId || togglingConnectorId == connector.ConnectorId)"
+                                                          disabled="@IsConnectorBusy(connector.ConnectorId)"
                                                        @onchange="(args) => ToggleConnectorAsync(connector, args)" />
                                             </div>
                                         </td>
@@ -100,6 +107,11 @@
                                             </span>
                                         </td>
                                         <td class="col-actions">
+                                            <button class="btn btn-sm btn-outline-secondary me-2"
+                                                    @onclick="() => TestSingleConnectorAsync(connector)"
+                                                    disabled="@IsConnectorBusy(connector.ConnectorId)">
+                                                @(IsConnectorTesting(connector.ConnectorId) ? "Testing..." : "Test")
+                                            </button>
                                             <button class="btn btn-sm btn-outline-primary me-2" @onclick="() => ShowEditModal(connector)">Edit</button>
                                             <button class="btn btn-sm btn-outline-danger me-2" @onclick="() => ShowDeleteModal(connector)">Delete</button>
                                         </td>
@@ -155,8 +167,9 @@
     private ConnectorForm editModel = new();
     private int editConnectorId;
     private Connector? selectedConnector;
-    private int? testingConnectorId;
+    private readonly HashSet<int> testingConnectorIds = new();
     private int? togglingConnectorId;
+    private bool isTestingAll;
 
     private bool isCreating;
     private bool isUpdating;
@@ -175,16 +188,56 @@
             ?? Configuration["GitHub::PersonalAccessToken"]
             ?? string.Empty;
         await LoadConnectorsAsync();
-        await TestAllConnectorsAsync();
     }
 
     private async Task TestAllConnectorsAsync()
     {
-        if (connectors == null || connectors.Count == 0)
+        if (connectors == null || connectors.Count == 0 || isTestingAll)
             return;
 
-        foreach (var connector in connectors.ToList())
-            await TestConnectorAsync(connector);
+        var connectorsToTest = connectors.ToList();
+
+        try
+        {
+            isTestingAll = true;
+            errorMessage = null;
+
+            foreach (var connector in connectorsToTest)
+            {
+                testingConnectorIds.Add(connector.ConnectorId);
+            }
+
+            await Task.WhenAll(connectorsToTest.Select(connector =>
+                ConnectorRepository.UpdateStatusAsync(connector.ConnectorId, "Testing", null)));
+
+            await LoadConnectorsAsync();
+            StateHasChanged();
+
+            await Task.WhenAll(connectorsToTest.Select(TestConnectorCoreAsync));
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error testing all connectors.");
+            errorMessage = $"Failed to test connectors: {ex.Message}";
+        }
+        finally
+        {
+            foreach (var connector in connectorsToTest)
+            {
+                testingConnectorIds.Remove(connector.ConnectorId);
+            }
+
+            isTestingAll = false;
+            await LoadConnectorsAsync();
+        }
+    }
+
+    private async Task TestSingleConnectorAsync(Connector connector)
+    {
+        if (isTestingAll || IsConnectorBusy(connector.ConnectorId))
+            return;
+
+        await TestConnectorAsync(connector);
     }
 
     private async Task LoadConnectorsAsync()
@@ -399,11 +452,24 @@
     {
         try
         {
-            testingConnectorId = connector.ConnectorId;
+            testingConnectorIds.Add(connector.ConnectorId);
             await ConnectorRepository.UpdateStatusAsync(connector.ConnectorId, "Testing", null);
             await LoadConnectorsAsync();
             StateHasChanged();
 
+            return await TestConnectorCoreAsync(connector);
+        }
+        finally
+        {
+            testingConnectorIds.Remove(connector.ConnectorId);
+            await LoadConnectorsAsync();
+        }
+    }
+
+    private async Task<bool> TestConnectorCoreAsync(Connector connector)
+    {
+        try
+        {
             var service = ConnectorServiceFactory.GetService(connector.ConnectorType);
             var result = await service.TestConnectionAsync(connector);
 
@@ -426,11 +492,6 @@
             await ConnectorRepository.UpdateStatusAsync(connector.ConnectorId, "Error", ex.Message);
             await ConnectorRepository.UpdateIsActiveAsync(connector.ConnectorId, false);
             return false;
-        }
-        finally
-        {
-            testingConnectorId = null;
-            await LoadConnectorsAsync();
         }
     }
 
@@ -465,6 +526,16 @@
         {
             togglingConnectorId = null;
         }
+    }
+
+    private bool IsConnectorTesting(int connectorId)
+    {
+        return testingConnectorIds.Contains(connectorId);
+    }
+
+    private bool IsConnectorBusy(int connectorId)
+    {
+        return IsConnectorTesting(connectorId) || togglingConnectorId == connectorId;
     }
 
     private static string GetStatusLabel(Connector connector)

--- a/src/GrayMoon.App/Components/Pages/Connectors.razor
+++ b/src/GrayMoon.App/Components/Pages/Connectors.razor
@@ -297,7 +297,7 @@
             UserName = connector.UserName,
             UserToken = string.IsNullOrWhiteSpace(connector.UserToken)
                 ? defaultUserToken
-                : connector.UserToken
+                : (ConnectorHelpers.UnprotectToken(connector.UserToken) ?? string.Empty)
         };
 
         editErrorMessage = null;

--- a/src/GrayMoon.App/Components/Pages/Connectors.razor
+++ b/src/GrayMoon.App/Components/Pages/Connectors.razor
@@ -27,7 +27,7 @@
                 <button class="btn btn-outline-primary"
                         @onclick="TestAllConnectorsAsync"
                         disabled="@(connectors == null || connectors.Count == 0 || isTestingAll)">
-                    @(isTestingAll ? "Testing..." : "Test Connectors")
+                    Test Connectors
                 </button>
                 <button class="btn btn-primary" @onclick="ShowCreateModal">
                     Add Connector
@@ -110,7 +110,7 @@
                                             <button class="btn btn-sm btn-outline-secondary me-2"
                                                     @onclick="() => TestSingleConnectorAsync(connector)"
                                                     disabled="@IsConnectorBusy(connector.ConnectorId)">
-                                                @(IsConnectorTesting(connector.ConnectorId) ? "Testing..." : "Test")
+                                                Test
                                             </button>
                                             <button class="btn btn-sm btn-outline-primary me-2" @onclick="() => ShowEditModal(connector)">Edit</button>
                                             <button class="btn btn-sm btn-outline-danger me-2" @onclick="() => ShowDeleteModal(connector)">Delete</button>

--- a/src/GrayMoon.App/Components/Pages/Connectors.razor.css
+++ b/src/GrayMoon.App/Components/Pages/Connectors.razor.css
@@ -43,11 +43,11 @@
     text-align: center;
 }
 
-/* Actions column: fit both buttons only – fixed width so it stays visible */
+/* Actions column: fit all three buttons – fixed width so it stays visible */
 .connectors-table th.col-actions,
 .connectors-table td.col-actions {
-    width: 140px;
-    min-width: 140px;
+    width: 160px;
+    min-width: 160px;
     overflow: visible;
     white-space: nowrap;
     box-sizing: content-box;

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
@@ -779,7 +779,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
     {
         if (workspace == null || isCommitSyncing || isSyncing || isUpdating)
             return;
-        ShowConfirm("Do you want to pull for this repository?", () => CommitSyncAsync(repositoryId));
+        _ = CommitSyncAsync(repositoryId);
     }
 
     /// <summary>When user clicks the not-upstreamed badge: check dependencies. Show modal only if at least one dependency repo needs push; otherwise push directly.</summary>
@@ -1021,9 +1021,9 @@ public sealed partial class WorkspaceRepositories : IDisposable
             return;
         }
         if (repoIdsWithIncoming.Count == 1)
-            ShowConfirm("Do you want to pull for this repository?", () => CommitSyncAsync(repoIdsWithIncoming[0]));
+            _ = CommitSyncAsync(repoIdsWithIncoming[0]);
         else
-            ShowConfirm($"Do you want to pull for {repoIdsWithIncoming.Count} repositories?", () => CommitSyncLevelAsync(repoIdsWithIncoming));
+            _ = CommitSyncLevelAsync(repoIdsWithIncoming);
     }
 
     /// <summary>Update button click: get update plan; if no updates, toast; else show modal (single vs multi-level).</summary>

--- a/src/GrayMoon.App/Components/Pages/Workspaces.razor
+++ b/src/GrayMoon.App/Components/Pages/Workspaces.razor
@@ -356,6 +356,7 @@
             .Select(link => link.RepositoryId)
             .ToHashSet();
         await EnsureRepositoriesAsync();
+        PruneInvalidSelectedRepositoryIds();
         showRepositoriesModal = true;
     }
 
@@ -456,6 +457,14 @@
     {
         if (editingWorkspaceId == null) return;
         if (isSavingRepositories) return;
+
+        var removedInvalidSelections = PruneInvalidSelectedRepositoryIds();
+        if (removedInvalidSelections > 0)
+        {
+            Logger.LogWarning("Removed {Count} stale repository selections before saving workspace {WorkspaceId}",
+                removedInvalidSelections,
+                editingWorkspaceId.Value);
+        }
 
         if (selectedRepositoryIds.Count == 0)
         {
@@ -565,10 +574,12 @@
             });
             var result = await RepositoryService.RefreshRepositoriesAsync(progress, _fetchRepositoriesCts.Token);
             repositories = result.Repositories.ToList();
+            PruneInvalidSelectedRepositoryIds();
         }
         catch (OperationCanceledException)
         {
             repositories = await RepositoryService.GetPersistedRepositoriesAsync();
+            PruneInvalidSelectedRepositoryIds();
         }
         catch (Exception ex)
         {
@@ -580,6 +591,22 @@
         {
             isPersisting = false;
         }
+    }
+
+    private int PruneInvalidSelectedRepositoryIds()
+    {
+        if (repositories == null || selectedRepositoryIds.Count == 0)
+        {
+            return 0;
+        }
+
+        var validRepositoryIds = repositories
+            .Select(repository => repository.RepositoryId)
+            .ToHashSet();
+
+        var before = selectedRepositoryIds.Count;
+        selectedRepositoryIds.RemoveWhere(repositoryId => !validRepositoryIds.Contains(repositoryId));
+        return before - selectedRepositoryIds.Count;
     }
 
     private async Task ToggleDefaultAsync(int workspaceId, string workspaceName)

--- a/src/GrayMoon.App/Repositories/WorkspaceRepository.cs
+++ b/src/GrayMoon.App/Repositories/WorkspaceRepository.cs
@@ -199,7 +199,22 @@ public class WorkspaceRepository(AppDbContext dbContext, WorkspaceService worksp
             .ToListAsync();
 
         var existingRepoIds = existing.Select(wr => wr.RepositoryId).ToHashSet();
-        var newRepoIds = repositoryIds.Distinct().ToHashSet();
+        var requestedRepoIds = repositoryIds.Distinct().ToHashSet();
+
+        var newRepoIds = await _dbContext.Repositories
+            .Where(repository => requestedRepoIds.Contains(repository.RepositoryId))
+            .Select(repository => repository.RepositoryId)
+            .ToHashSetAsync();
+
+        var invalidRepoIds = requestedRepoIds.Except(newRepoIds).ToList();
+        if (invalidRepoIds.Count > 0)
+        {
+            _logger.LogWarning(
+                "Ignoring {InvalidCount} invalid repository IDs while replacing workspace repositories. WorkspaceId={WorkspaceId}, RepositoryIds=[{RepositoryIds}]",
+                invalidRepoIds.Count,
+                workspaceId,
+                string.Join(", ", invalidRepoIds));
+        }
 
         var toRemove = existing.Where(wr => !newRepoIds.Contains(wr.RepositoryId)).ToList();
         var toAdd = newRepoIds.Except(existingRepoIds).ToList();

--- a/src/GrayMoon.App/Repositories/WorkspaceRepository.cs
+++ b/src/GrayMoon.App/Repositories/WorkspaceRepository.cs
@@ -201,10 +201,11 @@ public class WorkspaceRepository(AppDbContext dbContext, WorkspaceService worksp
         var existingRepoIds = existing.Select(wr => wr.RepositoryId).ToHashSet();
         var requestedRepoIds = repositoryIds.Distinct().ToHashSet();
 
-        var newRepoIds = await _dbContext.Repositories
+        var validRepoIds = await _dbContext.Repositories
             .Where(repository => requestedRepoIds.Contains(repository.RepositoryId))
             .Select(repository => repository.RepositoryId)
-            .ToHashSetAsync();
+            .ToListAsync();
+        var newRepoIds = validRepoIds.ToHashSet();
 
         var invalidRepoIds = requestedRepoIds.Except(newRepoIds).ToList();
         if (invalidRepoIds.Count > 0)

--- a/src/GrayMoon.App/Resources/install-agent.ps1
+++ b/src/GrayMoon.App/Resources/install-agent.ps1
@@ -20,6 +20,180 @@ $agentPath = Join-Path $env:ProgramData 'GrayMoon'
 $agentExe = Join-Path $agentPath 'graymoon-agent.exe'
 $downloadUrl = '{DOWNLOAD_URL}'
 
+Add-Type @"
+using System;
+using System.Runtime.InteropServices;
+
+public static class NativeLogonValidator
+{
+    [DllImport("advapi32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+    public static extern bool LogonUser(
+        string lpszUsername,
+        string lpszDomain,
+        string lpszPassword,
+        int dwLogonType,
+        int dwLogonProvider,
+        out IntPtr phToken);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    public static extern bool CloseHandle(IntPtr hObject);
+}
+"@
+
+function Split-AccountName {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$AccountName
+    )
+
+    if ($AccountName.Contains('\')) {
+        $parts = $AccountName.Split('\', 2)
+        return @{
+            Domain = $parts[0]
+            UserName = $parts[1]
+        }
+    }
+
+    if ($AccountName.Contains('@')) {
+        $parts = $AccountName.Split('@', 2)
+        return @{
+            Domain = $parts[1]
+            UserName = $parts[0]
+        }
+    }
+
+    return @{
+        Domain = $env:COMPUTERNAME
+        UserName = $AccountName
+    }
+}
+
+function Test-UserCredentials {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$AccountName,
+        [Parameter(Mandatory = $true)]
+        [string]$Password
+    )
+
+    $identity = Split-AccountName -AccountName $AccountName
+    $tokenHandle = [IntPtr]::Zero
+    $logonTypeInteractive = 2
+    $providerDefault = 0
+
+    $ok = [NativeLogonValidator]::LogonUser(
+        $identity.UserName,
+        $identity.Domain,
+        $Password,
+        $logonTypeInteractive,
+        $providerDefault,
+        [ref]$tokenHandle
+    )
+
+    if ($ok -and $tokenHandle -ne [IntPtr]::Zero) {
+        [void][NativeLogonValidator]::CloseHandle($tokenHandle)
+    }
+
+    return $ok
+}
+
+function Grant-ServiceLogonRight {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$AccountName
+    )
+
+    $sid = ([System.Security.Principal.NTAccount]$AccountName).Translate([System.Security.Principal.SecurityIdentifier]).Value
+    $sidEntry = "*$sid"
+    $tempDir = Join-Path $env:TEMP "GrayMoon-ServiceRights"
+    New-Item -ItemType Directory -Path $tempDir -Force | Out-Null
+
+    $cfgPath = Join-Path $tempDir "secpol.cfg"
+    $infPath = Join-Path $tempDir "secpol.inf"
+    $dbPath = Join-Path $tempDir "secpol.sdb"
+
+    try {
+        $null = & secedit /export /cfg "$cfgPath" /areas USER_RIGHTS
+        if ($LASTEXITCODE -ne 0) {
+            throw "Failed to export local security policy."
+        }
+
+        $content = if (Test-Path $cfgPath) { Get-Content -Path $cfgPath -ErrorAction Stop } else { @() }
+        $lineIndex = -1
+        for ($i = 0; $i -lt $content.Count; $i++) {
+            if ($content[$i] -match '^SeServiceLogonRight\s*=') {
+                $lineIndex = $i
+                break
+            }
+        }
+
+        $newLine = "SeServiceLogonRight = $sidEntry"
+        if ($lineIndex -ge 0) {
+            $existingPart = ($content[$lineIndex] -split '=', 2)[1]
+            $entries = @()
+            if (-not [string]::IsNullOrWhiteSpace($existingPart)) {
+                $entries = $existingPart.Split(',') | ForEach-Object { $_.Trim() } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+            }
+
+            if ($entries -contains $sidEntry) {
+                return
+            }
+
+            $entries += $sidEntry
+            $newLine = "SeServiceLogonRight = $($entries -join ',')"
+            $content[$lineIndex] = $newLine
+        } else {
+            $privilegeSectionIndex = -1
+            for ($i = 0; $i -lt $content.Count; $i++) {
+                if ($content[$i] -match '^\[Privilege Rights\]') {
+                    $privilegeSectionIndex = $i
+                    break
+                }
+            }
+
+            if ($privilegeSectionIndex -lt 0) {
+                $content += "[Privilege Rights]"
+                $content += $newLine
+            } else {
+                $insertIndex = $privilegeSectionIndex + 1
+                while ($insertIndex -lt $content.Count -and -not $content[$insertIndex].StartsWith('[')) {
+                    $insertIndex++
+                }
+
+                $before = @()
+                $after = @()
+                if ($insertIndex -gt 0) {
+                    $before = $content[0..($insertIndex - 1)]
+                }
+                if ($insertIndex -lt $content.Count) {
+                    $after = $content[$insertIndex..($content.Count - 1)]
+                }
+                $content = @($before + $newLine + $after)
+            }
+        }
+
+        @"
+[Unicode]
+Unicode=yes
+[Version]
+signature="`$CHICAGO`$"
+Revision=1
+[Privilege Rights]
+$newLine
+"@ | Set-Content -Path $infPath -Encoding Unicode -Force
+
+        $null = & secedit /configure /db "$dbPath" /cfg "$infPath" /areas USER_RIGHTS
+        if ($LASTEXITCODE -ne 0) {
+            throw "Failed to apply local security policy update."
+        }
+    }
+    finally {
+        Remove-Item -Path $cfgPath -Force -ErrorAction SilentlyContinue
+        Remove-Item -Path $infPath -Force -ErrorAction SilentlyContinue
+        Remove-Item -Path $dbPath -Force -ErrorAction SilentlyContinue
+    }
+}
+
 Write-Host 'Checking for existing service...' -ForegroundColor Yellow
 $existingService = Get-Service -Name $serviceName -ErrorAction SilentlyContinue
 $serviceExists = $null -ne $existingService
@@ -78,22 +252,34 @@ if ($serviceExists) {
         Write-Host "Service will run as: $currentUser" -ForegroundColor Cyan
         Write-Host "Enter password for $currentUser (required for service to access git credentials and dotnet tools):" -ForegroundColor Yellow
         $password = Read-Host -Prompt "Password" -AsSecureString
-        $passwordPlain = [Runtime.InteropServices.Marshal]::PtrToStringAuto([Runtime.InteropServices.Marshal]::SecureStringToBSTR($password))
-        
-        # Clear the secure string from memory
-        $password.Dispose()
-        
-        # Use sc.exe to create service with custom user account (New-Service doesn't support this)
-        # Note: sc.exe is still needed for setting custom user credentials
-        $result = & sc.exe create $serviceName binPath= $binPath start= auto DisplayName= "$serviceDisplayName" obj= "$currentUser" password= "$passwordPlain" 2>&1
-        if ($LASTEXITCODE -ne 0) {
-            $errorMsg = if ($result -is [System.Array]) { ($result | Out-String).Trim() } else { $result.ToString() }
-            throw "sc.exe create failed with exit code ${LASTEXITCODE}: $errorMsg"
+        $passwordBstr = [IntPtr]::Zero
+        try {
+            $passwordBstr = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($password)
+            $passwordPlain = [Runtime.InteropServices.Marshal]::PtrToStringBSTR($passwordBstr)
+
+            if (-not (Test-UserCredentials -AccountName $currentUser -Password $passwordPlain)) {
+                throw "Invalid credentials for '$currentUser'. Aborting installation."
+            }
+
+            Write-Host 'Granting "Log on as a service" right...' -ForegroundColor Yellow
+            Grant-ServiceLogonRight -AccountName $currentUser
+            
+            # Use sc.exe to create service with custom user account (New-Service doesn't support this)
+            # Note: sc.exe is still needed for setting custom user credentials
+            $result = & sc.exe create $serviceName binPath= $binPath start= auto DisplayName= "$serviceDisplayName" obj= "$currentUser" password= "$passwordPlain" 2>&1
+            if ($LASTEXITCODE -ne 0) {
+                $errorMsg = if ($result -is [System.Array]) { ($result | Out-String).Trim() } else { $result.ToString() }
+                throw "sc.exe create failed with exit code ${LASTEXITCODE}: $errorMsg"
+            }
         }
-        
-        # Clear password from memory immediately
-        $passwordPlain = $null
-        [System.GC]::Collect()
+        finally {
+            if ($passwordBstr -ne [IntPtr]::Zero) {
+                [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($passwordBstr)
+            }
+            $passwordPlain = $null
+            $password.Dispose()
+            [System.GC]::Collect()
+        }
         
         # Set description using sc.exe
         & sc.exe description $serviceName "$serviceDescription" | Out-Null

--- a/src/GrayMoon.App/Services/GitHubService.cs
+++ b/src/GrayMoon.App/Services/GitHubService.cs
@@ -212,7 +212,8 @@ public class GitHubService : IConnectorService
         {
             var message = MapHttpStatusToMessage(ex.StatusCode, "GitHub");
             _logger.LogError(ex, "Failed to test GitHub connector connection. Status={StatusCode}", ex.StatusCode);
-            return ConnectorTestResult.Fail(message);
+            var isConnectorFault = ex.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden or HttpStatusCode.NotFound;
+            return isConnectorFault ? ConnectorTestResult.Fault(message) : ConnectorTestResult.Fail(message);
         }
         catch (Exception ex)
         {

--- a/src/GrayMoon.App/Services/GitVersionCommandService.cs
+++ b/src/GrayMoon.App/Services/GitVersionCommandService.cs
@@ -7,6 +7,7 @@ namespace GrayMoon.App.Services;
 public class GitVersionCommandService(ILogger<GitVersionCommandService> logger, ICommandLineService commandLine)
 {
     private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
+    private readonly HashSet<string> _toolRestoreAttempted = new(StringComparer.OrdinalIgnoreCase);
 
     public async Task<GitVersionResult?> GetVersionAsync(string repositoryPath, CancellationToken cancellationToken = default)
     {
@@ -36,11 +37,36 @@ public class GitVersionCommandService(ILogger<GitVersionCommandService> logger, 
             }
             if (result.ExitCode != 0)
             {
-                logger.LogWarning("dotnet-gitversion failed with exit code {ExitCode} in {Path}. Stdout: {Stdout} Stderr: {Stderr}",
-                    result.ExitCode, repositoryPath,
-                    string.IsNullOrWhiteSpace(result.Stdout) ? "(none)" : result.Stdout.Trim(),
-                    string.IsNullOrWhiteSpace(result.Stderr) ? "(none)" : result.Stderr.Trim());
-                return null;
+                var combinedOutput = (!string.IsNullOrWhiteSpace(result.Stderr) ? result.Stderr : result.Stdout)?.Trim() ?? string.Empty;
+                if (combinedOutput.Contains("dotnet tool restore", StringComparison.OrdinalIgnoreCase)
+                    && _toolRestoreAttempted.Add(repositoryPath))
+                {
+                    logger.LogWarning("dotnet-gitversion requires tool restore. Running 'dotnet tool restore' in {Path}", repositoryPath);
+                    var restore = await commandLine.RunAsync("dotnet", "tool restore", repositoryPath, null, cancellationToken);
+                    if (restore.ExitCode != 0)
+                    {
+                        logger.LogError("dotnet tool restore failed. ExitCode={ExitCode}, Stderr={Stderr}", restore.ExitCode, restore.Stderr?.Trim());
+                        return null;
+                    }
+                    logger.LogInformation("dotnet tool restore succeeded in {Path}. Retrying dotnet-gitversion", repositoryPath);
+                    result = await commandLine.RunAsync("dotnet-gitversion", "/output json /nofetch /verbosity quiet", repositoryPath, null, cancellationToken);
+                    if (result.ExitCode != 0)
+                    {
+                        logger.LogWarning("dotnet-gitversion failed after tool restore. ExitCode={ExitCode} in {Path}. Stdout: {Stdout} Stderr: {Stderr}",
+                            result.ExitCode, repositoryPath,
+                            string.IsNullOrWhiteSpace(result.Stdout) ? "(none)" : result.Stdout.Trim(),
+                            string.IsNullOrWhiteSpace(result.Stderr) ? "(none)" : result.Stderr.Trim());
+                        return null;
+                    }
+                }
+                else
+                {
+                    logger.LogWarning("dotnet-gitversion failed with exit code {ExitCode} in {Path}. Stdout: {Stdout} Stderr: {Stderr}",
+                        result.ExitCode, repositoryPath,
+                        string.IsNullOrWhiteSpace(result.Stdout) ? "(none)" : result.Stdout.Trim(),
+                        string.IsNullOrWhiteSpace(result.Stderr) ? "(none)" : result.Stderr.Trim());
+                    return null;
+                }
             }
 
             var parsed = ParseGitVersionJson(result.Stdout);

--- a/src/GrayMoon.App/Services/GitVersionCommandService.cs
+++ b/src/GrayMoon.App/Services/GitVersionCommandService.cs
@@ -7,7 +7,6 @@ namespace GrayMoon.App.Services;
 public class GitVersionCommandService(ILogger<GitVersionCommandService> logger, ICommandLineService commandLine)
 {
     private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
-    private readonly HashSet<string> _toolRestoreAttempted = new(StringComparer.OrdinalIgnoreCase);
 
     public async Task<GitVersionResult?> GetVersionAsync(string repositoryPath, CancellationToken cancellationToken = default)
     {
@@ -37,11 +36,11 @@ public class GitVersionCommandService(ILogger<GitVersionCommandService> logger, 
             }
             if (result.ExitCode != 0)
             {
-                var combinedOutput = (!string.IsNullOrWhiteSpace(result.Stderr) ? result.Stderr : result.Stdout)?.Trim() ?? string.Empty;
-                if (combinedOutput.Contains("dotnet tool restore", StringComparison.OrdinalIgnoreCase)
-                    && _toolRestoreAttempted.Add(repositoryPath))
+                var manifestExists = File.Exists(Path.Combine(repositoryPath, "dotnet-tools.json"))
+                    || File.Exists(Path.Combine(repositoryPath, ".config", "dotnet-tools.json"));
+                if (manifestExists)
                 {
-                    logger.LogWarning("dotnet-gitversion requires tool restore. Running 'dotnet tool restore' in {Path}", repositoryPath);
+                    logger.LogWarning("dotnet-gitversion failed and tool manifest found. Running 'dotnet tool restore' in {Path}", repositoryPath);
                     var restore = await commandLine.RunAsync("dotnet", "tool restore", repositoryPath, null, cancellationToken);
                     if (restore.ExitCode != 0)
                     {
@@ -69,7 +68,7 @@ public class GitVersionCommandService(ILogger<GitVersionCommandService> logger, 
                 }
             }
 
-            var parsed = ParseGitVersionJson(result.Stdout);
+            var parsed = ParseGitVersionJson(result.Stdout ?? string.Empty);
             if (parsed != null)
             {
                 logger.LogInformation("GitVersion for {Path}: {InformationalVersion} ({Branch})", repositoryPath,

--- a/src/GrayMoon.App/Services/NuGetService.cs
+++ b/src/GrayMoon.App/Services/NuGetService.cs
@@ -189,7 +189,7 @@ public class NuGetService : IConnectorService
         // Other registries require token
         if (string.IsNullOrWhiteSpace(ConnectorHelpers.UnprotectToken(connector.UserToken)))
         {
-            return ConnectorTestResult.Fail("Connector token is required for this NuGet registry.");
+            return ConnectorTestResult.Fault("Connector token is required for this NuGet registry.");
         }
 
         return await TestAuthenticatedNuGetConnectionAsync(connector);
@@ -216,7 +216,8 @@ public class NuGetService : IConnectorService
 
             var message = MapHttpStatusToMessage(response.StatusCode, "NuGet");
             _logger.LogError("Failed to test NuGet.org connection. Status={StatusCode}", response.StatusCode);
-            return ConnectorTestResult.Fail(message);
+            var isConnectorFault = response.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden or HttpStatusCode.NotFound;
+            return isConnectorFault ? ConnectorTestResult.Fault(message) : ConnectorTestResult.Fail(message);
         }
         catch (Exception ex)
         {
@@ -263,7 +264,8 @@ public class NuGetService : IConnectorService
             var registryName = ConnectorHelpers.IsGitHubPackages(connector.ApiBaseUrl) ? "GitHub Packages" : "NuGet registry";
             var message = MapHttpStatusToMessage(response.StatusCode, registryName);
             _logger.LogError("Failed to test authenticated NuGet connection. Status={StatusCode}", response.StatusCode);
-            return ConnectorTestResult.Fail(message);
+            var isConnectorFault = response.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden or HttpStatusCode.NotFound;
+            return isConnectorFault ? ConnectorTestResult.Fault(message) : ConnectorTestResult.Fail(message);
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
## Summary

This PR improves connector reliability and workspace repository management with a set of targeted fixes and UX improvements.

---

## Connector: Fault Detection vs Transient Errors

Introduces a distinction between connector *configuration faults* and *transient failures* so that connectors are only deactivated when the problem is user-correctable.

- Added `IsConnectorFault` property and `Fault()` factory to `ConnectorTestResult`
- `401 Unauthorized`, `403 Forbidden`, `404 Not Found`, and missing token → `Fault()` → connector deactivated
- `429 Rate Limited`, `503 Service Unavailable`, network errors, and unexpected exceptions → `Fail()` → connector stays active, error shown
- Unexpected app exceptions in `TestConnectorCoreAsync` no longer deactivate the connector

**Files:** ConnectorTestResult.cs, GitHubService.cs, NuGetService.cs, Connectors.razor

---

## Connector Page: Test Controls

- Added **Test Connectors** bulk button next to *Add Connector* — runs all connector tests in parallel
- Added per-row **Test** button in the Actions column for single-connector testing
- Bulk test now updates each row progressively as each test completes (no waiting for all)
- Test buttons disable during testing but keep static labels (no "Testing..." text change)
- Connector tests no longer run automatically on page load
- Actions column widened to accommodate all three action buttons

---

## Workspace Repositories: Renamed Repository Fix

Fixes a `SQLite Error 19: FOREIGN KEY constraint failed` crash when saving workspace repositories after a GitHub repository rename caused stale selected IDs in the modal.

- Stale selected repository IDs are pruned when opening the modal, after fetch/refresh, and before save
- `WorkspaceRepository.ReplaceRepositoriesAsync` defensively validates all incoming IDs against the database, logging and ignoring any that no longer exist

---

## Agent Page & Install Script

- `.NET` installation info moved to the bottom of the Agent page
- Install script updated: added grant-as-logon support, token update flow, and link to create token with required permissions