### PR TITLE
Handle GitHub repository renames during fetch

### DIFF
--- a/src/GrayMoon.App/Components/Modals/WorkspaceRepositoriesModal.razor
+++ b/src/GrayMoon.App/Components/Modals/WorkspaceRepositoriesModal.razor
@@ -135,6 +135,25 @@
                         </div>
                     </div>
 
+                    @if (RenameWarnings is { Count: > 0 })
+                    {
+                        <div class="alert alert-warning">
+                            <i class="bi bi-exclamation-triangle me-1"></i>
+                            <strong>Repository rename detected.</strong> The following repositories were renamed in GitHub and have been updated automatically. Workspace links are preserved.
+                            <ul class="mb-0 mt-1">
+                                @foreach (var rename in RenameWarnings)
+                                {
+                                    <li>
+                                        @if (!string.IsNullOrWhiteSpace(rename.OrgName))
+                                        {
+                                            <span>@rename.OrgName / </span>
+                                        }
+                                        <strong>@rename.OldName</strong> &rarr; <strong>@rename.NewName</strong>
+                                    </li>
+                                }
+                            </ul>
+                        </div>
+                    }
                     @if (ErrorMessage != null)
                     {
                         <div class="alert alert-danger">@ErrorMessage</div>
@@ -166,6 +185,7 @@
     [Parameter] public bool IsSaving { get; set; }
     [Parameter] public bool IsFetching { get; set; }
     [Parameter] public string? ErrorMessage { get; set; }
+    [Parameter] public IReadOnlyList<RenamedRepositoryInfo>? RenameWarnings { get; set; }
     [Parameter] public EventCallback OnSave { get; set; }
     [Parameter] public EventCallback OnCancel { get; set; }
     [Parameter] public EventCallback OnFetchRepositories { get; set; }

--- a/src/GrayMoon.App/Components/Pages/Repositories.razor
+++ b/src/GrayMoon.App/Components/Pages/Repositories.razor
@@ -62,6 +62,22 @@
                         <button type="button" class="btn-close" aria-label="Close" @onclick="DismissConnectorErrors"></button>
                     </div>
                 }
+                @if (renamedRepositories?.Count > 0)
+                {
+                    <div class="alert alert-warning alert-dismissible fade show rounded-0 mb-0 border-0 border-bottom" role="alert">
+                        <strong><i class="bi bi-exclamation-triangle me-1"></i>Repository rename detected.</strong> The following repositories were renamed in GitHub and updated automatically:
+                        <ul class="mb-0 mt-1 ps-3">
+                            @foreach (var rename in renamedRepositories)
+                            {
+                                <li>
+                                    @if (!string.IsNullOrWhiteSpace(rename.OrgName)) { <span>@rename.OrgName / </span> }
+                                    <strong>@rename.OldName</strong> &rarr; <strong>@rename.NewName</strong>
+                                </li>
+                            }
+                        </ul>
+                        <button type="button" class="btn-close" aria-label="Close" @onclick="() => renamedRepositories = null"></button>
+                    </div>
+                }
                 <div class="card-body p-0">
                     <div class="table-responsive">
                         <table class="table table-striped table-hover mb-0 repositories-table resizable-columns">
@@ -138,6 +154,7 @@
 @code {
     private List<GitHubRepositoryEntry>? repositories;
     private IReadOnlyList<ConnectorFetchError>? connectorErrors;
+    private IReadOnlyList<RenamedRepositoryInfo>? renamedRepositories;
     private string? errorMessage;
     private string searchTerm = string.Empty;
     private bool isPersisting;
@@ -210,6 +227,7 @@
             var result = await RepositoryService.RefreshRepositoriesAsync(progress, _fetchRepositoriesCts.Token);
             repositories = result.Repositories.ToList();
             connectorErrors = result.ConnectorErrors.Count > 0 ? result.ConnectorErrors : null;
+            renamedRepositories = result.RenamedRepositories.Count > 0 ? result.RenamedRepositories : null;
         }
         catch (OperationCanceledException)
         {

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor
@@ -176,6 +176,7 @@
                             IsSaving="@_repositoriesModal.IsSaving"
                             IsFetching="@_repositoriesModal.IsFetching"
                             ErrorMessage="@_repositoriesModal.ErrorMessage"
+                            RenameWarnings="@_repositoriesModal.RenameWarnings"
                             OnSave="@SaveRepositoriesAsync"
                             OnCancel="@CloseRepositoriesModal"
                             OnFetchRepositories="@FetchRepositoriesAsync" />

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
@@ -1258,6 +1258,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
             });
             var result = await WorkspacePageService.RepositoryService.RefreshRepositoriesAsync(progress, _fetchRepositoriesCts.Token);
             _repositoriesModal.Repositories = result.Repositories.ToList();
