### PR TITLE
Workspace UI: shared headers, dependency graph search, Connectors/Repositories toolbar, and Actions chip styling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -421,3 +421,4 @@ FodyWeavers.xsd
 /src/GrayMoon.App/graymoon.db-wal
 db/
 
+/.cursor/verify-out-deps

--- a/.gitignore
+++ b/.gitignore
@@ -422,3 +422,4 @@ FodyWeavers.xsd
 db/
 
 /.cursor/verify-out-deps
+/.cursor/verify-out-connectors-repos

--- a/src/GrayMoon.App/Components/Pages/Connectors.razor
+++ b/src/GrayMoon.App/Components/Pages/Connectors.razor
@@ -7,23 +7,56 @@
 @inject ConnectorRepository ConnectorRepository
 @inject ConnectorServiceFactory ConnectorServiceFactory
 @inject ILogger<Connectors> Logger
+@using Microsoft.AspNetCore.Components.Web
 
 <PageTitle>Connectors - GrayMoon</PageTitle>
 
 <div class="container-fluid page-container grid-page">
     <div class="grid-page-header">
-        <div class="d-flex justify-content-between align-items-center mb-4">
-            <div>
-                <h2>Connectors</h2>
-                <p class="text-muted mb-0" style="min-height: 1.5rem;">
-                    @if (connectors?.Count > 0)
+        <div class="workspace-repos-header workspace-connectors-header">
+            <div class="workspace-repos-title-row">
+                <h2 class="workspace-repos-title">Connectors</h2>
+                <p class="text-muted mb-0 workspace-repos-subtitle workspace-connectors__subtitle">
+                    @if (connectors != null && connectors.Count > 0)
                     {
-                        @($"{connectors.Count} {(connectors.Count == 1 ? "connector" : "connectors")}")
+                        var connSuffix = HasSearchFilter ? " found" : "";
+                        var connCount = HasSearchFilter ? FilteredConnectorCount : connectors.Count;
+                        <span>@($"{connCount} {(connCount == 1 ? "connector" : "connectors")}{connSuffix}")</span>
                     }
-                    &nbsp;
+                    else if (connectors != null)
+                    {
+                        <span>0 connectors</span>
+                    }
+                    else
+                    {
+                        <span>&nbsp;</span>
+                    }
                 </p>
+                <span class="workspace-repos-title-spacer"></span>
             </div>
-            <div class="d-flex align-items-center gap-2">
+            <div class="d-flex gap-2 align-items-center workspace-repos-header-actions">
+                <div class="workspace-repos-search-wrapper">
+                    <div class="workspace-repos-search-input-wrap @(HasSearchFilter ? "has-filter" : null)">
+                        <input id="connectors-search"
+                               class="form-control workspace-repos-search"
+                               placeholder="Search name, URL, user, or type..."
+                               value="@searchTerm"
+                               disabled="@(connectors == null || connectors.Count == 0)"
+                               @oninput="OnSearchChanged"
+                               @onkeydown="OnSearchKeyDown" />
+                        @if (HasSearchFilter)
+                        {
+                            <button type="button"
+                                    class="workspace-repos-search-clear"
+                                    title="Clear filter"
+                                    aria-label="Clear search filter"
+                                    @onclick="ClearSearchFilter"
+                                    @onclick:stopPropagation="true">
+                                <i class="bi bi-x-circle" aria-hidden="true"></i>
+                            </button>
+                        }
+                    </div>
+                </div>
                 <button class="btn btn-outline-primary"
                         @onclick="TestAllConnectorsAsync"
                         disabled="@(connectors == null || connectors.Count == 0 || isTestingAll)">
@@ -78,9 +111,17 @@
                                     </td>
                                 </tr>
                             }
