### PR TITLE
GitHub Actions: multi-workflow workspace grid, live run terminal, and manual run/cancel

### DIFF
--- a/.cursor/plans/multi-workflow_actions_grid_b201ec86.plan.md
+++ b/.cursor/plans/multi-workflow_actions_grid_b201ec86.plan.md
@@ -1,0 +1,116 @@
+---
+name: Multi-workflow actions grid
+overview: Replace the single aggregated workflow per repository with one row per GitHub Actions workflow (name, status, run/dispatch), keep repository and branch only on the first row of each repo group, drop “Last checked”, and replace Bootstrap striping with per-repository group backgrounds so continuation rows match.
+todos:
+  - id: github-workflows-connector
+    content: Add connector-scoped GetWorkflowsAsync on GitHubService; implement GetWorkflowStatusesForBranchAsync (list workflows + latest run per workflow) in GitHubActionsService; wire WorkspaceActionService fetch to return list.
+    status: completed
+  - id: persistence-json
+    content: Add WorkflowsJson column + migration; extend WorkspaceRepositoryAction and WorkspaceActionRepository read/write with JSON list + legacy fallback.
+    status: completed
+  - id: workspace-row-model
+    content: Refactor WorkspaceActionRow to per-workflow lines with per-line RunInProgress; update refresh, auto-poll, rerun-all, counts, sort, and sync/branch invalidation.
+    status: completed
+  - id: razor-css-grid
+    content: "Update WorkspaceActions.razor: Workflow column, remove Last checked, nested loops with empty repo/branch cells, group striping classes; adjust WorkspaceActions.razor.css and remove table-striped."
+    status: completed
+isProject: false
+---
+
+# Multi-workflow workspace actions grid
+
+## Current behavior (problem)
+
+- [`GitHubActionsService.GetAggregateActionStatusForBranchAsync`](src/GrayMoon.App/Services/GitHubActionsService.cs) loads all runs for the branch, groups by `WorkflowId`, then **picks one “primary” run** and returns a single [`ActionStatusInfo`](src/GrayMoon.App/Models/ActionStatusInfo.cs). The UI in [`WorkspaceActions.razor`](src/GrayMoon.App/Components/Pages/WorkspaceActions.razor) / [`WorkspaceActions.razor.cs`](src/GrayMoon.App/Components/Pages/WorkspaceActions.razor.cs) binds one status and one Run/Re-run button to that aggregate.
+- Persistence in [`WorkspaceActionRepository`](src/GrayMoon.App/Repositories/WorkspaceActionRepository.cs) / [`WorkspaceRepositoryAction`](src/GrayMoon.App/Models/WorkspaceRepositoryAction.cs) is **one row per workspace–repository link**, storing only one workflow’s fields.
+
+## Target behavior
+
+- **Workflow column**: show each workflow’s display name (from GitHub’s workflow list, consistent with run names).
+- **Remove “Last checked”** column entirely (colspan and table header).
+- **Per-workflow status and actions**: each workflow line uses that workflow’s latest run on the branch for status/link; **Run** uses that workflow’s `WorkflowId`; **Re-run** uses that run’s `RunId` when failed.
+- **Repository / branch**: show only on the **first** `<tr>` for a repo; subsequent workflow lines use **empty** `<td>` for those columns (same table grid, no `rowspan` unless you prefer it later).
+- **Striping**: remove `table-striped` and apply **one background per repository group** (first + continuation rows share the same class), matching your option “sub-rows same bg as the first” / “colors only change when new repository.” Implement via CSS classes (e.g. `actions-group-0` / `actions-group-1`) in [`WorkspaceActions.razor.css`](src/GrayMoon.App/Components/Pages/WorkspaceActions.razor.css), with colors that work on the existing table body (avoid hard-coded light-only grays if the app supports dark tables; prefer `rgba` overlays or Bootstrap CSS variables where possible).
+- **Header counts** (`FailedCount`, `RunningCount`, etc.): count **workflow lines**, not repos, so badges stay meaningful.
+- **Sorting**: sort **repository groups** by worst status across their workflows (failed &lt; running &lt; success &lt; none), same priority as today’s `GetStatusSortOrder`; stable secondary sort by repo name.
+- **Errors** (GitHub fetch failure): treat as **repo-level**; show [`ActionBadge`](src/GrayMoon.App/Components/Shared/ActionBadge.razor) with `ErrorMessage` only on the **first** line of the group; other lines get no duplicate error badge (empty status or “—” as you prefer).
+
+## Backend / GitHub API
+
+1. **List workflows with the same auth as other workspace actions**  
+   [`GitHubService.GetWorkflowsAsync(string owner, string repo)`](src/GrayMoon.App/Services/GitHubService.cs) uses the global PAT (`EnsureConfigured`) and is **unused** today. Add **`GetWorkflowsAsync(Connector connector, string owner, string repo)`** mirroring `GetWorkflowRunsForBranchAsync` (connector-scoped `GetAsync`), and use it from the actions path so multi-connector setups stay correct.
+
+2. **New service method** (name TBD, e.g. `GetWorkflowStatusesForBranchAsync`) in [`GitHubActionsService`](src/GrayMoon.App/Services/GitHubActionsService.cs):
+   - Load **active** workflows for the repo (filter `State == "active"` when present).
+   - Load branch runs via existing `GetWorkflowRunsForBranchAsync`.
+   - Build **latest run per `WorkflowId`** (reuse the existing grouping logic).
+   - For **each** listed workflow (sorted by name): emit an `ActionStatusInfo` with `BranchName = branch`, `WorkflowId` / `WorkflowName` from the workflow definition, and if a latest run exists set `Status` / `HtmlUrl` / `UpdatedAt` / `RunId` from **that run only** (map conclusion/status using the same rules as today: failure conclusions → `failed`, non-completed → `running`, else `success`; no run → `none`).
+   - Optionally include runs whose `WorkflowId` is **not** in the workflow list (deleted/renamed workflow files) as extra rows—nice-to-have, not required for the first iteration.
+
+3. **Deprecate or narrow** `GetAggregateActionStatusForBranchAsync`: either remove if unused after the change or keep as a thin wrapper only if something else needs it (today only [`WorkspaceActionService`](src/GrayMoon.App/Services/WorkspaceActionService.cs) calls it).
+
+## Persistence
+
+- Add nullable **`WorkflowsJson`** (`TEXT`) on `WorkspaceRepositoryActions` via a new idempotent migration in [`Migrations.cs`](src/GrayMoon.App/Migrations.cs) + property on [`WorkspaceRepositoryAction`](src/GrayMoon.App/Models/WorkspaceRepositoryAction.cs) + [`AppDbContext`](src/GrayMoon.App/Data/AppDbContext.cs) config (max length optional for SQLite).
+- Serialize **`List<ActionStatusInfo>`** (or a small DTO with the same fields) with `System.Text.Json`.
+- **Read path** in [`WorkspaceActionRepository.GetByWorkspaceIdAsync`](src/GrayMoon.App/Repositories/WorkspaceActionRepository.cs): if `WorkflowsJson` is present, deserialize; else **fallback** to legacy single-row columns via existing `ToActionStatusInfo()` as a **one-element list** so existing DB rows keep working.
+- **Write path** in `UpsertAsync`: accept the list + branch; store JSON; optionally clear or mirror legacy scalar columns for compatibility (simplest: **populate JSON as source of truth** and leave legacy columns null on new writes, still readable via fallback for old rows only).
+
+## Workspace UI state model
+
+- Extend [`WorkspaceActionRow`](src/GrayMoon.App/Components/Pages/WorkspaceActions.razor.cs) with a **`List<WorkflowActionLine>`** (name TBD) holding `ActionStatusInfo` (or equivalent) and **`RunInProgress` per workflow** (move off the repo row).
+- Replace repo-level `Action` with the list (or keep `Action` only during transition—prefer removing to avoid ambiguity).
+- **`RefreshRowAsync`**: call updated `FetchAndPersistAsync` that returns `IReadOnlyList<ActionStatusInfo>`, assign to the row’s lines.
+- **`RunWorkflowAsync` / `RerunWorkflowAsync`**: take the **line** (or `workflowId` + row) so `BuildActionEntry` uses **that** workflow’s ids; after success, refresh the **whole repo** row once (same as today).
+- **`RerunAllFailedAsync`**: iterate **failed workflow lines** that have `RunId`, not one row per repo.
+- **Auto-poll** (`AutoPollLoopAsync`): treat “running” as **any** workflow line on the repo with `running` status (same refresh as today).
+- **`RefreshFromSyncAsync` / branch change**: clear all workflow lines when branch changes (same invalidation as today).
+
+## Razor / CSS
+
+- Table columns: **Repository | Branch | Workflow | Status | Actions** (drop Last checked; [`WorkspaceActions.razor.css`](src/GrayMoon.App/Components/Pages/WorkspaceActions.razor.css) already defines `.col-workflow`—wire it to the new column and rebalance widths vs `.col-repo`).
+- Remove `table-striped` from the `<table>` class list; add **group index** classes on each `<tr>`.
+- Adjust **colspan** for loading/empty rows from 5 → **4**.
+
+## Data flow (high level)
+
+```mermaid
+flowchart LR
+  subgraph ui [WorkspaceActions]
+    Row[WorkspaceActionRow]
+    Lines[Workflow lines]
+    Row --> Lines
+  end
+  subgraph svc [WorkspaceActionService]
+    Fetch[FetchAndPersistAsync]
+  end
+  subgraph gh [GitHubActionsService]
+    ListWf[List workflows]
+    ListRuns[Runs for branch]
+    Merge[Merge per WorkflowId]
+  end
+  subgraph db [WorkspaceActionRepository]
+    Json[WorkflowsJson]
+  end
+  Fetch --> ListWf
+  Fetch --> ListRuns
+  ListWf --> Merge
+  ListRuns --> Merge
+  Fetch --> Json
+  Json --> Row
+```
+
+## Files to touch (expected)
+
+- [`src/GrayMoon.App/Components/Pages/WorkspaceActions.razor`](src/GrayMoon.App/Components/Pages/WorkspaceActions.razor)
+- [`src/GrayMoon.App/Components/Pages/WorkspaceActions.razor.cs`](src/GrayMoon.App/Components/Pages/WorkspaceActions.razor.cs)
+- [`src/GrayMoon.App/Components/Pages/WorkspaceActions.razor.css`](src/GrayMoon.App/Components/Pages/WorkspaceActions.razor.css)
+- [`src/GrayMoon.App/Services/GitHubActionsService.cs`](src/GrayMoon.App/Services/GitHubActionsService.cs)
+- [`src/GrayMoon.App/Services/GitHubService.cs`](src/GrayMoon.App/Services/GitHubService.cs)
+- [`src/GrayMoon.App/Services/WorkspaceActionService.cs`](src/GrayMoon.App/Services/WorkspaceActionService.cs)
+- [`src/GrayMoon.App/Repositories/WorkspaceActionRepository.cs`](src/GrayMoon.App/Repositories/WorkspaceActionRepository.cs)
+- [`src/GrayMoon.App/Models/WorkspaceRepositoryAction.cs`](src/GrayMoon.App/Models/WorkspaceRepositoryAction.cs)
+- [`src/GrayMoon.App/Data/AppDbContext.cs`](src/GrayMoon.App/Data/AppDbContext.cs)
+- [`src/GrayMoon.App/Migrations.cs`](src/GrayMoon.App/Migrations.cs)
+
+No architecture doc update is required unless you want the design doc table refreshed (you asked to avoid extra markdown unless needed).

--- a/src/GrayMoon.App/Components/Pages/Settings.razor
+++ b/src/GrayMoon.App/Components/Pages/Settings.razor
@@ -74,9 +74,9 @@
                         <i class="bi bi-terminal" aria-hidden="true"></i>
                     </div>
                     <div>
-                        <h5 class="mb-1">Loading overlay &amp; command terminal</h5>
+                        <h5 class="mb-1">Terminal color</h5>
                         <p class="text-muted small mb-0">
-                            Changes save immediately. Only command lines and standard output tint switch between green and yellow; errors stay red.
+                            Changes save immediately. Applies to the loading-overlay command log and the live GitHub Actions terminal on workspace Actions. Only command lines and standard output tint switch between green and yellow; errors stay red.
                         </p>
                     </div>
                 </div>
@@ -85,7 +85,7 @@
                 <div class="row g-4">
                     <div class="col-12">
                         <fieldset class="border-0 m-0 p-0">
-                            <legend class="form-label fw-semibold text-uppercase small text-muted mb-3 letter-spacing-tight">Behavior</legend>
+                            <legend class="form-label fw-semibold text-uppercase small text-muted mb-3 letter-spacing-tight">Overlay behaviour</legend>
                             <div class="row g-3">
                                 <div class="col-12 col-lg-6">
                                     <label class="d-flex justify-content-between align-items-start gap-3 p-3 rounded-3 settings-terminal-card__row settings-terminal-card__row--clickable h-100 mb-0" for="terminalShowByDefault">

