### PR TITLE
Add default-branch safety warning before update and push actions

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,12 +1,9 @@
 mode: ContinuousDeployment
 assembly-versioning-scheme: MajorMinorPatch
-assembly-informational-format: '{MajorMinorPatch}-{EscapedBranchName:l}.{VersionSourceDistance}'
-increment: Patch
-next-version: 0.1.0
+assembly-file-versioning-scheme: MajorMinorPatchTag
+assembly-informational-format: '{SemVer}'
+continuous-delivery-fallback-tag: main
 
 branches:
-  main:
-    regex: ^main$
-
-  unknown:
-    regex: ^(?<BranchName>.+)$
+  master:
+    regex: ^(main)$

--- a/dotnet-tools.json
+++ b/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "gitversion.tool": {
-      "version": "6.6.0",
+      "version": "5.12.0",
       "commands": [
         "dotnet-gitversion"
       ],

--- a/src/GrayMoon.Agent/GrayMoon.Agent.csproj
+++ b/src/GrayMoon.Agent/GrayMoon.Agent.csproj
@@ -32,7 +32,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="GitVersion.MsBuild" Version="6.6.0">
+		<PackageReference Include="GitVersion.MsBuild" Version="5.12.*">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/src/GrayMoon.App/Components/Modals/DefaultBranchWarningModal.razor
+++ b/src/GrayMoon.App/Components/Modals/DefaultBranchWarningModal.razor
@@ -1,0 +1,65 @@
+@using Microsoft.AspNetCore.Components.Web
+
+@if (IsVisible)
+{
+    <div class="modal show d-block" tabindex="-1" style="background-color: rgba(0,0,0,0.5);"
+         @onkeydown="HandleKeyDown"
+         @ref="_modalElement">
+        <div class="modal-dialog modal-dialog-scrollable default-branch-warning-modal">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Default Branch Warning</h5>
+                    <button type="button" class="btn-close" aria-label="Close" @onclick="OnCancel"></button>
+                </div>
+                <div class="modal-body">
+                    <p class="mb-2 small">
+                        @Message
+                    </p>
+                    <div class="default-branch-warning-scroll small mb-3">
+                        <ul class="list-unstyled mb-0 ps-0">
+                            @foreach (var item in RepoItems)
+                            {
+                                <li class="mb-1"><code>@item.RepoName</code> <span class="text-muted">(@item.DefaultBranchName)</span></li>
+                            }
+                        </ul>
+                    </div>
+                    <p class="small text-muted mb-0">
+                        The branch may be protected. Proceed with caution.
+                    </p>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-warning" @onclick="OnProceed">
+                        Proceed
+                    </button>
+                    <button type="button" class="btn btn-outline-secondary" @onclick="OnCancel">
+                        Cancel
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+}
+
+@code {
+    [Parameter] public bool IsVisible { get; set; }
+    [Parameter] public string Message { get; set; } = "";
+    [Parameter] public IReadOnlyList<(string RepoName, string DefaultBranchName)> RepoItems { get; set; } = Array.Empty<(string, string)>();
+    [Parameter] public EventCallback OnProceed { get; set; }
+    [Parameter] public EventCallback OnCancel { get; set; }
+
+    private ElementReference _modalElement;
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (IsVisible)
+            await _modalElement.FocusAsync();
+    }
+
+    private async Task HandleKeyDown(KeyboardEventArgs e)
+    {
+        if (e.Key == "Escape")
+            await OnCancel.InvokeAsync();
+        else if (e.Key == "Enter")
+            await OnProceed.InvokeAsync();
+    }
+}

