### PR TITLE
Show dependency level in Update and Push overlay progress messages

### DIFF
--- a/src/GrayMoon.App/Components/Shared/LoadingOverlay.razor
+++ b/src/GrayMoon.App/Components/Shared/LoadingOverlay.razor
@@ -33,7 +33,13 @@
             var messageText = idx >= 0 ? Message[..idx].Trim() : Message;
             @if (!string.IsNullOrEmpty(countdown))
             {
-                <p class="loading-overlay-countdown">@countdown</p>
+                @foreach (var countdownLine in countdown.Split('\n'))
+                {
+                    if (!string.IsNullOrWhiteSpace(countdownLine))
+                    {
+                        <p class="loading-overlay-countdown">@countdownLine.Trim()</p>
+                    }
+                }
             }
             <p class="loading-overlay-message">@messageText</p>
         }

--- a/src/GrayMoon.App/Services/DependencyUpdateOrchestrator.cs
+++ b/src/GrayMoon.App/Services/DependencyUpdateOrchestrator.cs
@@ -62,6 +62,8 @@ public sealed class DependencyUpdateOrchestrator(
             if (repoIds.Count == 0)
                 break;
 
+            Action<string> levelProgress = msg => setProgress($"{msg}\nLevel {level}");
+
             // Version files must be committed first because those commits can change
             // versions consumed by dependency updates at this and higher levels.
             if (!await UpdateAndCommitVersionFilesAsync(
@@ -69,7 +71,7 @@ public sealed class DependencyUpdateOrchestrator(
                     repoIds,
                     level,
                     cancellationToken,
-                    setProgress,
+                    levelProgress,
                     onAppSideComplete,
                     OnRepoError))
             {
@@ -84,23 +86,23 @@ public sealed class DependencyUpdateOrchestrator(
             if (reposAtLevel.Count == 0)
                 continue;
 
-            setProgress($"Updating {reposAtLevel.Count} {(reposAtLevel.Count == 1 ? "repository" : "repositories")}...");
+            levelProgress($"Updating {reposAtLevel.Count} {(reposAtLevel.Count == 1 ? "repository" : "repositories")}...");
             await workspaceGitService.SyncDependenciesAsync(
                 workspaceId,
-                onProgress: (c, t, _) => setProgress($"Syncing {c} of {t}"),
+                onProgress: (c, t, _) => levelProgress($"Syncing {c} of {t}"),
                 onRepoError: OnRepoError,
                 repoIdsToSync: repoIds,
                 cancellationToken);
             if (hadError)
                 break;
 
-            setProgress("Committing...");
+            levelProgress("Committing...");
             var commitResults = await workspaceGitService.CommitDependencyUpdatesAsync(
                 workspaceId,
                 reposAtLevel,
                 onProgress: (c, t, _) =>
                 {
-                    setProgress($"Committed {c} of {t}");
+                    levelProgress($"Committed {c} of {t}");
                     if (c == t)
                         onAppSideComplete?.Invoke();
                 },
@@ -120,7 +122,7 @@ public sealed class DependencyUpdateOrchestrator(
                     reposAtLevel.Select(r => r.RepoId).ToList(),
                     workspaceId,
                     cancellationToken,
-                    setProgress,
+                    levelProgress,
                     onAppSideComplete,
                     OnRepoError))
             {
@@ -220,7 +222,7 @@ public sealed class DependencyUpdateOrchestrator(
         Action? onAppSideComplete,
         Action<int, string> onRepoError)
     {
-        setProgress($"Updating version files in level {level}...");
+        setProgress("Updating version files...");
         var (_, _, fileError, updatedFiles) = await fileVersionService.UpdateAllVersionsAsync(
             workspaceId,
             selectedRepositoryIds: selectedRepositoryIds,
@@ -242,7 +244,7 @@ public sealed class DependencyUpdateOrchestrator(
             .Select(g => (g.Key.RepositoryId, g.Key.RepoName, (IReadOnlyList<string>)g.Select(x => x.FilePath).Distinct().ToList()))
             .ToList();
 
-        setProgress($"Committing updated versions in level {level}...");
+        setProgress("Committing updated versions...");
         var vfCommitResults = await workspaceGitService.CommitFilePathsAsync(
             workspaceId,
             byRepo,

--- a/src/GrayMoon.App/Services/WorkspacePushService.cs
+++ b/src/GrayMoon.App/Services/WorkspacePushService.cs
@@ -137,6 +137,7 @@ public sealed class WorkspacePushService(
             cancellationToken.ThrowIfCancellationRequested();
             var reposAtLevel = payload.Where(p => (p.DependencyLevel ?? 0) == level).ToList();
             if (reposAtLevel.Count == 0) continue;
+            var levelProgress = onProgressMessage == null ? (Action<string>?)null : msg => onProgressMessage($"{msg}\nLevel {level}");
 
             var requiredForLevel = reposAtLevel
                 .SelectMany(r => r.RequiredPackages)
@@ -173,7 +174,7 @@ public sealed class WorkspacePushService(
                     var remaining = deadline - DateTime.UtcNow;
                     if (remaining <= TimeSpan.Zero)
                     {
-                        onProgressMessage?.Invoke("Timed out.");
+                        levelProgress?.Invoke("Timed out.");
                         _logger.LogWarning("Push wait: timed out after {TotalMinutes:F1} min. Found {Found} of {Total}.", totalTimeout.TotalMinutes, getFoundCount(), totalDeps);
                         throw new OperationCanceledException("Push wait for dependencies timed out.");
                     }
@@ -184,7 +185,7 @@ public sealed class WorkspacePushService(
                     var totalSec = (int)remaining.TotalSeconds;
                     var mm = totalSec / 60;
                     var ss = totalSec % 60;
-                    onProgressMessage?.Invoke($"{line1}\n{mm:D2}:{ss:D2}");
+                    levelProgress?.Invoke($"{line1}\n{mm:D2}:{ss:D2}");
 
                     if ((DateTime.UtcNow - lastPollUtc).TotalSeconds >= 2)
                     {
@@ -236,12 +237,12 @@ public sealed class WorkspacePushService(
                 }
             }
 
-            onProgressMessage?.Invoke($"Pushing {reposAtLevel.Count} {(reposAtLevel.Count == 1 ? "repository" : "repositories")}...");
+            levelProgress?.Invoke($"Pushing {reposAtLevel.Count} {(reposAtLevel.Count == 1 ? "repository" : "repositories")}...");
             await PushReposAsync(
                 workspace,
                 reposAtLevel,
                 bearerByRepoId,
-                onProgressMessage,
+                levelProgress,
                 onRepoError,
                 onAppSideComplete: level == lastLevel ? null : onAppSideComplete,
                 cancellationToken);
@@ -349,8 +350,9 @@ public sealed class WorkspacePushService(
             cancellationToken.ThrowIfCancellationRequested();
             var reposAtLevel = payload.Where(p => (p.DependencyLevel ?? 0) == level).ToList();
             if (reposAtLevel.Count == 0) continue;
-            onProgressMessage?.Invoke($"Pushing {reposAtLevel.Count} {(reposAtLevel.Count == 1 ? "repository" : "repositories")}...");
-            await PushReposAsync(workspace, reposAtLevel, bearerByRepoId, onProgressMessage, onRepoError, onAppSideComplete: null, cancellationToken);
+            var levelProgress = onProgressMessage == null ? (Action<string>?)null : msg => onProgressMessage($"{msg}\nLevel {level}");
+            levelProgress?.Invoke($"Pushing {reposAtLevel.Count} {(reposAtLevel.Count == 1 ? "repository" : "repositories")}...");
+            await PushReposAsync(workspace, reposAtLevel, bearerByRepoId, levelProgress, onRepoError, onAppSideComplete: null, cancellationToken);
             await UpdateCommitCountsAndUpstreamAfterPushAsync(workspaceId, reposAtLevel, cancellationToken);
         }
 


### PR DESCRIPTION
## Summary

The loading overlay now shows the current dependency level during Update and synchronized Push operations, so it's clear which level is being processed.

## Changes

**`DependencyUpdateOrchestrator`**
- Added a `levelProgress` delegate at the start of each level iteration that prepends the current message as `{msg}\nLevel {level}`
- All progress calls inside the loop (syncing, committing, refreshing versions, updating version files) now use `levelProgress` instead of `setProgress`

**`WorkspacePushService`**
- Same pattern applied in both `RunPushAsync` (synchronized level-ordered push) and `RunPushReposInLevelOrderAsync`
- The `levelProgress` delegate is also passed through to `PushReposAsync` so per-repo counter messages (`Pushed x of y`) also carry the level context

**`LoadingOverlay`**
- The countdown section (the part after `\n` in the message) now splits on `\n` and renders each segment as its own `<p>`, preventing the timer and level label from appearing on the same line

## Example overlay output
```
Level 3
Updating 4 repositories...
```
```
Level 1
02:30
Waiting for 2 packages...
```