--- a/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor
@@ -118,8 +118,13 @@
                                         {
                                             var line = displayLines[li];
                                             var firstLine = li == 0;
-                                            var isLastInRepo = li == displayLines.Count - 1;
-                                            var trClass = $"{stripeClass} actions-data-row" + (isLastInRepo ? " actions-row-repo-end" : "") + (firstLine && row.ErrorMessage != null ? " actions-error-row" : "");
+                                            var isLastWorkflowLineInRepo = li == displayLines.Count - 1;
+                                            var showGhaTerminal = string.IsNullOrWhiteSpace(row.ErrorMessage)
+                                                && IsLineRunningForBranch(row, line)
+                                                && (line.Action?.RunId ?? 0) > 0;
+                                            var repoEndOnDataRow = isLastWorkflowLineInRepo && !showGhaTerminal;
+                                            var repoEndOnGhaRow = isLastWorkflowLineInRepo && showGhaTerminal;
+                                            var trClass = $"{stripeClass} actions-data-row" + (repoEndOnDataRow ? " actions-row-repo-end" : "") + (firstLine && row.ErrorMessage != null ? " actions-error-row" : "");
                                             <tr class="@trClass">
                                                 <td class="col-repo">
                                                     @if (firstLine)
@@ -153,7 +158,16 @@
                                                 <td class="col-workflow">
                                                     @if (!string.IsNullOrWhiteSpace(line.Action?.WorkflowName))
                                                     {
-                                                        <span class="text-muted">@line.Action!.WorkflowName</span>
+                                                        var workflowUrl = GetWorkflowPageUrl(row, line);
+                                                        @if (!string.IsNullOrWhiteSpace(workflowUrl))
+                                                        {
+                                                            <a href="@workflowUrl" target="_blank" rel="noopener noreferrer"
+                                                               class="actions-workflow-link" title="Open workflow on GitHub">@line.Action!.WorkflowName</a>
+                                                        }
+                                                        else
+                                                        {
+                                                            <span class="text-muted">@line.Action!.WorkflowName</span>
+                                                        }
                                                     }
                                                     else
                                                     {
@@ -200,8 +214,8 @@
                                                         {
                                                             <button class="btn btn-outline-primary action-run-btn"
                                                                     @onclick="() => RunWorkflowAsync(row, line)"
-                                                                    disabled="@line.RunInProgress"
-                                                                    title="Run workflow: @line.Action?.WorkflowName">
+                                                                    disabled="@IsRunWorkflowBusy(row, line)"
+                                                                    title="@(IsLineRunningForBranch(row, line) ? "This workflow is already running for this branch." : $"Run workflow: {line.Action?.WorkflowName}")">
                                                                 @if (line.RunInProgress)
                                                                 {
                                                                     <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
@@ -215,6 +229,19 @@
                                                     }
                                                 </td>
                                             </tr>
+                                            @if (showGhaTerminal)
+                                            {
+                                                <tr class="@($"{stripeClass} actions-gha-feed-row actions-data-row{(repoEndOnGhaRow ? " actions-row-repo-end" : "")}")">
+                                                    <td colspan="5" class="p-0 border-0">
+                                                        <GhaWorkflowLiveTerminal @key="@($"{row.Repo.RepositoryId}-{(line.Action?.WorkflowId ?? 0)}-{(line.Action?.RunId ?? 0)}")"
+                                                                                 ConnectorName="@row.Repo.ConnectorName"
+                                                                                 Owner="@(row.Repo.OrgName ?? "")"
+                                                                                 RepositoryName="@row.Repo.RepositoryName"
+                                                                                 RunId="@(line.Action!.RunId!.Value)"
+                                                                                 WorkflowDisplayName="@line.Action.WorkflowName" />
+                                                    </td>
+                                                </tr>
+                                            }
                                         }
 
                                         groupIndex++;

--- a/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor
@@ -113,10 +113,13 @@
                                     @foreach (var row in rows.OrderBy(GetStatusSortOrder).ThenBy(r => r.Repo.RepositoryName, System.StringComparer.OrdinalIgnoreCase))
                                     {
                                         var stripeClass = GroupStripeClass(groupIndex);
-                                        var firstLine = true;
-                                        @foreach (var line in LinesForDisplay(row))
+                                        var displayLines = LinesForDisplay(row).ToList();
+                                        @for (var li = 0; li < displayLines.Count; li++)
                                         {
-                                            var trClass = stripeClass + (firstLine && row.ErrorMessage != null ? " actions-error-row" : "");
+                                            var line = displayLines[li];
+                                            var firstLine = li == 0;
+                                            var isLastInRepo = li == displayLines.Count - 1;
+                                            var trClass = $"{stripeClass} actions-data-row" + (isLastInRepo ? " actions-row-repo-end" : "") + (firstLine && row.ErrorMessage != null ? " actions-error-row" : "");
                                             <tr class="@trClass">
                                                 <td class="col-repo">
                                                     @if (firstLine)
@@ -212,7 +215,6 @@
                                                     }
                                                 </td>
                                             </tr>
-                                            firstLine = false;
                                         }
 
                                         groupIndex++;

--- a/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor
@@ -80,12 +80,12 @@
             <div class="card page-card mb-4">
                 <div class="card-body p-0">
                     <div class="table-responsive">
-                        <table class="table table-striped table-hover mb-0 actions-table resizable-columns">
+                        <table class="table table-hover mb-0 actions-table resizable-columns">
                             <thead class="table-dark">
                                 <tr>
                                     <th class="col-repo">Repository</th>
                                     <th class="col-branch">Branch</th>
-                                    <th class="col-updated">Last checked</th>
+                                    <th class="col-workflow">Workflow</th>
                                     <th class="col-action-status">Status</th>
                                     <th class="col-actions">Actions</th>
                                 </tr>
@@ -109,78 +109,113 @@
                                 }
                                 else
                                 {
-                                    @foreach (var row in rows.OrderBy(GetStatusSortOrder))
+                                    var groupIndex = 0;
+                                    @foreach (var row in rows.OrderBy(GetStatusSortOrder).ThenBy(r => r.Repo.RepositoryName, System.StringComparer.OrdinalIgnoreCase))
                                     {
-                                        var effectiveAction = GetEffectiveAction(row);
-                                        <tr>
-                                            <td class="col-repo">
-                                                @{
-                                                    var repoUrl = GrayMoon.App.Services.RepositoryUrlHelper.GetRepositoryUrl(row.Repo.CloneUrl);
-                                                }
-                                                @if (!string.IsNullOrWhiteSpace(repoUrl))
-                                                {
-                                                    <a href="@repoUrl" target="_blank" rel="noopener noreferrer" class="repo-link">
-                                                        <strong>@row.Repo.RepositoryName</strong>
-                                                    </a>
-                                                }
-                                                else
-                                                {
-                                                    <strong>@row.Repo.RepositoryName</strong>
-                                                }
-                                            </td>
-                                            <td class="col-branch">
-                                                @if (!string.IsNullOrWhiteSpace(row.Link.BranchName))
-                                                {
-                                                    <span class="text-muted">@row.Link.BranchName</span>
-                                                }
-                                                else
-                                                {
-                                                    <span class="text-muted">-</span>
-                                                }
-                                            </td>
-                                            <td class="col-updated text-muted">
-                                                @(effectiveAction?.UpdatedAt?.ToLocalTime().ToString("g") ?? "-")
-                                            </td>
-                                            <td class="col-action-status text-center">
-                                                <ActionBadge Status="@(effectiveAction?.Status)"
-                                                             HtmlUrl="@effectiveAction?.HtmlUrl"
-                                                             ErrorMessage="@row.ErrorMessage" />
-                                            </td>
-                                            <td class="col-actions ps-3">
-                                                @if (CanRerun(row))
-                                                {
-                                                    <button class="btn btn-outline-primary action-run-btn"
-                                                            @onclick="() => RerunWorkflowAsync(row)"
-                                                            disabled="@row.RunInProgress"
-                                                            title="Re-run failed workflow: @row.Action?.WorkflowName">
-                                                        @if (row.RunInProgress)
+                                        var stripeClass = GroupStripeClass(groupIndex);
+                                        var firstLine = true;
+                                        @foreach (var line in LinesForDisplay(row))
+                                        {
+                                            var trClass = stripeClass + (firstLine && row.ErrorMessage != null ? " actions-error-row" : "");
+                                            <tr class="@trClass">
+                                                <td class="col-repo">
+                                                    @if (firstLine)
+                                                    {
+                                                        var repoUrl = GrayMoon.App.Services.RepositoryUrlHelper.GetRepositoryUrl(row.Repo.CloneUrl);
+                                                        @if (!string.IsNullOrWhiteSpace(repoUrl))
                                                         {
-                                                            <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
+                                                            <a href="@repoUrl" target="_blank" rel="noopener noreferrer" class="repo-link">
+                                                                <strong>@row.Repo.RepositoryName</strong>
+                                                            </a>
                                                         }
                                                         else
                                                         {
-                                                            @:Re-run
+                                                            <strong>@row.Repo.RepositoryName</strong>
                                                         }
-                                                    </button>
-                                                }
-                                                else if (CanRun(row))
-                                                {
-                                                    <button class="btn btn-outline-primary action-run-btn"
-                                                            @onclick="() => RunWorkflowAsync(row)"
-                                                            disabled="@row.RunInProgress"
-                                                            title="Run workflow: @row.Action?.WorkflowName">
-                                                        @if (row.RunInProgress)
+                                                    }
+                                                </td>
+                                                <td class="col-branch">
+                                                    @if (firstLine)
+                                                    {
+                                                        @if (!string.IsNullOrWhiteSpace(row.Link.BranchName))
                                                         {
-                                                            <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
+                                                            <span class="text-muted">@row.Link.BranchName</span>
                                                         }
                                                         else
                                                         {
-                                                            @:Run
+                                                            <span class="text-muted">-</span>
                                                         }
-                                                    </button>
-                                                }
-                                            </td>
-                                        </tr>
+                                                    }
+                                                </td>
+                                                <td class="col-workflow">
+                                                    @if (!string.IsNullOrWhiteSpace(line.Action?.WorkflowName))
+                                                    {
+                                                        <span class="text-muted">@line.Action!.WorkflowName</span>
+                                                    }
+                                                    else
+                                                    {
+                                                        <span class="text-muted">-</span>
+                                                    }
+                                                </td>
+                                                <td class="col-action-status text-center">
+                                                    @if (firstLine)
+                                                    {
+                                                        <ActionBadge Status="@(line.Action?.Status)"
+                                                                     HtmlUrl="@line.Action?.HtmlUrl"
+                                                                     ErrorMessage="@row.ErrorMessage" />
+                                                    }
+                                                    else if (string.IsNullOrWhiteSpace(row.ErrorMessage))
+                                                    {
+                                                        <ActionBadge Status="@(line.Action?.Status)"
+                                                                     HtmlUrl="@line.Action?.HtmlUrl" />
+                                                    }
+                                                    else
+                                                    {
+                                                        <span class="text-muted">—</span>
+                                                    }
+                                                </td>
+                                                <td class="col-actions ps-3">
+                                                    @if (string.IsNullOrWhiteSpace(row.ErrorMessage))
+                                                    {
+                                                        @if (CanRerun(row, line))
+                                                        {
+                                                            <button class="btn btn-outline-primary action-run-btn"
+                                                                    @onclick="() => RerunWorkflowAsync(row, line)"
+                                                                    disabled="@line.RunInProgress"
+                                                                    title="Re-run failed workflow: @line.Action?.WorkflowName">
+                                                                @if (line.RunInProgress)
+                                                                {
+                                                                    <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
+                                                                }
+                                                                else
+                                                                {
+                                                                    @:Re-run
+                                                                }
+                                                            </button>
+                                                        }
+                                                        else if (CanRun(row, line))
+                                                        {
+                                                            <button class="btn btn-outline-primary action-run-btn"
+                                                                    @onclick="() => RunWorkflowAsync(row, line)"
+                                                                    disabled="@line.RunInProgress"
+                                                                    title="Run workflow: @line.Action?.WorkflowName">
+                                                                @if (line.RunInProgress)
+                                                                {
+                                                                    <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
+                                                                }
+                                                                else
+                                                                {
+                                                                    @:Run
+                                                                }
+                                                            </button>
+                                                        }
+                                                    }
+                                                </td>
+                                            </tr>
+                                            firstLine = false;
+                                        }
+
+                                        groupIndex++;
                                     }
                                 }
                             </tbody>
@@ -193,13 +228,3 @@
 </div>
 
 <LoadingOverlay IsVisible="@isRerunningAll" Message="@RerunAllOverlayMessage" />
-
-@code {
-    private static ActionStatusInfo? GetEffectiveAction(WorkspaceActionRow row)
-    {
-        if (row.Action == null) return null;
-        if (!string.Equals(row.Action.BranchName, row.Link.BranchName, StringComparison.OrdinalIgnoreCase))
-            return null;
-        return row.Action;
-    }
-}

--- a/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor
@@ -122,12 +122,20 @@
                                             var showGhaTerminal = string.IsNullOrWhiteSpace(row.ErrorMessage)
                                                 && IsLineRunningForBranch(row, line)
                                                 && (line.Action?.RunId ?? 0) > 0;
+                                            var showRepoBranchInRow = firstLine
+                                                || IsLineRunningForBranch(row, line)
+                                                || line.RunInProgress;
                                             var repoEndOnDataRow = isLastWorkflowLineInRepo && !showGhaTerminal;
                                             var repoEndOnGhaRow = isLastWorkflowLineInRepo && showGhaTerminal;
-                                            var trClass = $"{stripeClass} actions-data-row" + (repoEndOnDataRow ? " actions-row-repo-end" : "") + (firstLine && row.ErrorMessage != null ? " actions-error-row" : "");
+                                            var isRunningWorkflowRow = IsLineRunningForBranch(row, line);
+                                            var trClass = $"{stripeClass} actions-data-row"
+                                                + (repoEndOnDataRow ? " actions-row-repo-end" : "")
+                                                + (firstLine && row.ErrorMessage != null ? " actions-error-row" : "")
+                                                + (isRunningWorkflowRow ? " actions-row-running" : "")
+                                                + (showGhaTerminal ? " actions-row-running-above-terminal" : "");
                                             <tr class="@trClass">
                                                 <td class="col-repo">
-                                                    @if (firstLine)
+                                                    @if (showRepoBranchInRow)
                                                     {
                                                         var repoUrl = GrayMoon.App.Services.RepositoryUrlHelper.GetRepositoryUrl(row.Repo.CloneUrl);
                                                         @if (!string.IsNullOrWhiteSpace(repoUrl))
@@ -143,7 +151,7 @@
                                                     }
                                                 </td>
                                                 <td class="col-branch">
-                                                    @if (firstLine)
+                                                    @if (showRepoBranchInRow)
                                                     {
                                                         @if (!string.IsNullOrWhiteSpace(row.Link.BranchName))
                                                         {
@@ -231,7 +239,7 @@
                                             </tr>
                                             @if (showGhaTerminal)
                                             {
-                                                <tr class="@($"{stripeClass} actions-gha-feed-row actions-data-row{(repoEndOnGhaRow ? " actions-row-repo-end" : "")}")">
+                                                <tr class="@($"{stripeClass} actions-gha-feed-row actions-data-row actions-row-running actions-row-running-terminal{(repoEndOnGhaRow ? " actions-row-repo-end" : "")}")">
                                                     <td colspan="5" class="p-0 border-0">
                                                         <GhaWorkflowLiveTerminal @key="@($"{row.Repo.RepositoryId}-{(line.Action?.WorkflowId ?? 0)}-{(line.Action?.RunId ?? 0)}")"
                                                                                  ConnectorName="@row.Repo.ConnectorName"

--- a/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor.cs
@@ -22,19 +22,21 @@ public sealed partial class WorkspaceActions : IDisposable
 
     private int MaxConcurrency => Math.Max(1, WorkspaceOptions.Value.MaxParallelOperations);
 
+    internal sealed class WorkflowActionLine
+    {
+        public ActionStatusInfo? Action { get; set; }
+        public bool RunInProgress { get; set; }
+    }
+
     internal sealed class WorkspaceActionRow
     {
         public required WorkspaceRepositoryLink Link { get; set; }
         public required GitHubRepositoryEntry Repo { get; init; }
 
-        /// <summary>Persisted or freshly-fetched aggregate action status. Null until first DB load or fetch.</summary>
-        public ActionStatusInfo? Action { get; set; }
+        public List<WorkflowActionLine> WorkflowLines { get; set; } = [];
 
-        /// <summary>True once the status has been verified against GitHub for the current branch.</summary>
         public bool IsVerified { get; set; }
-
         public bool IsRefreshing { get; set; }
-        public bool RunInProgress { get; set; }
         public string? ErrorMessage { get; set; }
     }
 
@@ -53,36 +55,23 @@ public sealed partial class WorkspaceActions : IDisposable
     private const int SyncDebounceMs = 500;
     private const int AutoPollIntervalMs = 5000;
 
-    internal bool HasFailedRows => rows.Any(r =>
-        string.Equals(r.Action?.Status, "failed", StringComparison.OrdinalIgnoreCase) &&
-        string.Equals(r.Action?.BranchName, r.Link.BranchName, StringComparison.OrdinalIgnoreCase));
-
-    private bool HasRunningRows => rows.Any(r =>
-        string.Equals(r.Action?.Status, "running", StringComparison.OrdinalIgnoreCase) &&
-        string.Equals(r.Action?.BranchName, r.Link.BranchName, StringComparison.OrdinalIgnoreCase));
+    internal bool HasFailedRows => rows.Any(row =>
+        row.WorkflowLines.Any(line =>
+            IsLineFailedForBranch(row, line)));
 
     internal int ErrorCount => rows.Count(r => !string.IsNullOrWhiteSpace(r.ErrorMessage));
 
-    internal int FailedCount => rows.Count(r =>
-        string.IsNullOrWhiteSpace(r.ErrorMessage) &&
-        string.Equals(r.Action?.Status, "failed", StringComparison.OrdinalIgnoreCase) &&
-        string.Equals(r.Action?.BranchName, r.Link.BranchName, StringComparison.OrdinalIgnoreCase));
+    internal int FailedCount => rows.Sum(row => row.WorkflowLines.Count(line =>
+        string.IsNullOrWhiteSpace(row.ErrorMessage) && IsLineFailedForBranch(row, line)));
 
-    internal int RunningCount => rows.Count(r =>
-        string.IsNullOrWhiteSpace(r.ErrorMessage) &&
-        string.Equals(r.Action?.Status, "running", StringComparison.OrdinalIgnoreCase) &&
-        string.Equals(r.Action?.BranchName, r.Link.BranchName, StringComparison.OrdinalIgnoreCase));
+    internal int RunningCount => rows.Sum(row => row.WorkflowLines.Count(line =>
+        string.IsNullOrWhiteSpace(row.ErrorMessage) && IsLineRunningForBranch(row, line)));
 
-    internal int SuccessCount => rows.Count(r =>
-        string.IsNullOrWhiteSpace(r.ErrorMessage) &&
-        string.Equals(r.Action?.Status, "success", StringComparison.OrdinalIgnoreCase) &&
-        string.Equals(r.Action?.BranchName, r.Link.BranchName, StringComparison.OrdinalIgnoreCase));
+    internal int SuccessCount => rows.Sum(row => row.WorkflowLines.Count(line =>
+        string.IsNullOrWhiteSpace(row.ErrorMessage) && IsLineSuccessForBranch(row, line)));
 
-    internal int NoneCount => rows.Count(r =>
-        string.IsNullOrWhiteSpace(r.ErrorMessage) &&
-        (r.Action == null ||
-        !string.Equals(r.Action.BranchName, r.Link.BranchName, StringComparison.OrdinalIgnoreCase) ||
-        string.Equals(r.Action.Status, "none", StringComparison.OrdinalIgnoreCase)));
+    internal int NoneCount => rows.Sum(row => row.WorkflowLines.Count(line =>
+        string.IsNullOrWhiteSpace(row.ErrorMessage) && IsLineNoneForBranch(row, line)));
 
     internal string RerunAllOverlayMessage =>
         _rerunCompleted == 0
@@ -158,9 +147,22 @@ public sealed partial class WorkspaceActions : IDisposable
                 .OrderBy(link => link.Repository!.RepositoryName)
                 .Select(link =>
                 {
-                    var hasPersisted = persistedActions.TryGetValue(link.RepositoryId, out var info);
+                    var hasPersisted = persistedActions.TryGetValue(link.RepositoryId, out var persisted);
                     var branchMatches = hasPersisted &&
-                        string.Equals(info?.BranchName, link.BranchName, StringComparison.OrdinalIgnoreCase);
+                        string.Equals(persisted?.BranchName, link.BranchName, StringComparison.OrdinalIgnoreCase);
+
+                    List<WorkflowActionLine> workflowLines;
+                    if (branchMatches && persisted != null && persisted.Workflows.Count > 0)
+                    {
+                        workflowLines = persisted.Workflows
+                            .Select(w => new WorkflowActionLine { Action = w })
+                            .ToList();
+                    }
+                    else
+                    {
+                        workflowLines = [new WorkflowActionLine()];
+                    }
+
                     return new WorkspaceActionRow
                     {
                         Link = link,
@@ -173,9 +175,8 @@ public sealed partial class WorkspaceActions : IDisposable
                             Visibility = link.Repository.Visibility,
                             CloneUrl = link.Repository.CloneUrl
                         },
-                        // Only use persisted status if it is for the current branch
-                        Action = branchMatches ? info : null,
-                        IsVerified = branchMatches
+                        WorkflowLines = workflowLines,
+                        IsVerified = branchMatches && hasPersisted
                     };
                 })
                 .ToList();
@@ -192,10 +193,6 @@ public sealed partial class WorkspaceActions : IDisposable
         }
     }
 
-    /// <summary>
-    /// Called when WorkspaceSynced is received. Reloads workspace links from a fresh DB scope,
-    /// updates branch names in-place, and triggers background fetches only for rows where the branch changed.
-    /// </summary>
     private async Task RefreshFromSyncAsync()
     {
         try
@@ -222,8 +219,7 @@ public sealed partial class WorkspaceActions : IDisposable
 
                 if (branchChanged)
                 {
-                    // Branch mismatch → invalidate cached status so badge shows "none" immediately
-                    row.Action = null;
+                    row.WorkflowLines = [new WorkflowActionLine()];
                     row.IsVerified = false;
                     rowsToRefresh.Add(row);
                 }
@@ -269,9 +265,8 @@ public sealed partial class WorkspaceActions : IDisposable
 
                 var runningRows = rows
                     .Where(r =>
-                        string.Equals(r.Action?.Status, "running", StringComparison.OrdinalIgnoreCase) &&
-                        string.Equals(r.Action?.BranchName, r.Link.BranchName, StringComparison.OrdinalIgnoreCase) &&
-                        !string.IsNullOrWhiteSpace(r.Link.BranchName))
+                        !string.IsNullOrWhiteSpace(r.Link.BranchName) &&
+                        r.WorkflowLines.Any(line => IsLineRunningForBranch(r, line)))
                     .ToList();
 
                 if (runningRows.Count == 0) break;
@@ -295,19 +290,21 @@ public sealed partial class WorkspaceActions : IDisposable
         {
             row.IsRefreshing = true;
 
-            var info = await ActionService.FetchAndPersistAsync(
+            var list = await ActionService.FetchAndPersistAsync(
                 row.Link.WorkspaceRepositoryId,
                 row.Repo,
                 row.Link.BranchName!,
                 cancellationToken);
 
-            if (!cancellationToken.IsCancellationRequested)
+            if (!cancellationToken.IsCancellationRequested && list != null)
             {
-                row.Action = info;
+                row.WorkflowLines = list
+                    .Select(w => new WorkflowActionLine { Action = w })
+                    .ToList();
                 row.IsVerified = true;
                 row.ErrorMessage = null;
 
-                if (string.Equals(info?.Status, "running", StringComparison.OrdinalIgnoreCase))
+                if (row.WorkflowLines.Any(line => IsLineRunningForBranch(row, line)))
                     EnsureAutoPollRunning();
             }
         }
@@ -354,17 +351,17 @@ public sealed partial class WorkspaceActions : IDisposable
         }
     }
 