+                            else if (NoConnectorsMatchSearch)
+                            {
+                                <tr>
+                                    <td colspan="6" class="text-center text-muted py-4">
+                                        No connectors match your search.
+                                    </td>
+                                </tr>
+                            }
                             else
                             {
-                                @foreach (var connector in connectors)
+                                @foreach (var connector in FilteredConnectors)
                                 {
                                     <tr>
                                         <td>
@@ -158,7 +199,59 @@
 
 @code {
     private List<Connector>? connectors;
+    private string searchTerm = string.Empty;
     private string? errorMessage;
+
+    private bool HasSearchFilter => !string.IsNullOrWhiteSpace(searchTerm);
+
+    private IReadOnlyList<Connector> FilteredConnectors => GetFilteredConnectors();
+
+    private int FilteredConnectorCount => FilteredConnectors.Count;
+
+    private bool NoConnectorsMatchSearch =>
+        connectors != null && connectors.Count > 0 && HasSearchFilter && FilteredConnectors.Count == 0;
+
+    private IReadOnlyList<Connector> GetFilteredConnectors()
+    {
+        if (connectors == null) return Array.Empty<Connector>();
+        var words = SplitSearchWords(searchTerm);
+        if (words.Count == 0) return connectors;
+        return connectors.Where(c =>
+        {
+            var typeStr = c.ConnectorType.ToString();
+            var haystack = $"{c.ConnectorName} {c.ApiBaseUrl} {c.UserName} {typeStr}";
+            return words.All(w => haystack.Contains(w, StringComparison.OrdinalIgnoreCase));
+        }).ToList();
+    }
+
+    private static List<string> SplitSearchWords(string term) =>
+        term
+            .Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(w => w.Trim())
+            .Where(w => w.Length > 0)
+            .ToList();
+
+    private void OnSearchChanged(ChangeEventArgs e)
+    {
+        searchTerm = e.Value?.ToString() ?? string.Empty;
+        StateHasChanged();
+    }
+
+    private void ClearSearchFilter()
+    {
+        searchTerm = string.Empty;
+        StateHasChanged();
+    }
+
+    private void OnSearchKeyDown(KeyboardEventArgs e)
+    {
+        if (e.Key == "Escape")
+        {
+            searchTerm = string.Empty;
+            StateHasChanged();
+        }
+    }
+
     private bool showCreateModal;
     private bool showEditModal;
     private bool showDeleteModal;

--- a/src/GrayMoon.App/Components/Pages/Connectors.razor.css
+++ b/src/GrayMoon.App/Components/Pages/Connectors.razor.css
@@ -1,3 +1,12 @@
+/* Header: match workspace search toolbar */
+.workspace-connectors-header .workspace-repos-subtitle.workspace-connectors__subtitle {
+    white-space: normal;
+    overflow: visible;
+    text-overflow: clip;
+    flex: 0 0 auto;
+    min-width: 0;
+}
+
 /* Match Repositories / Workspaces: left-align all columns; use global resizable-columns padding for header spacing */
 .connectors-table th,
 .connectors-table td {

--- a/src/GrayMoon.App/Components/Pages/Repositories.razor
+++ b/src/GrayMoon.App/Components/Pages/Repositories.razor
@@ -6,36 +6,61 @@
 @using GrayMoon.App.Components.Shared
 @inject GitHubRepositoryService RepositoryService
 @inject ILogger<Repositories> Logger
+@using Microsoft.AspNetCore.Components.Web
 
 <PageTitle>Repositories - GrayMoon</PageTitle>
 
 <div class="container-fluid page-container grid-page">
     <div class="grid-page-header">
-        <div class="d-flex flex-wrap justify-content-between align-items-center mb-4 gap-3">
-            <div>
-                <h2>Repositories</h2>
-                <p class="text-muted mb-0" style="min-height: 1.5rem;">
-                    @if (GetFilteredRepositories()?.Count > 0)
+        <div class="workspace-repos-header repositories-page-header">
+            <div class="workspace-repos-title-row">
+                <h2 class="workspace-repos-title">Repositories</h2>
+                <p class="text-muted mb-0 workspace-repos-subtitle repositories-page__subtitle">
+                    @if (repositories != null && repositories.Count > 0)
                     {
-                        var count = GetFilteredRepositories()?.Count ?? 0;
-                        @($"{count} {(count == 1 ? "repository" : "repositories")}")
+                        var repoSuffix = HasSearchFilter ? " found" : "";
+                        var repoCount = HasSearchFilter ? (GetFilteredRepositories()?.Count ?? 0) : repositories.Count;
+                        <span>@($"{repoCount} {(repoCount == 1 ? "repository" : "repositories")}{repoSuffix}")</span>
                     }
-                    &nbsp;
+                    else if (repositories != null)
+                    {
+                        <span>0 repositories</span>
+                    }
+                    else
+                    {
+                        <span>&nbsp;</span>
+                    }
                 </p>
+                <span class="workspace-repos-title-spacer"></span>
             </div>
-            <div class="d-flex flex-column">
-                <div class="d-flex align-items-center mb-1">
-                    <input class="form-control" placeholder="Search repositories..."
-                           @bind="searchTerm" @bind:event="oninput" />
-                    <button class="btn btn-outline-secondary ms-2"
-                            @onclick="ReloadRepositoriesAsync"
-                            disabled="@(isPersisting)">
-                        Fetch
-                    </button>
+            <div class="d-flex gap-2 align-items-center workspace-repos-header-actions">
+                <div class="workspace-repos-search-wrapper">
+                    <div class="workspace-repos-search-input-wrap @(HasSearchFilter ? "has-filter" : null)">
+                        <input id="repositories-search"
+                               class="form-control workspace-repos-search"
+                               placeholder="Search name, owner, topics, or connector (all words must match)..."
+                               value="@searchTerm"
+                               disabled="@(repositories == null || repositories.Count == 0)"
+                               @oninput="OnSearchChanged"
+                               @onkeydown="OnSearchKeyDown" />
+                        @if (HasSearchFilter)
+                        {
+                            <button type="button"
+                                    class="workspace-repos-search-clear"
+                                    title="Clear filter"
+                                    aria-label="Clear search filter"
+                                    @onclick="ClearSearchFilter"
+                                    @onclick:stopPropagation="true">
+                                <i class="bi bi-x-circle" aria-hidden="true"></i>
+                            </button>
+                        }
+                    </div>
                 </div>
-                <small class="form-text text-muted mb-2">
-                    Search by repository name, owner, topics, or connector; multiple words all must match.
-                </small>
+                <button class="btn btn-outline-secondary"
+                        @onclick="ReloadRepositoriesAsync"
+                        disabled="@(isPersisting)">
+                    Fetch
+                </button>
             </div>
         </div>
         @if (errorMessage != null)
@@ -158,6 +183,30 @@
     private string? errorMessage;
     private string searchTerm = string.Empty;
     private bool isPersisting;
+
+    private bool HasSearchFilter => !string.IsNullOrWhiteSpace(searchTerm);
+
+    private void OnSearchChanged(ChangeEventArgs e)
+    {
+        searchTerm = e.Value?.ToString() ?? string.Empty;
+        StateHasChanged();
+    }
+
+    private void ClearSearchFilter()
+    {
+        searchTerm = string.Empty;
+        StateHasChanged();
+    }
+
+    private void OnSearchKeyDown(KeyboardEventArgs e)
+    {
+        if (e.Key == "Escape")
+        {
+            searchTerm = string.Empty;
+            StateHasChanged();
+        }
+    }
+
     private int? fetchedRepositoryCount;
     private CancellationTokenSource? _fetchRepositoriesCts;
 
@@ -252,12 +301,7 @@
             return null;
         }
 
-        var words = searchTerm
-            .Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-            .Select(w => w.Trim())
-            .Where(w => w.Length > 0)
-            .ToList();
-
+        var words = SplitSearchWords(searchTerm);
         if (words.Count == 0)
         {
             return repositories;
@@ -277,4 +321,11 @@
                 connectorName.Contains(word, StringComparison.OrdinalIgnoreCase));
         }).ToList();
     }
+
+    private static List<string> SplitSearchWords(string term) =>
+        term
+            .Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(w => w.Trim())
+            .Where(w => w.Length > 0)
+            .ToList();
 }