+            _repositoriesModal.RenameWarnings = result.RenamedRepositories.Count > 0 ? result.RenamedRepositories : null;
         }
         catch (OperationCanceledException)
         {
@@ -2295,6 +2296,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
     {
         public bool IsVisible { get; set; }
         public string? ErrorMessage { get; set; }
+        public IReadOnlyList<RenamedRepositoryInfo>? RenameWarnings { get; set; }
         public List<GitHubRepositoryEntry>? Repositories { get; set; }
         public HashSet<int> SelectedRepositoryIds { get; set; } = new();
         public bool IsSaving { get; set; }

--- a/src/GrayMoon.App/Components/Pages/Workspaces.razor
+++ b/src/GrayMoon.App/Components/Pages/Workspaces.razor
@@ -162,6 +162,7 @@
                             IsSaving="@isSavingRepositories"
                             IsFetching="@isPersisting"
                             ErrorMessage="@repositoriesModalErrorMessage"
+                            RenameWarnings="@repositoriesModalRenameWarnings"
                             OnSave="@SaveRepositoriesAsync"
                             OnCancel="@CloseRepositoriesModal"
                             OnFetchRepositories="@FetchRepositoriesAsync" />
@@ -213,6 +214,7 @@
     private string repositoriesModalWorkspaceName = string.Empty;
     private string? editorErrorMessage;
     private string? repositoriesModalErrorMessage;
+    private IReadOnlyList<RenamedRepositoryInfo>? repositoriesModalRenameWarnings;
     private string editorTitle = "Add Workspace";
     private int? editingWorkspaceId;
     private string? editingWorkspaceRootPath;
@@ -352,6 +354,7 @@
         editingWorkspaceId = workspaceId;
         repositoriesModalWorkspaceName = workspace.Name;
         repositoriesModalErrorMessage = null;
+        repositoriesModalRenameWarnings = null;
         selectedRepositoryIds = workspace.Repositories
             .Select(link => link.RepositoryId)
             .ToHashSet();
@@ -370,6 +373,7 @@
     {
         showRepositoriesModal = false;
         repositoriesModalErrorMessage = null;
+        repositoriesModalRenameWarnings = null;
     }
 
     private async Task SaveWorkspaceAsync()
@@ -574,6 +578,7 @@
             });
             var result = await RepositoryService.RefreshRepositoriesAsync(progress, _fetchRepositoriesCts.Token);
             repositories = result.Repositories.ToList();
+            repositoriesModalRenameWarnings = result.RenamedRepositories.Count > 0 ? result.RenamedRepositories : null;
             PruneInvalidSelectedRepositoryIds();
         }
         catch (OperationCanceledException)

--- a/src/GrayMoon.App/Models/RefreshRepositoriesResult.cs
+++ b/src/GrayMoon.App/Models/RefreshRepositoriesResult.cs
@@ -1,10 +1,11 @@
 namespace GrayMoon.App.Models;
 
-/// <summary>Result of refreshing repositories from GitHub; may include per-connector fetch errors.</summary>
+/// <summary>Result of refreshing repositories from GitHub; may include per-connector fetch errors and detected renames.</summary>
 public sealed class RefreshRepositoriesResult
 {
     public IReadOnlyList<GitHubRepositoryEntry> Repositories { get; init; } = [];
     public IReadOnlyList<ConnectorFetchError> ConnectorErrors { get; init; } = [];
+    public IReadOnlyList<RenamedRepositoryInfo> RenamedRepositories { get; init; } = [];
 }
 
 /// <summary>Error for a single connector when fetching its repositories.</summary>
@@ -12,4 +13,12 @@ public sealed class ConnectorFetchError
 {
     public string ConnectorName { get; init; } = string.Empty;
     public string Message { get; init; } = string.Empty;
+}
+
+/// <summary>Describes a repository that was renamed in GitHub and updated in place during a fetch.</summary>
+public sealed class RenamedRepositoryInfo
+{
+    public string OldName { get; init; } = string.Empty;
+    public string NewName { get; init; } = string.Empty;
+    public string? OrgName { get; init; }
 }