-    internal async Task RerunWorkflowAsync(WorkspaceActionRow row)
+    internal async Task RerunWorkflowAsync(WorkspaceActionRow row, WorkflowActionLine line)
     {
-        if (row.Action?.RunId == null) return;
+        if (line.Action?.RunId == null) return;
 
         row.ErrorMessage = null;
-        row.RunInProgress = true;
+        line.RunInProgress = true;
         await InvokeAsync(StateHasChanged);
 
         try
         {
-            var actionEntry = BuildActionEntry(row);
+            var actionEntry = BuildActionEntry(row, line);
             await GitHubActionsService.RerunWorkflowAsync(actionEntry);
             await RefreshRowAsync(row, _cts.Token);
         }
@@ -376,24 +373,23 @@ public sealed partial class WorkspaceActions : IDisposable
         }
         finally
         {
-            row.RunInProgress = false;
+            line.RunInProgress = false;
             await InvokeAsync(StateHasChanged);
         }
     }
 
-    internal async Task RunWorkflowAsync(WorkspaceActionRow row)
+    internal async Task RunWorkflowAsync(WorkspaceActionRow row, WorkflowActionLine line)
     {
-        if (row.Action?.WorkflowId == null) return;
+        if (line.Action?.WorkflowId == null) return;
 
         row.ErrorMessage = null;
-        row.RunInProgress = true;
+        line.RunInProgress = true;
         await InvokeAsync(StateHasChanged);
 
         try
         {
-            var actionEntry = BuildActionEntry(row);
+            var actionEntry = BuildActionEntry(row, line);
             await GitHubActionsService.RunWorkflowAsync(actionEntry);
-            // Brief delay so GitHub registers the new run before we poll
             await Task.Delay(2000);
             await RefreshRowAsync(row, _cts.Token);
         }
@@ -405,35 +401,38 @@ public sealed partial class WorkspaceActions : IDisposable
         }
         finally
         {
-            row.RunInProgress = false;
+            line.RunInProgress = false;
             await InvokeAsync(StateHasChanged);
         }
     }
 