--- a/src/GrayMoon.App/Components/Pages/Repositories.razor.css
+++ b/src/GrayMoon.App/Components/Pages/Repositories.razor.css
@@ -1,3 +1,12 @@
+/* Header: match workspace search toolbar */
+.repositories-page-header .workspace-repos-subtitle.repositories-page__subtitle {
+    white-space: normal;
+    overflow: visible;
+    text-overflow: clip;
+    flex: 0 0 auto;
+    min-width: 0;
+}
+
 .repositories-table th,
 .repositories-table td {
     white-space: nowrap;

--- a/src/GrayMoon.App/Components/Pages/WorkspaceDependencies.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceDependencies.razor
@@ -3,6 +3,7 @@
 @using GrayMoon.App.Models
 @using GrayMoon.App.Repositories
 @using GrayMoon.App.Components.Shared
+@using Microsoft.AspNetCore.Components.Web
 @inject WorkspaceRepository WorkspaceRepository
 @inject WorkspaceProjectRepository WorkspaceProjectRepository
 @inject NavigationManager NavigationManager
@@ -15,59 +16,97 @@
 
 <div class="container-fluid page-container grid-page dependencies-page">
     <div class="grid-page-header">
-        <div class="d-flex justify-content-between align-items-center mb-4 deps-header-row">
-            <div>
-                <h2>@(workspace?.Name ?? "workspace") Dependency Graph</h2>
-                <p class="text-muted mb-0" style="min-height: 1.5rem;">
-                    @if (graph != null)
+        <div class="workspace-repos-header workspace-dependencies-header">
+            <div class="workspace-repos-title-row">
+                <h2 class="workspace-repos-title">@(workspace?.Name ?? "workspace") Dependency Graph</h2>
+                <p class="text-muted mb-0 workspace-repos-subtitle workspace-dependencies__subtitle">
+                    @if (!isLoading && graph != null && graph.Nodes.Count > 0)
                     {
                         var (nodeCount, edgeCount) = GetFilteredCounts();
-                        @($"{nodeCount} repositories, {edgeCount} dependencies")
+                        var searchNote = HasSearchFilter ? " - matching search" : "";
+                        <span>@($"{nodeCount} repositories, {edgeCount} dependencies{searchNote}")</span>
                     }
-                    &nbsp;
+                    else if (!isLoading && workspace != null && graph != null && graph.Nodes.Count == 0)
+                    {
+                        <span>No dependency data</span>
+                    }
+                    else if (!isLoading && workspace != null)
+                    {
+                        <span>&nbsp;</span>
+                    }
+                    else if (isLoading)
+                    {
+                        <span>&nbsp;</span>
+                    }
                 </p>
+                <span class="workspace-repos-title-spacer"></span>
             </div>
-            @if (graph != null && graph.Nodes.Count > 0)
-            {
-                <div class="deps-filter-dropdown @(showFilterMenu ? "show" : "")">
-                    <button type="button"
-                            class="btn btn-outline-secondary dropdown-toggle deps-filter-toggle"
-                            aria-expanded="@showFilterMenu"
-                            title="@GetFilterLabel()"
-                            @onclick="ToggleFilterMenu">
-                        <span class="deps-filter-toggle-label">@GetFilterLabel()</span>
-                    </button>
-                    <div class="deps-filter-menu">
-                        <button type="button"
-                                class="dropdown-item deps-filter-option @(selectedFilterValue == "" ? "active" : "")"
-                                @onclick='() => SelectFilter("")'>
-                            All repositories
-                        </button>
-                        @foreach (var level in GetOrderedDependencyLevels())
+            <div class="d-flex gap-2 align-items-center workspace-repos-header-actions deps-header-actions">
+                <div class="workspace-repos-search-wrapper">
+                    <div class="workspace-repos-search-input-wrap @(HasSearchFilter ? "has-filter" : null)">
+                        <input id="workspace-dependencies-search"
+                               class="form-control workspace-repos-search"
+                               placeholder="Search repositories (shows each match and its dependency tree)..."
+                               value="@searchTerm"
+                               disabled="@(isLoading || graph == null || graph.Nodes.Count == 0)"
+                               @oninput="OnSearchChanged"
+                               @onkeydown="OnSearchKeyDown" />
+                        @if (HasSearchFilter)
                         {
-                            var levelVal = $"level-{level}";
                             <button type="button"
-                                    class="dropdown-item deps-filter-option @(selectedFilterValue == levelVal ? "active" : "")"
-                                    @onclick="() => SelectFilter(levelVal)">
-                                Level @level
-                            </button>
-                        }
-                        @foreach (var n in graph.Nodes.OrderBy(n => n.RepositoryName, StringComparer.OrdinalIgnoreCase))
-                        {
-                            var repoVal = n.RepositoryId.ToString();
-                            <button type="button"
-                                    class="dropdown-item deps-filter-option @(selectedFilterValue == repoVal ? "active" : "")"
-                                    @onclick="() => SelectFilter(repoVal)">
-                                @n.RepositoryName
+                                    class="workspace-repos-search-clear"
+                                    title="Clear filter"
+                                    aria-label="Clear search filter"
+                                    @onclick="ClearSearchFilter"
+                                    @onclick:stopPropagation="true">
+                                <i class="bi bi-x-circle" aria-hidden="true"></i>
                             </button>
                         }
                     </div>
-                    @if (showFilterMenu)
-                    {
-                        <div class="deps-filter-backdrop" @onclick="CloseFilterMenu"></div>
-                    }
                 </div>
-            }
+                @if (graph != null && graph.Nodes.Count > 0)
+                {
+                    <div class="deps-filter-dropdown @(showFilterMenu ? "show" : "")">
+                        <button type="button"
+                                class="btn btn-outline-secondary dropdown-toggle deps-filter-toggle"
+                                aria-expanded="@showFilterMenu"
+                                title="@(HasSearchFilter ? "Clear search to apply this scope to the graph." : GetFilterLabel())"
+                                disabled="@HasSearchFilter"
+                                @onclick="ToggleFilterMenu">
+                            <span class="deps-filter-toggle-label">@GetFilterLabel()</span>
+                        </button>
+                        <div class="deps-filter-menu">
+                            <button type="button"
+                                    class="dropdown-item deps-filter-option @(selectedFilterValue == "" ? "active" : "")"
+                                    @onclick='() => SelectFilter("")'>
+                                All repositories
+                            </button>
+                            @foreach (var level in GetOrderedDependencyLevels())
+                            {
+                                var levelVal = $"level-{level}";
+                                <button type="button"
+                                        class="dropdown-item deps-filter-option @(selectedFilterValue == levelVal ? "active" : "")"
+                                        @onclick="() => SelectFilter(levelVal)">
+                                    Level @level
+                                </button>
+                            }
+                            @foreach (var n in graph.Nodes.OrderBy(n => n.RepositoryName, StringComparer.OrdinalIgnoreCase))
+                            {
+                                var repoVal = n.RepositoryId.ToString();
+                                <button type="button"
+                                        class="dropdown-item deps-filter-option @(selectedFilterValue == repoVal ? "active" : "")"
+                                        @onclick="() => SelectFilter(repoVal)">
+                                    @n.RepositoryName
+                                </button>
+                            }
+                        </div>
+                        @if (showFilterMenu)
+                        {
+                            <div class="deps-filter-backdrop" @onclick="CloseFilterMenu"></div>
+                        }
+                    </div>
+                }
+            </div>
         </div>
         @if (errorMessage != null)
         {
@@ -84,6 +123,10 @@
             {
                 <p class="dependencies-empty-message text-muted text-center mb-0">No dependencies to display. Sync repositories to discover projects and dependencies.</p>
             }
+            else if (NoRepositoriesMatchSearch)
+            {
+                <p class="dependencies-empty-message text-muted text-center mb-0">No repositories match your search.</p>
+            }
         </div>
     }
 </div>
@@ -98,8 +141,18 @@
     private string? errorMessage;
     private bool isLoading = true;
     private string selectedFilterValue = "";
-    private string _lastRenderedFilter = "";
+    private string _lastRenderedState = "";
     private bool showFilterMenu;
+    private string searchTerm = string.Empty;
+
+    private bool HasSearchFilter => !string.IsNullOrWhiteSpace(searchTerm);
+
+    /// <summary>Graph has data but the repository search matched nothing.</summary>
+    private bool NoRepositoriesMatchSearch =>
+        graph != null
+        && graph.Nodes.Count > 0
+        && HasSearchFilter
+        && GetFilteredNodesAndEdges().Nodes.Count == 0;
     private const string GraphContainerId = "cytoscape-dependency-graph";
     private const string LevelPrefix = "level-";
 
@@ -145,6 +198,7 @@
 
     private void ToggleFilterMenu()
     {
+        if (HasSearchFilter) return;
         showFilterMenu = !showFilterMenu;
     }
 
@@ -157,6 +211,37 @@
     {
         selectedFilterValue = value;
         showFilterMenu = false;
+        StateHasChanged();
+    }
+
+    private static List<string> SplitSearchWords(string term) =>
+        term
+            .Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(w => w.Trim())
+            .Where(w => w.Length > 0)
+            .ToList();
+
+    private void OnSearchChanged(ChangeEventArgs e)
+    {
+        searchTerm = e.Value?.ToString() ?? string.Empty;
+        showFilterMenu = false;
+        StateHasChanged();
+    }
+
+    private void ClearSearchFilter()
+    {
+        searchTerm = string.Empty;
+        StateHasChanged();
+    }
+
+    private void OnSearchKeyDown(KeyboardEventArgs e)
+    {
+        if (e.Key == "Escape")
+        {
+            searchTerm = string.Empty;
+            showFilterMenu = false;
+            StateHasChanged();
+        }
     }
 
     private string GetFilterLabel()
@@ -175,39 +260,71 @@
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         if (graph == null || graph.Nodes.Count == 0) return;
-        if (firstRender || _lastRenderedFilter != selectedFilterValue)
-        {
-            _lastRenderedFilter = selectedFilterValue;
-            try
-            {
-                await JSRuntime.InvokeVoidAsync("destroyCytoscapeGraph", GraphContainerId);
-            }
-            catch { /* ignore */ }
 
-            try
+        var stateKey = $"{selectedFilterValue}|{searchTerm}";
+        if (!firstRender && _lastRenderedState == stateKey) return;
+
+        _lastRenderedState = stateKey;
+        try
+        {
+            await JSRuntime.InvokeVoidAsync("destroyCytoscapeGraph", GraphContainerId);
+        }
+        catch { /* ignore */ }
+
+        var (filteredNodes, filteredEdges) = GetFilteredNodesAndEdges();
+        if (filteredNodes.Count == 0) return;
+
+        try
+        {
+            var prefixByRepoId = GetLabelsWithGroupPrefixStripped(graph.Nodes.Select(n => (n.RepositoryId, n.RepositoryName)).ToList());
+            var nodes = filteredNodes.Select(n => new
             {
-                var prefixByRepoId = GetLabelsWithGroupPrefixStripped(graph.Nodes.Select(n => (n.RepositoryId, n.RepositoryName)).ToList());
-                var (filteredNodes, filteredEdges) = GetFilteredNodesAndEdges();
-                var nodes = filteredNodes.Select(n => new
-                {
-                    id = n.RepositoryId.ToString(),
-                    label = prefixByRepoId.TryGetValue(n.RepositoryId, out var label) ? label : n.RepositoryName,
-                    nodeType = n.RepositoryType?.ToString().ToLowerInvariant() ?? "other"
-                }).ToList();
-                var edges = filteredEdges.Select(e => new { source = e.DependentRepositoryId.ToString(), target = e.ReferencedRepositoryId.ToString() }).ToList();
-                var roots = filteredNodes.Select(n => n.RepositoryId.ToString()).Except(edges.Select(e => e.target)).ToList();
-                await JSRuntime.InvokeVoidAsync("renderCytoscapeGraph", GraphContainerId, nodes, edges, roots);
-            }
-            catch (Exception ex)
-            {
-                Logger.LogWarning(ex, "Cytoscape render failed for workspace {WorkspaceId}", WorkspaceId);
-            }
+                id = n.RepositoryId.ToString(),
+                label = prefixByRepoId.TryGetValue(n.RepositoryId, out var label) ? label : n.RepositoryName,
+                nodeType = n.RepositoryType?.ToString().ToLowerInvariant() ?? "other"
+            }).ToList();
+            var edges = filteredEdges.Select(e => new { source = e.DependentRepositoryId.ToString(), target = e.ReferencedRepositoryId.ToString() }).ToList();
+            var roots = filteredNodes.Select(n => n.RepositoryId.ToString()).Except(edges.Select(e => e.target)).ToList();
+            await JSRuntime.InvokeVoidAsync("renderCytoscapeGraph", GraphContainerId, nodes, edges, roots);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex, "Cytoscape render failed for workspace {WorkspaceId}", WorkspaceId);
         }
     }
 
     private (IReadOnlyList<RepositoryDependencyNode> Nodes, IReadOnlyList<RepositoryDependencyEdge> Edges) GetFilteredNodesAndEdges()
     {
         if (graph == null) return (new List<RepositoryDependencyNode>(), new List<RepositoryDependencyEdge>());
+
+        if (HasSearchFilter)
+        {
+            var words = SplitSearchWords(searchTerm);
+            if (words.Count == 0)
+                return (graph.Nodes, graph.Edges);
+
+            var matched = graph.Nodes.Where(n =>
+            {
+                var name = n.RepositoryName ?? string.Empty;
+                return words.All(w => name.Contains(w, StringComparison.OrdinalIgnoreCase));
+            }).ToList();
+            if (matched.Count == 0)
+                return (new List<RepositoryDependencyNode>(), new List<RepositoryDependencyEdge>());
+
+            var nodeIds = new HashSet<int>();
+            foreach (var m in matched)
+            {
+                foreach (var id in GetTransitiveReferencedRepositoryIds(m.RepositoryId))
+                    nodeIds.Add(id);
+            }
+
+            var filteredNodes = graph.Nodes.Where(n => nodeIds.Contains(n.RepositoryId)).ToList();
+            var filteredEdges = graph.Edges
+                .Where(e => nodeIds.Contains(e.DependentRepositoryId) && nodeIds.Contains(e.ReferencedRepositoryId))
+                .ToList();
+            return (filteredNodes, filteredEdges);
+        }
+
         if (string.IsNullOrEmpty(selectedFilterValue))
             return (graph.Nodes, graph.Edges);
 
@@ -237,6 +354,30 @@
         }
 
         return (graph.Nodes, graph.Edges);