--- a/src/GrayMoon.App/Repositories/RepositoryRepository.cs
+++ b/src/GrayMoon.App/Repositories/RepositoryRepository.cs
@@ -67,10 +67,12 @@ public class GitHubRepositoryRepository(AppDbContext dbContext, ILogger<GitHubRe
 
     /// <summary>
     /// Merges fetched repositories with existing ones using <see cref="Repository.CloneUrl"/> as the unique key.
-    /// Updates existing rows when CloneUrl matches; adds new rows for new CloneUrls.
-    /// Removes repositories that are not in <paramref name="repositories"/> (and their workspace links via cascade).
+    /// Detects GitHub renames (same connector, org and URL owner-prefix, only the name segment differs) and updates
+    /// the existing row in place — preserving <see cref="Repository.RepositoryId"/> and all workspace links.
+    /// Adds new rows for genuinely new clone URLs and removes rows no longer returned by GitHub.
     /// </summary>
-    public async Task MergeRepositoriesAsync(IReadOnlyCollection<Repository> repositories)
+    /// <returns>Repositories that were detected as renames and updated in place.</returns>
+    public async Task<IReadOnlyList<RenamedRepositoryInfo>> MergeRepositoriesAsync(IReadOnlyCollection<Repository> repositories)
     {
         var normalized = repositories
             .Select(r => new Repository
@@ -91,30 +93,97 @@ public class GitHubRepositoryRepository(AppDbContext dbContext, ILogger<GitHubRe
 
         await using var transaction = await _dbContext.Database.BeginTransactionAsync();
 
-        var existing = await _dbContext.Repositories.ToListAsync();
+        var existing = await _dbContext.Repositories.AsNoTracking().ToListAsync();
         var toRemove = existing.Where(r => !fetchedUrls.Contains(r.CloneUrl.Trim())).ToList();
-        if (toRemove.Count > 0)
+
+        // Identify new repos (fetched URLs not yet in DB) — candidates for rename targets
+        var existingUrls = new HashSet<string>(existing.Select(r => r.CloneUrl.Trim()), StringComparer.OrdinalIgnoreCase);
+        var newRepos = normalized.Where(r => !existingUrls.Contains(r.CloneUrl)).ToList();
+
+        // Detect renames: match removed repos to new repos by same connector + org + URL owner-prefix
+        var renames = new List<RenamedRepositoryInfo>();
+        var renamedOldUrls = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var renamedNewUrls = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var oldRepo in toRemove)
         {
-            _dbContext.Repositories.RemoveRange(toRemove);
-            await _dbContext.SaveChangesAsync();
-            _logger.LogInformation("Persistence: Repository. Action=Merge (remove not fetched), RemovedCount={RemovedCount}", toRemove.Count);
+            foreach (var newRepo in newRepos)
+            {
+                if (renamedNewUrls.Contains(newRepo.CloneUrl)) continue;
+                if (IsLikelyRename(oldRepo, newRepo))
+                {
+                    renames.Add(new RenamedRepositoryInfo
+                    {
+                        OldName = oldRepo.RepositoryName,
+                        NewName = newRepo.RepositoryName,
+                        OrgName = oldRepo.OrgName
+                    });
+                    renamedOldUrls.Add(oldRepo.CloneUrl.Trim());
+                    renamedNewUrls.Add(newRepo.CloneUrl);
+                    _logger.LogInformation(
+                        "Detected GitHub rename: '{OldName}' → '{NewName}' (ConnectorId={ConnectorId}, Org={OrgName})",
+                        oldRepo.RepositoryName, newRepo.RepositoryName, oldRepo.ConnectorId, oldRepo.OrgName);
+                    break;
+                }
+            }
         }
 
+        // Repos to actually delete = toRemove minus those identified as renames
+        var actualRemovals = toRemove.Where(r => !renamedOldUrls.Contains(r.CloneUrl.Trim())).ToList();
+        if (actualRemovals.Count > 0)
+        {
+            // Load the rows into the tracker so EF Core can issue the DELETEs
+            var removalIds = actualRemovals.Select(r => r.RepositoryId).ToHashSet();
+            var trackedRemovals = await _dbContext.Repositories
+                .Where(r => removalIds.Contains(r.RepositoryId))
+                .ToListAsync();
+            _dbContext.Repositories.RemoveRange(trackedRemovals);
+            await _dbContext.SaveChangesAsync();
+            _logger.LogInformation("Persistence: Repository. Action=Merge (remove not fetched), RemovedCount={RemovedCount}", actualRemovals.Count);
+        }
+
+        // Apply updates and inserts; for renames, UPDATE the existing row in place (preserves RepositoryId + workspace links)
         var existingByUrl = existing
-            .Where(r => fetchedUrls.Contains(r.CloneUrl.Trim()))
+            .Where(r => fetchedUrls.Contains(r.CloneUrl.Trim()) && !renamedOldUrls.Contains(r.CloneUrl.Trim()))
             .GroupBy(r => r.CloneUrl.Trim(), StringComparer.OrdinalIgnoreCase)
             .ToDictionary(g => g.Key, g => g.First(), StringComparer.OrdinalIgnoreCase);
 
+        // Map renamed old repo by old URL so we can load it for in-place update
+        var renameByOldUrl = toRemove
+            .Where(r => renamedOldUrls.Contains(r.CloneUrl.Trim()))
+            .ToDictionary(r => r.CloneUrl.Trim(), StringComparer.OrdinalIgnoreCase);
+
         foreach (var repo in normalized)
         {
-            if (existingByUrl.TryGetValue(repo.CloneUrl, out var existingRepo))
+            if (renamedNewUrls.Contains(repo.CloneUrl))
             {
-                existingRepo.ConnectorId = repo.ConnectorId;
-                existingRepo.OrgName = repo.OrgName;
-                existingRepo.RepositoryName = repo.RepositoryName;
-                existingRepo.Visibility = repo.Visibility;
-                existingRepo.CloneUrl = repo.CloneUrl;
-                existingRepo.Topics = repo.Topics;
+                // Find the existing row that this new repo renames, load it tracked, then update in place
+                var matchingOldRepo = renameByOldUrl.Values.FirstOrDefault(old => IsLikelyRename(old, repo));
+                if (matchingOldRepo != null)
+                {
+                    var trackedExisting = await _dbContext.Repositories.FindAsync(matchingOldRepo.RepositoryId);
+                    if (trackedExisting != null)
+                    {
+                        trackedExisting.RepositoryName = repo.RepositoryName;
+                        trackedExisting.CloneUrl = repo.CloneUrl;
+                        trackedExisting.OrgName = repo.OrgName;
+                        trackedExisting.Visibility = repo.Visibility;
+                        trackedExisting.Topics = repo.Topics;
+                    }
+                }
+            }
+            else if (existingByUrl.TryGetValue(repo.CloneUrl, out var existingEntry))
+            {
+                var trackedExisting = await _dbContext.Repositories.FindAsync(existingEntry.RepositoryId);
+                if (trackedExisting != null)
+                {
+                    trackedExisting.ConnectorId = repo.ConnectorId;
+                    trackedExisting.OrgName = repo.OrgName;
+                    trackedExisting.RepositoryName = repo.RepositoryName;
+                    trackedExisting.Visibility = repo.Visibility;
+                    trackedExisting.CloneUrl = repo.CloneUrl;
+                    trackedExisting.Topics = repo.Topics;
+                }
             }
             else
             {
@@ -123,8 +192,39 @@ public class GitHubRepositoryRepository(AppDbContext dbContext, ILogger<GitHubRe
         }
 
         await _dbContext.SaveChangesAsync();
-        _logger.LogInformation("Persistence: Repository. Action=Merge, TotalFetched={TotalFetched}, UpdatedOrAdded={UpdatedOrAdded}", normalized.Count, normalized.Count);
+        _logger.LogInformation(
+            "Persistence: Repository. Action=Merge, TotalFetched={TotalFetched}, Renames={Renames}, Removed={Removed}",
+            normalized.Count, renames.Count, actualRemovals.Count);
         await transaction.CommitAsync();
+
+        return renames;
+    }
+
+    private static bool IsLikelyRename(Repository oldRepo, Repository newRepo)
+    {
+        if (oldRepo.ConnectorId != newRepo.ConnectorId) return false;
+        if (!string.Equals(oldRepo.OrgName, newRepo.OrgName, StringComparison.OrdinalIgnoreCase)) return false;
+
+        if (!Uri.TryCreate(oldRepo.CloneUrl, UriKind.Absolute, out var oldUri) ||
+            !Uri.TryCreate(newRepo.CloneUrl, UriKind.Absolute, out var newUri))
+            return false;
+
+        if (!string.Equals(oldUri.Scheme, newUri.Scheme, StringComparison.OrdinalIgnoreCase)) return false;
+        if (!string.Equals(oldUri.Host, newUri.Host, StringComparison.OrdinalIgnoreCase)) return false;
+
+        var oldPath = oldUri.AbsolutePath.TrimEnd('/');
+        var newPath = newUri.AbsolutePath.TrimEnd('/');
+
+        if (oldPath.EndsWith(".git", StringComparison.OrdinalIgnoreCase)) oldPath = oldPath[..^4];
+        if (newPath.EndsWith(".git", StringComparison.OrdinalIgnoreCase)) newPath = newPath[..^4];
+
+        var oldSlash = oldPath.LastIndexOf('/');
+        var newSlash = newPath.LastIndexOf('/');
+        if (oldSlash < 0 || newSlash < 0) return false;
+
+        // Same owner/org path prefix, only the trailing repo-name segment differs
+        return string.Equals(oldPath[..oldSlash], newPath[..newSlash], StringComparison.OrdinalIgnoreCase)
+               && !string.Equals(oldPath, newPath, StringComparison.OrdinalIgnoreCase);
     }
 
     public async Task DeleteOrphanedAsync(IReadOnlyCollection<int> connectorIds)

--- a/src/GrayMoon.App/Services/GitHubRepositoryService.cs
+++ b/src/GrayMoon.App/Services/GitHubRepositoryService.cs
@@ -86,12 +86,18 @@ public class GitHubRepositoryService(
             }
         }
 
+        IReadOnlyList<RenamedRepositoryInfo> renamedRepositories = [];
         if (allFetched.Count > 0)
         {
-            await repositoryRepository.MergeRepositoriesAsync(allFetched);
+            renamedRepositories = await repositoryRepository.MergeRepositoriesAsync(allFetched);
         }
 
         var repositoriesList = await repositoryRepository.GetAllEntriesAsync();
-        return new RefreshRepositoriesResult { Repositories = repositoriesList, ConnectorErrors = connectorErrors };
+        return new RefreshRepositoriesResult
+        {
+            Repositories = repositoriesList,
+            ConnectorErrors = connectorErrors,
+            RenamedRepositories = renamedRepositories
+        };
     }
 }


### PR DESCRIPTION
### Problem

When a repository is renamed in GitHub, its clone URL changes (e.g. `github.com/org/old-name.git` → `github.com/org/new-name.git`). During **Fetch repositories**, `MergeRepositoriesAsync` uses the clone URL as the unique key, so the old record was treated as deleted and the renamed repo inserted as a brand-new row with a different `RepositoryId`. Any `WorkspaceRepositoryLink` rows referencing the original `RepositoryId` were orphaned or cascade-deleted. When EF Core still had those entities tracked in the same scoped `DbContext` (e.g. from a concurrent background PR refresh), it attempted to issue `DELETE` statements for already-gone rows, producing:

> `DbUpdateConcurrencyException: The database operation was expected to affect 1 row(s) but actually affected 0 row(s).`

The generic "Failed to fetch repositories. Please try again later." error was shown with no way to recover short of manually removing the renamed repo from all workspaces before fetching.

### Solution

**Detect renames and update in place.** A rename is identified when a "to-remove" repo and a newly-fetched repo share the same `ConnectorId`, `OrgName`, and URL host + owner-path prefix — only the trailing repo-name segment differs. Detected renames are updated in place (preserving `RepositoryId`), so all `WorkspaceRepositoryLink`, `WorkspaceRepositoryPullRequest`, `WorkspaceRepositoryAction`, and `RepositoryBranch` rows remain intact with no data loss.

Rename events are surfaced to the user as a dismissible yellow warning banner in all three fetch entry points.

### Changes

- **`RepositoryRepository.MergeRepositoriesAsync`** — Returns `IReadOnlyList<RenamedRepositoryInfo>`. Detects renames via `IsLikelyRename` (same connector + org + URL owner prefix, different name segment). Renamed repos are updated in place; only genuinely removed repos are deleted. Switched initial load to `AsNoTracking` to avoid stale EF tracker state.
- **`RefreshRepositoriesResult`** — Added `RenamedRepositories` property and `RenamedRepositoryInfo` model (`OldName`, `NewName`, `OrgName`).
- **`GitHubRepositoryService`** — Propagates `RenamedRepositories` into the result.
- **`WorkspaceRepositoriesModal`** — Added `RenameWarnings` parameter; displays a yellow alert listing each rename with old → new name when present.
- **WorkspaceRepositories.razor / `.razor.cs`** — Passes rename warnings from fetch result to the modal state.
- **Workspaces.razor** — Captures and passes rename warnings to the modal; clears them on open/close.
- **Repositories.razor** — Shows inline dismissible rename warning banner after fetch.