-    private static GitHubActionEntry BuildActionEntry(WorkspaceActionRow row) => new()
+    private static GitHubActionEntry BuildActionEntry(WorkspaceActionRow row, WorkflowActionLine line) => new()
     {
-        RunId = row.Action?.RunId ?? 0,
-        WorkflowId = row.Action?.WorkflowId ?? 0,
+        RunId = line.Action?.RunId ?? 0,
+        WorkflowId = line.Action?.WorkflowId ?? 0,
         ConnectorName = row.Repo.ConnectorName,
         Owner = row.Repo.OrgName ?? string.Empty,
         RepositoryName = row.Repo.RepositoryName,
-        WorkflowName = row.Action?.WorkflowName ?? string.Empty,
+        WorkflowName = line.Action?.WorkflowName ?? string.Empty,
         Status = string.Empty,
         HeadBranch = row.Link.BranchName
     };
 
     internal async Task RerunAllFailedAsync()
     {
-        var failedRows = rows
-            .Where(r =>
-                string.Equals(r.Action?.Status, "failed", StringComparison.OrdinalIgnoreCase) &&
-                string.Equals(r.Action?.BranchName, r.Link.BranchName, StringComparison.OrdinalIgnoreCase) &&
-                (r.Action?.RunId ?? 0) > 0)
-            .ToList();
+        var failedPairs = new List<(WorkspaceActionRow Row, WorkflowActionLine Line)>();
+        foreach (var row in rows)
+        {
+            foreach (var line in row.WorkflowLines)
+            {
+                if (IsLineFailedForBranch(row, line) && (line.Action?.RunId ?? 0) > 0)
+                    failedPairs.Add((row, line));
+            }
+        }
 
-        if (failedRows.Count == 0) return;
+        if (failedPairs.Count == 0) return;
 
-        _rerunTotal = failedRows.Count;
+        _rerunTotal = failedPairs.Count;
         _rerunCompleted = 0;
         isRerunningAll = true;
         await InvokeAsync(StateHasChanged);
@@ -441,17 +440,17 @@ public sealed partial class WorkspaceActions : IDisposable
         try
         {
             using var semaphore = new SemaphoreSlim(MaxConcurrency, MaxConcurrency);
-            var tasks = failedRows.Select(async row =>
+            var tasks = failedPairs.Select(async pair =>
             {
                 await semaphore.WaitAsync(_cts.Token);
                 try
                 {
-                    var actionEntry = BuildActionEntry(row);
+                    var actionEntry = BuildActionEntry(pair.Row, pair.Line);
                     await GitHubActionsService.RerunWorkflowAsync(actionEntry);
                 }
                 catch (Exception ex)
                 {
-                    Logger.LogError(ex, "Error re-running workflow for {Repo}", row.Repo.RepositoryName);
+                    Logger.LogError(ex, "Error re-running workflow for {Repo}", pair.Row.Repo.RepositoryName);
                 }
                 finally
                 {
@@ -466,7 +465,6 @@ public sealed partial class WorkspaceActions : IDisposable
         {
             isRerunningAll = false;
             await InvokeAsync(StateHasChanged);
-            // Refresh all rows so badges reflect the new run state
             _ = RefreshAllAsync();
         }
     }
@@ -495,28 +493,76 @@ public sealed partial class WorkspaceActions : IDisposable
         var status = GetEffectiveStatusForSort(row);
         return status switch
         {
-            "failed"  => 1,
+            "failed" => 1,
             "running" => 2,
             "success" => 3,
-            _         => 4  // none or unknown
+            _ => 4
         };
     }
 
     private static string? GetEffectiveStatusForSort(WorkspaceActionRow row)
     {
-        if (row.Action == null) return null;
-        if (!string.Equals(row.Action.BranchName, row.Link.BranchName, StringComparison.OrdinalIgnoreCase))
-            return null;
-        return row.Action.Status;
+        var order = 4;
+        string? worst = null;
+        foreach (var line in row.WorkflowLines)
+        {
+            var a = line.Action;
+            if (a == null || !string.Equals(a.BranchName, row.Link.BranchName, StringComparison.OrdinalIgnoreCase))
+                continue;
+            var o = a.Status switch
+            {
+                "failed" => 1,
+                "running" => 2,
+                "success" => 3,
+                _ => 4
+            };
+            if (o < order)
+            {
+                order = o;
+                worst = a.Status;
+            }
+        }
+
+        return worst;
     }
 
-    internal static bool CanRerun(WorkspaceActionRow row) =>
-        string.Equals(row.Action?.Status, "failed", StringComparison.OrdinalIgnoreCase) &&
-        (row.Action?.RunId ?? 0) > 0;
+    private static bool IsLineFailedForBranch(WorkspaceActionRow row, WorkflowActionLine line) =>
+        line.Action != null &&
+        string.Equals(line.Action.BranchName, row.Link.BranchName, StringComparison.OrdinalIgnoreCase) &&
+        string.Equals(line.Action.Status, "failed", StringComparison.OrdinalIgnoreCase);
 
-    internal static bool CanRun(WorkspaceActionRow row) =>
-        (row.Action?.WorkflowId ?? 0) > 0 &&
+    private static bool IsLineRunningForBranch(WorkspaceActionRow row, WorkflowActionLine line) =>
+        line.Action != null &&
+        string.Equals(line.Action.BranchName, row.Link.BranchName, StringComparison.OrdinalIgnoreCase) &&
+        string.Equals(line.Action.Status, "running", StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsLineSuccessForBranch(WorkspaceActionRow row, WorkflowActionLine line) =>
+        line.Action != null &&
+        string.Equals(line.Action.BranchName, row.Link.BranchName, StringComparison.OrdinalIgnoreCase) &&
+        string.Equals(line.Action.Status, "success", StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsLineNoneForBranch(WorkspaceActionRow row, WorkflowActionLine line) =>
+        line.Action == null ||
+        !string.Equals(line.Action.BranchName, row.Link.BranchName, StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(line.Action.Status, "none", StringComparison.OrdinalIgnoreCase);
+
+    internal static bool CanRerun(WorkspaceActionRow row, WorkflowActionLine line) =>
+        IsLineFailedForBranch(row, line) && (line.Action?.RunId ?? 0) > 0;
+
+    internal static bool CanRun(WorkspaceActionRow row, WorkflowActionLine line) =>
+        (line.Action?.SupportsWorkflowDispatch ?? false) &&
+        (line.Action?.WorkflowId ?? 0) > 0 &&
         !string.IsNullOrWhiteSpace(row.Link.BranchName);
+
+    internal static IEnumerable<WorkflowActionLine> LinesForDisplay(WorkspaceActionRow row)
+    {
+        if (row.WorkflowLines.Count > 0)
+            return row.WorkflowLines;
+        return [new WorkflowActionLine()];
+    }
+
+    internal static string GroupStripeClass(int groupIndex) =>
+        (groupIndex % 2 == 0) ? "actions-group-even" : "actions-group-odd";
 
     public void Dispose()
     {

--- a/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor.cs
@@ -381,6 +381,7 @@ public sealed partial class WorkspaceActions : IDisposable
     internal async Task RunWorkflowAsync(WorkspaceActionRow row, WorkflowActionLine line)
     {
         if (line.Action?.WorkflowId == null) return;
+        if (IsLineRunningForBranch(row, line)) return;
 
         row.ErrorMessage = null;
         line.RunInProgress = true;
@@ -553,6 +554,25 @@ public sealed partial class WorkspaceActions : IDisposable
         (line.Action?.SupportsWorkflowDispatch ?? false) &&
         (line.Action?.WorkflowId ?? 0) > 0 &&
         !string.IsNullOrWhiteSpace(row.Link.BranchName);
+
+    /// <summary>True when Run should be non-interactive: dispatch in flight or latest run still in progress on GitHub.</summary>
+    internal static bool IsRunWorkflowBusy(WorkspaceActionRow row, WorkflowActionLine line) =>
+        line.RunInProgress || IsLineRunningForBranch(row, line);
+
+    /// <summary>GitHub Actions workflow page (not a specific run); uses persisted <see cref="ActionStatusInfo.WorkflowHtmlUrl"/> or builds from repo + workflow id.</summary>
+    internal static string? GetWorkflowPageUrl(WorkspaceActionRow row, WorkflowActionLine line)
+    {
+        if (line.Action == null)
+            return null;
+        return RepositoryUrlHelper.BuildWorkflowPageUrl(
+            line.Action.WorkflowHtmlUrl,
+            row.Repo.CloneUrl,
+            row.Repo.OrgName,
+            row.Repo.RepositoryName,
+            line.Action.WorkflowId ?? 0,
+            line.Action.WorkflowPath,
+            null);
+    }
 
     internal static IEnumerable<WorkflowActionLine> LinesForDisplay(WorkspaceActionRow row)
     {

--- a/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor.cs
@@ -363,7 +363,8 @@ public sealed partial class WorkspaceActions : IDisposable
         {
             var actionEntry = BuildActionEntry(row, line);
             await GitHubActionsService.RerunWorkflowAsync(actionEntry);
-            await RefreshRowAsync(row, _cts.Token);
+            await Task.Delay(2000, CancellationToken.None);
+            await RefreshRowAsync(row, CancellationToken.None);
         }
         catch (Exception ex)
         {
@@ -391,8 +392,8 @@ public sealed partial class WorkspaceActions : IDisposable
         {
             var actionEntry = BuildActionEntry(row, line);
             await GitHubActionsService.RunWorkflowAsync(actionEntry);
-            await Task.Delay(2000);
-            await RefreshRowAsync(row, _cts.Token);
+            await Task.Delay(2000, CancellationToken.None);
+            await RefreshRowAsync(row, CancellationToken.None);
         }
         catch (Exception ex)
         {
@@ -479,12 +480,20 @@ public sealed partial class WorkspaceActions : IDisposable
                 "Forbidden (403). The token does not have permission to access GitHub Actions.",
             HttpRequestException { StatusCode: HttpStatusCode.NotFound } =>
                 "Not found (404). The repository or workflow was not found.",
+            HttpRequestException { StatusCode: HttpStatusCode.UnprocessableEntity } http422 =>
+                string.IsNullOrWhiteSpace(http422.Message)
+                    ? "GitHub rejected the workflow request (422). It may not support manual runs on this branch, or required workflow inputs are missing."
+                    : http422.Message,
             HttpRequestException { StatusCode: HttpStatusCode.TooManyRequests } =>
                 "Rate limited (429). Too many requests to GitHub. Try again later.",
             HttpRequestException { StatusCode: HttpStatusCode.ServiceUnavailable } =>
                 "GitHub service unavailable (503). Try again later.",
             HttpRequestException httpEx =>
-                $"GitHub API error: {httpEx.Message}",
+                string.IsNullOrWhiteSpace(httpEx.Message)
+                    ? "GitHub API request failed."
+                    : httpEx.Message,
+            OperationCanceledException =>
+                "The operation was cancelled (for example, refresh was interrupted). Try Run again or use Refresh.",
             _ => ex.Message
         };
 

--- a/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor.cs
@@ -55,6 +55,12 @@ public sealed partial class WorkspaceActions : IDisposable
     private const int SyncDebounceMs = 500;
     private const int AutoPollIntervalMs = 5000;
 
+    /// <summary>After dispatch/rerun, GitHub may not list the new run immediately; refresh until we see running or exhaust attempts.</summary>
+    private const int RunWorkflowVisibilityMaxAttempts = 10;
+
+    private const int RunWorkflowVisibilityFirstDelayMs = 2000;
+    private const int RunWorkflowVisibilityRetryDelayMs = 3000;
+
     internal bool HasFailedRows => rows.Any(row =>
         row.WorkflowLines.Any(line =>
             IsLineFailedForBranch(row, line)));
@@ -323,6 +329,70 @@ public sealed partial class WorkspaceActions : IDisposable
         }
     }
 
+    /// <summary>Refreshes the row until the given workflow shows as running with a run id, or max attempts (GitHub listing lag after dispatch/rerun).</summary>
+    private async Task<bool> TryRefreshUntilWorkflowLineRunningAsync(
+        WorkspaceActionRow row,
+        long workflowId,
+        string operationLabel,
+        CancellationToken cancellationToken)
+    {
+        for (var attempt = 1; attempt <= RunWorkflowVisibilityMaxAttempts; attempt++)
+        {
+            var delayMs = attempt == 1 ? RunWorkflowVisibilityFirstDelayMs : RunWorkflowVisibilityRetryDelayMs;
+            try
+            {
+                await Task.Delay(delayMs, cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                return false;
+            }
+
+            await RefreshRowAsync(row, cancellationToken);
+
+            if (!string.IsNullOrWhiteSpace(row.ErrorMessage))
+            {
+                Logger.LogWarning(
+                    "{Operation}: refresh failed for row after attempt {Attempt}; stopping visibility retries",
+                    operationLabel,
+                    attempt);
+                return false;
+            }
+
+            var wfLine = row.WorkflowLines.FirstOrDefault(l => l.Action?.WorkflowId == workflowId);
+            if (wfLine != null
+                && IsLineRunningForBranch(row, wfLine)
+                && (wfLine.Action?.RunId ?? 0) > 0)
+            {
+                Logger.LogInformation(
+                    "{Operation}: GitHub shows running workflow after attempt {Attempt}/{Max} WorkflowId={WorkflowId} RunId={RunId}",
+                    operationLabel,
+                    attempt,
+                    RunWorkflowVisibilityMaxAttempts,
+                    workflowId,
+                    wfLine.Action!.RunId);
+                return true;
+            }
+
+            if (attempt < RunWorkflowVisibilityMaxAttempts)
+            {
+                Logger.LogDebug(
+                    "{Operation}: attempt {Attempt}/{Max} — workflow not running in API yet WorkflowId={WorkflowId}",
+                    operationLabel,
+                    attempt,
+                    RunWorkflowVisibilityMaxAttempts,
+                    workflowId);
+            }
+        }
+
+        Logger.LogWarning(
+            "{Operation}: no running workflow after {Max} refresh attempts WorkflowId={WorkflowId} (run may still be queued; grid will update on next poll)",
+            operationLabel,
+            RunWorkflowVisibilityMaxAttempts,
+            workflowId);
+        return false;
+    }
+
     internal async Task RefreshAllAsync()
     {
         if (workspace == null || rows.Count == 0) return;
@@ -362,13 +432,40 @@ public sealed partial class WorkspaceActions : IDisposable
         try
         {
             var actionEntry = BuildActionEntry(row, line);
+            Logger.LogInformation(
+                "GHA Re-run requested: WorkspaceId={WorkspaceId} Connector={Connector} {Owner}/{Repo} branch={Branch} workflow={WorkflowName} WorkflowId={WorkflowId} RunId={RunId}",
+                WorkspaceId,
+                row.Repo.ConnectorName,
+                actionEntry.Owner,
+                actionEntry.RepositoryName,
+                actionEntry.HeadBranch,
+                actionEntry.WorkflowName,
+                actionEntry.WorkflowId,
+                actionEntry.RunId);
             await GitHubActionsService.RerunWorkflowAsync(actionEntry);
-            await Task.Delay(2000, CancellationToken.None);
-            await RefreshRowAsync(row, CancellationToken.None);
+            var rerunVisible = await TryRefreshUntilWorkflowLineRunningAsync(
+                row,
+                actionEntry.WorkflowId,
+                "GHA Re-run",
+                CancellationToken.None);
+            Logger.LogInformation(
+                "GHA Re-run completed (refresh phase): WorkspaceId={WorkspaceId} {Owner}/{Repo} workflow={WorkflowName} priorRunId={RunId} runningVisible={RunningVisible}",
+                WorkspaceId,
+                actionEntry.Owner,
+                actionEntry.RepositoryName,
+                actionEntry.WorkflowName,
+                actionEntry.RunId,
+                rerunVisible);
         }
         catch (Exception ex)
         {
-            Logger.LogError(ex, "Error re-running workflow for {Repo}", row.Repo.RepositoryName);
+            Logger.LogError(ex,
+                "GHA Re-run failed: WorkspaceId={WorkspaceId} {Owner}/{Repo} workflow={WorkflowName} RunId={RunId}",
+                WorkspaceId,
+                row.Repo.OrgName,
+                row.Repo.RepositoryName,
+                line.Action?.WorkflowName,
+                line.Action?.RunId);
             row.ErrorMessage = GetFriendlyErrorMessage(ex);
             await InvokeAsync(StateHasChanged);
         }
@@ -391,13 +488,41 @@ public sealed partial class WorkspaceActions : IDisposable
         try
         {
             var actionEntry = BuildActionEntry(row, line);
+            Logger.LogInformation(
+                "GHA Run (workflow_dispatch) requested: WorkspaceId={WorkspaceId} Connector={Connector} {Owner}/{Repo} branch={Branch} workflow={WorkflowName} WorkflowId={WorkflowId}",
+                WorkspaceId,
+                row.Repo.ConnectorName,
+                actionEntry.Owner,
+                actionEntry.RepositoryName,
+                actionEntry.HeadBranch,
+                actionEntry.WorkflowName,
+                actionEntry.WorkflowId);
             await GitHubActionsService.RunWorkflowAsync(actionEntry);
-            await Task.Delay(2000, CancellationToken.None);
-            await RefreshRowAsync(row, CancellationToken.None);
+            var runVisible = await TryRefreshUntilWorkflowLineRunningAsync(
+                row,
+                actionEntry.WorkflowId,
+                "GHA Run",
+                CancellationToken.None);
+            Logger.LogInformation(
+                "GHA Run completed (dispatch + refresh phase): WorkspaceId={WorkspaceId} {Owner}/{Repo} branch={Branch} workflow={WorkflowName} WorkflowId={WorkflowId} runningVisible={RunningVisible}",
+                WorkspaceId,
+                actionEntry.Owner,
+                actionEntry.RepositoryName,
+                actionEntry.HeadBranch,
+                actionEntry.WorkflowName,
+                actionEntry.WorkflowId,
+                runVisible);
         }
         catch (Exception ex)
         {
-            Logger.LogError(ex, "Error running workflow for {Repo}", row.Repo.RepositoryName);
+            Logger.LogError(ex,
+                "GHA Run failed: WorkspaceId={WorkspaceId} {Owner}/{Repo} branch={Branch} workflow={WorkflowName} WorkflowId={WorkflowId}",
+                WorkspaceId,
+                row.Repo.OrgName,
+                row.Repo.RepositoryName,
+                row.Link.BranchName,
+                line.Action?.WorkflowName,
+                line.Action?.WorkflowId);
             row.ErrorMessage = GetFriendlyErrorMessage(ex);
             await InvokeAsync(StateHasChanged);
         }
@@ -434,6 +559,11 @@ public sealed partial class WorkspaceActions : IDisposable
 
         if (failedPairs.Count == 0) return;
 
+        Logger.LogInformation(
+            "GHA Re-run all failed requested: WorkspaceId={WorkspaceId} count={Count}",
+            WorkspaceId,
+            failedPairs.Count);
+
         _rerunTotal = failedPairs.Count;
         _rerunCompleted = 0;
         isRerunningAll = true;
@@ -448,11 +578,28 @@ public sealed partial class WorkspaceActions : IDisposable
                 try
                 {
                     var actionEntry = BuildActionEntry(pair.Row, pair.Line);
+                    Logger.LogInformation(
+                        "GHA Re-run all: invoking {Owner}/{Repo} workflow={WorkflowName} RunId={RunId}",
+                        actionEntry.Owner,
+                        actionEntry.RepositoryName,
+                        actionEntry.WorkflowName,
+                        actionEntry.RunId);
                     await GitHubActionsService.RerunWorkflowAsync(actionEntry);
+                    Logger.LogInformation(
+                        "GHA Re-run all: API ok {Owner}/{Repo} workflow={WorkflowName} RunId={RunId}",
+                        actionEntry.Owner,
+                        actionEntry.RepositoryName,
+                        actionEntry.WorkflowName,
+                        actionEntry.RunId);
                 }
                 catch (Exception ex)
                 {
-                    Logger.LogError(ex, "Error re-running workflow for {Repo}", pair.Row.Repo.RepositoryName);
+                    Logger.LogError(ex,
+                        "GHA Re-run all item failed: WorkspaceId={WorkspaceId} {Owner}/{Repo} RunId={RunId}",
+                        WorkspaceId,
+                        pair.Row.Repo.OrgName,
+                        pair.Row.Repo.RepositoryName,
+                        pair.Line.Action?.RunId);
                 }
                 finally
                 {
@@ -462,6 +609,10 @@ public sealed partial class WorkspaceActions : IDisposable
                 }
             });
             await Task.WhenAll(tasks);
+            Logger.LogInformation(
+                "GHA Re-run all finished (API phase): WorkspaceId={WorkspaceId} attempted={Count}",
+                WorkspaceId,
+                failedPairs.Count);
         }
         finally
         {

--- a/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor.css
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor.css
@@ -145,3 +145,33 @@
 .grid-page-body .table.actions-table tbody tr.actions-data-row.actions-row-repo-end > td {
     border-bottom: 1px solid var(--border-color) !important;
 }
+
+/* Running workflow: same backdrop as GHA live terminal for a seamless block */
+.grid-page-body .table.actions-table tbody tr.actions-row-running > td {
+    background-color: rgba(6, 8, 10, 0.94) !important;
+    color: rgba(230, 235, 240, 0.96);
+    border-bottom: none !important;
+}
+
+.grid-page-body .table.actions-table tbody tr.actions-row-running .text-muted {
+    color: rgba(186, 194, 188, 0.92) !important;
+}
+
+.grid-page-body .table.actions-table tbody tr.actions-row-running .repo-link,
+.grid-page-body .table.actions-table tbody tr.actions-row-running .repo-link strong,
+.grid-page-body .table.actions-table tbody tr.actions-row-running td.col-repo strong {
+    color: rgba(240, 244, 248, 0.98) !important;
+}
+
+.grid-page-body .table.actions-table tbody tr.actions-row-running-above-terminal > td {
+    border-bottom: none !important;
+}
+
+.grid-page-body .table.actions-table tbody tr.actions-row-running-terminal > td {
+    background-color: rgba(6, 8, 10, 0.94) !important;
+    border-bottom: none !important;
+}
+
+.grid-page-body .table.actions-table tbody tr.actions-row-running-terminal.actions-row-repo-end > td {
+    border-bottom: 1px solid var(--border-color) !important;
+}

--- a/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor.css
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor.css
@@ -1,3 +1,16 @@
+/* Actions grid: workflow name → GitHub Actions workflow tab (not default blue link) */
+.actions-workflow-link {
+    color: rgba(236, 240, 245, 0.9) !important;
+    text-decoration: none;
+}
+
+.actions-workflow-link:hover,
+.actions-workflow-link:focus {
+    color: rgba(255, 255, 255, 0.98) !important;
+    text-decoration: underline;
+    text-decoration-color: rgba(255, 255, 255, 0.45);
+}
+
 .action-link {
     color: inherit !important;
     text-decoration: none;

--- a/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor.css
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor.css
@@ -45,11 +45,15 @@
 }
 
 .col-repo {
-    width: 30%;
+    width: 26%;
+}
+
+.col-branch {
+    width: 16%;
 }
 
 .col-workflow {
-    width: 20%;
+    width: 22%;
 }
 
 .col-event {
@@ -60,13 +64,17 @@
     width: 18%;
 }
 
-.col-updated {
-    width: 12%;
-}
-
 /* Last column: actions (match Workspaces.razor) */
 .col-actions {
-    width: 10%;
+    width: 18%;
+}
+
+.actions-table tbody tr.actions-group-even {
+    background-color: transparent;
+}
+
+.actions-table tbody tr.actions-group-odd {
+    background-color: var(--bs-table-striped-bg, rgba(0, 0, 0, 0.05));
 }
 
 /* Status / Result: center header and body text (override global col-status-badge right alignment) */

--- a/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor.css
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor.css
@@ -119,3 +119,16 @@
 .actions-table tbody tr.actions-error-row td {
     color: #842029;
 }
+
+/*
+ * One gray line only after the last workflow row of each repository (not between workflows).
+ * Use app theme --border-color and !important so we win over .table defaults and
+ * .table tbody tr:last-child td { border-bottom-width: 0 } in app.css.
+ */
+.grid-page-body .table.actions-table tbody tr.actions-data-row > td {
+    border-bottom: none !important;
+}
+
+.grid-page-body .table.actions-table tbody tr.actions-data-row.actions-row-repo-end > td {
+    border-bottom: 1px solid var(--border-color) !important;
+}

--- a/src/GrayMoon.App/Components/Shared/GhaWorkflowLiveTerminal.razor
+++ b/src/GrayMoon.App/Components/Shared/GhaWorkflowLiveTerminal.razor
@@ -1,0 +1,238 @@
+@using GrayMoon.App.Models
+@using GrayMoon.App.Repositories
+@inject GitHubService GitHubService
+@inject ConnectorRepository ConnectorRepository
+@inject LoadingOverlayUiSettingsService OverlayUiSettings
+@inject ILogger<GhaWorkflowLiveTerminal> Logger
+@implements IAsyncDisposable
+
+@if (RunId > 0 && !string.IsNullOrWhiteSpace(ConnectorName) && !string.IsNullOrWhiteSpace(Owner) && !string.IsNullOrWhiteSpace(RepositoryName))
+{
+    <div class="actions-gha-terminal">
+        <div class="actions-gha-terminal__wrap">
+            <div class="loading-overlay-terminal @(OverlayUiSettings.TerminalColorScheme == TerminalColorScheme.Yellow ? "loading-overlay-terminal--scheme-yellow" : "") actions-gha-terminal__terminal">
+                <div class="actions-gha-terminal__caption" title="@_caption">
+                    <span class="actions-gha-terminal__caption-prefix">▶</span><span class="actions-gha-terminal__caption-text">@_caption</span>
+                </div>
+                <div class="loading-overlay-terminal__inner actions-gha-terminal__scroll" aria-live="polite">
+                    @foreach (var line in _visibleLines)
+                    {
+                        <p class="loading-overlay-terminal__line loading-overlay-terminal__line--out actions-gha-terminal__line">
+                            @if (string.IsNullOrWhiteSpace(line))
+                            {
+                                <span class="loading-overlay-terminal__text">&nbsp;</span>
+                            }
+                            else
+                            {
+                                <span class="loading-overlay-terminal__prefix">[gha]</span><span class="loading-overlay-terminal__text">@line</span>
+                            }
+                        </p>
+                    }
+                </div>
+            </div>
+        </div>
+    </div>
+}
+
+@code {
+    [Parameter, EditorRequired] public string ConnectorName { get; set; } = string.Empty;
+    [Parameter, EditorRequired] public string Owner { get; set; } = string.Empty;
+    [Parameter, EditorRequired] public string RepositoryName { get; set; } = string.Empty;
+    [Parameter] public long RunId { get; set; }
+    [Parameter] public string? WorkflowDisplayName { get; set; }
+
+    private readonly List<string> _buffer = [];
+    private readonly Dictionary<string, string> _stepSignatures = new(StringComparer.Ordinal);
+    private bool _snapshottedSteps;
+    private string _caption = "Workflow · Connecting to GitHub Actions…";
+    private CancellationTokenSource? _cts;
+    private Task? _pollTask;
+
+    private const int BodyLineCount = 8;
+
+    private IReadOnlyList<string> _visibleLines
+    {
+        get
+        {
+            List<string> take;
+            if (_buffer.Count >= BodyLineCount)
+                take = _buffer.Skip(_buffer.Count - BodyLineCount).ToList();
+            else
+                take = _buffer.ToList();
+            while (take.Count < BodyLineCount)
+                take.Insert(0, "");
+            return take;
+        }
+    }
+
+    protected override void OnInitialized()
+    {
+        OverlayUiSettings.Changed += OnOverlayUiSettingsChanged;
+        _buffer.Add($"Run #{RunId} · Subscribing to job updates…");
+    }
+
+    private void OnOverlayUiSettingsChanged(object? sender, EventArgs e) =>
+        _ = InvokeAsync(StateHasChanged);
+
+    protected override Task OnParametersSetAsync()
+    {
+        if (RunId > 0 && _pollTask == null)
+        {
+            _cts = new CancellationTokenSource();
+            _pollTask = PollLoopAsync(_cts.Token);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private async Task PollLoopAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                await PollOnceAsync(cancellationToken);
+                await InvokeAsync(StateHasChanged);
+                await Task.Delay(3000, cancellationToken);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            /* disposed */
+        }
+    }
+
+    private async Task PollOnceAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            var connector = await ConnectorRepository.GetByNameAsync(ConnectorName);
+            if (connector == null)
+            {
+                AppendUnique("Connector not found — cannot load job status.");
+                return;
+            }
+
+            var response = await GitHubService.GetWorkflowRunJobsAsync(connector, Owner, RepositoryName, RunId, cancellationToken);
+            var jobs = response?.Jobs ?? [];
+            _caption = BuildCaption(jobs, WorkflowDisplayName);
+
+            if (jobs.Count == 0)
+            {
+                AppendUnique("Waiting for GitHub to assign jobs to this run…");
+                return;
+            }
+
+            if (!_snapshottedSteps)
+            {
+                _snapshottedSteps = true;
+                foreach (var job in jobs.OrderBy(j => j.Id))
+                {
+                    foreach (var step in (job.Steps ?? []).OrderBy(s => s.Number))
+                        _stepSignatures[$"{job.Id}:{step.Number}"] = $"{step.Status}|{step.Conclusion}";
+                }
+
+                var stepCount = jobs.Sum(j => j.Steps?.Count ?? 0);
+                AppendUnique($"Live · {jobs.Count} job(s), {stepCount} step(s) — streaming updates…");
+                return;
+            }
+
+            foreach (var job in jobs.OrderBy(j => j.Id))
+            {
+                var steps = job.Steps ?? [];
+                foreach (var step in steps.OrderBy(s => s.Number))
+                {
+                    var key = $"{job.Id}:{step.Number}";
+                    var sig = $"{step.Status}|{step.Conclusion}";
+                    if (_stepSignatures.TryGetValue(key, out var prev) && prev == sig)
+                        continue;
+                    _stepSignatures[key] = sig;
+                    AppendUnique(FormatStepTransition(job.Name, step));
+                }
+            }
+        }
+        catch (Exception ex) when (!cancellationToken.IsCancellationRequested)
+        {
+            Logger.LogDebug(ex, "GHA live feed poll failed for run {RunId}", RunId);
+            AppendUnique($"Update failed: {ex.Message}");
+        }
+    }
+
+    private void AppendUnique(string line)
+    {
+        if (_buffer.Count > 0 && string.Equals(_buffer[^1], line, StringComparison.Ordinal))
+            return;
+        _buffer.Add(line);
+        while (_buffer.Count > 120)
+            _buffer.RemoveAt(0);
+    }
+
+    private static string BuildCaption(IReadOnlyList<GitHubWorkflowJobDto> jobs, string? workflowName)
+    {
+        var wf = string.IsNullOrWhiteSpace(workflowName) ? "Workflow" : workflowName!;
+        if (jobs.Count == 0)
+            return $"{wf} · Waiting for jobs…";
+
+        var job = jobs.FirstOrDefault(j => string.Equals(j.Status, "in_progress", StringComparison.OrdinalIgnoreCase))
+                  ?? jobs.FirstOrDefault(j => string.Equals(j.Status, "queued", StringComparison.OrdinalIgnoreCase))
+                  ?? jobs.FirstOrDefault(j => string.Equals(j.Status, "waiting", StringComparison.OrdinalIgnoreCase))
+                  ?? jobs[0];
+
+        var steps = job.Steps ?? [];
+        var step = steps.FirstOrDefault(s => string.Equals(s.Status, "in_progress", StringComparison.OrdinalIgnoreCase))
+                   ?? steps.LastOrDefault(s => string.Equals(s.Status, "completed", StringComparison.OrdinalIgnoreCase));
+
+        var stepLabel = step?.Name;
+        if (string.IsNullOrWhiteSpace(stepLabel))
+        {
+            if (string.Equals(job.Status, "queued", StringComparison.OrdinalIgnoreCase))
+                stepLabel = "Queued for runner…";
+            else if (string.Equals(job.Status, "in_progress", StringComparison.OrdinalIgnoreCase))
+                stepLabel = "Running…";
+            else
+                stepLabel = job.Status;
+        }
+
+        return $"{wf} · {job.Name} › {stepLabel}";
+    }
+
+    private static string FormatStepTransition(string jobName, GitHubWorkflowJobStepDto step)
+    {
+        if (string.Equals(step.Status, "completed", StringComparison.OrdinalIgnoreCase))
+        {
+            var c = step.Conclusion ?? "";
+            if (string.Equals(c, "success", StringComparison.OrdinalIgnoreCase))
+                return $"✓ {jobName} › {step.Name}";
+            if (string.Equals(c, "skipped", StringComparison.OrdinalIgnoreCase))
+                return $"⊘ {jobName} › {step.Name} (skipped)";
+            if (string.Equals(c, "failure", StringComparison.OrdinalIgnoreCase) || string.Equals(c, "cancelled", StringComparison.OrdinalIgnoreCase))
+                return $"✗ {jobName} › {step.Name} ({c})";
+            return $"• {jobName} › {step.Name} — {c}";
+        }
+
+        if (string.Equals(step.Status, "in_progress", StringComparison.OrdinalIgnoreCase))
+            return $"⧗ {jobName} › {step.Name}…";
+
+        return $"… {jobName} › {step.Name} — {step.Status}";
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        OverlayUiSettings.Changed -= OnOverlayUiSettingsChanged;
+        try
+        {
+            _cts?.Cancel();
+            if (_pollTask != null)
+                await _pollTask;
+        }
+        catch (OperationCanceledException)
+        {
+            /* ok */
+        }
+        finally
+        {
+            _cts?.Dispose();
+            _cts = null;
+        }
+    }
+}

--- a/src/GrayMoon.App/Components/Shared/GhaWorkflowLiveTerminal.razor
+++ b/src/GrayMoon.App/Components/Shared/GhaWorkflowLiveTerminal.razor
@@ -11,8 +11,14 @@
     <div class="actions-gha-terminal">
         <div class="actions-gha-terminal__wrap">
             <div class="loading-overlay-terminal @(OverlayUiSettings.TerminalColorScheme == TerminalColorScheme.Yellow ? "loading-overlay-terminal--scheme-yellow" : "") actions-gha-terminal__terminal">
-                <div class="actions-gha-terminal__caption" title="@_caption">
-                    <span class="actions-gha-terminal__caption-prefix">▶</span><span class="actions-gha-terminal__caption-text">@_caption</span>
+                <div class="actions-gha-terminal__caption" title="@_captionTooltip">
+                    <span class="actions-gha-terminal__caption-main">
+                        <span class="actions-gha-terminal__caption-prefix">▶</span><span class="actions-gha-terminal__caption-text">@_caption</span>
+                    </span>
+                    @if (!string.IsNullOrWhiteSpace(_stepProgress))
+                    {
+                        <span class="actions-gha-terminal__caption-steps">@_stepProgress</span>
+                    }
                 </div>
                 <div class="loading-overlay-terminal__inner actions-gha-terminal__scroll" aria-live="polite">
                     @foreach (var line in _visibleLines)
@@ -45,6 +51,7 @@
     private readonly Dictionary<string, string> _stepSignatures = new(StringComparer.Ordinal);
     private bool _snapshottedSteps;
     private string _caption = "Workflow · Connecting to GitHub Actions…";
+    private string? _stepProgress;
     private CancellationTokenSource? _cts;
     private Task? _pollTask;
 
@@ -64,6 +71,9 @@
             return take;
         }
     }
+
+    private string _captionTooltip =>
+        string.IsNullOrWhiteSpace(_stepProgress) ? _caption : $"{_caption} · {_stepProgress}";
 
     protected override void OnInitialized()
     {
@@ -116,9 +126,11 @@
             var response = await GitHubService.GetWorkflowRunJobsAsync(connector, Owner, RepositoryName, RunId, cancellationToken);
             var jobs = response?.Jobs ?? [];
             _caption = BuildCaption(jobs, WorkflowDisplayName);
+            _stepProgress = BuildStepProgressForCaptionJob(jobs);
 
             if (jobs.Count == 0)
             {
+                _stepProgress = null;
                 AppendUnique("Waiting for GitHub to assign jobs to this run…");
                 return;
             }
@@ -173,11 +185,7 @@
         if (jobs.Count == 0)
             return $"{wf} · Waiting for jobs…";
 
-        var job = jobs.FirstOrDefault(j => string.Equals(j.Status, "in_progress", StringComparison.OrdinalIgnoreCase))
-                  ?? jobs.FirstOrDefault(j => string.Equals(j.Status, "queued", StringComparison.OrdinalIgnoreCase))
-                  ?? jobs.FirstOrDefault(j => string.Equals(j.Status, "waiting", StringComparison.OrdinalIgnoreCase))
-                  ?? jobs[0];
-
+        var job = GetCaptionJob(jobs)!;
         var steps = job.Steps ?? [];
         var step = steps.FirstOrDefault(s => string.Equals(s.Status, "in_progress", StringComparison.OrdinalIgnoreCase))
                    ?? steps.LastOrDefault(s => string.Equals(s.Status, "completed", StringComparison.OrdinalIgnoreCase));
@@ -194,6 +202,40 @@
         }
 
         return $"{wf} · {job.Name} › {stepLabel}";
+    }
+
+    /// <summary>Same "current" job as <see cref="BuildCaption"/>; step counts come from the jobs API for that run.</summary>
+    private static GitHubWorkflowJobDto? GetCaptionJob(IReadOnlyList<GitHubWorkflowJobDto> jobs)
+    {
+        if (jobs.Count == 0) return null;
+        return jobs.FirstOrDefault(j => string.Equals(j.Status, "in_progress", StringComparison.OrdinalIgnoreCase))
+               ?? jobs.FirstOrDefault(j => string.Equals(j.Status, "queued", StringComparison.OrdinalIgnoreCase))
+               ?? jobs.FirstOrDefault(j => string.Equals(j.Status, "waiting", StringComparison.OrdinalIgnoreCase))
+               ?? jobs[0];
+    }
+
+    /// <summary>1-based index of the active step and total steps for the caption job (YAML steps GitHub reports for that job).</summary>
+    private static string? BuildStepProgressForCaptionJob(IReadOnlyList<GitHubWorkflowJobDto> jobs)
+    {
+        var job = GetCaptionJob(jobs);
+        if (job == null) return null;
+
+        var ordered = (job.Steps ?? []).OrderBy(s => s.Number).ToList();
+        var y = ordered.Count;
+        if (y == 0)
+            return null;
+
+        var inProgressIdx = ordered.FindIndex(s => string.Equals(s.Status, "in_progress", StringComparison.OrdinalIgnoreCase));
+        if (inProgressIdx >= 0)
+            return $"Step {inProgressIdx + 1} of {y}";
+
+        for (var i = 0; i < ordered.Count; i++)
+        {
+            if (!string.Equals(ordered[i].Status, "completed", StringComparison.OrdinalIgnoreCase))
+                return $"Step {i + 1} of {y}";
+        }
+
+        return $"Step {y} of {y}";
     }
 
     private static string FormatStepTransition(string jobName, GitHubWorkflowJobStepDto step)

--- a/src/GrayMoon.App/Components/Shared/GhaWorkflowLiveTerminal.razor.css
+++ b/src/GrayMoon.App/Components/Shared/GhaWorkflowLiveTerminal.razor.css
@@ -40,7 +40,23 @@
     border-bottom: 1px solid rgba(148, 152, 158, 0.18);
     white-space: nowrap;
     overflow: hidden;
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 0.65rem;
+}
+
+.actions-gha-terminal__caption-main {
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
     text-overflow: ellipsis;
+}
+
+.actions-gha-terminal__caption-steps {
+    flex-shrink: 0;
+    color: rgba(168, 178, 172, 0.95);
+    text-align: right;
 }
 
 .actions-gha-terminal__caption-prefix {

--- a/src/GrayMoon.App/Components/Shared/GhaWorkflowLiveTerminal.razor.css
+++ b/src/GrayMoon.App/Components/Shared/GhaWorkflowLiveTerminal.razor.css
@@ -55,7 +55,6 @@
 
 .actions-gha-terminal__caption-steps {
     flex-shrink: 0;
-    color: rgba(168, 178, 172, 0.95);
     text-align: right;
 }
 
@@ -67,10 +66,6 @@
 
 .loading-overlay-terminal--scheme-yellow .actions-gha-terminal__caption-prefix {
     color: rgba(230, 200, 90, 0.92);
-}
-
-.actions-gha-terminal__caption-text {
-    color: rgba(188, 196, 190, 0.96);
 }
 
 .actions-gha-terminal__scroll.loading-overlay-terminal__inner {

--- a/src/GrayMoon.App/Components/Shared/GhaWorkflowLiveTerminal.razor.css
+++ b/src/GrayMoon.App/Components/Shared/GhaWorkflowLiveTerminal.razor.css
@@ -1,0 +1,90 @@
+/* Fixed 8-line body, flush to table cell (no radius / no scroll). Line metrics match loading-overlay-terminal. */
+.actions-gha-terminal {
+    margin: 0;
+    width: 100%;
+}
+
+.actions-gha-terminal__wrap {
+    border-radius: 0;
+    overflow: hidden;
+    box-shadow: none;
+    border: none;
+    background: rgba(6, 8, 10, 0.94);
+    width: 100%;
+}
+
+.actions-gha-terminal__terminal.loading-overlay-terminal {
+    position: relative;
+    inset: auto;
+    left: auto;
+    right: auto;
+    top: auto;
+    bottom: auto;
+    height: auto;
+    min-height: 0;
+    max-height: none;
+    z-index: 0;
+    pointer-events: auto;
+    padding: 0;
+}
+
+.actions-gha-terminal__caption {
+    font-family: "GrayMoon Terminus", "Terminus", "Terminus (TTF)", "xos4 Terminus", "Ubuntu Mono",
+        "Noto Sans Mono", "DejaVu Sans Mono", "Liberation Mono", ui-monospace, "Cascadia Mono",
+        "Cascadia Code", "Segoe UI Mono", Menlo, Monaco, Consolas, "Courier New", monospace;
+    font-size: 0.78rem;
+    font-weight: 400;
+    line-height: 1.45;
+    letter-spacing: 0.02em;
+    padding: 0.35rem 0.65rem;
+    border-bottom: 1px solid rgba(148, 152, 158, 0.18);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.actions-gha-terminal__caption-prefix {
+    color: rgba(120, 210, 150, 0.88);
+    margin-right: 0.4rem;
+    font-weight: 500;
+}
+
+.loading-overlay-terminal--scheme-yellow .actions-gha-terminal__caption-prefix {
+    color: rgba(230, 200, 90, 0.92);
+}
+
+.actions-gha-terminal__caption-text {
+    color: rgba(188, 196, 190, 0.96);
+}
+
+.actions-gha-terminal__scroll.loading-overlay-terminal__inner {
+    --gha-line: calc(0.78rem * 1.45);
+    flex: none;
+    height: calc(8 * var(--gha-line));
+    max-height: calc(8 * var(--gha-line));
+    min-height: calc(8 * var(--gha-line));
+    overflow: hidden;
+    padding: 0 0.65rem 0.25rem;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+    scrollbar-width: none;
+    -ms-overflow-style: none;
+}
+
+.actions-gha-terminal__scroll.loading-overlay-terminal__inner::-webkit-scrollbar {
+    display: none;
+}
+
+.actions-gha-terminal__line {
+    margin: 0 !important;
+    padding: 0 !important;
+    flex: 0 0 var(--gha-line);
+    height: var(--gha-line);
+    min-height: var(--gha-line);
+    max-height: var(--gha-line);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    box-sizing: border-box;
+}

--- a/src/GrayMoon.App/Migrations.cs
+++ b/src/GrayMoon.App/Migrations.cs
@@ -32,6 +32,7 @@ public static class Migrations
         await MigrateWorkspaceRepositoryPullRequestsAsync(dbContext);
         await MigrateWorkspaceRepositoryPullRequestsChangedFilesAsync(dbContext);
         await MigrateWorkspaceRepositoryActionsAsync(dbContext);
+        await MigrateWorkspaceRepositoryActionsWorkflowsJsonAsync(dbContext);
         await MigrateWorkspaceRepositoriesRepositoryTypeAsync(dbContext);
     }
 
@@ -825,6 +826,36 @@ public static class Migrations
                         LastCheckedAt TEXT NOT NULL,
                         FOREIGN KEY (WorkspaceRepositoryId) REFERENCES WorkspaceRepositories(WorkspaceRepositoryId) ON DELETE CASCADE
                     )";
+                    await cmd.ExecuteNonQueryAsync();
+                }
+            }
+        }
+        catch
+        {
+            // Migration may already be applied or table doesn't exist yet
+        }
+    }
+
+    /// <summary>Adds WorkflowsJson column for per-workflow CI status list.</summary>
+    public static async Task MigrateWorkspaceRepositoryActionsWorkflowsJsonAsync(AppDbContext dbContext)
+    {
+        try
+        {
+            var conn = dbContext.Database.GetDbConnection();
+            if (conn.State != System.Data.ConnectionState.Open)
+                await conn.OpenAsync();
+
+            await using (var cmd = conn.CreateCommand())
+            {
+                cmd.CommandText = "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='WorkspaceRepositoryActions'";
+                if (Convert.ToInt32(await cmd.ExecuteScalarAsync()) == 0)
+                    return;
+
+                cmd.CommandText = "SELECT COUNT(*) FROM pragma_table_info('WorkspaceRepositoryActions') WHERE name='WorkflowsJson'";
+                var hasColumn = Convert.ToInt32(await cmd.ExecuteScalarAsync()) > 0;
+                if (!hasColumn)
+                {
+                    cmd.CommandText = "ALTER TABLE WorkspaceRepositoryActions ADD COLUMN WorkflowsJson TEXT";
                     await cmd.ExecuteNonQueryAsync();
                 }
             }

--- a/src/GrayMoon.App/Models/ActionStatusInfo.cs
+++ b/src/GrayMoon.App/Models/ActionStatusInfo.cs
@@ -21,4 +21,7 @@ public sealed class ActionStatusInfo
 
     /// <summary>Display name of the most relevant workflow.</summary>
     public string? WorkflowName { get; set; }
+
+    /// <summary>True when the workflow file declares a <c>workflow_dispatch</c> trigger (manual run is allowed).</summary>
+    public bool SupportsWorkflowDispatch { get; set; }
 }

--- a/src/GrayMoon.App/Models/ActionStatusInfo.cs
+++ b/src/GrayMoon.App/Models/ActionStatusInfo.cs
@@ -22,6 +22,12 @@ public sealed class ActionStatusInfo
     /// <summary>Display name of the most relevant workflow.</summary>
     public string? WorkflowName { get; set; }
 
+    /// <summary>Browser URL for this workflow (Actions tab for the definition), not a specific run.</summary>
+    public string? WorkflowHtmlUrl { get; set; }
+
+    /// <summary>Repo-relative workflow file path (e.g. <c>.github/workflows/build-app.yml</c>) for building the Actions workflow tab URL.</summary>
+    public string? WorkflowPath { get; set; }
+
     /// <summary>True when the workflow file declares a <c>workflow_dispatch</c> trigger (manual run is allowed).</summary>
     public bool SupportsWorkflowDispatch { get; set; }
 }