--- a/src/GrayMoon.App/Components/Modals/DefaultBranchWarningModal.razor.css
+++ b/src/GrayMoon.App/Components/Modals/DefaultBranchWarningModal.razor.css
@@ -1,0 +1,40 @@
+/* Constrain dialog to viewport; modal-dialog-scrollable makes the body scroll */
+.default-branch-warning-modal {
+    max-height: calc(100vh - 2rem);
+    margin: 1rem auto;
+}
+
+.default-branch-warning-modal .modal-body {
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+}
+
+/* Scrollable repo list */
+.default-branch-warning-scroll {
+    flex: 0 1 auto;
+    font-size: 0.875rem;
+    max-height: 12rem;
+    overflow-y: auto;
+    overflow-x: hidden;
+    scrollbar-width: auto;
+    scrollbar-color: #6c757d transparent;
+}
+
+.default-branch-warning-scroll::-webkit-scrollbar {
+    width: 0.6rem;
+    height: 0.6rem;
+}
+
+.default-branch-warning-scroll::-webkit-scrollbar-track {
+    background: transparent;
+}
+
+.default-branch-warning-scroll::-webkit-scrollbar-thumb {
+    background: #6c757d;
+    border-radius: 0.3rem;
+}
+
+.default-branch-warning-scroll::-webkit-scrollbar-thumb:hover {
+    background: #5a6268;
+}

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor
@@ -229,6 +229,12 @@
               OnConfirm="@OnConfirmModalYesAsync"
               OnCancel="@CloseConfirmModal" />
 
+<DefaultBranchWarningModal IsVisible="@_defaultBranchWarningModal.IsVisible"
+                           Message="@_defaultBranchWarningModal.Message"
+                           RepoItems="@_defaultBranchWarningModal.RepoItems"
+                           OnProceed="@OnDefaultBranchWarningProceedAsync"
+                           OnCancel="@CloseDefaultBranchWarningModal" />
+
 <LoadingOverlay IsVisible="@isLoading" Message="Loading workspace..." />
 <LoadingOverlay IsVisible="@isSyncing"
                 Message="@GetOverlayMessage(syncProgressMessage, isSyncing, _syncAwaitingAgentTasks)"

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
@@ -95,6 +95,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
     private UpdateSingleRepoDependenciesModalState _updateSingleRepoModal = new();
     private PushWithDependenciesModalState _pushWithDependenciesModal = new();
     private ConfirmModalState _confirmModal = new();
+    private DefaultBranchWarningModalState _defaultBranchWarningModal = new();
     private string searchTerm = string.Empty;
 
     private bool _syncAwaitingAgentTasks;
@@ -535,6 +536,36 @@ public sealed partial class WorkspaceRepositories : IDisposable
         StateHasChanged();
     }
 
+    private void ShowDefaultBranchWarning(string message, IReadOnlyList<(string RepoName, string DefaultBranchName)> repoItems, Func<Task> onProceed)
+    {
+        _defaultBranchWarningModal = _defaultBranchWarningModal with
+        {
+            IsVisible = true,
+            Message = message,
+            RepoItems = repoItems,
+            PendingAction = onProceed,
+        };
+        StateHasChanged();
+    }
+
+    private void CloseDefaultBranchWarningModal()
+    {
+        _defaultBranchWarningModal = _defaultBranchWarningModal with
+        {
+            IsVisible = false,
+            PendingAction = null,
+        };
+        StateHasChanged();
+    }
+
+    private async Task OnDefaultBranchWarningProceedAsync()
+    {
+        var action = _defaultBranchWarningModal.PendingAction;
+        CloseDefaultBranchWarningModal();
+        if (action != null)
+            await action();
+    }
+
 
     private void ShowConfirmOpenPr(IEnumerable<WorkspaceRepositoryLink> group)
     {
@@ -702,20 +733,38 @@ public sealed partial class WorkspaceRepositories : IDisposable
             }
             var repoPayload = payload[0];
             var repoName = workspaceRepositories.FirstOrDefault(wr => wr.RepositoryId == repositoryId)?.Repository?.RepositoryName;
-            _updateSingleRepoModal = _updateSingleRepoModal with
+
+            var repo = workspaceRepositories.FirstOrDefault(wr => wr.RepositoryId == repositoryId);
+            if (repo != null
+                && !string.IsNullOrWhiteSpace(repo.DefaultBranchName)
+                && string.Equals(repo.BranchName, repo.DefaultBranchName, StringComparison.Ordinal))
             {
-                IsVisible = true,
-                Payload = repoPayload,
-                RepositoryId = repositoryId,
-                RepoName = repoName
-            };
-            await InvokeAsync(StateHasChanged);
+                ShowDefaultBranchWarning(
+                    "The following repository is on its default branch. Updating dependencies will commit changes directly to the default (protected) branch.",
+                    new[] { (repoName ?? $"repo {repositoryId}", repo.DefaultBranchName!) },
+                    () => OpenUpdateSingleRepoModalAsync(repoPayload, repositoryId, repoName));
+                return;
+            }
+
+            await OpenUpdateSingleRepoModalAsync(repoPayload, repositoryId, repoName);
         }
         catch (Exception ex)
         {
             Logger.LogError(ex, "Error getting update plan for repository {RepositoryId}", repositoryId);
             ToastService.Show("Could not load dependency updates.");
         }