+    }
+
+    /// <summary>Repository ids reachable from <paramref name="rootRepoId"/> by following dependency edges (this repo depends on ...).</summary>
+    private HashSet<int> GetTransitiveReferencedRepositoryIds(int rootRepoId)
+    {
+        if (graph == null) return [];
+
+        var byDependent = graph.Edges
+            .GroupBy(e => e.DependentRepositoryId)
+            .ToDictionary(g => g.Key, g => g.Select(e => e.ReferencedRepositoryId).ToList());
+
+        var visited = new HashSet<int>();
+        var stack = new Stack<int>();
+        stack.Push(rootRepoId);
+        while (stack.Count > 0)
+        {
+            var id = stack.Pop();
+            if (!visited.Add(id)) continue;
+            if (!byDependent.TryGetValue(id, out var refs)) continue;
+            foreach (var r in refs)
+                stack.Push(r);
+        }
+
+        return visited;
     }
 
     private HashSet<int> GetRepoIdsAtLevel(int level)

--- a/src/GrayMoon.App/Components/Pages/WorkspaceDependencies.razor.css
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceDependencies.razor.css
@@ -28,16 +28,30 @@
     transform: translate(-50%, -50%);
 }
 
+/* Header: match workspace search toolbar subtitle wrapping */
+.workspace-dependencies-header .workspace-repos-subtitle.workspace-dependencies__subtitle {
+    white-space: normal;
+    overflow: visible;
+    text-overflow: clip;
+    flex: 0 0 auto;
+    min-width: 0;
+}
+
+.dependencies-page .deps-header-actions {
+    flex-wrap: wrap;
+}
+
 .deps-filter-dropdown {
-    flex-shrink: 0;
+    flex: 0 1 20rem;
+    min-width: 10rem;
+    max-width: 100%;
     position: relative;
     z-index: 1050;
-    margin-left: auto;
 }
 
 .deps-filter-toggle {
-    min-width: 5rem;
-    width: 25rem;
+    min-width: 0;
+    width: 100%;
     display: flex;
     justify-content: space-between;
     align-items: center;
@@ -129,17 +143,13 @@
 }
 
 @media (max-width: 900px) {
-    .dependencies-page .deps-header-row {
+    .dependencies-page .deps-header-actions {
         flex-direction: column;
-        align-items: flex-start !important;
+        align-items: stretch !important;
     }
 
     .deps-filter-dropdown {
-        width: 100%;
-        margin-left: 0;
-    }
-
-    .deps-filter-toggle {
-        width: 100%;
+        flex: 1 1 auto;
+        max-width: none;
     }
 }

--- a/src/GrayMoon.App/Components/Pages/WorkspaceFiles.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceFiles.razor
@@ -7,6 +7,7 @@
 @using GrayMoon.App.Services
 @using GrayMoon.App.Components.Modals
 @using GrayMoon.App.Api.Endpoints
+@using Microsoft.AspNetCore.Components.Web
 @inject WorkspaceRepository WorkspaceRepository
 @inject WorkspaceFileRepository WorkspaceFileRepository
 @inject WorkspaceFileVersionConfigRepository VersionConfigRepository
@@ -20,18 +21,50 @@
 
 <div class="container-fluid page-container grid-page">
     <div class="grid-page-header">
-        <div class="d-flex justify-content-between align-items-center mb-4">
-            <div>
-                <h2>@(workspace?.Name ?? "Workspace") Files</h2>
-                <p class="text-muted mb-0" style="min-height: 1.5rem;">
-                    @if (files.Count > 0)
+        <div class="workspace-repos-header workspace-files-header">
+            <div class="workspace-repos-title-row">
+                <h2 class="workspace-repos-title">@(workspace?.Name ?? "Workspace") Files</h2>
+                <p class="text-muted mb-0 workspace-repos-subtitle workspace-files__subtitle">
+                    @if (!isLoading && files.Count > 0)
                     {
-                        @($"{files.Count} {(files.Count == 1 ? "file" : "files")}")
+                        var fileSuffix = HasSearchFilter ? " found" : "";
+                        var fileCount = HasSearchFilter ? FilteredFileCount : files.Count;
+                        <span>@($"{fileCount} {(fileCount == 1 ? "file" : "files")}{fileSuffix}")</span>
                     }
-                    &nbsp;
+                    else if (!isLoading && workspace != null)
+                    {
+                        <span>0 files</span>
+                    }
+                    else if (isLoading)
+                    {
+                        <span>&nbsp;</span>
+                    }
                 </p>
+                <span class="workspace-repos-title-spacer"></span>
             </div>
-            <div class="d-flex gap-2">
+            <div class="d-flex gap-2 align-items-center workspace-repos-header-actions">
+                <div class="workspace-repos-search-wrapper">
+                    <div class="workspace-repos-search-input-wrap @(HasSearchFilter ? "has-filter" : null)">
+                        <input id="workspace-files-search"
+                               class="form-control workspace-repos-search"
+                               placeholder="Search file name, path, or repository..."
+                               value="@searchTerm"
+                               disabled="@(isLoading || files.Count == 0)"
+                               @oninput="OnSearchChanged"
+                               @onkeydown="OnSearchKeyDown" />
+                        @if (HasSearchFilter)
+                        {
+                            <button type="button"
+                                    class="workspace-repos-search-clear"
+                                    title="Clear filter"
+                                    aria-label="Clear search filter"
+                                    @onclick="ClearSearchFilter"
+                                    @onclick:stopPropagation="true">
+                                <i class="bi bi-x-circle" aria-hidden="true"></i>
+                            </button>
+                        }
+                    </div>
+                </div>
                 <button class="btn btn-outline-primary" @onclick="UpdateVersionsAsync"
                         disabled="@(fileVersionConfigs.Count == 0)" title="Update versions in all configured files">
                     Update
@@ -48,68 +81,79 @@
             </div>
         }
     </div>