--- a/src/GrayMoon.App/Models/GitHubDtos.cs
+++ b/src/GrayMoon.App/Models/GitHubDtos.cs
@@ -49,6 +49,9 @@ public class GitHubWorkflowDto
     [JsonPropertyName("path")]
     public string Path { get; set; } = string.Empty;
 
+    [JsonPropertyName("html_url")]
+    public string HtmlUrl { get; set; } = string.Empty;
+
     [JsonPropertyName("state")]
     public string State { get; set; } = string.Empty;
 }
@@ -93,6 +96,49 @@ public class GitHubWorkflowRunsResponse
 {
     [JsonPropertyName("workflow_runs")]
     public List<GitHubWorkflowRunDto> WorkflowRuns { get; set; } = new();
+}
+
+/// <summary>GET /repos/{owner}/{repo}/actions/runs/{run_id}/jobs</summary>
+public sealed class GitHubWorkflowJobsResponse
+{
+    [JsonPropertyName("total_count")]
+    public int TotalCount { get; set; }
+
+    [JsonPropertyName("jobs")]
+    public List<GitHubWorkflowJobDto> Jobs { get; set; } = new();
+}
+
+public sealed class GitHubWorkflowJobDto
+{
+    [JsonPropertyName("id")]
+    public long Id { get; set; }
+
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = string.Empty;
+
+    [JsonPropertyName("status")]
+    public string Status { get; set; } = string.Empty;
+
+    [JsonPropertyName("conclusion")]
+    public string? Conclusion { get; set; }
+
+    [JsonPropertyName("steps")]
+    public List<GitHubWorkflowJobStepDto> Steps { get; set; } = new();
+}
+
+public sealed class GitHubWorkflowJobStepDto
+{
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = string.Empty;
+
+    [JsonPropertyName("status")]
+    public string Status { get; set; } = string.Empty;
+
+    [JsonPropertyName("conclusion")]
+    public string? Conclusion { get; set; }
+
+    [JsonPropertyName("number")]
+    public long Number { get; set; }
 }
 
 /// <summary>Single file from GET /repos/{owner}/{repo}/contents/{path}.</summary>

