### PR TITLE
Workspace Actions: status filters, search, header layout, and focus/UI polish

### DIFF
--- a/src/GrayMoon.App/Components/Modals/BranchModal.razor.css
+++ b/src/GrayMoon.App/Components/Modals/BranchModal.razor.css
@@ -40,7 +40,7 @@
 }
 
 .branch-modal-tabs .nav-link:focus-visible {
-    box-shadow: 0 0 0 0.1rem var(--bg-primary), 0 0 0 0.25rem var(--accent-blue);
+    box-shadow: 0 0 0 1px var(--focus-ring-outer);
 }
 
 /* Based-on dropdown (same as before) */

--- a/src/GrayMoon.App/Components/Modals/SwitchBranchModal.razor.css
+++ b/src/GrayMoon.App/Components/Modals/SwitchBranchModal.razor.css
@@ -47,7 +47,7 @@
 }
 
 .switch-branch-tabs .nav-link:focus-visible {
-    box-shadow: 0 0 0 0.1rem var(--bg-primary), 0 0 0 0.25rem var(--accent-blue);
+    box-shadow: 0 0 0 1px var(--focus-ring-outer);
 }
 
 /* Tab count / branch count next to title: smaller, dark gray */

--- a/src/GrayMoon.App/Components/Pages/Agent.razor.css
+++ b/src/GrayMoon.App/Components/Pages/Agent.razor.css
@@ -30,7 +30,7 @@
 }
 
 .card-header-tabs .nav-link:focus-visible {
-    box-shadow: 0 0 0 0.1rem var(--bg-primary), 0 0 0 0.25rem var(--accent-blue);
+    box-shadow: 0 0 0 1px var(--focus-ring-outer);
 }
 
 .card-header-tabs .nav-link.host-tab-missing,

--- a/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor
@@ -2,99 +2,129 @@
 @rendermode @(new InteractiveServerRenderMode(prerender: false))
 @using GrayMoon.App.Models
 @using GrayMoon.App.Components.Shared
+@using Microsoft.AspNetCore.Components.Web
 @using WorkspaceModel = GrayMoon.App.Models.Workspace
 
 <PageTitle>@(workspace?.Name ?? "Workspace") Actions - GrayMoon</PageTitle>
 
 <div class="container-fluid page-container grid-page">
     <div class="grid-page-header">
-        <div class="d-flex justify-content-between align-items-center mb-4">
-            <div>
-                <h2>@(workspace?.Name ?? "Workspace") Actions</h2>
-                <p class="text-muted mb-0 d-flex align-items-center gap-2 flex-wrap workspace-actions__subtitle" style="min-height: 1.5rem;">
+        <div class="workspace-repos-header workspace-actions-header">
+            <div class="workspace-repos-title-row">
+                <h2 class="workspace-repos-title">@(workspace?.Name ?? "Workspace") Actions</h2>
+                <p class="text-muted mb-0 workspace-repos-subtitle workspace-actions__subtitle">
                     @if (!isLoading && rows.Count > 0)
                     {
-                        @($"{rows.Count} {(rows.Count == 1 ? "repository" : "repositories")}")
-                        @if (ErrorCount > 0 || FailedCount > 0 || AbortedCount > 0 || RunningCount > 0 || SuccessCount > 0 || NoneCount > 0)
-                        {
-                            <span class="workspace-actions__filter-sep" aria-hidden="true">|</span>
-                            <span class="workspace-actions__filters d-inline-flex align-items-center flex-wrap gap-1" role="toolbar" aria-label="Filter workflows by status">
-                                @if (ErrorCount > 0)
-                                {
-                                    <button type="button"
-                                            class="gha-status-filter @(_showErrors ? "gha-status-filter--on" : "gha-status-filter--off")"
-                                            aria-pressed="@_showErrors"
-                                            aria-label="Filter repository load errors"
-                                            @onclick="ToggleShowErrors">
-                                        <span class="gha-status-filter__label">errors</span>
-                                        <span class="gha-status-filter__count gha-status-filter__count--errors">@ErrorCount</span>
-                                    </button>
-                                }
-                                @if (FailedCount > 0)
-                                {
-                                    <button type="button"
-                                            class="gha-status-filter @(_showFailed ? "gha-status-filter--on" : "gha-status-filter--off")"
-                                            aria-pressed="@_showFailed"
-                                            aria-label="Filter failed workflows"
-                                            @onclick="ToggleShowFailed">
-                                        <span class="gha-status-filter__label">failed</span>
-                                        <span class="gha-status-filter__count gha-status-filter__count--failed">@FailedCount</span>
-                                    </button>
-                                }
-                                @if (AbortedCount > 0)
-                                {
-                                    <button type="button"
-                                            class="gha-status-filter @(_showAborted ? "gha-status-filter--on" : "gha-status-filter--off")"
-                                            aria-pressed="@_showAborted"
-                                            aria-label="Filter aborted workflows"
-                                            @onclick="ToggleShowAborted">
-                                        <span class="gha-status-filter__label">aborted</span>
-                                        <span class="gha-status-filter__count gha-status-filter__count--aborted">@AbortedCount</span>
-                                    </button>
-                                }
-                                @if (RunningCount > 0)
-                                {
-                                    <button type="button"
-                                            class="gha-status-filter @(_showRunning ? "gha-status-filter--on" : "gha-status-filter--off")"
-                                            aria-pressed="@_showRunning"
-                                            aria-label="Filter running workflows"
-                                            @onclick="ToggleShowRunning">
-                                        <span class="gha-status-filter__label">running</span>
-                                        <span class="gha-status-filter__count gha-status-filter__count--running">@RunningCount</span>
-                                    </button>
-                                }
-                                @if (SuccessCount > 0)
-                                {
-                                    <button type="button"
-                                            class="gha-status-filter @(_showSuccess ? "gha-status-filter--on" : "gha-status-filter--off")"
-                                            aria-pressed="@_showSuccess"
-                                            aria-label="Filter successful workflows"
-                                            @onclick="ToggleShowSuccess">
-                                        <span class="gha-status-filter__label">success</span>
-                                        <span class="gha-status-filter__count gha-status-filter__count--success">@SuccessCount</span>
-                                    </button>
-                                }
-                                @if (NoneCount > 0)
-                                {
-                                    <button type="button"
-                                            class="gha-status-filter @(_showNone ? "gha-status-filter--on" : "gha-status-filter--off")"
-                                            aria-pressed="@_showNone"
-                                            aria-label="Filter workflows with no status"
-                                            @onclick="ToggleShowNone">
-                                        <span class="gha-status-filter__label">none</span>
-                                        <span class="gha-status-filter__count gha-status-filter__count--none">@NoneCount</span>
-                                    </button>
-                                }
-                            </span>
-                        }
+                        var wfSuffix = HasSearchFilter ? " found" : "";
+                        var wfCount = HasSearchFilter ? FilteredWorkflowLineCount : VisibleWorkflowLineCount;
+                        <span>@($"{wfCount} {(wfCount == 1 ? "workflow" : "workflows")}{wfSuffix}")</span>
                     }