-    <div class="grid-page-body">
-        <div class="card page-card mb-4">
-            <div class="card-body p-0">
-                <div class="table-responsive">
-                    <table class="table table-striped table-hover mb-0 workspaces-table resizable-columns">
-                        <thead class="table-dark">
-                            <tr>
-                                <th class="col-filename text-nowrap">File Name</th>
-                                <th class="col-filepath text-nowrap">File Path</th>
-                                <th class="col-repo text-nowrap">Repository</th>
-                                <th class="col-actions text-nowrap">Actions</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            @if (isLoading)
-                            {
+    @if (errorMessage == null)
+    {
+        <div class="grid-page-body">
+            <div class="card page-card mb-4">
+                <div class="card-body p-0">
+                    <div class="table-responsive">
+                        <table class="table table-striped table-hover mb-0 workspaces-table resizable-columns">
+                            <thead class="table-dark">
                                 <tr>
-                                    <td colspan="4" class="text-center text-muted py-4">Loading files...</td>
+                                    <th class="col-filename text-nowrap">File Name</th>
+                                    <th class="col-filepath text-nowrap">File Path</th>
+                                    <th class="col-repo text-nowrap">Repository</th>
+                                    <th class="col-actions text-nowrap">Actions</th>
                                 </tr>
-                            }
-                            else if (files.Count == 0)
-                            {
-                                <tr>
-                                    <td colspan="4" class="text-center text-muted py-4">
-                                        No files in this workspace. Use "Add Files" to search and add files from your repositories.
-                                    </td>
-                                </tr>
-                            }
-                            else
-                            {
-                                @foreach (var f in files)
+                            </thead>
+                            <tbody>
+                                @if (isLoading)
                                 {
                                     <tr>
-                                        <td class="col-filename"><strong>@f.FileName</strong></td>
-                                        <td class="col-filepath text-muted">@f.FilePath</td>
-                                        <td class="col-repo">@(f.RepositoryName ?? "-")</td>
-                                        <td class="col-actions">
-                                            <button class="btn btn-sm btn-outline-secondary me-2"
-                                                    @onclick="() => OpenViewFileModal(f)"
-                                                    title="View file contents">
-                                                View
-                                            </button>
-                                            <button class="btn btn-sm me-2 @(fileVersionConfigs.ContainsKey(f.FileId) ? "btn-info" : "btn-outline-secondary")"
-                                                    @onclick="() => OpenVersionConfigModal(f)"
-                                                    title="@(fileVersionConfigs.ContainsKey(f.FileId) ? "Edit version configuration" : "Configure versioning")">
-                                                Configure
-                                            </button>
-                                            <button class="btn btn-sm btn-outline-danger"
-                                                    @onclick="() => RemoveFileAsync(f)"
-                                                    title="Remove file">
-                                                Remove
-                                            </button>
+                                        <td colspan="4" class="text-center text-muted py-4">Loading files...</td>
+                                    </tr>
+                                }
+                                else if (files.Count == 0)
+                                {
+                                    <tr>
+                                        <td colspan="4" class="text-center text-muted py-4">
+                                            No files in this workspace. Use "Add Files" to search and add files from your repositories.
                                         </td>
                                     </tr>
                                 }
-                            }
-                        </tbody>
-                    </table>
+                                else if (NoFilesMatchSearch)
+                                {
+                                    <tr>
+                                        <td colspan="4" class="text-center text-muted py-4">
+                                            No files match your search.
+                                        </td>
+                                    </tr>
+                                }
+                                else
+                                {
+                                    @foreach (var f in FilteredFiles)
+                                    {
+                                        <tr>
+                                            <td class="col-filename"><strong>@f.FileName</strong></td>
+                                            <td class="col-filepath text-muted">@f.FilePath</td>
+                                            <td class="col-repo">@(f.RepositoryName ?? "-")</td>
+                                            <td class="col-actions">
+                                                <button class="btn btn-sm btn-outline-secondary me-2"
+                                                        @onclick="() => OpenViewFileModal(f)"
+                                                        title="View file contents">
+                                                    View
+                                                </button>
+                                                <button class="btn btn-sm me-2 @(fileVersionConfigs.ContainsKey(f.FileId) ? "btn-info" : "btn-outline-secondary")"
+                                                        @onclick="() => OpenVersionConfigModal(f)"
+                                                        title="@(fileVersionConfigs.ContainsKey(f.FileId) ? "Edit version configuration" : "Configure versioning")">
+                                                    Configure
+                                                </button>
+                                                <button class="btn btn-sm btn-outline-danger"
+                                                        @onclick="() => RemoveFileAsync(f)"
+                                                        title="Remove file">
+                                                    Remove
+                                                </button>
+                                            </td>
+                                        </tr>
+                                    }
+                                }
+                            </tbody>
+                        </table>
+                    </div>
                 </div>
             </div>
         </div>
-    </div>
+    }
 </div>
 
 <AddFilesModal IsVisible="@showFileModal"