--- a/src/GrayMoon.App/Models/GitHubDtos.cs
+++ b/src/GrayMoon.App/Models/GitHubDtos.cs
@@ -95,6 +95,19 @@ public class GitHubWorkflowRunsResponse
     public List<GitHubWorkflowRunDto> WorkflowRuns { get; set; } = new();
 }
 
+/// <summary>Single file from GET /repos/{owner}/{repo}/contents/{path}.</summary>
+public sealed class GitHubContentResponse
+{
+    [JsonPropertyName("type")]
+    public string Type { get; set; } = string.Empty;
+
+    [JsonPropertyName("encoding")]
+    public string? Encoding { get; set; }
+
+    [JsonPropertyName("content")]
+    public string? Content { get; set; }
+}
+
 /// <summary>Pull request list item from GET /repos/{owner}/{repo}/pulls.</summary>
 public class GitHubPullRequestDto
 {

--- a/src/GrayMoon.App/Models/RepositoryActionsPersistedState.cs
+++ b/src/GrayMoon.App/Models/RepositoryActionsPersistedState.cs
@@ -1,0 +1,9 @@
+namespace GrayMoon.App.Models;
+
+/// <summary>CI action status loaded from persistence for one workspace–repository link (multiple workflows).</summary>
+public sealed class RepositoryActionsPersistedState
+{
+    public string? BranchName { get; init; }
+
+    public IReadOnlyList<ActionStatusInfo> Workflows { get; init; } = Array.Empty<ActionStatusInfo>();
+}

--- a/src/GrayMoon.App/Models/WorkspaceRepositoryAction.cs
+++ b/src/GrayMoon.App/Models/WorkspaceRepositoryAction.cs
@@ -26,6 +26,9 @@ public class WorkspaceRepositoryAction
 
     public string? WorkflowName { get; set; }
 
+    /// <summary>Serialized <see cref="List{ActionStatusInfo}"/> when using multi-workflow persistence; legacy rows use scalar columns only.</summary>
+    public string? WorkflowsJson { get; set; }
+
     public DateTime LastCheckedAt { get; set; }
 
     public ActionStatusInfo ToActionStatusInfo() => new()
@@ -36,6 +39,7 @@ public class WorkspaceRepositoryAction
         BranchName = BranchName,
         RunId = RunId,
         WorkflowId = WorkflowId,
-        WorkflowName = WorkflowName
+        WorkflowName = WorkflowName,
+        SupportsWorkflowDispatch = false
     };
 }

--- a/src/GrayMoon.App/Repositories/WorkspaceActionRepository.cs
+++ b/src/GrayMoon.App/Repositories/WorkspaceActionRepository.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using GrayMoon.App.Data;
 using GrayMoon.App.Models;
 using Microsoft.EntityFrameworkCore;