-                    else
+                    else if (!isLoading && workspace != null)
                     {
-                        @:&nbsp;
+                        <span>0 workflows</span>
+                    }
+                    else if (isLoading)
+                    {
+                        <span>&nbsp;</span>
                     }
                 </p>
+                @if (!isLoading && rows.Count > 0 && (ErrorCount > 0 || FailedCount > 0 || AbortedCount > 0 || RunningCount > 0 || SuccessCount > 0 || NoneCount > 0))
+                {
+                    <span class="workspace-actions__filter-sep text-muted" aria-hidden="true">|</span>
+                    <span class="workspace-actions__filters d-inline-flex align-items-center flex-wrap gap-1" role="toolbar" aria-label="Filter workflows by status">
+                        @if (ErrorCount > 0)
+                        {
+                            <button type="button"
+                                    class="gha-status-filter @(_showErrors ? "gha-status-filter--on" : "gha-status-filter--off")"
+                                    aria-pressed="@_showErrors"
+                                    aria-label="Filter repository load errors"
+                                    @onclick="ToggleShowErrors">
+                                <span class="gha-status-filter__label">errors</span>
+                                <span class="gha-status-filter__count gha-status-filter__count--errors">@ErrorCount</span>
+                            </button>
+                        }
+                        @if (FailedCount > 0)
+                        {
+                            <button type="button"
+                                    class="gha-status-filter @(_showFailed ? "gha-status-filter--on" : "gha-status-filter--off")"
+                                    aria-pressed="@_showFailed"
+                                    aria-label="Filter failed workflows"
+                                    @onclick="ToggleShowFailed">
+                                <span class="gha-status-filter__label">failed</span>
+                                <span class="gha-status-filter__count gha-status-filter__count--failed">@FailedCount</span>
+                            </button>
+                        }
+                        @if (AbortedCount > 0)
+                        {
+                            <button type="button"
+                                    class="gha-status-filter @(_showAborted ? "gha-status-filter--on" : "gha-status-filter--off")"
+                                    aria-pressed="@_showAborted"
+                                    aria-label="Filter aborted workflows"
+                                    @onclick="ToggleShowAborted">
+                                <span class="gha-status-filter__label">aborted</span>
+                                <span class="gha-status-filter__count gha-status-filter__count--aborted">@AbortedCount</span>
+                            </button>
+                        }
+                        @if (RunningCount > 0)
+                        {
+                            <button type="button"
+                                    class="gha-status-filter @(_showRunning ? "gha-status-filter--on" : "gha-status-filter--off")"
+                                    aria-pressed="@_showRunning"
+                                    aria-label="Filter running workflows"
+                                    @onclick="ToggleShowRunning">
+                                <span class="gha-status-filter__label">running</span>
+                                <span class="gha-status-filter__count gha-status-filter__count--running">@RunningCount</span>
+                            </button>
+                        }
+                        @if (SuccessCount > 0)
+                        {
+                            <button type="button"
+                                    class="gha-status-filter @(_showSuccess ? "gha-status-filter--on" : "gha-status-filter--off")"
+                                    aria-pressed="@_showSuccess"
+                                    aria-label="Filter successful workflows"
+                                    @onclick="ToggleShowSuccess">
+                                <span class="gha-status-filter__label">success</span>
+                                <span class="gha-status-filter__count gha-status-filter__count--success">@SuccessCount</span>
+                            </button>
+                        }
+                        @if (NoneCount > 0)
+                        {
+                            <button type="button"
+                                    class="gha-status-filter @(_showNone ? "gha-status-filter--on" : "gha-status-filter--off")"
+                                    aria-pressed="@_showNone"
+                                    aria-label="Filter workflows with no status"
+                                    @onclick="ToggleShowNone">
+                                <span class="gha-status-filter__label">none</span>
+                                <span class="gha-status-filter__count gha-status-filter__count--none">@NoneCount</span>
+                            </button>
+                        }
+                    </span>
+                }
+                <span class="workspace-repos-title-spacer"></span>
             </div>