+    }
+
+    private async Task OpenUpdateSingleRepoModalAsync(SyncDependenciesRepoPayload repoPayload, int repositoryId, string? repoName)
+    {
+        _updateSingleRepoModal = _updateSingleRepoModal with
+        {
+            IsVisible = true,
+            Payload = repoPayload,
+            RepositoryId = repositoryId,
+            RepoName = repoName
+        };
+        await InvokeAsync(StateHasChanged);
     }
 
     private void CloseUpdateSingleRepositoryDependenciesModal()
@@ -788,6 +837,24 @@ public sealed partial class WorkspaceRepositories : IDisposable
         if (workspace == null || isPushing || isSyncing || isUpdating)
             return;
 
+        var repo = workspaceRepositories.FirstOrDefault(r => r.RepositoryId == repositoryId);
+        if (repo != null
+            && !string.IsNullOrWhiteSpace(repo.DefaultBranchName)
+            && string.Equals(repo.BranchName, repo.DefaultBranchName, StringComparison.Ordinal))
+        {
+            var repoName = repo.Repository?.RepositoryName ?? $"repo {repositoryId}";
+            ShowDefaultBranchWarning(
+                "The following repository is on its default branch. Pushing will commit directly to the default (protected) branch.",
+                new[] { (repoName, repo.DefaultBranchName!) },
+                () => PushBadgeClickCoreAsync(repositoryId, branchName));
+            return;
+        }
+
+        await PushBadgeClickCoreAsync(repositoryId, branchName);
+    }
+
+    private async Task PushBadgeClickCoreAsync(int repositoryId, string? branchName)
+    {
         try
         {
             var repoIdsThatNeedPush = workspaceRepositories
@@ -1036,6 +1103,28 @@ public sealed partial class WorkspaceRepositories : IDisposable
         if (workspace == null || workspaceRepositories.Count == 0 || isUpdating || isSyncing)
             return;
 
+        var reposOnDefault = workspaceRepositories
+            .Where(wr => !string.IsNullOrWhiteSpace(wr.DefaultBranchName)
+                && string.Equals(wr.BranchName, wr.DefaultBranchName, StringComparison.Ordinal))
+            .ToList();
+
+        if (reposOnDefault.Count > 0)
+        {
+            var repoItems = reposOnDefault
+                .Select(wr => (wr.Repository?.RepositoryName ?? $"repo {wr.RepositoryId}", wr.DefaultBranchName!))
+                .ToList();
+            ShowDefaultBranchWarning(
+                "The following repositories are on their default branch. Update will commit dependency changes directly to the default (protected) branch.",
+                repoItems,
+                OpenUpdateModalAsync);
+            return;
+        }
+
+        await OpenUpdateModalAsync();
+    }
+
+    private async Task OpenUpdateModalAsync()
+    {
         try
         {
             _updateModal = _updateModal with
@@ -2289,6 +2378,14 @@ public sealed partial class WorkspaceRepositories : IDisposable
         public bool IsVisible { get; init; }
         public string Message { get; init; } = "";
         public string ButtonText { get; init; } = "Yes";
+        public Func<Task>? PendingAction { get; init; }
+    }
+
+    private sealed record DefaultBranchWarningModalState
+    {
+        public bool IsVisible { get; init; }
+        public string Message { get; init; } = "";
+        public IReadOnlyList<(string RepoName, string DefaultBranchName)> RepoItems { get; init; } = Array.Empty<(string, string)>();
         public Func<Task>? PendingAction { get; init; }
     }
 

--- a/src/GrayMoon.App/Components/Shared/LoadingOverlay.razor
+++ b/src/GrayMoon.App/Components/Shared/LoadingOverlay.razor
@@ -33,7 +33,13 @@
             var messageText = idx >= 0 ? Message[..idx].Trim() : Message;
             @if (!string.IsNullOrEmpty(countdown))
             {
-                <p class="loading-overlay-countdown">@countdown</p>
+                @foreach (var countdownLine in countdown.Split('\n'))
+                {
+                    if (!string.IsNullOrWhiteSpace(countdownLine))
+                    {
+                        <p class="loading-overlay-countdown">@countdownLine.Trim()</p>
+                    }
+                }
             }
             <p class="loading-overlay-message">@messageText</p>
         }

--- a/src/GrayMoon.App/GrayMoon.App.csproj
+++ b/src/GrayMoon.App/GrayMoon.App.csproj
@@ -25,7 +25,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.11" />
-    <PackageReference Include="GitVersion.MsBuild" Version="6.6.0">
+    <PackageReference Include="GitVersion.MsBuild" Version="5.12.*">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/GrayMoon.App/Services/DependencyUpdateOrchestrator.cs
+++ b/src/GrayMoon.App/Services/DependencyUpdateOrchestrator.cs
@@ -62,6 +62,8 @@ public sealed class DependencyUpdateOrchestrator(
             if (repoIds.Count == 0)
                 break;
 
+            Action<string> levelProgress = msg => setProgress($"{msg}\nLevel {level}");
+
             // Version files must be committed first because those commits can change
             // versions consumed by dependency updates at this and higher levels.
             if (!await UpdateAndCommitVersionFilesAsync(
@@ -69,7 +71,7 @@ public sealed class DependencyUpdateOrchestrator(
                     repoIds,
                     level,
                     cancellationToken,
-                    setProgress,
+                    levelProgress,
                     onAppSideComplete,
                     OnRepoError))
             {
@@ -84,23 +86,23 @@ public sealed class DependencyUpdateOrchestrator(
             if (reposAtLevel.Count == 0)
                 continue;
 
-            setProgress($"Updating {reposAtLevel.Count} {(reposAtLevel.Count == 1 ? "repository" : "repositories")}...");
+            levelProgress($"Updating {reposAtLevel.Count} {(reposAtLevel.Count == 1 ? "repository" : "repositories")}...");
             await workspaceGitService.SyncDependenciesAsync(
                 workspaceId,
-                onProgress: (c, t, _) => setProgress($"Syncing {c} of {t}"),
+                onProgress: (c, t, _) => levelProgress($"Syncing {c} of {t}"),
                 onRepoError: OnRepoError,
                 repoIdsToSync: repoIds,
                 cancellationToken);
             if (hadError)
                 break;
 
-            setProgress("Committing...");
+            levelProgress("Committing...");
             var commitResults = await workspaceGitService.CommitDependencyUpdatesAsync(
                 workspaceId,
                 reposAtLevel,
                 onProgress: (c, t, _) =>
                 {
-                    setProgress($"Committed {c} of {t}");
+                    levelProgress($"Committed {c} of {t}");
                     if (c == t)
                         onAppSideComplete?.Invoke();
                 },
@@ -120,7 +122,7 @@ public sealed class DependencyUpdateOrchestrator(
                     reposAtLevel.Select(r => r.RepoId).ToList(),
                     workspaceId,
                     cancellationToken,
-                    setProgress,
+                    levelProgress,
                     onAppSideComplete,
                     OnRepoError))
             {
@@ -220,7 +222,7 @@ public sealed class DependencyUpdateOrchestrator(
         Action? onAppSideComplete,
         Action<int, string> onRepoError)
     {
-        setProgress($"Updating version files in level {level}...");
+        setProgress("Updating version files...");
         var (_, _, fileError, updatedFiles) = await fileVersionService.UpdateAllVersionsAsync(
             workspaceId,
             selectedRepositoryIds: selectedRepositoryIds,
@@ -242,7 +244,7 @@ public sealed class DependencyUpdateOrchestrator(
             .Select(g => (g.Key.RepositoryId, g.Key.RepoName, (IReadOnlyList<string>)g.Select(x => x.FilePath).Distinct().ToList()))
             .ToList();
 
-        setProgress($"Committing updated versions in level {level}...");
+        setProgress("Committing updated versions...");
         var vfCommitResults = await workspaceGitService.CommitFilePathsAsync(
             workspaceId,
             byRepo,

--- a/src/GrayMoon.App/Services/WorkspacePushService.cs
+++ b/src/GrayMoon.App/Services/WorkspacePushService.cs
@@ -137,6 +137,7 @@ public sealed class WorkspacePushService(
             cancellationToken.ThrowIfCancellationRequested();
             var reposAtLevel = payload.Where(p => (p.DependencyLevel ?? 0) == level).ToList();
             if (reposAtLevel.Count == 0) continue;
+            var levelProgress = onProgressMessage == null ? (Action<string>?)null : msg => onProgressMessage($"{msg}\nLevel {level}");
 
             var requiredForLevel = reposAtLevel
                 .SelectMany(r => r.RequiredPackages)
@@ -173,7 +174,7 @@ public sealed class WorkspacePushService(
                     var remaining = deadline - DateTime.UtcNow;
                     if (remaining <= TimeSpan.Zero)
                     {
-                        onProgressMessage?.Invoke("Timed out.");
+                        levelProgress?.Invoke("Timed out.");
                         _logger.LogWarning("Push wait: timed out after {TotalMinutes:F1} min. Found {Found} of {Total}.", totalTimeout.TotalMinutes, getFoundCount(), totalDeps);
                         throw new OperationCanceledException("Push wait for dependencies timed out.");
                     }
@@ -184,7 +185,7 @@ public sealed class WorkspacePushService(
                     var totalSec = (int)remaining.TotalSeconds;
                     var mm = totalSec / 60;
                     var ss = totalSec % 60;
-                    onProgressMessage?.Invoke($"{line1}\n{mm:D2}:{ss:D2}");
+                    levelProgress?.Invoke($"{line1}\n{mm:D2}:{ss:D2}");
 
                     if ((DateTime.UtcNow - lastPollUtc).TotalSeconds >= 2)
                     {
@@ -236,12 +237,12 @@ public sealed class WorkspacePushService(
                 }
             }
 
-            onProgressMessage?.Invoke($"Pushing {reposAtLevel.Count} {(reposAtLevel.Count == 1 ? "repository" : "repositories")}...");
+            levelProgress?.Invoke($"Pushing {reposAtLevel.Count} {(reposAtLevel.Count == 1 ? "repository" : "repositories")}...");
             await PushReposAsync(
                 workspace,
                 reposAtLevel,
                 bearerByRepoId,
-                onProgressMessage,
+                levelProgress,
                 onRepoError,
                 onAppSideComplete: level == lastLevel ? null : onAppSideComplete,
                 cancellationToken);
@@ -349,8 +350,9 @@ public sealed class WorkspacePushService(
             cancellationToken.ThrowIfCancellationRequested();
             var reposAtLevel = payload.Where(p => (p.DependencyLevel ?? 0) == level).ToList();
             if (reposAtLevel.Count == 0) continue;
-            onProgressMessage?.Invoke($"Pushing {reposAtLevel.Count} {(reposAtLevel.Count == 1 ? "repository" : "repositories")}...");
-            await PushReposAsync(workspace, reposAtLevel, bearerByRepoId, onProgressMessage, onRepoError, onAppSideComplete: null, cancellationToken);
+            var levelProgress = onProgressMessage == null ? (Action<string>?)null : msg => onProgressMessage($"{msg}\nLevel {level}");
+            levelProgress?.Invoke($"Pushing {reposAtLevel.Count} {(reposAtLevel.Count == 1 ? "repository" : "repositories")}...");
+            await PushReposAsync(workspace, reposAtLevel, bearerByRepoId, levelProgress, onRepoError, onAppSideComplete: null, cancellationToken);
             await UpdateCommitCountsAndUpstreamAfterPushAsync(workspaceId, reposAtLevel, cancellationToken);
         }
 


### PR DESCRIPTION
## Summary
Adds a safeguard to prevent accidental commits to default/protected branches by requiring explicit confirmation before risky actions proceed.

## What changed
- Added a dedicated default-branch warning modal with:
  - Yellow `Proceed` action button
  - Scrollable repository list so the dialog stays within viewport
  - Repository + default branch display for clear impact visibility
- Wired warning checks into:
  - Workspace `Update` action
  - Single-repository push badge action
  - Dependency badge flow (before dependency-update commit path)
- Reused centralized modal state and callback handling so each action only continues after explicit confirmation.

## Behavior
- If target repo(s) are on their default branch, user sees warning first.
- User must choose `Proceed` to continue, otherwise action is canceled.
- Works for both single-repo and multi-repo update scenarios.