@@ -7,8 +8,13 @@ namespace GrayMoon.App.Repositories;
 /// <summary>Persistence for CI action status per workspace–repository link. Single place for all action table read/write.</summary>
 public sealed class WorkspaceActionRepository(AppDbContext dbContext, ILogger<WorkspaceActionRepository> logger)
 {
-    /// <summary>Returns persisted action state for all repositories in the workspace, keyed by RepositoryId. Missing row yields null (never checked).</summary>
-    public async Task<IReadOnlyDictionary<int, ActionStatusInfo?>> GetByWorkspaceIdAsync(int workspaceId, CancellationToken cancellationToken = default)
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    /// <summary>Returns persisted action state for all repositories in the workspace, keyed by RepositoryId. Missing row omitted (never checked).</summary>
+    public async Task<IReadOnlyDictionary<int, RepositoryActionsPersistedState>> GetByWorkspaceIdAsync(int workspaceId, CancellationToken cancellationToken = default)
     {
         var links = await dbContext.WorkspaceRepositories
             .AsNoTracking()
@@ -16,51 +22,65 @@ public sealed class WorkspaceActionRepository(AppDbContext dbContext, ILogger<Wo
             .Where(wr => wr.WorkspaceId == workspaceId)
             .ToListAsync(cancellationToken);
 
-        var result = new Dictionary<int, ActionStatusInfo?>();
+        var result = new Dictionary<int, RepositoryActionsPersistedState>();
         foreach (var link in links)
         {
             if (link.Action == null) continue;
-            result[link.RepositoryId] = link.Action.ToActionStatusInfo();
+
+            IReadOnlyList<ActionStatusInfo> workflows;
+            if (!string.IsNullOrWhiteSpace(link.Action.WorkflowsJson))
+            {
+                var list = JsonSerializer.Deserialize<List<ActionStatusInfo>>(link.Action.WorkflowsJson, JsonOptions) ?? [];
+                workflows = list;
+            }
+            else
+            {
+                workflows = [link.Action.ToActionStatusInfo()];
+            }
+
+            result[link.RepositoryId] = new RepositoryActionsPersistedState
+            {
+                BranchName = link.Action.BranchName,
+                Workflows = workflows
+            };
         }
+
         return result;
     }
 
-    /// <summary>Inserts or updates the action row for the given workspace–repo link.</summary>
-    public async Task UpsertAsync(int workspaceRepositoryId, ActionStatusInfo? info, CancellationToken cancellationToken = default)
+    /// <summary>Inserts or updates the action row for the given workspace–repo link. JSON is the source of truth; legacy scalar columns are cleared.</summary>
+    public async Task UpsertAsync(int workspaceRepositoryId, IReadOnlyList<ActionStatusInfo> workflows, string? branchName, CancellationToken cancellationToken = default)
     {
         var now = DateTime.UtcNow;
+        var json = JsonSerializer.Serialize(workflows, JsonOptions);
         var existing = await dbContext.WorkspaceRepositoryActions
             .FirstOrDefaultAsync(a => a.WorkspaceRepositoryId == workspaceRepositoryId, cancellationToken);
 
         if (existing != null)
         {
-            existing.Status = info?.Status;
-            existing.HtmlUrl = info?.HtmlUrl;
-            existing.UpdatedAt = info?.UpdatedAt;
-            existing.BranchName = info?.BranchName;
-            existing.RunId = info?.RunId;
-            existing.WorkflowId = info?.WorkflowId;
-            existing.WorkflowName = info?.WorkflowName;
+            existing.BranchName = branchName;
+            existing.WorkflowsJson = json;
             existing.LastCheckedAt = now;
+            existing.Status = null;
+            existing.HtmlUrl = null;
+            existing.UpdatedAt = null;
+            existing.RunId = null;
+            existing.WorkflowId = null;
+            existing.WorkflowName = null;
         }
         else
         {
             dbContext.WorkspaceRepositoryActions.Add(new WorkspaceRepositoryAction
             {
                 WorkspaceRepositoryId = workspaceRepositoryId,
-                Status = info?.Status,
-                HtmlUrl = info?.HtmlUrl,
-                UpdatedAt = info?.UpdatedAt,
-                BranchName = info?.BranchName,
-                RunId = info?.RunId,
-                WorkflowId = info?.WorkflowId,
-                WorkflowName = info?.WorkflowName,
+                BranchName = branchName,
+                WorkflowsJson = json,
                 LastCheckedAt = now
             });
         }
 
         await dbContext.SaveChangesAsync(cancellationToken);
-        logger.LogTrace("Upserted Action for WorkspaceRepositoryId={WorkspaceRepositoryId}, Status={Status}, Branch={Branch}",
-            workspaceRepositoryId, info?.Status, info?.BranchName);
+        logger.LogTrace("Upserted Actions for WorkspaceRepositoryId={WorkspaceRepositoryId}, Branch={Branch}, WorkflowCount={Count}",
+            workspaceRepositoryId, branchName, workflows.Count);
     }
 }

--- a/src/GrayMoon.App/Services/GitHubActionsService.cs
+++ b/src/GrayMoon.App/Services/GitHubActionsService.cs
@@ -175,12 +175,22 @@ public class GitHubActionsService(
             {
                 latestByWorkflowId.TryGetValue(wf.Id, out var run);
                 var supportsDispatch = dispatchById.GetValueOrDefault(wf.Id, false);
+                var workflowPageUrl = RepositoryUrlHelper.BuildWorkflowPageUrl(
+                    wf.HtmlUrl,
+                    repository.CloneUrl,
+                    owner,
+                    repoName,
+                    wf.Id,
+                    wf.Path,
+                    connector.ApiBaseUrl);
                 result.Add(ToPerWorkflowActionStatus(
                     branch,
                     wf.Id,
                     wf.Name,
                     run,
                     supportsDispatch,
+                    workflowPageUrl,
+                    wf.Path,
                     owner,
                     repoName,
                     repository.CloneUrl,
@@ -196,12 +206,22 @@ public class GitHubActionsService(
                     ? null
                     : await gitHubService.GetRepositoryFileUtf8TextAsync(connector, owner, repoName, meta.Path, cancellationToken);
                 var supportsDispatch = YamlAppearsToHaveWorkflowDispatch(yaml);
+                var workflowPageUrl = RepositoryUrlHelper.BuildWorkflowPageUrl(
+                    meta?.HtmlUrl,
+                    repository.CloneUrl,
+                    owner,
+                    repoName,
+                    run.WorkflowId,
+                    meta?.Path,
+                    connector.ApiBaseUrl);
                 result.Add(ToPerWorkflowActionStatus(
                     branch,
                     run.WorkflowId,
                     run.Name,
                     run,
                     supportsDispatch,
+                    workflowPageUrl,
+                    meta?.Path,
                     owner,
                     repoName,
                     repository.CloneUrl,
@@ -227,6 +247,8 @@ public class GitHubActionsService(
         string workflowName,
         GitHubWorkflowRunDto? run,
         bool supportsWorkflowDispatch,
+        string? workflowPageUrl,
+        string? workflowFilePath,
         string owner,
         string repoName,
         string cloneUrl,
@@ -240,6 +262,8 @@ public class GitHubActionsService(
                 BranchName = branch,
                 WorkflowId = workflowId,
                 WorkflowName = workflowName,
+                WorkflowHtmlUrl = workflowPageUrl,
+                WorkflowPath = workflowFilePath,
                 SupportsWorkflowDispatch = supportsWorkflowDispatch
             };
         }
@@ -266,6 +290,8 @@ public class GitHubActionsService(
             RunId = run.Id,
             WorkflowId = workflowId,
             WorkflowName = displayName,
+            WorkflowHtmlUrl = workflowPageUrl,
+            WorkflowPath = workflowFilePath,
             SupportsWorkflowDispatch = supportsWorkflowDispatch
         };
     }

--- a/src/GrayMoon.App/Services/GitHubActionsService.cs
+++ b/src/GrayMoon.App/Services/GitHubActionsService.cs
@@ -53,7 +53,13 @@ public class GitHubActionsService(
                         Status = run.Status,
                         Conclusion = run.Conclusion,
                         UpdatedAt = run.UpdatedAt,
-                        HtmlUrl = run.HtmlUrl,
+                        HtmlUrl = RepositoryUrlHelper.GetWorkflowRunWebUrl(
+                                      repository.CloneUrl,
+                                      repository.OrgName,
+                                      repository.RepositoryName,
+                                      run.Id,
+                                      connector.ApiBaseUrl)
+                                  ?? run.HtmlUrl,
                         HeadBranch = run.HeadBranch
                     });
                 }
@@ -105,7 +111,13 @@ public class GitHubActionsService(
                 Status = run.Status,
                 Conclusion = run.Conclusion,
                 UpdatedAt = run.UpdatedAt,
-                HtmlUrl = run.HtmlUrl,
+                HtmlUrl = RepositoryUrlHelper.GetWorkflowRunWebUrl(
+                              repository.CloneUrl,
+                              repository.OrgName,
+                              repository.RepositoryName,
+                              run.Id,
+                              connector.ApiBaseUrl)
+                          ?? run.HtmlUrl,
                 HeadBranch = run.HeadBranch
             };
         }
@@ -163,7 +175,16 @@ public class GitHubActionsService(
             {
                 latestByWorkflowId.TryGetValue(wf.Id, out var run);
                 var supportsDispatch = dispatchById.GetValueOrDefault(wf.Id, false);
-                result.Add(ToPerWorkflowActionStatus(branch, wf.Id, wf.Name, run, supportsDispatch));
+                result.Add(ToPerWorkflowActionStatus(
+                    branch,
+                    wf.Id,
+                    wf.Name,
+                    run,
+                    supportsDispatch,
+                    owner,
+                    repoName,
+                    repository.CloneUrl,
+                    connector.ApiBaseUrl));
             }
         }
         else
@@ -175,7 +196,16 @@ public class GitHubActionsService(
                     ? null
                     : await gitHubService.GetRepositoryFileUtf8TextAsync(connector, owner, repoName, meta.Path, cancellationToken);
                 var supportsDispatch = YamlAppearsToHaveWorkflowDispatch(yaml);
-                result.Add(ToPerWorkflowActionStatus(branch, run.WorkflowId, run.Name, run, supportsDispatch));
+                result.Add(ToPerWorkflowActionStatus(
+                    branch,
+                    run.WorkflowId,
+                    run.Name,
+                    run,
+                    supportsDispatch,
+                    owner,
+                    repoName,
+                    repository.CloneUrl,
+                    connector.ApiBaseUrl));
             }
         }
 
@@ -191,7 +221,16 @@ public class GitHubActionsService(
 
     private static readonly Regex WorkflowDispatchTriggerRegex = new(@"\bworkflow_dispatch\b", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled);
 
-    private static ActionStatusInfo ToPerWorkflowActionStatus(string branch, long workflowId, string workflowName, GitHubWorkflowRunDto? run, bool supportsWorkflowDispatch)
+    private static ActionStatusInfo ToPerWorkflowActionStatus(
+        string branch,
+        long workflowId,
+        string workflowName,
+        GitHubWorkflowRunDto? run,
+        bool supportsWorkflowDispatch,
+        string owner,
+        string repoName,
+        string cloneUrl,
+        string? connectorApiBaseUrl)
     {
         if (run == null)
         {
@@ -214,10 +253,14 @@ public class GitHubActionsService(
             status = "success";
 
         var displayName = string.IsNullOrWhiteSpace(run.Name) ? workflowName : run.Name;
+        var htmlUrl = RepositoryUrlHelper.GetWorkflowRunWebUrl(cloneUrl, owner, repoName, run.Id, connectorApiBaseUrl);
+        if (string.IsNullOrWhiteSpace(htmlUrl) && Uri.TryCreate(run.HtmlUrl, UriKind.Absolute, out _))
+            htmlUrl = run.HtmlUrl;
+
         return new ActionStatusInfo
         {
             Status = status,
-            HtmlUrl = run.HtmlUrl,
+            HtmlUrl = htmlUrl,
             UpdatedAt = run.UpdatedAt,
             BranchName = branch,
             RunId = run.Id,

--- a/src/GrayMoon.App/Services/GitHubActionsService.cs
+++ b/src/GrayMoon.App/Services/GitHubActionsService.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using GrayMoon.App.Models;
 using GrayMoon.App.Repositories;
 
@@ -116,76 +117,113 @@ public class GitHubActionsService(
     }
 
     /// <summary>
-    /// Fetches all recent workflow runs for the given branch and returns an aggregated status.
-    /// Groups by workflow, takes the latest run per workflow, then returns:
-    /// "failed" if any has a failure conclusion, "running" if any is still in progress,
-    /// "success" if all completed successfully, or "none" if no runs found.
+    /// Fetches active workflows and the latest run per workflow for <paramref name="branch"/>.
+    /// Each entry is independent (not cross-workflow aggregate).
     /// </summary>
-    public async Task<ActionStatusInfo?> GetAggregateActionStatusForBranchAsync(GitHubRepositoryEntry repository, string branch)
+    public async Task<IReadOnlyList<ActionStatusInfo>?> GetWorkflowStatusesForBranchAsync(GitHubRepositoryEntry repository, string branch, CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(repository.OrgName) || string.IsNullOrWhiteSpace(repository.RepositoryName))
             return null;
 
         if (string.IsNullOrWhiteSpace(branch))
-            return new ActionStatusInfo { Status = "none" };
+            return [new ActionStatusInfo { Status = "none", BranchName = branch }];
 
         var connector = await connectorRepository.GetByNameAsync(repository.ConnectorName);
         if (connector == null)
         {
-            logger.LogWarning("Connector {ConnectorName} not found for aggregate actions.", repository.ConnectorName);
+            logger.LogWarning("Connector {ConnectorName} not found for workflow statuses.", repository.ConnectorName);
             return null;
         }
 
-        var runs = await gitHubService.GetWorkflowRunsForBranchAsync(connector, repository.OrgName, repository.RepositoryName, branch);
-        if (runs.Count == 0)
-            return new ActionStatusInfo { Status = "none", BranchName = branch };
+        var owner = repository.OrgName!;
+        var repoName = repository.RepositoryName;
 
-        // Take the latest run per workflow to avoid stale duplicates counting against aggregate
-        var latestPerWorkflow = runs
-            .GroupBy(r => r.WorkflowId)
-            .Select(g => g.OrderByDescending(r => r.UpdatedAt).First())
+        var workflows = (await gitHubService.GetWorkflowsAsync(connector, owner, repoName, cancellationToken))
+            .Where(w => string.Equals(w.State, "active", StringComparison.OrdinalIgnoreCase))
+            .OrderBy(w => w.Name, StringComparer.OrdinalIgnoreCase)
             .ToList();
 
-        var failedRun = latestPerWorkflow
-            .Where(r => IsFailureConclusion(r.Conclusion))
-            .OrderByDescending(r => r.UpdatedAt)
-            .FirstOrDefault();
+        var runs = await gitHubService.GetWorkflowRunsForBranchAsync(
+            connector, owner, repoName, branch, perPage: 100);
+        var latestByWorkflowId = runs
+            .GroupBy(r => r.WorkflowId)
+            .ToDictionary(g => g.Key, g => g.OrderByDescending(r => r.UpdatedAt).First());
 
-        var runningRun = latestPerWorkflow
-            .Where(r => !string.Equals(r.Status, "completed", StringComparison.OrdinalIgnoreCase))
-            .OrderByDescending(r => r.UpdatedAt)
-            .FirstOrDefault();
-
-        var latestRun = latestPerWorkflow.OrderByDescending(r => r.UpdatedAt).First();
-
-        string status;
-        GitHubWorkflowRunDto primaryRun;
-
-        if (failedRun != null)
+        var result = new List<ActionStatusInfo>();
+        if (workflows.Count > 0)
         {
-            status = "failed";
-            primaryRun = failedRun;
-        }
-        else if (runningRun != null)
-        {
-            status = "running";
-            primaryRun = runningRun;
+            var dispatchPairs = await Task.WhenAll(workflows.Select(async wf =>
+            {
+                var yaml = await gitHubService.GetRepositoryFileUtf8TextAsync(connector, owner, repoName, wf.Path, cancellationToken);
+                return (wf.Id, Supports: YamlAppearsToHaveWorkflowDispatch(yaml));
+            }));
+            var dispatchById = dispatchPairs.ToDictionary(x => x.Id, x => x.Supports);
+
+            foreach (var wf in workflows)
+            {
+                latestByWorkflowId.TryGetValue(wf.Id, out var run);
+                var supportsDispatch = dispatchById.GetValueOrDefault(wf.Id, false);
+                result.Add(ToPerWorkflowActionStatus(branch, wf.Id, wf.Name, run, supportsDispatch));
+            }
         }
         else
         {
-            status = "success";
-            primaryRun = latestRun;
+            foreach (var run in latestByWorkflowId.Values.OrderBy(r => r.Name, StringComparer.OrdinalIgnoreCase))
+            {
+                var meta = await gitHubService.GetWorkflowByIdAsync(connector, owner, repoName, run.WorkflowId, cancellationToken);
+                var yaml = string.IsNullOrWhiteSpace(meta?.Path)
+                    ? null
+                    : await gitHubService.GetRepositoryFileUtf8TextAsync(connector, owner, repoName, meta.Path, cancellationToken);
+                var supportsDispatch = YamlAppearsToHaveWorkflowDispatch(yaml);
+                result.Add(ToPerWorkflowActionStatus(branch, run.WorkflowId, run.Name, run, supportsDispatch));
+            }
         }
 
+        return result;
+    }
+
+    /// <summary>Detects a <c>workflow_dispatch</c> trigger in workflow YAML without a full parser.</summary>
+    private static bool YamlAppearsToHaveWorkflowDispatch(string? yaml)
+    {
+        if (string.IsNullOrWhiteSpace(yaml)) return false;
+        return WorkflowDispatchTriggerRegex.IsMatch(yaml);
+    }
+
+    private static readonly Regex WorkflowDispatchTriggerRegex = new(@"\bworkflow_dispatch\b", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+    private static ActionStatusInfo ToPerWorkflowActionStatus(string branch, long workflowId, string workflowName, GitHubWorkflowRunDto? run, bool supportsWorkflowDispatch)
+    {
+        if (run == null)
+        {
+            return new ActionStatusInfo
+            {
+                Status = "none",
+                BranchName = branch,
+                WorkflowId = workflowId,
+                WorkflowName = workflowName,
+                SupportsWorkflowDispatch = supportsWorkflowDispatch
+            };
+        }
+
+        string status;
+        if (IsFailureConclusion(run.Conclusion))
+            status = "failed";
+        else if (!string.Equals(run.Status, "completed", StringComparison.OrdinalIgnoreCase))
+            status = "running";
+        else
+            status = "success";
+
+        var displayName = string.IsNullOrWhiteSpace(run.Name) ? workflowName : run.Name;
         return new ActionStatusInfo
         {
             Status = status,
-            HtmlUrl = primaryRun.HtmlUrl,
-            UpdatedAt = primaryRun.UpdatedAt,
+            HtmlUrl = run.HtmlUrl,
+            UpdatedAt = run.UpdatedAt,
             BranchName = branch,
-            RunId = primaryRun.Id,
-            WorkflowId = primaryRun.WorkflowId,
-            WorkflowName = primaryRun.Name
+            RunId = run.Id,
+            WorkflowId = workflowId,
+            WorkflowName = displayName,
+            SupportsWorkflowDispatch = supportsWorkflowDispatch
         };
     }
 

--- a/src/GrayMoon.App/Services/GitHubService.cs
+++ b/src/GrayMoon.App/Services/GitHubService.cs
@@ -230,6 +230,23 @@ public class GitHubService : IConnectorService
         return response?.WorkflowRuns ?? new List<GitHubWorkflowRunDto>();
     }
 
+    /// <summary>Lists jobs for a workflow run (steps, status).</summary>
+    public async Task<GitHubWorkflowJobsResponse?> GetWorkflowRunJobsAsync(Connector connector, string owner, string repo, long runId, CancellationToken cancellationToken = default)
+    {
+        EnsureConnectorConfigured(connector);
+        if (string.IsNullOrWhiteSpace(owner))
+            throw new ArgumentException("Owner is required.", nameof(owner));
+        if (string.IsNullOrWhiteSpace(repo))
+            throw new ArgumentException("Repository is required.", nameof(repo));
+        if (runId <= 0)
+            throw new ArgumentException("Run id is required.", nameof(runId));
+
+        return await GetAsync<GitHubWorkflowJobsResponse>(
+            connector,
+            $"repos/{owner}/{repo}/actions/runs/{runId}/jobs?per_page=100",
+            cancellationToken);
+    }
+
     public async Task RerunWorkflowRunAsync(Connector connector, string owner, string repo, long runId)
     {
         EnsureConnectorConfigured(connector);

--- a/src/GrayMoon.App/Services/GitHubService.cs
+++ b/src/GrayMoon.App/Services/GitHubService.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Net.Http.Headers;
+using System.Text;
 using System.Text.Json;
 using GrayMoon.Abstractions.Models;
 using GrayMoon.App.Models;
@@ -104,6 +105,88 @@ public class GitHubService : IConnectorService
 
         var response = await GetAsync<GitHubWorkflowsResponse>($"repos/{owner}/{repo}/actions/workflows");
         return response?.Workflows ?? new List<GitHubWorkflowDto>();
+    }
+
+    /// <summary>Lists workflows for a repo using the connector token (workspace / multi-connector actions).</summary>
+    public async Task<List<GitHubWorkflowDto>> GetWorkflowsAsync(Connector connector, string owner, string repo, CancellationToken cancellationToken = default)
+    {
+        EnsureConnectorConfigured(connector);
+        if (string.IsNullOrWhiteSpace(owner))
+            throw new ArgumentException("Owner is required.", nameof(owner));
+        if (string.IsNullOrWhiteSpace(repo))
+            throw new ArgumentException("Repository is required.", nameof(repo));
+
+        var response = await GetAsync<GitHubWorkflowsResponse>(connector, $"repos/{owner}/{repo}/actions/workflows", cancellationToken);
+        return response?.Workflows ?? new List<GitHubWorkflowDto>();
+    }
+
+    /// <summary>GET /repos/{owner}/{repo}/actions/workflows/{workflow_id}. Returns null if not found.</summary>
+    public async Task<GitHubWorkflowDto?> GetWorkflowByIdAsync(Connector connector, string owner, string repo, long workflowId, CancellationToken cancellationToken = default)
+    {
+        EnsureConnectorConfigured(connector);
+        if (string.IsNullOrWhiteSpace(owner))
+            throw new ArgumentException("Owner is required.", nameof(owner));
+        if (string.IsNullOrWhiteSpace(repo))
+            throw new ArgumentException("Repository is required.", nameof(repo));
+
+        using var response = await GetResponseAsync(connector, $"repos/{owner}/{repo}/actions/workflows/{workflowId}", cancellationToken);
+        if (response.StatusCode == HttpStatusCode.NotFound)
+            return null;
+        if (!response.IsSuccessStatusCode)
+        {
+            var errorContent = await response.Content.ReadAsStringAsync(cancellationToken);
+            _logger.LogError("GitHub API call failed. Status: {StatusCode}, URL: {Url}, Response: {Response}",
+                response.StatusCode,
+                response.RequestMessage?.RequestUri,
+                errorContent);
+            response.EnsureSuccessStatusCode();
+        }
+
+        return await response.Content.ReadFromJsonAsync<GitHubWorkflowDto>(_jsonOptions, cancellationToken);
+    }
+
+    /// <summary>Loads a repository file as UTF-8 text (e.g. workflow YAML). Returns null if missing or not a file.</summary>
+    public async Task<string?> GetRepositoryFileUtf8TextAsync(Connector connector, string owner, string repo, string filePath, CancellationToken cancellationToken = default)
+    {
+        EnsureConnectorConfigured(connector);
+        if (string.IsNullOrWhiteSpace(owner))
+            throw new ArgumentException("Owner is required.", nameof(owner));
+        if (string.IsNullOrWhiteSpace(repo))
+            throw new ArgumentException("Repository is required.", nameof(repo));
+        if (string.IsNullOrWhiteSpace(filePath))
+            return null;
+
+        var encodedPath = string.Join("/", filePath.Split('/', StringSplitOptions.RemoveEmptyEntries).Select(Uri.EscapeDataString));
+        using var response = await GetResponseAsync(connector, $"repos/{owner}/{repo}/contents/{encodedPath}", cancellationToken);
+        if (response.StatusCode == HttpStatusCode.NotFound)
+            return null;
+        if (!response.IsSuccessStatusCode)
+        {
+            var errorContent = await response.Content.ReadAsStringAsync(cancellationToken);
+            _logger.LogError("GitHub API call failed. Status: {StatusCode}, URL: {Url}, Response: {Response}",
+                response.StatusCode,
+                response.RequestMessage?.RequestUri,
+                errorContent);
+            response.EnsureSuccessStatusCode();
+        }
+
+        var dto = await response.Content.ReadFromJsonAsync<GitHubContentResponse>(_jsonOptions, cancellationToken);
+        if (dto == null || !string.Equals(dto.Type, "file", StringComparison.OrdinalIgnoreCase))
+            return null;
+        if (!string.Equals(dto.Encoding, "base64", StringComparison.OrdinalIgnoreCase) || string.IsNullOrEmpty(dto.Content))
+            return null;
+
+        try
+        {
+            var raw = dto.Content.Replace("\n", "", StringComparison.Ordinal).Replace("\r", "", StringComparison.Ordinal);
+            var bytes = Convert.FromBase64String(raw);
+            return Encoding.UTF8.GetString(bytes);
+        }
+        catch (FormatException ex)
+        {
+            _logger.LogDebug(ex, "Could not decode repository file as base64. Path={Path}", filePath);
+            return null;
+        }
     }
 
     public async Task<GitHubWorkflowRunDto?> GetLatestWorkflowRunAsync(Connector connector, string owner, string repo)

--- a/src/GrayMoon.App/Services/GitHubService.cs
+++ b/src/GrayMoon.App/Services/GitHubService.cs
@@ -72,6 +72,28 @@ public class GitHubService : IConnectorService
             })
             .Build();
 
+    /// <summary>Retries transient failures for GitHub REST <strong>mutations</strong> (POST). Read-only calls use <see cref="GitHubGetRetryPipeline"/>.</summary>
+    private static readonly ResiliencePipeline<HttpResponseMessage> GitHubMutationRetryPipeline =
+        new ResiliencePipelineBuilder<HttpResponseMessage>()
+            .AddRetry(new RetryStrategyOptions<HttpResponseMessage>
+            {
+                ShouldHandle = new PredicateBuilder<HttpResponseMessage>()
+                    .HandleResult(r => r.StatusCode is HttpStatusCode.TooManyRequests or HttpStatusCode.BadGateway or HttpStatusCode.ServiceUnavailable)
+                    .Handle<HttpRequestException>()
+                    .Handle<TaskCanceledException>(),
+                MaxRetryAttempts = 3,
+                Delay = TimeSpan.FromSeconds(1),
+                BackoffType = DelayBackoffType.Exponential,
+                UseJitter = true,
+                OnRetry = static args =>
+                {
+                    if (args.Outcome.Result is HttpResponseMessage prev)
+                        prev.Dispose();
+                    return ValueTask.CompletedTask;
+                }
+            })
+            .Build();
+
     public async Task<List<GitHubOrganizationDto>> GetOrganizationsAsync()
     {
         EnsureConfigured();
@@ -247,7 +269,7 @@ public class GitHubService : IConnectorService
             cancellationToken);
     }
 
-    public async Task RerunWorkflowRunAsync(Connector connector, string owner, string repo, long runId)
+    public async Task RerunWorkflowRunAsync(Connector connector, string owner, string repo, long runId, CancellationToken cancellationToken = default)
     {
         EnsureConnectorConfigured(connector);
 
@@ -266,10 +288,10 @@ public class GitHubService : IConnectorService
             throw new ArgumentException("Workflow run id is required.", nameof(runId));
         }
 
-        await PostAsync(connector, $"repos/{owner}/{repo}/actions/runs/{runId}/rerun");
+        await PostAsync(connector, $"repos/{owner}/{repo}/actions/runs/{runId}/rerun", payload: null, cancellationToken: cancellationToken);
     }
 
-    public async Task DispatchWorkflowAsync(Connector connector, string owner, string repo, long workflowId, string branch)
+    public async Task DispatchWorkflowAsync(Connector connector, string owner, string repo, long workflowId, string branch, CancellationToken cancellationToken = default)
     {
         EnsureConnectorConfigured(connector);
 
@@ -294,7 +316,7 @@ public class GitHubService : IConnectorService
         }
 
         var payload = JsonSerializer.Serialize(new { @ref = branch });
-        await PostAsync(connector, $"repos/{owner}/{repo}/actions/workflows/{workflowId}/dispatches", payload);
+        await PostAsync(connector, $"repos/{owner}/{repo}/actions/workflows/{workflowId}/dispatches", payload, cancellationToken);
     }
 
     public async Task<ConnectorTestResult> TestConnectionAsync(Connector connector)
@@ -488,21 +510,17 @@ public class GitHubService : IConnectorService
         return await response.Content.ReadFromJsonAsync<T>(_jsonOptions, cancellationToken);
     }
 
-    private async Task PostAsync(Connector connector, string requestUri, string? payload = null)
+    private HttpRequestMessage CreatePostRequest(Connector connector, string requestUri, string? payload)
     {
         var baseUrl = string.IsNullOrWhiteSpace(connector.ApiBaseUrl)
             ? "https://api.github.com/"
             : connector.ApiBaseUrl.TrimEnd('/') + "/";
 
-        using var request = new HttpRequestMessage(HttpMethod.Post, new Uri(new Uri(baseUrl), requestUri));
+        var request = new HttpRequestMessage(HttpMethod.Post, new Uri(new Uri(baseUrl), requestUri));
         if (payload != null)
-        {
-            request.Content = new StringContent(payload, System.Text.Encoding.UTF8, "application/json");
-        }
+            request.Content = new StringContent(payload, Encoding.UTF8, "application/json");
         else
-        {
-            request.Content = new StringContent("{}", System.Text.Encoding.UTF8, "application/json");
-        }
+            request.Content = new StringContent("{}", Encoding.UTF8, "application/json");
         request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.github+json"));
         request.Headers.UserAgent.ParseAdd("GrayMoon");
         request.Headers.Add("X-GitHub-Api-Version", "2022-11-28");
@@ -510,17 +528,54 @@ public class GitHubService : IConnectorService
         if (string.IsNullOrWhiteSpace(token))
             throw new InvalidOperationException("Connector token is not configured.");
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        return request;
+    }
 
-        var response = await _httpClient.SendAsync(request);
-        if (!response.IsSuccessStatusCode)
+    private async Task PostAsync(Connector connector, string requestUri, string? payload = null, CancellationToken cancellationToken = default)
+    {
+        var baseUrl = string.IsNullOrWhiteSpace(connector.ApiBaseUrl)
+            ? "https://api.github.com/"
+            : connector.ApiBaseUrl.TrimEnd('/') + "/";
+
+        using var response = await GitHubMutationRetryPipeline.ExecuteAsync(async ct =>
         {
-            var errorContent = await response.Content.ReadAsStringAsync();
-            _logger.LogError("GitHub API call failed. Status: {StatusCode}, URL: {Url}, Response: {Response}",
-                response.StatusCode,
-                new Uri(new Uri(baseUrl), requestUri),
-                errorContent);
-            response.EnsureSuccessStatusCode();
+            using var request = CreatePostRequest(connector, requestUri, payload);
+            return await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, ct);
+        }, cancellationToken);
+
+        if (response.IsSuccessStatusCode)
+            return;
+
+        var errorContent = await response.Content.ReadAsStringAsync(cancellationToken);
+        _logger.LogError("GitHub API POST failed. Status: {StatusCode}, URL: {Url}, Response: {Response}",
+            response.StatusCode,
+            new Uri(new Uri(baseUrl), requestUri),
+            errorContent);
+
+        var detail = TryParseGitHubApiUserMessage(errorContent);
+        var summary = string.IsNullOrWhiteSpace(detail)
+            ? $"GitHub returned {(int)response.StatusCode} ({response.ReasonPhrase})."
+            : detail.Trim();
+        throw new HttpRequestException(summary, inner: null, statusCode: response.StatusCode);
+    }
+
+    /// <summary>Extracts the user-visible <c>message</c> field from a GitHub API JSON error body.</summary>
+    private static string? TryParseGitHubApiUserMessage(string jsonBody)
+    {
+        if (string.IsNullOrWhiteSpace(jsonBody))
+            return null;
+        try
+        {
+            using var doc = JsonDocument.Parse(jsonBody);
+            if (doc.RootElement.TryGetProperty("message", out var m) && m.ValueKind == JsonValueKind.String)
+                return m.GetString();
         }
+        catch (JsonException)
+        {
+            /* not JSON */
+        }
+
+        return null;
     }
 
     private async Task<List<GitHubRepositoryDto>> GetRepositoriesPagedAsync(string requestUri)