-            <div class="d-flex align-items-center gap-2">
+            <div class="d-flex gap-2 align-items-center workspace-repos-header-actions">
+                <div class="workspace-repos-search-wrapper">
+                    <div class="workspace-repos-search-input-wrap @(HasSearchFilter ? "has-filter" : null)">
+                        <input id="workspace-actions-search"
+                               class="form-control workspace-repos-search"
+                               placeholder="Search repository or workflow..."
+                               value="@searchTerm"
+                               disabled="@(isLoading || rows.Count == 0)"
+                               @oninput="OnSearchChanged"
+                               @onkeydown="OnSearchKeyDown" />
+                        @if (HasSearchFilter)
+                        {
+                            <button type="button"
+                                    class="workspace-repos-search-clear"
+                                    title="Clear filter"
+                                    aria-label="Clear search filter"
+                                    @onclick="ClearSearchFilter"
+                                    @onclick:stopPropagation="true">
+                                <i class="bi bi-x-circle" aria-hidden="true"></i>
+                            </button>
+                        }
+                    </div>
+                </div>
                 @if (HasFailedRows)
                 {
                     <button class="btn btn-danger"
@@ -155,11 +185,11 @@
                                         </td>
                                     </tr>
                                 }
-                                else if (NoWorkflowRowsMatchFilters)
+                                else if (NoVisibleWorkflowRows)
                                 {
                                     <tr>
                                         <td colspan="5" class="text-center text-muted py-4">
-                                            No workflows match the current filters.
+                                            @(HasSearchFilter ? "No workflows match your search." : "No workflows match the current filters.")
                                         </td>
                                     </tr>
                                 }