@@ -154,6 +198,59 @@
     private bool isUpdating;
     private string updateMessage = "";
     private CancellationTokenSource? _updateCts;
+    private string searchTerm = string.Empty;
+
+    private bool HasSearchFilter => !string.IsNullOrWhiteSpace(searchTerm);
+
+    private IReadOnlyList<WorkspaceFileDto> FilteredFiles => GetFilteredFiles();
+
+    private int FilteredFileCount => FilteredFiles.Count;
+
+    private bool NoFilesMatchSearch =>
+        !isLoading && files.Count > 0 && FilteredFiles.Count == 0;
+
+    private IReadOnlyList<WorkspaceFileDto> GetFilteredFiles()
+    {
+        var words = SplitSearchWords(searchTerm);
+        if (words.Count == 0)
+            return files;
+        return files.Where(f =>
+        {
+            var name = f.FileName ?? string.Empty;
+            var path = f.FilePath ?? string.Empty;
+            var repo = f.RepositoryName ?? string.Empty;
+            var haystack = $"{name} {path} {repo}";
+            return words.All(w => haystack.Contains(w, StringComparison.OrdinalIgnoreCase));
+        }).ToList();
+    }
+
+    private static List<string> SplitSearchWords(string term) =>
+        term
+            .Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(w => w.Trim())
+            .Where(w => w.Length > 0)
+            .ToList();
+
+    private void OnSearchChanged(ChangeEventArgs e)
+    {
+        searchTerm = e.Value?.ToString() ?? string.Empty;
+        StateHasChanged();
+    }
+
+    private void ClearSearchFilter()
+    {
+        searchTerm = string.Empty;
+        StateHasChanged();
+    }
+
+    private void OnSearchKeyDown(KeyboardEventArgs e)
+    {
+        if (e.Key == "Escape")
+        {
+            searchTerm = string.Empty;
+            StateHasChanged();
+        }
+    }
 
     protected override async Task OnInitializedAsync()
     {

--- a/src/GrayMoon.App/Components/Pages/WorkspaceFiles.razor.css
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceFiles.razor.css
@@ -1,3 +1,12 @@
+/* Header: match workspace search toolbar (Repositories / Projects / Packages) */
+.workspace-files-header .workspace-repos-subtitle.workspace-files__subtitle {
+    white-space: normal;
+    overflow: visible;
+    text-overflow: clip;
+    flex: 0 0 auto;
+    min-width: 0;
+}
+
 .workspaces-table th,
 .workspaces-table td {
     white-space: nowrap;

--- a/src/GrayMoon.App/Components/Pages/WorkspacePackages.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspacePackages.razor
@@ -4,6 +4,7 @@
 @using GrayMoon.App.Repositories
 @using GrayMoon.App.Services
 @using GrayMoon.App.Components.Shared
+@using Microsoft.AspNetCore.Components.Web
 @inject WorkspaceRepository WorkspaceRepository
 @inject WorkspaceProjectRepository WorkspaceProjectRepository
 @inject PackageRegistrySyncService PackageRegistrySyncService
@@ -14,22 +15,56 @@
 
 <div class="container-fluid page-container grid-page">
     <div class="grid-page-header">
-        <div class="d-flex justify-content-between align-items-center mb-4">
-            <div>
-                <h2>@(workspace?.Name ?? "Workspace") Packages</h2>
-                <p class="text-muted mb-0" style="min-height: 1.5rem;">
-                    @if (packages.Count > 0)
+        <div class="workspace-repos-header workspace-packages-header">
+            <div class="workspace-repos-title-row">
+                <h2 class="workspace-repos-title">@(workspace?.Name ?? "Workspace") Packages</h2>
+                <p class="text-muted mb-0 workspace-repos-subtitle workspace-packages__subtitle">
+                    @if (!isLoading && packages.Count > 0)
                     {
-                        @($"{packages.Count} {(packages.Count == 1 ? "package" : "packages")}")
+                        var pkgSuffix = HasSearchFilter ? " found" : "";
+                        var pkgCount = HasSearchFilter ? FilteredPackageCount : packages.Count;
+                        <span>@($"{pkgCount} {(pkgCount == 1 ? "package" : "packages")}{pkgSuffix}")</span>
                     }
-                    &nbsp;
+                    else if (!isLoading && workspace != null)
+                    {
+                        <span>0 packages</span>
+                    }
+                    else if (isLoading)
+                    {
+                        <span>&nbsp;</span>
+                    }
                 </p>
+                <span class="workspace-repos-title-spacer"></span>
             </div>
-            <button class="btn btn-outline-primary"
-                    @onclick="SyncRegistriesAsync"
-                    disabled="@(isSyncingRegistries || packages.Count == 0)">
-                Sync registries
-            </button>
+            <div class="d-flex gap-2 align-items-center workspace-repos-header-actions">
+                <div class="workspace-repos-search-wrapper">
+                    <div class="workspace-repos-search-input-wrap @(HasSearchFilter ? "has-filter" : null)">
+                        <input id="workspace-packages-search"
+                               class="form-control workspace-repos-search"
+                               placeholder="Search package id..."
+                               value="@searchTerm"
+                               disabled="@(isLoading || packages.Count == 0)"
+                               @oninput="OnSearchChanged"
+                               @onkeydown="OnSearchKeyDown" />
+                        @if (HasSearchFilter)
+                        {
+                            <button type="button"
+                                    class="workspace-repos-search-clear"
+                                    title="Clear filter"
+                                    aria-label="Clear search filter"
+                                    @onclick="ClearSearchFilter"
+                                    @onclick:stopPropagation="true">
+                                <i class="bi bi-x-circle" aria-hidden="true"></i>
+                            </button>
+                        }
+                    </div>
+                </div>
+                <button class="btn btn-outline-primary"
+                        @onclick="SyncRegistriesAsync"
+                        disabled="@(isSyncingRegistries || packages.Count == 0)">
+                    Sync registries
+                </button>
+            </div>
         </div>
         @if (errorMessage != null)
         {
@@ -69,9 +104,17 @@
                                         </td>
                                     </tr>
                                 }
+                                else if (NoPackagesMatchSearch)
+                                {
+                                    <tr>
+                                        <td colspan="3" class="text-center text-muted py-4">
+                                            No packages match your search.
+                                        </td>
+                                    </tr>
+                                }
                                 else
                                 {
-                                    @foreach (var p in packages)
+                                    @foreach (var p in FilteredPackages)
                                     {
                                         <tr>
                                             <td class="col-packageid"><strong>@(p.PackageId ?? "-")</strong></td>
@@ -100,6 +143,56 @@
     private string? errorMessage;
     private bool isLoading = true;
     private bool isSyncingRegistries = false;
+    private string searchTerm = string.Empty;
+
+    private bool HasSearchFilter => !string.IsNullOrWhiteSpace(searchTerm);
+
+    private IReadOnlyList<WorkspaceProject> FilteredPackages => GetFilteredPackages();
+
+    private int FilteredPackageCount => FilteredPackages.Count;
+
+    private bool NoPackagesMatchSearch =>
+        !isLoading && packages.Count > 0 && FilteredPackages.Count == 0;
+
+    private IReadOnlyList<WorkspaceProject> GetFilteredPackages()
+    {
+        var words = SplitSearchWords(searchTerm);
+        if (words.Count == 0)
+            return packages;
+        return packages.Where(p =>
+        {
+            var id = p.PackageId ?? string.Empty;
+            return words.All(w => id.Contains(w, StringComparison.OrdinalIgnoreCase));
+        }).ToList();
+    }
+
+    private static List<string> SplitSearchWords(string term) =>
+        term
+            .Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(w => w.Trim())
+            .Where(w => w.Length > 0)
+            .ToList();
+
+    private void OnSearchChanged(ChangeEventArgs e)
+    {
+        searchTerm = e.Value?.ToString() ?? string.Empty;
+        StateHasChanged();
+    }
+
+    private void ClearSearchFilter()
+    {
+        searchTerm = string.Empty;
+        StateHasChanged();
+    }
+
+    private void OnSearchKeyDown(KeyboardEventArgs e)
+    {
+        if (e.Key == "Escape")
+        {
+            searchTerm = string.Empty;
+            StateHasChanged();
+        }
+    }
 
     protected override async Task OnInitializedAsync()
     {

--- a/src/GrayMoon.App/Components/Pages/WorkspacePackages.razor.css
+++ b/src/GrayMoon.App/Components/Pages/WorkspacePackages.razor.css
@@ -1,3 +1,12 @@
+/* Header: match workspace search toolbar (WorkspaceRepositories / WorkspaceActions) */
+.workspace-packages-header .workspace-repos-subtitle.workspace-packages__subtitle {
+    white-space: normal;
+    overflow: visible;
+    text-overflow: clip;
+    flex: 0 0 auto;
+    min-width: 0;
+}
+
 /* Match Repositories / Workspaces: left-align all columns; use global resizable-columns padding for header spacing */
 .packages-table th,
 .packages-table td {

--- a/src/GrayMoon.App/Components/Pages/WorkspaceProjects.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceProjects.razor
@@ -3,6 +3,7 @@
 @using GrayMoon.App.Models
 @using GrayMoon.App.Repositories
 @using GrayMoon.App.Components.Shared
+@using Microsoft.AspNetCore.Components.Web
 @inject WorkspaceRepository WorkspaceRepository
 @inject WorkspaceProjectRepository WorkspaceProjectRepository
 @inject ILogger<WorkspaceProjects> Logger
@@ -12,16 +13,50 @@
 
 <div class="container-fluid page-container grid-page">
     <div class="grid-page-header">
-        <div class="d-flex justify-content-between align-items-center mb-4">
-            <div>
-                <h2>@(workspace?.Name ?? "Workspace") Projects</h2>
-                <p class="text-muted mb-0" style="min-height: 1.5rem;">
-                    @if (projects.Count > 0)
+        <div class="workspace-repos-header workspace-projects-header">
+            <div class="workspace-repos-title-row">
+                <h2 class="workspace-repos-title">@(workspace?.Name ?? "Workspace") Projects</h2>
+                <p class="text-muted mb-0 workspace-repos-subtitle workspace-projects__subtitle">
+                    @if (!isLoading && projects.Count > 0)
                     {
-                        @($"{projects.Count} {(projects.Count == 1 ? "project" : "projects")}")
+                        var projSuffix = HasSearchFilter ? " found" : "";
+                        var projCount = HasSearchFilter ? FilteredProjectCount : projects.Count;
+                        <span>@($"{projCount} {(projCount == 1 ? "project" : "projects")}{projSuffix}")</span>
                     }
-                    &nbsp;
+                    else if (!isLoading && workspace != null)
+                    {
+                        <span>0 projects</span>
+                    }
+                    else if (isLoading)
+                    {
+                        <span>&nbsp;</span>
+                    }
                 </p>
+                <span class="workspace-repos-title-spacer"></span>
+            </div>
+            <div class="d-flex gap-2 align-items-center workspace-repos-header-actions">
+                <div class="workspace-repos-search-wrapper">
+                    <div class="workspace-repos-search-input-wrap @(HasSearchFilter ? "has-filter" : null)">
+                        <input id="workspace-projects-search"
+                               class="form-control workspace-repos-search"
+                               placeholder="Search project name or file..."
+                               value="@searchTerm"
+                               disabled="@(isLoading || projects.Count == 0)"
+                               @oninput="OnSearchChanged"
+                               @onkeydown="OnSearchKeyDown" />
+                        @if (HasSearchFilter)
+                        {
+                            <button type="button"
+                                    class="workspace-repos-search-clear"
+                                    title="Clear filter"
+                                    aria-label="Clear search filter"
+                                    @onclick="ClearSearchFilter"
+                                    @onclick:stopPropagation="true">
+                                <i class="bi bi-x-circle" aria-hidden="true"></i>
+                            </button>
+                        }
+                    </div>
+                </div>
             </div>
         </div>
         @if (errorMessage != null)
@@ -63,9 +98,17 @@
                                         </td>
                                     </tr>
                                 }
+                                else if (NoProjectsMatchSearch)
+                                {
+                                    <tr>
+                                        <td colspan="4" class="text-center text-muted py-4">
+                                            No projects match your search.
+                                        </td>
+                                    </tr>
+                                }
                                 else
                                 {
-                                    @foreach (var p in projects)
+                                    @foreach (var p in FilteredProjects)
                                     {
                                         <tr>
                                             <td class="col-name"><strong>@p.ProjectName</strong></td>
@@ -93,6 +136,58 @@
     private List<WorkspaceProject> projects = new();
     private string? errorMessage;
     private bool isLoading = true;
+    private string searchTerm = string.Empty;
+
+    private bool HasSearchFilter => !string.IsNullOrWhiteSpace(searchTerm);
+
+    private IReadOnlyList<WorkspaceProject> FilteredProjects => GetFilteredProjects();
+
+    private int FilteredProjectCount => FilteredProjects.Count;
+
+    private bool NoProjectsMatchSearch =>
+        !isLoading && projects.Count > 0 && FilteredProjects.Count == 0;
+
+    private IReadOnlyList<WorkspaceProject> GetFilteredProjects()
+    {
+        var words = SplitSearchWords(searchTerm);
+        if (words.Count == 0)
+            return projects;
+        return projects.Where(p =>
+        {
+            var name = p.ProjectName ?? string.Empty;
+            var file = p.ProjectFilePath ?? string.Empty;
+            var haystack = $"{name} {file}";
+            return words.All(w => haystack.Contains(w, StringComparison.OrdinalIgnoreCase));
+        }).ToList();
+    }
+
+    private static List<string> SplitSearchWords(string term) =>
+        term
+            .Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(w => w.Trim())
+            .Where(w => w.Length > 0)
+            .ToList();
+
+    private void OnSearchChanged(ChangeEventArgs e)
+    {
+        searchTerm = e.Value?.ToString() ?? string.Empty;
+        StateHasChanged();
+    }
+
+    private void ClearSearchFilter()
+    {
+        searchTerm = string.Empty;
+        StateHasChanged();
+    }
+
+    private void OnSearchKeyDown(KeyboardEventArgs e)
+    {
+        if (e.Key == "Escape")
+        {
+            searchTerm = string.Empty;
+            StateHasChanged();
+        }
+    }
 
     protected override async Task OnInitializedAsync()
     {

--- a/src/GrayMoon.App/Components/Pages/WorkspaceProjects.razor.css
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceProjects.razor.css
@@ -1,3 +1,12 @@
+/* Header: match workspace search toolbar (WorkspaceRepositories / WorkspaceActions) */
+.workspace-projects-header .workspace-repos-subtitle.workspace-projects__subtitle {
+    white-space: normal;
+    overflow: visible;
+    text-overflow: clip;
+    flex: 0 0 auto;
+    min-width: 0;
+}
+
 /* Match Repositories / Workspaces: left-align all columns; use global resizable-columns padding for header spacing */
 .projects-table th,
 .projects-table td {

--- a/src/GrayMoon.App/wwwroot/app.css
+++ b/src/GrayMoon.App/wwwroot/app.css
@@ -466,6 +466,13 @@ h1:focus {
 .workspace-repos-header .workspace-repos-search-input-wrap.has-filter .workspace-repos-search {
     padding-right: 2.25rem;
 }
+/* Match enabled field: Bootstrap disabled uses light secondary-bg on dark theme */
+.workspace-repos-header .workspace-repos-search:disabled {
+    background-color: var(--bg-input) !important;
+    border-color: var(--border-input) !important;
+    color: var(--text-primary) !important;
+    opacity: 1;
+}
 .workspace-repos-header .workspace-repos-search-clear {
     position: absolute;
     right: 0.25rem;


### PR DESCRIPTION
This PR aligns several workspace and admin pages with the same **header + search toolbar** pattern used elsewhere (`workspace-repos-header`, search with clear and Escape, disabled inputs matching the dark theme), and tightens a few UX details.

### Workspace pages
- **Files:** Search filters the table (name, path, repository) with space-separated AND tokens, “found” counts, and an empty state when nothing matches. Table is hidden when a load error is shown, consistent with other workspace grids.
- **Dependencies:** Header matches the shared layout with **search and scope dropdown on one row**. Repository search uses AND tokens; each match includes its **full transitive dependency-down** subgraph; union of matches is shown. Dropdown is disabled while search is active; empty message when search matches no repo.
- **Global:** Disabled `.workspace-repos-search` inputs under `.workspace-repos-header` keep the same background/border as enabled (no light Bootstrap disabled fill).

### Admin pages
- **Connectors:** Same toolbar layout; search on name, URL, user, and type; “found” counts and no-match row.
- **Repositories:** Same toolbar layout; search + Fetch on one row; subtitle “found” when filtering; placeholder carries the old helper text.

### Workspace Actions
- Status filter pills (**on**): darker border, then **gray panel** background using `var(--bg-tertiary)` for clearer “active” affordance.