--- a/src/GrayMoon.App/Services/RepositoryUrlHelper.cs
+++ b/src/GrayMoon.App/Services/RepositoryUrlHelper.cs
@@ -3,6 +3,75 @@ namespace GrayMoon.App.Services;
 /// <summary>Converts git clone URLs to GitHub web URLs for links.</summary>
 public static class RepositoryUrlHelper
 {
+    /// <summary>
+    /// Builds the browser URL for a workflow run. Prefer the clone URL host (GitHub.com or Enterprise)
+    /// plus <c>owner/repo/actions/runs/{runId}</c> so links match the repo and avoid bad or relative <c>html_url</c> from the API.
+    /// </summary>
+    public static string? GetWorkflowRunWebUrl(string? cloneUrl, string? owner, string? repositoryName, long runId, string? connectorApiBaseUrl = null)
+    {
+        if (runId <= 0 || string.IsNullOrWhiteSpace(owner) || string.IsNullOrWhiteSpace(repositoryName))
+            return null;
+
+        var root = TryGetGitHostRootFromCloneUrl(cloneUrl, out var hostRoot)
+            ? hostRoot
+            : GetWebRootFromConnectorApiBase(connectorApiBaseUrl);
+        if (string.IsNullOrWhiteSpace(root))
+            return null;
+
+        root = root.TrimEnd('/');
+        return $"{root}/{owner}/{repositoryName}/actions/runs/{runId}";
+    }
+
+    /// <summary>HTTPS origin (scheme + host, no path) from a git remote URL, when parseable.</summary>
+    public static bool TryGetGitHostRootFromCloneUrl(string? cloneUrl, out string? root)
+    {
+        root = null;
+        if (string.IsNullOrWhiteSpace(cloneUrl))
+            return false;
+
+        var u = cloneUrl.Trim();
+        if (u.StartsWith("git@", StringComparison.OrdinalIgnoreCase))
+        {
+            var colon = u.IndexOf(':');
+            if (colon <= "git@".Length)
+                return false;
+            var sshHost = u["git@".Length..colon];
+            if (string.IsNullOrWhiteSpace(sshHost))
+                return false;
+            root = $"https://{sshHost}";
+            return true;
+        }
+
+        if (!Uri.TryCreate(u, UriKind.Absolute, out var uri) || uri.Scheme is not ("http" or "https"))
+            return false;
+        if (string.IsNullOrEmpty(uri.Host))
+            return false;
+
+        root = $"{uri.Scheme}://{uri.Authority}";
+        return true;
+    }
+
+    /// <summary>Web UI root from connector API base (GitHub.com or GHES <c>.../api/v3</c>).</summary>
+    public static string? GetWebRootFromConnectorApiBase(string? apiBaseUrl)
+    {
+        if (string.IsNullOrWhiteSpace(apiBaseUrl))
+            return "https://github.com";
+
+        var baseTrim = apiBaseUrl.Trim().TrimEnd('/');
+        if (baseTrim.Contains("api.github.com", StringComparison.OrdinalIgnoreCase))
+            return "https://github.com";
+
+        const string suffix = "/api/v3";
+        if (baseTrim.EndsWith(suffix, StringComparison.OrdinalIgnoreCase))
+            return baseTrim[..^suffix.Length];
+
+        var idx = baseTrim.IndexOf("/api/v3/", StringComparison.OrdinalIgnoreCase);
+        if (idx >= 0)
+            return baseTrim[..idx];
+
+        return baseTrim;
+    }
+
     /// <summary>Converts a repository's CloneUrl to a GitHub web URL, or null if not a GitHub repo.</summary>
     public static string? GetRepositoryUrl(string? cloneUrl)
     {

--- a/src/GrayMoon.App/Services/RepositoryUrlHelper.cs
+++ b/src/GrayMoon.App/Services/RepositoryUrlHelper.cs
@@ -1,8 +1,83 @@
+using System.Globalization;
+
 namespace GrayMoon.App.Services;
 
 /// <summary>Converts git clone URLs to GitHub web URLs for links.</summary>
 public static class RepositoryUrlHelper
 {
+    /// <summary>
+    /// Browser URL for the Actions <strong>workflow</strong> tab (<c>…/actions/workflows/build-app.yml</c>), not a run and not the repo file/blob view.
+    /// When <paramref name="workflowPath"/> is set, the segment is the path under <c>…/workflows/</c> (e.g. <c>build-app.yml</c> or <c>ci%2Fnested.yml</c>).
+    /// </summary>
+    public static string? BuildWorkflowPageUrl(
+        string? apiWorkflowHtmlUrl,
+        string? cloneUrl,
+        string? owner,
+        string? repositoryName,
+        long workflowId,
+        string? workflowPath,
+        string? connectorApiBaseUrl = null)
+    {
+        if (string.IsNullOrWhiteSpace(owner) || string.IsNullOrWhiteSpace(repositoryName))
+            return null;
+
+        var root = TryGetGitHostRootFromCloneUrl(cloneUrl, out var hostRoot)
+            ? hostRoot
+            : GetWebRootFromConnectorApiBase(connectorApiBaseUrl);
+        if (string.IsNullOrWhiteSpace(root))
+            return null;
+
+        root = root.TrimEnd('/');
+
+        var segment = ActionsWorkflowsTabPathSegment(workflowPath);
+        if (!string.IsNullOrWhiteSpace(segment))
+            return $"{root}/{owner}/{repositoryName}/actions/workflows/{segment}";
+
+        if (IsActionsWorkflowsTabUrl(apiWorkflowHtmlUrl))
+            return apiWorkflowHtmlUrl;
+
+        if (workflowId > 0)
+            return $"{root}/{owner}/{repositoryName}/actions/workflows/{workflowId.ToString(CultureInfo.InvariantCulture)}";
+
+        return null;
+    }
+
+    /// <summary>True when <paramref name="url"/> is an Actions workflows tab link, not blob/tree.</summary>
+    private static bool IsActionsWorkflowsTabUrl(string? url)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+            return false;
+        if (url.Contains("/blob/", StringComparison.Ordinal) || url.Contains("/tree/", StringComparison.Ordinal))
+            return false;
+        return url.Contains("/actions/workflows/", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>Path segment after <c>owner/repo/actions/workflows/</c>: YAML name or nested path with <c>/</c> encoded as <c>%2F</c>.</summary>
+    private static string? ActionsWorkflowsTabPathSegment(string? workflowPath)
+    {
+        if (string.IsNullOrWhiteSpace(workflowPath))
+            return null;
+
+        var p = workflowPath.Replace('\\', '/').TrimStart('/');
+        const string marker = "workflows/";
+        var idx = p.IndexOf(marker, StringComparison.OrdinalIgnoreCase);
+        string relative;
+        if (idx >= 0)
+            relative = p[(idx + marker.Length)..];
+        else
+        {
+            var parts = p.Split('/', StringSplitOptions.RemoveEmptyEntries);
+            if (parts.Length == 0)
+                return null;
+            relative = parts[^1];
+        }
+
+        if (string.IsNullOrWhiteSpace(relative))
+            return null;
+
+        return Uri.EscapeDataString(relative);
+    }
+
     /// <summary>
     /// Builds the browser URL for a workflow run. Prefer the clone URL host (GitHub.com or Enterprise)
     /// plus <c>owner/repo/actions/runs/{runId}</c> so links match the repo and avoid bad or relative <c>html_url</c> from the API.

--- a/src/GrayMoon.App/Services/WorkspaceActionService.cs
+++ b/src/GrayMoon.App/Services/WorkspaceActionService.cs
@@ -9,24 +9,27 @@ public sealed class WorkspaceActionService(
     GitHubActionsService gitHubActionsService)
 {
     /// <summary>Returns persisted action state for the workspace keyed by RepositoryId. Used when building the grid from cache.</summary>
-    public async Task<IReadOnlyDictionary<int, ActionStatusInfo?>> GetPersistedActionsForWorkspaceAsync(int workspaceId, CancellationToken cancellationToken = default)
+    public async Task<IReadOnlyDictionary<int, RepositoryActionsPersistedState>> GetPersistedActionsForWorkspaceAsync(int workspaceId, CancellationToken cancellationToken = default)
     {
         return await actionRepository.GetByWorkspaceIdAsync(workspaceId, cancellationToken);
     }
 
     /// <summary>
-    /// Fetches the aggregate CI status for <paramref name="branch"/> of the given repository from GitHub and persists it.
-    /// Returns the fetched status, or null if the repository has no valid connector/org.
+    /// Fetches CI status per workflow for <paramref name="branch"/> from GitHub and persists it.
+    /// Returns null if the repository has no valid connector/org (nothing persisted).
     /// Throws on GitHub API errors (e.g. HTTP 401/403) so the caller can surface them as error badges.
     /// </summary>
-    public async Task<ActionStatusInfo?> FetchAndPersistAsync(
+    public async Task<IReadOnlyList<ActionStatusInfo>?> FetchAndPersistAsync(
         int workspaceRepositoryId,
         GitHubRepositoryEntry repository,
         string branch,
         CancellationToken cancellationToken = default)
     {
-        var info = await gitHubActionsService.GetAggregateActionStatusForBranchAsync(repository, branch);
-        await actionRepository.UpsertAsync(workspaceRepositoryId, info, cancellationToken);
-        return info;
+        var workflows = await gitHubActionsService.GetWorkflowStatusesForBranchAsync(repository, branch, cancellationToken);
+        if (workflows == null)
+            return null;
+
+        await actionRepository.UpsertAsync(workspaceRepositoryId, workflows, branch, cancellationToken);
+        return workflows;
     }
 }

--- a/src/GrayMoon.App/wwwroot/css/loading-overlay.css
+++ b/src/GrayMoon.App/wwwroot/css/loading-overlay.css
@@ -168,16 +168,26 @@
   background: rgba(0, 0, 0, 0.42) !important;
 }
 
-.actions-gha-terminal .loading-overlay-terminal__prefix {
-  color: rgba(95, 102, 98, 0.7) !important;
+/*
+ * GHA stream colors must beat WorkspaceActions running-row td { color: light gray } inheritance.
+ * Yellow worked because .loading-overlay-terminal--scheme-yellow added extra selector weight; green (default)
+ * needs :not(.loading-overlay-terminal--scheme-yellow) at equal chain length. Embed lives under tr.actions-row-running-terminal.
+ */
+.grid-page-body .table.actions-table tbody tr.actions-row-running-terminal .actions-gha-terminal .loading-overlay-terminal:not(.loading-overlay-terminal--scheme-yellow) .loading-overlay-terminal__prefix {
+  color: rgba(95, 102, 98, 0.75) !important;
 }
 
-.actions-gha-terminal .loading-overlay-terminal__line--out .loading-overlay-terminal__text {
-  color: rgba(58, 112, 78, 0.88) !important;
+.grid-page-body .table.actions-table tbody tr.actions-row-running-terminal .actions-gha-terminal .loading-overlay-terminal:not(.loading-overlay-terminal--scheme-yellow) .loading-overlay-terminal__line--out .loading-overlay-terminal__text {
+  /* Match overlay green stdout (.loading-overlay-terminal__line--out) */
+  color: rgba(120, 210, 150, 0.88) !important;
 }
 
-.actions-gha-terminal .loading-overlay-terminal--scheme-yellow .loading-overlay-terminal__line--out .loading-overlay-terminal__text {
-  color: rgba(130, 108, 40, 0.85) !important;
+.grid-page-body .table.actions-table tbody tr.actions-row-running-terminal .actions-gha-terminal .loading-overlay-terminal--scheme-yellow .loading-overlay-terminal__prefix {
+  color: rgba(95, 102, 98, 0.75) !important;
+}
+
+.grid-page-body .table.actions-table tbody tr.actions-row-running-terminal .actions-gha-terminal .loading-overlay-terminal--scheme-yellow .loading-overlay-terminal__line--out .loading-overlay-terminal__text {
+  color: rgba(220, 190, 72, 0.9) !important;
 }
 
 /* Brand at top-left of overlay – same position and font as sidebar header; above full-height terminal */

--- a/src/GrayMoon.App/wwwroot/css/loading-overlay.css
+++ b/src/GrayMoon.App/wwwroot/css/loading-overlay.css
@@ -155,6 +155,31 @@
   color: rgba(220, 190, 72, 0.88);
 }
 
+/*
+ * Workspace Actions: embedded GHA live terminal (GhaWorkflowLiveTerminal).
+ * Global selectors — Blazor scoped CSS from the component bundle does not reliably override these rules.
+ */
+.actions-gha-terminal .actions-gha-terminal__caption-text,
+.actions-gha-terminal .actions-gha-terminal__caption-steps {
+  color: rgba(248, 250, 252, 0.98) !important;
+}
+
+.actions-gha-terminal .actions-gha-terminal__scroll.loading-overlay-terminal__inner {
+  background: rgba(0, 0, 0, 0.42) !important;
+}
+
+.actions-gha-terminal .loading-overlay-terminal__prefix {
+  color: rgba(95, 102, 98, 0.7) !important;
+}
+
+.actions-gha-terminal .loading-overlay-terminal__line--out .loading-overlay-terminal__text {
+  color: rgba(58, 112, 78, 0.88) !important;
+}
+
+.actions-gha-terminal .loading-overlay-terminal--scheme-yellow .loading-overlay-terminal__line--out .loading-overlay-terminal__text {
+  color: rgba(130, 108, 40, 0.85) !important;
+}
+
 /* Brand at top-left of overlay – same position and font as sidebar header; above full-height terminal */
 .loading-overlay__brand {
   position: absolute;


### PR DESCRIPTION
### Summary

This work replaces the single “latest run” view on **Workspace → Actions** with a **per-workflow** grid for the selected branch, persists that state, and adds richer GitHub Actions integration: manual **workflow_dispatch**, **re-run**, **cancel**, resilient refresh after mutations, and an embedded **live job log** terminal while runs are in progress. Settings expose terminal theming/behavior; shared URL helpers centralize GitHub links.

### User-facing changes

- **Actions table** shows one row per workflow (per repository / branch) with status, links to the workflow definition and run, and actions that depend on state: **Re-run** (failed), **Run** (when `workflow_dispatch` is allowed), **Abort** (while a run is in progress).
- **Status** includes **aborted** for GitHub runs completed with conclusion `cancelled`, with matching badge styling and summary counts.
- **Run / Abort / Re-run** use **per-row latches** so controls stay disabled through refresh and cannot double-post; busy state survives row rebuilds after API refresh.
- **Live terminal** (`GhaWorkflowLiveTerminal`) streams/polls GitHub Actions job log output under in-progress runs; **Settings** include related preferences (e.g. terminal colors / overlay behavior where wired).
- **Cancel** calls the GitHub cancel API; **409** responses for an already-completed run are treated as a no-op (no error spam); refresh still runs to sync the grid.

### Backend / data

- **Migration**: persisted actions store a **JSON list of workflows** for a repo+branch (alongside existing fields); repository read/write paths updated accordingly.
- **`GitHubService`**: workflows listing, workflow metadata, repository file fetch (YAML), run jobs for logs, **POST** helpers with mutation retry for rerun, **dispatch**, and **cancel** (with special handling for benign 409 on cancel).
- **`GitHubActionsService`**: resolves per-workflow latest run on a branch, derives **`SupportsWorkflowDispatch`** from workflow YAML, maps statuses (including **aborted** for cancelled runs), and orchestrates run / rerun / cancel entry points.
- **`RepositoryUrlHelper`**: builds consistent workflow and run URLs for the UI.

### Other

- **`loading-overlay.css`**: styling adjustments used by long-running overlays (e.g. terminal/loading flows).
- **`.cursor/plans/multi-workflow_actions_grid_b201ec86.plan.md`**: planning artifact; remove from the PR if you prefer not to commit `.cursor` content.

### How to test

1. Open a workspace with repos on a branch that has **multiple** workflows; confirm each workflow appears with correct status and links.
2. Use **Run** on a workflow with `workflow_dispatch`; confirm status moves to **running**, **Abort** appears, and the **live terminal** shows activity where applicable.
3. Use **Abort**; confirm the run ends as **aborted** (or success/failure as appropriate) and the terminal row clears when no longer running.
4. Double-click **Run** / **Abort** quickly; confirm only one mutation is applied and the button stays busy through refresh.
5. If a run finishes before cancel completes, confirm **no** user-facing error for GitHub **409** “cannot cancel completed run” and the grid refreshes to the final state.
6. Change branch / workspace sync; confirm rows reset and persisted workflow list updates after refresh.