@@ -168,7 +198,7 @@
                                     var groupIndex = 0;
                                     @foreach (var row in rows.OrderBy(GetStatusSortOrder).ThenBy(r => r.Repo.RepositoryName, System.StringComparer.OrdinalIgnoreCase))
                                     {
-                                        var displayLines = LinesForGrid(row).ToList();
+                                        var displayLines = LinesForTable(row).ToList();
                                         if (displayLines.Count == 0)
                                         {
                                             continue;

--- a/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor
@@ -222,7 +222,6 @@
                                             var isRunningWorkflowRow = IsLineRunningForBranch(row, line);
                                             var trClass = $"{stripeClass} actions-data-row"
                                                 + (repoEndOnDataRow ? " actions-row-repo-end" : "")
-                                                + (firstLine && row.ErrorMessage != null ? " actions-error-row" : "")
                                                 + (isRunningWorkflowRow ? " actions-row-running" : "")
                                                 + (showGhaTerminal ? " actions-row-running-above-terminal" : "");
                                             <tr class="@trClass">

--- a/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor
@@ -11,37 +11,81 @@
         <div class="d-flex justify-content-between align-items-center mb-4">
             <div>
                 <h2>@(workspace?.Name ?? "Workspace") Actions</h2>
-                <p class="text-muted mb-0 d-flex align-items-center gap-2 flex-wrap" style="min-height: 1.5rem;">
+                <p class="text-muted mb-0 d-flex align-items-center gap-2 flex-wrap workspace-actions__subtitle" style="min-height: 1.5rem;">
                     @if (!isLoading && rows.Count > 0)
                     {
                         @($"{rows.Count} {(rows.Count == 1 ? "repository" : "repositories")}")
                         @if (ErrorCount > 0 || FailedCount > 0 || AbortedCount > 0 || RunningCount > 0 || SuccessCount > 0 || NoneCount > 0)
                         {
-                            <span>|</span>
-                        }
-                        @if (ErrorCount > 0)
-                        {
-                            <span>errors <span class="badge action-badge action-badge-failed">@ErrorCount</span></span>
-                        }
-                        @if (FailedCount > 0)
-                        {
-                            <span>failed <span class="badge action-badge action-badge-failed">@FailedCount</span></span>
-                        }
-                        @if (AbortedCount > 0)
-                        {
-                            <span>aborted <span class="badge action-badge action-badge-aborted">@AbortedCount</span></span>
-                        }
-                        @if (RunningCount > 0)
-                        {
-                            <span>running <span class="badge action-badge action-badge-running">@RunningCount</span></span>
-                        }
-                        @if (SuccessCount > 0)
-                        {
-                            <span>success <span class="badge action-badge action-badge-success">@SuccessCount</span></span>
-                        }
-                        @if (NoneCount > 0)
-                        {
-                            <span>none <span class="badge action-badge action-badge-none">@NoneCount</span></span>
+                            <span class="workspace-actions__filter-sep" aria-hidden="true">|</span>
+                            <span class="workspace-actions__filters d-inline-flex align-items-center flex-wrap gap-1" role="toolbar" aria-label="Filter workflows by status">
+                                @if (ErrorCount > 0)
+                                {
+                                    <button type="button"
+                                            class="gha-status-filter @(_showErrors ? "gha-status-filter--on" : "gha-status-filter--off")"
+                                            aria-pressed="@_showErrors"
+                                            aria-label="Filter repository load errors"
+                                            @onclick="ToggleShowErrors">
+                                        <span class="gha-status-filter__label">errors</span>
+                                        <span class="gha-status-filter__count gha-status-filter__count--errors">@ErrorCount</span>
+                                    </button>
+                                }
+                                @if (FailedCount > 0)
+                                {
+                                    <button type="button"
+                                            class="gha-status-filter @(_showFailed ? "gha-status-filter--on" : "gha-status-filter--off")"
+                                            aria-pressed="@_showFailed"
+                                            aria-label="Filter failed workflows"
+                                            @onclick="ToggleShowFailed">
+                                        <span class="gha-status-filter__label">failed</span>
+                                        <span class="gha-status-filter__count gha-status-filter__count--failed">@FailedCount</span>
+                                    </button>
+                                }
+                                @if (AbortedCount > 0)
+                                {
+                                    <button type="button"
+                                            class="gha-status-filter @(_showAborted ? "gha-status-filter--on" : "gha-status-filter--off")"
+                                            aria-pressed="@_showAborted"
+                                            aria-label="Filter aborted workflows"
+                                            @onclick="ToggleShowAborted">
+                                        <span class="gha-status-filter__label">aborted</span>
+                                        <span class="gha-status-filter__count gha-status-filter__count--aborted">@AbortedCount</span>
+                                    </button>
+                                }
+                                @if (RunningCount > 0)
+                                {
+                                    <button type="button"
+                                            class="gha-status-filter @(_showRunning ? "gha-status-filter--on" : "gha-status-filter--off")"
+                                            aria-pressed="@_showRunning"
+                                            aria-label="Filter running workflows"
+                                            @onclick="ToggleShowRunning">
+                                        <span class="gha-status-filter__label">running</span>
+                                        <span class="gha-status-filter__count gha-status-filter__count--running">@RunningCount</span>
+                                    </button>
+                                }
+                                @if (SuccessCount > 0)
+                                {
+                                    <button type="button"
+                                            class="gha-status-filter @(_showSuccess ? "gha-status-filter--on" : "gha-status-filter--off")"
+                                            aria-pressed="@_showSuccess"
+                                            aria-label="Filter successful workflows"
+                                            @onclick="ToggleShowSuccess">
+                                        <span class="gha-status-filter__label">success</span>
+                                        <span class="gha-status-filter__count gha-status-filter__count--success">@SuccessCount</span>
+                                    </button>
+                                }
+                                @if (NoneCount > 0)
+                                {
+                                    <button type="button"
+                                            class="gha-status-filter @(_showNone ? "gha-status-filter--on" : "gha-status-filter--off")"
+                                            aria-pressed="@_showNone"
+                                            aria-label="Filter workflows with no status"
+                                            @onclick="ToggleShowNone">
+                                        <span class="gha-status-filter__label">none</span>
+                                        <span class="gha-status-filter__count gha-status-filter__count--none">@NoneCount</span>
+                                    </button>
+                                }
+                            </span>
                         }
                     }
                     else
@@ -111,13 +155,26 @@
                                         </td>
                                     </tr>
                                 }
+                                else if (NoWorkflowRowsMatchFilters)
+                                {
+                                    <tr>
+                                        <td colspan="5" class="text-center text-muted py-4">
+                                            No workflows match the current filters.
+                                        </td>
+                                    </tr>
+                                }
                                 else
                                 {
                                     var groupIndex = 0;
                                     @foreach (var row in rows.OrderBy(GetStatusSortOrder).ThenBy(r => r.Repo.RepositoryName, System.StringComparer.OrdinalIgnoreCase))
                                     {
+                                        var displayLines = LinesForGrid(row).ToList();
+                                        if (displayLines.Count == 0)
+                                        {
+                                            continue;
+                                        }
+
                                         var stripeClass = GroupStripeClass(groupIndex);
-                                        var displayLines = LinesForDisplay(row).ToList();
                                         @for (var li = 0; li < displayLines.Count; li++)
                                         {
                                             var line = displayLines[li];

--- a/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor.cs
@@ -3,6 +3,7 @@ using GrayMoon.App.Models;
 using GrayMoon.App.Repositories;
 using GrayMoon.App.Services;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.SignalR.Client;
 using Microsoft.Extensions.Options;
 
@@ -78,6 +79,7 @@ public sealed partial class WorkspaceActions : IDisposable
     private bool _showRunning = true;
     private bool _showSuccess = true;
     private bool _showNone;
+    private string searchTerm = string.Empty;
 
     private enum ActionLineFilterBucket
     {
@@ -114,9 +116,38 @@ public sealed partial class WorkspaceActions : IDisposable
             ? "Re-running actions..."
             : $"Re-running {_rerunCompleted} of {_rerunTotal}";
 
-    /// <summary>True when the workspace has repos but every line is hidden by status filters.</summary>
-    internal bool NoWorkflowRowsMatchFilters =>
-        !isLoading && rows.Count > 0 && !rows.Any(row => LinesForGrid(row).Any());
+    internal bool HasSearchFilter => !string.IsNullOrWhiteSpace(searchTerm);
+
+    /// <summary>Workflow table rows visible with current status filters (before text search).</summary>
+    internal int VisibleWorkflowLineCount => rows.Sum(r => LinesForGrid(r).Count());
+
+    /// <summary>Workflow table rows visible after status filters and text search.</summary>
+    internal int FilteredWorkflowLineCount => rows.Sum(r => LinesForTable(r).Count());
+
+    /// <summary>True when the workspace has repos but no row is visible (status filters and/or search).</summary>
+    internal bool NoVisibleWorkflowRows =>
+        !isLoading && rows.Count > 0 && !rows.Any(row => LinesForTable(row).Any());
+
+    internal void OnSearchChanged(ChangeEventArgs e)
+    {
+        searchTerm = e.Value?.ToString() ?? string.Empty;
+        StateHasChanged();
+    }
+
+    internal void ClearSearchFilter()
+    {
+        searchTerm = string.Empty;
+        StateHasChanged();
+    }
+
+    internal void OnSearchKeyDown(KeyboardEventArgs e)
+    {
+        if (e.Key == "Escape")
+        {
+            searchTerm = string.Empty;
+            StateHasChanged();
+        }
+    }
 
     internal void ToggleShowErrors()
     {
@@ -1079,6 +1110,34 @@ public sealed partial class WorkspaceActions : IDisposable
                 yield return line;
         }
     }
+
+    /// <summary>Lines to render after status toggles and repository/workflow text search.</summary>
+    internal IEnumerable<WorkflowActionLine> LinesForTable(WorkspaceActionRow row)
+    {
+        foreach (var line in LinesForGrid(row))
+        {
+            if (LineMatchesSearch(row, line))
+                yield return line;
+        }
+    }
+
+    private bool LineMatchesSearch(WorkspaceActionRow row, WorkflowActionLine line)
+    {
+        var words = SplitSearchWords(searchTerm);
+        if (words.Count == 0)
+            return true;
+        var repo = row.Repo.RepositoryName ?? string.Empty;
+        var workflow = line.Action?.WorkflowName ?? string.Empty;
+        var haystack = $"{repo} {workflow}";
+        return words.All(w => haystack.Contains(w, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static List<string> SplitSearchWords(string term) =>
+        term
+            .Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(w => w.Trim())
+            .Where(w => w.Length > 0)
+            .ToList();
 
     private bool IsBucketVisible(ActionLineFilterBucket bucket) =>
         bucket switch

--- a/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor.cs
@@ -72,6 +72,22 @@ public sealed partial class WorkspaceActions : IDisposable
     private const int RunWorkflowVisibilityFirstDelayMs = 2000;
     private const int RunWorkflowVisibilityRetryDelayMs = 3000;
 
+    private bool _showErrors = true;
+    private bool _showFailed = true;
+    private bool _showAborted = true;
+    private bool _showRunning = true;
+    private bool _showSuccess = true;
+    private bool _showNone;
+
+    private enum ActionLineFilterBucket
+    {
+        Failed,
+        Running,
+        Aborted,
+        Success,
+        None
+    }
+
     internal bool HasFailedRows => rows.Any(row =>
         row.WorkflowLines.Any(line =>
             IsLineFailedForBranch(row, line)));
@@ -97,6 +113,46 @@ public sealed partial class WorkspaceActions : IDisposable
         _rerunCompleted == 0
             ? "Re-running actions..."
             : $"Re-running {_rerunCompleted} of {_rerunTotal}";
+
+    /// <summary>True when the workspace has repos but every line is hidden by status filters.</summary>
+    internal bool NoWorkflowRowsMatchFilters =>
+        !isLoading && rows.Count > 0 && !rows.Any(row => LinesForGrid(row).Any());
+
+    internal void ToggleShowErrors()
+    {
+        _showErrors = !_showErrors;
+        StateHasChanged();
+    }
+
+    internal void ToggleShowFailed()
+    {
+        _showFailed = !_showFailed;
+        StateHasChanged();
+    }
+
+    internal void ToggleShowAborted()
+    {
+        _showAborted = !_showAborted;
+        StateHasChanged();
+    }
+
+    internal void ToggleShowRunning()
+    {
+        _showRunning = !_showRunning;
+        StateHasChanged();
+    }
+
+    internal void ToggleShowSuccess()
+    {
+        _showSuccess = !_showSuccess;
+        StateHasChanged();
+    }
+
+    internal void ToggleShowNone()
+    {
+        _showNone = !_showNone;
+        StateHasChanged();
+    }
 
     protected override async Task OnInitializedAsync()
     {
@@ -1003,6 +1059,50 @@ public sealed partial class WorkspaceActions : IDisposable
         if (row.WorkflowLines.Count > 0)
             return row.WorkflowLines;
         return [new WorkflowActionLine()];
+    }
+
+    /// <summary>Workflow lines to render after applying status filter toggles (repo errors: all lines or none).</summary>
+    internal IEnumerable<WorkflowActionLine> LinesForGrid(WorkspaceActionRow row)
+    {
+        if (!string.IsNullOrWhiteSpace(row.ErrorMessage))
+        {
+            if (!_showErrors)
+                yield break;
+            foreach (var line in LinesForDisplay(row))
+                yield return line;
+            yield break;
+        }
+
+        foreach (var line in LinesForDisplay(row))
+        {
+            if (IsBucketVisible(GetLineFilterBucket(row, line)))
+                yield return line;
+        }
+    }
+
+    private bool IsBucketVisible(ActionLineFilterBucket bucket) =>
+        bucket switch
+        {
+            ActionLineFilterBucket.Failed => _showFailed,
+            ActionLineFilterBucket.Running => _showRunning,
+            ActionLineFilterBucket.Aborted => _showAborted,
+            ActionLineFilterBucket.Success => _showSuccess,
+            ActionLineFilterBucket.None => _showNone,
+            _ => true
+        };
+
+    /// <summary>Matches <see cref="ActionBadge"/> status order: failed, running, aborted, success, else none.</summary>
+    private static ActionLineFilterBucket GetLineFilterBucket(WorkspaceActionRow row, WorkflowActionLine line)
+    {
+        if (IsLineFailedForBranch(row, line))
+            return ActionLineFilterBucket.Failed;
+        if (IsLineRunningForBranch(row, line))
+            return ActionLineFilterBucket.Running;
+        if (IsLineAbortedForBranch(row, line))
+            return ActionLineFilterBucket.Aborted;
+        if (IsLineSuccessForBranch(row, line))
+            return ActionLineFilterBucket.Success;
+        return ActionLineFilterBucket.None;
     }
 
     internal static string GroupStripeClass(int groupIndex) =>

--- a/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor.css
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor.css
@@ -1,3 +1,22 @@
+/*
+ * Title row: use same baseline alignment as app.css .workspace-repos-header .workspace-repos-title-row
+ * (do not override with flex-end — that sat the subtitle lower than the h2 text).
+ * Workflow count stays in <p> like WorkspaceRepositories; status chips are siblings so they don't stretch the subtitle.
+ */
+.workspace-actions-header .workspace-repos-subtitle.workspace-actions__subtitle {
+    white-space: normal;
+    overflow: visible;
+    text-overflow: clip;
+    flex: 0 0 auto;
+    min-width: 0;
+}
+
+.workspace-actions-header .workspace-actions__filters,
+.workspace-actions-header .workspace-actions__filter-sep {
+    flex: 0 0 auto;
+    align-self: baseline;
+}
+
 /* Status filter chips (subtitle toolbar) */
 .workspace-actions__filter-sep {
     opacity: 0.45;

--- a/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor.css
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor.css
@@ -215,7 +215,7 @@
     width: 18%;
 }
 
-.col-status {
+.col-action-status {
     width: 18%;
 }
 
@@ -232,10 +232,15 @@
     background-color: var(--bs-table-striped-bg, rgba(0, 0, 0, 0.05));
 }
 
-/* Status / Result: center header and body text (override global col-status-badge right alignment) */
-.actions-table th.col-status,
-.actions-table td.col-status {
+/* Status: center header and body (column class is col-action-status in WorkspaceActions.razor) */
+.actions-table th.col-action-status,
+.actions-table td.col-action-status {
     text-align: center;
+}
+
+/* Optical alignment: badges read left of the column center vs. the "Status" header text */
+.actions-table td.col-action-status .action-badge {
+    margin-left: 0.35rem;
 }
 
 .actions-buttons {

--- a/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor.css
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor.css
@@ -37,13 +37,28 @@
     transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease, opacity 0.15s ease;
 }
 
-.gha-status-filter:focus {
+/* Focus ring: same as app.css .btn / .form-control (Workspace Repositories header) */
+.gha-status-filter:focus,
+.gha-status-filter:active:focus {
     outline: none;
 }
 
 .gha-status-filter:focus-visible {
-    outline: 2px solid var(--bs-primary, #0d6efd);
-    outline-offset: 2px;
+    outline: none;
+    box-shadow: 0 0 0 1px var(--focus-ring-outer);
+}
+
+.workspace-actions-header .workspace-repos-search:focus,
+.workspace-actions-header .workspace-repos-search:focus-visible {
+    border-color: var(--focus-ring-outer) !important;
+    box-shadow: none !important;
+}
+
+.workspace-actions-header .workspace-repos-search-clear:focus,
+.workspace-actions-header .workspace-repos-search-clear:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 1px var(--focus-ring-outer);
+    border-radius: 0.25rem;
 }
 
 .gha-status-filter__label {
@@ -126,6 +141,12 @@
     text-decoration-color: rgba(255, 255, 255, 0.45);
 }
 
+.actions-workflow-link:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 1px var(--focus-ring-outer);
+    border-radius: 0.125rem;
+}
+
 .action-link {
     color: inherit !important;
     text-decoration: none;
@@ -146,6 +167,12 @@
     color: inherit !important;
     text-decoration: underline;
     text-decoration-color: inherit;
+}
+
+.repo-link:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 1px var(--focus-ring-outer);
+    border-radius: 0.125rem;
 }
 
 /* Match Repositories / Workspaces: left-align all columns; Status and Result right-aligned via col-status-badge; last column (Action) matches Workspaces col-actions; use global resizable-columns padding for header spacing */

--- a/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor.css
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor.css
@@ -271,15 +271,6 @@
     min-height: 0;
 }
 
-.actions-table tbody tr.actions-error-row,
-.actions-table tbody tr.actions-error-row:hover {
-    background-color: #f8d7da;
-}
-
-.actions-table tbody tr.actions-error-row td {
-    color: #842029;
-}
-
 /*
  * One gray line only after the last workflow row of each repository (not between workflows).
  * Use app theme --border-color and !important so we win over .table defaults and

--- a/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor.css
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor.css
@@ -5,13 +5,14 @@
 }
 
 .gha-status-filter {
+    --gha-status-filter-radius: 0.75rem;
     display: inline-flex;
     align-items: center;
     gap: 0.35rem;
-    padding: 0.2rem 0.55rem;
+    padding: calc(0.2rem + 1px) 0.55rem;
     font-size: 0.8125rem;
     line-height: 1.2;
-    border-radius: 999px;
+    border-radius: var(--gha-status-filter-radius);
     border: 1px solid transparent;
     cursor: pointer;
     transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease, opacity 0.15s ease;
@@ -40,7 +41,7 @@
     font-size: 0.72rem;
     font-weight: 600;
     line-height: 1.35;
-    border-radius: 999px;
+    border-radius: var(--gha-status-filter-radius);
 }
 
 .gha-status-filter--on {

--- a/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor.css
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor.css
@@ -1,3 +1,98 @@
+/* Status filter chips (subtitle toolbar) */
+.workspace-actions__filter-sep {
+    opacity: 0.45;
+    user-select: none;
+}
+
+.gha-status-filter {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.2rem 0.55rem;
+    font-size: 0.8125rem;
+    line-height: 1.2;
+    border-radius: 999px;
+    border: 1px solid transparent;
+    cursor: pointer;
+    transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease, opacity 0.15s ease;
+}
+
+.gha-status-filter:focus {
+    outline: none;
+}
+
+.gha-status-filter:focus-visible {
+    outline: 2px solid var(--bs-primary, #0d6efd);
+    outline-offset: 2px;
+}
+
+.gha-status-filter__label {
+    font-weight: 500;
+    letter-spacing: 0.01em;
+}
+
+.gha-status-filter__count {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 1.25rem;
+    padding: 0 0.28rem;
+    font-size: 0.72rem;
+    font-weight: 600;
+    line-height: 1.35;
+    border-radius: 999px;
+}
+
+.gha-status-filter--on {
+    background-color: #1a1a1a;
+    color: rgba(255, 255, 255, 0.92);
+    border-color: rgba(255, 255, 255, 0.35);
+}
+
+/* Count pill colors when filter is on — match wwwroot/app.css .action-badge-* */
+.gha-status-filter--on .gha-status-filter__count--errors,
+.gha-status-filter--on .gha-status-filter__count--failed {
+    background-color: #da3633;
+    color: #fff;
+}
+
+.gha-status-filter--on .gha-status-filter__count--aborted {
+    background-color: #8957e5;
+    color: #fff;
+}
+
+.gha-status-filter--on .gha-status-filter__count--running {
+    background-color: #d29922;
+    color: #000;
+}
+
+.gha-status-filter--on .gha-status-filter__count--success {
+    background-color: #238636;
+    color: #fff;
+}
+
+.gha-status-filter--on .gha-status-filter__count--none {
+    background-color: #495057;
+    color: #fff;
+}
+
+.gha-status-filter--off {
+    background-color: rgba(0, 0, 0, 0.04);
+    color: var(--bs-secondary-color, #6c757d);
+    border-color: rgba(0, 0, 0, 0.12);
+    opacity: 0.92;
+}
+
+.gha-status-filter--off .gha-status-filter__count {
+    background-color: rgba(0, 0, 0, 0.06);
+    color: var(--bs-secondary-color, #6c757d);
+}
+
+.gha-status-filter--off:hover {
+    opacity: 1;
+    border-color: rgba(0, 0, 0, 0.18);
+}
+
 /* Actions grid: workflow name → GitHub Actions workflow tab (not default blue link) */
 .actions-workflow-link {
     color: rgba(236, 240, 245, 0.9) !important;

--- a/src/GrayMoon.App/wwwroot/app.css
+++ b/src/GrayMoon.App/wwwroot/app.css
@@ -48,6 +48,9 @@
     --accent-blue-hover: #1177bb;
     --accent-blue-active: #0a4d73;
     --accent-blue-light: #264f78;
+
+    /* Keyboard focus: white-ish thin frame (buttons/links: 1px box-shadow; inputs: 1px border) */
+    --focus-ring-outer: rgba(255, 255, 255, 0.52);
     
     --success: #89d185;
     --warning: #dcdcaa;
@@ -232,8 +235,27 @@ a.workspaces-breadcrumb-link:hover {
     color: var(--bg-primary);
 }
 
-.btn:focus, .btn:active:focus, .btn-link.nav-link:focus, .form-control:focus, .form-check-input:focus {
-    box-shadow: 0 0 0 0.1rem var(--bg-primary), 0 0 0 0.25rem var(--accent-blue);
+/* Buttons: single thin frame (not double ring) */
+.btn:focus,
+.btn:active:focus,
+.btn-link.nav-link:focus {
+    outline: none;
+    box-shadow: 0 0 0 1px var(--focus-ring-outer);
+}
+
+/* Text inputs / selects: border-only focus like workspace repository search — no glow */
+.form-control:focus,
+.form-select:focus,
+.form-check-input:focus {
+    outline: none;
+    box-shadow: none !important;
+}
+
+/* Plain links (not Bootstrap .btn) — thin frame to match buttons */
+a:focus-visible:not(.btn) {
+    outline: none;
+    box-shadow: 0 0 0 1px var(--focus-ring-outer);
+    border-radius: 0.125rem;
 }
 
 .content {
@@ -264,8 +286,13 @@ h1:focus {
 
 .form-control:focus, .form-select:focus {
     background-color: var(--bg-input);
-    border-color: var(--accent-blue) !important;
+    border-color: var(--focus-ring-outer) !important;
     color: var(--text-primary);
+    box-shadow: none !important;
+}
+
+.form-check-input:focus {
+    border-color: var(--focus-ring-outer);
 }
 
 .form-control::placeholder {
@@ -968,6 +995,11 @@ table.resizable-columns th:hover .resize-handle::after {
     border-radius: 0.25rem;
     cursor: pointer;
     transition: background-color 0.12s ease, border-color 0.12s ease, color 0.12s ease, box-shadow 0.12s ease;
+}
+
+.repositories-table td.col-divergence .divergence-link:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 1px var(--focus-ring-outer);
 }
 
 .repositories-table td.col-divergence .divergence-link-behind {


### PR DESCRIPTION
### Summary
Improves the GitHub Actions workspace page with status filter chips, repository/workflow search, a header layout consistent with the workspace repositories page (without the workspace breadcrumb), and several global and page-level UI fixes.

### Features
- **Status filters:** Pill toggles for errors, failed, aborted, running, success, and none. Filters apply to grid rows; global counts stay on the chips. Default: all on except **none** (hidden by default). Chips only render when their count is greater than zero.
- **Search:** Live filter on repository and workflow names (word tokens, case-insensitive), with clear control and Escape to reset. Subtitle shows total **workflows** (table rows) and **workflows found** when search is active.
- **Header:** Title row uses the same structural pattern as workspace repositories (baseline alignment, search + actions row). Refresh (and Re-run when present) aligns with the search field.

### UI / UX
- Filter chip styling: compact rounded rectangles, badge-colored count pills when active, focus rings aligned with the app’s thin white-ish frame.
- Status column: centered header and body; small left offset on status badges for alignment with the header.
- API/workflow error rows no longer use a full-row pink/red background; error state remains on the status badge only.
- GHA copy uses ASCII hyphen (`-`) instead of em/en dashes in the actions grid, live terminal strings, and related log messages.

### Technical notes
- **`LinesForTable`:** Composes status filters (`LinesForGrid`) and text search.
- **Global `app.css`:** Introduces `--focus-ring-outer`; buttons use a 1px focus ring; inputs use border-only focus (no double ring). Plain links use the same thin ring.

### Suggested verification
- Toggle filters and confirm grid updates; confirm **Re-run** still considers failed rows when filtered out.
- Search by repo and workflow fragments; clear and Escape.
- Tab through header filters, search, Refresh, grid links and Run buttons; confirm focus is a thin light frame, not a heavy blue halo.
- Load a repo with workflow API errors and confirm row background stays neutral and the error badge still shows.