### PR TITLE
Fix high priority known issues and prerelease

### DIFF
--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
@@ -1216,7 +1216,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
         await InvokeAsync(StateHasChanged);
         try
         {
-            await WorkspacePageService.WorkspaceRepository.UpdateAsync(WorkspaceId, workspace.Name, _repositoriesModal.SelectedRepositoryIds);
+            await WorkspacePageService.WorkspaceRepository.UpdateAsync(WorkspaceId, workspace.Name, _repositoriesModal.SelectedRepositoryIds, workspace.RootPath);
             CloseRepositoriesModal();
             await ReloadWorkspaceDataAsync();
             ApplySyncStateFromWorkspace();

--- a/src/GrayMoon.App/Components/Pages/Workspaces.razor
+++ b/src/GrayMoon.App/Components/Pages/Workspaces.razor
@@ -430,7 +430,7 @@
             else
             {
                 Logger.LogInformation("User edited workspace {WorkspaceName}", workspaceName);
-                await WorkspaceRepository.UpdateAsync(editingWorkspaceId.Value, workspaceName, editingWorkspaceRepositoryIds);
+                await WorkspaceRepository.UpdateAsync(editingWorkspaceId.Value, workspaceName, editingWorkspaceRepositoryIds, editingWorkspaceRootPath);
 
                 if (existingRepositoryCount > 0)
                     await TrySuggestImportsAsync(editingWorkspaceId.Value, workspaceName);
@@ -479,7 +479,7 @@
         try
         {
             Logger.LogInformation("User added {Count} repositories to workspace {WorkspaceName}", selectedRepositoryIds.Count, repositoriesModalWorkspaceName);
-            await WorkspaceRepository.UpdateAsync(editingWorkspaceId.Value, repositoriesModalWorkspaceName, selectedRepositoryIds);
+            await WorkspaceRepository.UpdateAsync(editingWorkspaceId.Value, repositoriesModalWorkspaceName, selectedRepositoryIds, editingWorkspaceRootPath);
 
             CloseRepositoriesModal();
             await LoadWorkspacesAsync();

--- a/src/GrayMoon.App/Repositories/WorkspaceRepository.cs
+++ b/src/GrayMoon.App/Repositories/WorkspaceRepository.cs
@@ -52,7 +52,7 @@ public class WorkspaceRepository(AppDbContext dbContext, WorkspaceService worksp
         return workspace;
     }
 
-    public async Task UpdateAsync(int workspaceId, string name, IReadOnlyCollection<int> repositoryIds)
+    public async Task UpdateAsync(int workspaceId, string name, IReadOnlyCollection<int> repositoryIds, string? rootPath)
     {
         var normalized = NormalizeName(name);
         if (await NameExistsAsync(normalized, workspaceId))
@@ -70,6 +70,7 @@ public class WorkspaceRepository(AppDbContext dbContext, WorkspaceService worksp
         }
 
         workspace.Name = normalized;
+        workspace.RootPath = string.IsNullOrWhiteSpace(rootPath) ? null : rootPath.Trim();
         await _dbContext.SaveChangesAsync();
         _logger.LogInformation("Persistence: saved Workspace. Action=Update, WorkspaceId={WorkspaceId}, Name={Name}", workspaceId, workspace.Name);
 

--- a/src/GrayMoon.App/Services/AgentBridge.cs
+++ b/src/GrayMoon.App/Services/AgentBridge.cs
@@ -17,6 +17,8 @@ public sealed class AgentBridge(
     AgentConnectionTracker connectionTracker,
     ILogger<AgentBridge> logger) : IAgentBridge
 {
+    private static readonly TimeSpan AgentResponseTimeout = TimeSpan.FromMinutes(2);
+
     public bool IsAgentConnected => connectionTracker.GetAgentConnectionId() != null;
 
     public async Task<AgentCommandResponse> SendCommandAsync(string command, object args, CancellationToken cancellationToken = default)
@@ -28,7 +30,7 @@ public sealed class AgentBridge(
         var requestId = Guid.NewGuid().ToString("N");
         var argsJson = args != null ? JsonSerializer.SerializeToElement(args) : (JsonElement?)null;
 
-        var task = AgentResponseDelivery.WaitAsync(requestId, cancellationToken);
+        var task = AgentResponseDelivery.WaitAsync(requestId, AgentResponseTimeout, cancellationToken);
 
         try
         {
@@ -42,6 +44,7 @@ public sealed class AgentBridge(
         }
         catch (Exception ex)
         {
+            AgentResponseDelivery.Fail(requestId, ex);
             logger.LogError(ex, "Failed to send command {Command} to agent", command);
             return new AgentCommandResponse(false, null, ex.Message);
         }

--- a/src/GrayMoon.App/Services/AgentResponseDelivery.cs
+++ b/src/GrayMoon.App/Services/AgentResponseDelivery.cs
@@ -6,23 +6,65 @@ namespace GrayMoon.App.Services;
 /// <summary>Static registry for pending command responses. Agent calls ResponseCommand which completes the TCS.</summary>
 public static class AgentResponseDelivery
 {
-    private static readonly ConcurrentDictionary<string, TaskCompletionSource<AgentCommandResponse>> Pending = new();
+    private sealed record PendingRequest(
+        TaskCompletionSource<AgentCommandResponse> Completion,
+        CancellationTokenRegistration Registration,
+        CancellationTokenSource TimeoutCts);
 
-    public static Task<AgentCommandResponse> WaitAsync(string requestId, CancellationToken cancellationToken)
+    private static readonly ConcurrentDictionary<string, PendingRequest> Pending = new();
+
+    public static Task<AgentCommandResponse> WaitAsync(string requestId, TimeSpan timeout, CancellationToken cancellationToken)
     {
-        var tcs = new TaskCompletionSource<AgentCommandResponse>();
-        Pending[requestId] = tcs;
-        cancellationToken.Register(() =>
+        var completion = new TaskCompletionSource<AgentCommandResponse>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeoutCts.CancelAfter(timeout);
+
+        var registration = timeoutCts.Token.Register(() =>
         {
-            if (Pending.TryRemove(requestId, out var removed))
-                removed.TrySetCanceled(cancellationToken);
+            if (!Pending.TryRemove(requestId, out var pending))
+                return;
+
+            pending.Registration.Dispose();
+            pending.TimeoutCts.Dispose();
+
+            if (cancellationToken.IsCancellationRequested)
+            {
+                pending.Completion.TrySetCanceled(cancellationToken);
+            }
+            else
+            {
+                pending.Completion.TrySetException(new TimeoutException($"Timed out waiting for agent response for request '{requestId}' after {timeout}."));
+            }
+
         });
-        return tcs.Task;
+
+        if (!Pending.TryAdd(requestId, new PendingRequest(completion, registration, timeoutCts)))
+        {
+            registration.Dispose();
+            timeoutCts.Dispose();
+            throw new InvalidOperationException($"Duplicate pending request ID '{requestId}'.");
+        }
+
+        return completion.Task;
     }
 
     public static void Complete(string requestId, AgentCommandResponse response)
     {
-        if (Pending.TryRemove(requestId, out var tcs))
-            tcs.TrySetResult(response);
+        if (!Pending.TryRemove(requestId, out var pending))
+            return;
+
+        pending.Registration.Dispose();
+        pending.TimeoutCts.Dispose();
+        pending.Completion.TrySetResult(response);
+    }
+
+    public static void Fail(string requestId, Exception exception)
+    {
+        if (!Pending.TryRemove(requestId, out var pending))
+            return;
+
+        pending.Registration.Dispose();
+        pending.TimeoutCts.Dispose();
+        pending.Completion.TrySetException(exception);
     }
 }


### PR DESCRIPTION
Completed the high-priority work by persisting RootPath in WorkspaceRepository.cs, updating the edit/repository-save call sites to pass root path in Workspaces.razor and WorkspaceRepositories.razor.cs, adding timeout plus cleanup for stale pending agent responses (including explicit failure-path removal) in AgentResponseDelivery.cs and AgentBridge.cs, and verifying the sync-to-default endpoint already uses per-workspace root resolution in BranchEndpoints.cs, with solution build currently blocked only by file locks from running GrayMoon.App/graymoon-agent processes rather than code errors in these edits.

