### PR TITLE
Windows agent: Program Files install, ZIP layout, CIM-based service install/update

### DIFF
--- a/.cursor/plans/agent_install_path_and_signing_ed1579a8.plan.md
+++ b/.cursor/plans/agent_install_path_and_signing_ed1579a8.plan.md
@@ -1,0 +1,111 @@
+---
+name: Agent install path and signing
+overview: Move install to `%ProgramFiles%\GrayMoon`, repoint existing service via `sc config`, extend uninstall to remove that install directory (with safe legacy ProgramData cleanup), and add GHA signing (Windows signtool or Linux osslsigncode/Key Vault) plus Docker COPY of the signed exe.
+todos:
+  - id: install-ps1-path
+    content: Change install-agent.ps1 to use $env:ProgramFiles\GrayMoon; ensure directory creation and download target match
+    status: pending
+  - id: install-ps1-sc-config
+    content: When GrayMoonAgent exists, after successful download run sc.exe config to set binPath to new exe + run -u hub URL; keep sc create path for new installs
+    status: pending
+  - id: dockerfile-artifact
+    content: "Dockerfile: COPY prebuilt win-x64 graymoon-agent.exe from repo context; remove in-image win-x64 dotnet publish"
+    status: pending
+  - id: gha-sign-agent
+    content: "docker-build.yml: job publishes win-x64 agent, signs (signtool on windows-latest or osslsigncode/AzureSignTool on ubuntu), uploads artifact; docker job needs + download + COPY into image"
+    status: pending
+  - id: uninstall-remove-install-dir
+    content: "uninstall-agent.ps1: after service removal, delete Program Files\\GrayMoon install folder (graymoon-agent.exe and siblings); optional legacy ProgramData\\GrayMoon exe cleanup if present"
+    status: pending
+  - id: optional-readme-docker
+    content: "Optional: README/local docker note for docker build without CI artifact"
+    status: pending
+isProject: false
+---
+
+# Agent install path, service migration, and code signing
+
+## Current behavior
+
+- [`src/GrayMoon.App/Resources/install-agent.ps1`](src/GrayMoon.App/Resources/install-agent.ps1) installs `graymoon-agent.exe` under `Join-Path $env:ProgramData 'GrayMoon'`, stops the service if running, downloads over the existing file, and **only** runs `sc create` when the service does not exist. If the service already exists, it never updates `binPath`, so a path change alone would leave the service pointing at the old executable.
+- [`Dockerfile`](Dockerfile) publishes `GrayMoon.Agent` for `win-x64` inside the **Linux** SDK stage (unsigned PE). [`/.github/workflows/docker-build.yml`](.github/workflows/docker-build.yml) is **ubuntu-latest** only.
+- Agent logs remain under `%ProgramData%\GrayMoon\logs` via [`RunCommandHandler.cs`](src/GrayMoon.Agent/Cli/RunCommandHandler.cs) (`CommonApplicationData`) — **no change recommended**; writable data under ProgramData is normal, and avoids permission issues under `Program Files`.
+
+## 1. Install path: `Program Files\GrayMoon`
+
+In [`install-agent.ps1`](src/GrayMoon.App/Resources/install-agent.ps1):
+
+- Set install root to **`Join-Path $env:ProgramFiles 'GrayMoon'`** (equivalent to `Program Files\GrayMoon` on typical x64 systems where the published agent is `win-x64`).
+- Keep administrator check; creating that directory and writing the exe already requires elevation.
+
+## 1b. Uninstall: remove install directory under `Program Files`
+
+Update [`uninstall-agent.ps1`](src/GrayMoon.App/Resources/uninstall-agent.ps1) so that **after** the service is removed (or if it was already absent):
+
+- Define `$agentPath = Join-Path $env:ProgramFiles 'GrayMoon'` (same root as install).
+- If that directory exists, remove it recursively (`Remove-Item -Recurse -Force`), or delete only known agent payloads (e.g. `graymoon-agent.exe` and any files the install script drops there) if you prefer a narrower delete — full folder removal is simplest if the directory is dedicated to GrayMoon.
+- **Optional legacy cleanup:** If `%ProgramData%\GrayMoon\graymoon-agent.exe` still exists from older installs, delete that file (or the whole `%ProgramData%\GrayMoon` tree only if safe — today logs live under `%ProgramData%\GrayMoon\logs` from the running agent, so prefer removing **only** `graymoon-agent.exe` under ProgramData unless you confirm nothing else uses that folder). Safer default: remove `ProgramData\GrayMoon\graymoon-agent.exe` only when uninstalling, leave `logs` for user inspection or document manual cleanup.
+
+## 2. Existing service: repoint `binPath` without removing old binaries
+
+After the “stop service if running” block and **successful** download to the **new** `$agentExe` under Program Files:
+
+- If **`Get-Service GrayMoonAgent`** exists, compute the same `binPath` string used at create time, e.g.  
+  `"$agentExe" run -u "$hubUrl"`  
+  using the script’s existing `{HUB_URL}` placeholder (already substituted by [`AgentEndpoints.cs`](src/GrayMoon.App/Api/Endpoints/AgentEndpoints.cs) when the script is served).
+- Run **`sc.exe config $serviceName binPath= <value>`** with the same `binPath=` spacing rules as `sc create` (space after `binPath=`; outer quoting so the whole executable + arguments is one value). Check `$LASTEXITCODE` and surface errors clearly.
+- Do **not** delete `%ProgramData%\GrayMoon` (or any old exe) — per your request.
+- Then start the service (existing logic).
+
+New installs (`-not $serviceExists`): unchanged flow except `$agentPath` / `$agentExe` point to Program Files.
+
+**Caveat (document in script comment or release notes):** Re-running the install script from the app always sets `binPath` to `run -u "<current app hub URL>"`. That matches today’s “new install” behavior but would overwrite a manually edited service command line.
+
+## 3. Pipeline: sign the Windows agent and use it in Docker
+
+The Docker **Linux** stage cannot use Microsoft’s `signtool` without a Windows SDK image, but **Authenticode signing does not require Windows**: you can `dotnet publish -r win-x64` on **Ubuntu** (already works in the Dockerfile today) and sign the PE with **[osslsigncode](https://github.com/mtrojnar/osslsigncode)** or similar using a **PFX** and OpenSSL, or use **AzureSignTool** from a Linux job against **Azure Key Vault** (JWT auth, no exportable key). **Windows is not mandatory** — it is simply the most common choice because `signtool` ships on `windows-latest` and official docs target it.
+
+**Two viable GHA patterns:**
+
+| Approach | Runner | Typical tools |
+|----------|--------|----------------|
+| A (common) | `windows-latest` | `dotnet publish`, `signtool sign` (Windows SDK on image) |
+| B | `ubuntu-latest` | `dotnet publish -r win-x64`, `osslsigncode sign` (install package or use prebuilt binary), or AzureSignTool + Key Vault |
+
+Either way, produce a single **`graymoon-agent.exe`** artifact for the Docker job to `COPY` (same as the current plan: remove in-image win-x64 publish, consume artifact).
+
+**Prerequisites for the signing workflow to work in GitHub Actions**
+
+1. **Code-signing certificate**
+   - **Public CA (recommended for distribution):** From DigiCert, Sectigo, SSL.com, etc., with the **Code Signing** EKU. EV vs standard OV is a business/reputation tradeoff. This is what helps **SmartScreen**, **Bitdefender**, and other products build **reputation** for your binary.
+   - **Self-signed / private CA:** You *can* create a self-signed cert (e.g. `New-SelfSignedCertificate` with `Type CodeSigningCert` on Windows, or OpenSSL) and sign with `signtool` / `osslsigncode`. The PE will show as signed, and the pipeline is valid for **learning CI** or **strictly internal** machines where you deploy your own root as trusted. For **end users and AV**, a self-signed signature does **not** substitute for a public CA: the publisher is still “unknown” to the world, SmartScreen may still warn, and **false positives are unlikely to improve** in a meaningful way. Timestamping self-signed builds usually uses a public TSA anyway (fine) but does not fix trust of the publisher identity.
+2. **Private key usable in CI**
+   - **PFX path:** Export a `.pfx` (password-protected) from the CA workflow or certificate manager. Store in GitHub as a **secret** (e.g. Base64-encoded `WINDOWS_CODE_SIGNING_PFX_B64`) and a second secret for the **PFX password**. Restrict which branches/workflows can use these secrets (environment protection rules recommended).
+   - **Key Vault path (preferred for production):** Certificate/key non-exportable in Azure Key Vault; GHA uses OIDC (`azure/login`) + AzureSignTool with `-kv` options — no long-lived PFX in secrets.
+3. **Repository settings:** Secrets (and optional **Environments** with required reviewers) available to the workflow; note **fork PRs do not receive secrets** — workflow should `if: secrets... != ''` to skip signing and still upload an unsigned artifact, or fail only on protected branches as you prefer.
+4. **Timestamping (strongly recommended):** A public **RFC3161** timestamp URL (your CA usually documents one, e.g. DigiCert/Sectigo HTTP TS) so the signature stays valid after the signing cert expires.
+5. **For `signtool` on Windows runners:** `windows-latest` already includes the Windows SDK; locate `signtool.exe` under `Program Files (x86)\Windows Kits\10\bin\<version>\x64\` (or use `vswhere`/known version pin). No separate SDK install step is usually required.
+6. **For `osslsigncode` on Linux:** Install the package or download a release binary in a workflow step; ensure OpenSSL can read the PFX (decrypt with password from secret).
+
+**Secrets / variables (illustrative names)**
+
+- PFX flow: `CODE_SIGNING_PFX_B64`, `CODE_SIGNING_PFX_PASSWORD`, optional `CODE_SIGNING_TIMESTAMP_URL`.
+- Key Vault flow: Azure service principal or OIDC federated credential, `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_SUBSCRIPTION_ID`, Key Vault URI, certificate name — per AzureSignTool docs.
+
+**Docker build job** (`needs: build-agent-windows` or whatever job produces the exe):
+
+- `actions/download-artifact` into a fixed path (e.g. `docker/agent-windows/graymoon-agent.exe`).
+- [`Dockerfile`](Dockerfile): **remove** in-container `dotnet publish ... win-x64`; **`COPY`** the artifact into `/agent/publish-win/` as before.
+
+**Local `docker build`:** Without the artifact, COPY fails — optional README or `docker-build.ps1` prerequisite (publish win-x64 to the expected folder).
+
+## 4. Further actions to reduce AV false positives (recommendations)
+
+- **Authenticode:** Prefer a **standard code-signing** cert (EV if budget allows); builds reputation faster. Use a **public timestamp** (`/tr` HTTP RFC3161) so signatures stay valid after cert expiry.
+- **Microsoft:** Submit false positives via [Microsoft Security Intelligence](https://www.microsoft.com/en-us/wdsi/filesubmission) when SmartScreen/Defender flags the file.
+- **Bitdefender:** Use their consumer/business false-positive report flow with the **signed** binary hash and version metadata.
+- **Assembly / file metadata:** Ensure [`GrayMoon.Agent.csproj`](src/GrayMoon.Agent/GrayMoon.Agent.csproj) sets `Company`, `Product`, `Copyright`, and optionally `ApplicationIcon` / `AssemblyTitle` — improves heuristics vs generic “unknown .NET single-file”.
+- **Behavior reputation:** Avoid obfuscation; keep download URLs **HTTPS** only in production; versioned, immutable release assets help.
+- **Single-file:** `PublishSingleFile` can look suspicious to some heuristics; if problems persist after signing, consider publishing **non-single-file** for the downloadable Windows agent only (larger payload, often better reputation) — tradeoff to revisit only if needed.
+
+No change required to [`AgentEndpoints.cs`](src/GrayMoon.App/Api/Endpoints/AgentEndpoints.cs) unless you add new placeholders (optional: `{INSTALL_DIR}` for support docs — not necessary for functionality).

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,12 @@ RUN dotnet publish "src/GrayMoon.App/GrayMoon.App.csproj" -c Release -o /app/pub
   /p:UseAppHost=false \
   /p:Version=$VERSION /p:DisableGitVersionTask=true
 
-# Publish Agent as single-file trimmed self-contained (Linux x64 and Windows x64 for download)
+# Publish Agent (framework-dependent, multi-file) for Linux x64 and Windows x64; pack as zip for download
+RUN apt-get update && apt-get install -y --no-install-recommends zip && rm -rf /var/lib/apt/lists/*
 RUN dotnet publish "src/GrayMoon.Agent/GrayMoon.Agent.csproj" -c Release -r linux-x64 -o /agent/publish-linux /p:Version=$VERSION /p:DisableGitVersionTask=true
 RUN dotnet publish "src/GrayMoon.Agent/GrayMoon.Agent.csproj" -c Release -r win-x64 -o /agent/publish-win /p:Version=$VERSION /p:DisableGitVersionTask=true
+RUN cd /agent/publish-linux && zip -q -r /agent/graymoon-agent-linux.zip .
+RUN cd /agent/publish-win && zip -q -r /agent/graymoon-agent-windows.zip .
 
 FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS runtime
 WORKDIR /app
@@ -24,9 +27,8 @@ WORKDIR /app
 COPY --from=build /app/publish .
 # Pack agent executables for download (runs on host)
 RUN mkdir -p /app/agent
-COPY --from=build /agent/publish-linux/graymoon-agent /app/agent/graymoon-agent
-COPY --from=build /agent/publish-win/graymoon-agent.exe /app/agent/graymoon-agent.exe
-RUN chmod +x /app/agent/graymoon-agent
+COPY --from=build /agent/graymoon-agent-linux.zip /app/agent/graymoon-agent-linux.zip
+COPY --from=build /agent/graymoon-agent-windows.zip /app/agent/graymoon-agent-windows.zip
 
 # Database stored in /app/db for easy volume persistence: -v ./data:/app/db
 VOLUME ["/app/db"]

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ docker pull jandini/graymoon:latest && docker stop graymoon || true && docker rm
 
 The app runs in a container and does not run git or access your workspace filesystem. A **host-side agent** does that: it runs on the machine where your repos live, connects to the app via SignalR, and runs git, GitVersion, and workspace I/O.
 
-1. **Download** — On the home page, use **Download Agent**. The correct executable (Windows or Linux) is chosen from your browser.
+1. **Download** — On the home page, use **Download Agent**. Your browser gets a **zip** of the framework-dependent build (Windows or Linux): extract it and run `graymoon-agent` / `graymoon-agent.exe`. The host needs the **.NET 8 runtime** installed for that RID.
 2. **Run on the host** — Run the agent on the same machine (or network) as your repositories, e.g. as a console app or Windows/Linux service.
 
 When the agent is connected, the app shows an **online** badge; sync and repository operations use the agent.

--- a/src/GrayMoon.Agent/GrayMoon.Agent.csproj
+++ b/src/GrayMoon.Agent/GrayMoon.Agent.csproj
@@ -12,9 +12,8 @@
 		<PackageType>DotnetTool</PackageType>
 		<PackAsTool>true</PackAsTool>
 		<ToolCommandName>graymoon-agent</ToolCommandName>
-		<PublishSingleFile>true</PublishSingleFile>
+		<PublishSingleFile>false</PublishSingleFile>
 		<SelfContained>false</SelfContained>
-		<IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
 		<SatelliteResourceLanguages>en</SatelliteResourceLanguages>
 		<IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
 	</PropertyGroup>

--- a/src/GrayMoon.App/Api/Endpoints/AgentEndpoints.cs
+++ b/src/GrayMoon.App/Api/Endpoints/AgentEndpoints.cs
@@ -4,8 +4,8 @@ namespace GrayMoon.App.Api.Endpoints;
 
 public static class AgentEndpoints
 {
-    public const string AgentFileNameLinux = "graymoon-agent";
-    public const string AgentFileNameWindows = "graymoon-agent.exe";
+    public const string AgentArchiveLinux = "graymoon-agent-linux.zip";
+    public const string AgentArchiveWindows = "graymoon-agent-windows.zip";
 
     public static IEndpointRouteBuilder MapAgentEndpoints(this IEndpointRouteBuilder routes)
     {
@@ -22,15 +22,15 @@ public static class AgentEndpoints
     {
         var logger = loggerFactory.CreateLogger("GrayMoon.App.Api.Agent");
         var isWindows = string.Equals(platform, "windows", StringComparison.OrdinalIgnoreCase);
-        var fileName = isWindows ? AgentFileNameWindows : AgentFileNameLinux;
+        var fileName = isWindows ? AgentArchiveWindows : AgentArchiveLinux;
         var path = Path.Combine(env.ContentRootPath, "agent", fileName);
         if (!System.IO.File.Exists(path))
         {
-            logger.LogWarning("Agent binary not found at {Path}", path);
+            logger.LogWarning("Agent archive not found at {Path}", path);
             return Results.NotFound();
         }
         var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read);
-        return Results.File(stream, "application/octet-stream", fileName, enableRangeProcessing: true);
+        return Results.File(stream, "application/zip", fileName, enableRangeProcessing: true);
     }
 
     private static IResult InstallAgent(HttpContext httpContext, IWebHostEnvironment env, ILoggerFactory loggerFactory)

--- a/src/GrayMoon.App/Components/App.razor
+++ b/src/GrayMoon.App/Components/App.razor
@@ -47,7 +47,7 @@
             const platform = (navigator.platform || '').toLowerCase();
             const isWindows = /win(dows|32|64|ce)/.test(ua) || platform.indexOf('win') === 0;
             const qs = isWindows ? '?platform=windows' : '';
-            const filename = isWindows ? 'graymoon-agent.exe' : 'graymoon-agent';
+            const filename = isWindows ? 'graymoon-agent-windows.zip' : 'graymoon-agent-linux.zip';
             const base = (document.querySelector('base')?.getAttribute('href') || '/').replace(/\/$/, '') || '';
             const path = base + '/api/agent/download' + qs;
             const url = path.startsWith('http') ? path : (window.location.origin + path);

--- a/src/GrayMoon.App/Resources/install-agent.ps1
+++ b/src/GrayMoon.App/Resources/install-agent.ps1
@@ -196,6 +196,76 @@ $newLine
     }
 }
 
+function Build-AgentServiceCommandLine {
+    param(
+        [Parameter(Mandatory)]
+        [string]$AgentExePath,
+        [Parameter(Mandatory)]
+        [string]$HubUrl
+    )
+    '"' + $AgentExePath + '" run -u "' + $HubUrl + '"'
+}
+
+function Set-Win32ServicePathName {
+    param(
+        [Parameter(Mandatory)]
+        [string]$Name,
+        [Parameter(Mandatory)]
+        [string]$PathName
+    )
+    $svc = Get-CimInstance -ClassName Win32_Service -Filter "Name='$Name'" -ErrorAction Stop
+    $out = Invoke-CimMethod -InputObject $svc -MethodName Change -Arguments @{ PathName = $PathName }
+    if ($out.ReturnValue -ne 0) {
+        throw "Win32_Service.Change failed with return code $($out.ReturnValue). PathName: $PathName"
+    }
+}
+
+function Set-ServiceDescriptionRegistry {
+    param(
+        [Parameter(Mandatory)]
+        [string]$Name,
+        [Parameter(Mandatory)]
+        [string]$Description
+    )
+    $keyPath = "HKLM:\SYSTEM\CurrentControlSet\Services\$Name"
+    if (-not (Test-Path -LiteralPath $keyPath)) {
+        return
+    }
+    Set-ItemProperty -LiteralPath $keyPath -Name Description -Value $Description -Type String -Force -ErrorAction SilentlyContinue | Out-Null
+}
+
+function New-Win32ServiceWithLogon {
+    param(
+        [Parameter(Mandatory)]
+        [string]$Name,
+        [Parameter(Mandatory)]
+        [string]$DisplayName,
+        [Parameter(Mandatory)]
+        [string]$PathName,
+        [Parameter(Mandatory)]
+        [string]$StartName,
+        [Parameter(Mandatory)]
+        [string]$StartPassword
+    )
+    $out = Invoke-CimMethod -ClassName Win32_Service -MethodName Create -Arguments @{
+        Name = $Name
+        DisplayName = $DisplayName
+        PathName = $PathName
+        ServiceType = [uint8]16
+        ErrorControl = [uint32]1
+        StartMode = 'Automatic'
+        DesktopInteract = $false
+        StartName = $StartName
+        StartPassword = $StartPassword
+        LoadOrderGroup = ''
+        LoadOrderGroupDependencies = ''
+        ServiceDependencies = ''
+    }
+    if ($out.ReturnValue -ne 0) {
+        throw "Win32_Service.Create failed with return code $($out.ReturnValue)."
+    }
+}
+
 Write-Host 'Checking for existing service...' -ForegroundColor Yellow
 $existingService = Get-Service -Name $serviceName -ErrorAction SilentlyContinue
 $serviceExists = $null -ne $existingService
@@ -268,15 +338,13 @@ if ($serviceExists) {
     Write-Host 'Updating service to use the new binary path and hub URL...' -ForegroundColor Yellow
     try {
         $hubUrl = '{HUB_URL}'
-        $binPath = "`"$agentExe`" run -u `"$hubUrl`""
-        $result = & sc.exe config $serviceName binPath= $binPath 2>&1
-        if ($LASTEXITCODE -ne 0) {
-            $errorMsg = if ($result -is [System.Array]) { ($result | Out-String).Trim() } else { $result.ToString() }
-            throw "sc.exe config failed with exit code ${LASTEXITCODE}: $errorMsg"
-        }
+        $binPath = Build-AgentServiceCommandLine -AgentExePath $agentExe -HubUrl $hubUrl
+        Set-Win32ServicePathName -Name $serviceName -PathName $binPath
+        Set-ServiceDescriptionRegistry -Name $serviceName -Description $serviceDescription
         Write-Host 'Service configuration updated successfully.' -ForegroundColor Green
     } catch {
         Write-Host "ERROR: Failed to update service binary path: $_" -ForegroundColor Red
+        Write-Host "Agent files are under $agentPath but the service was not updated. Fix the service command line or re-run this script after resolving the error." -ForegroundColor Yellow
         return 1
     }
 } else {
@@ -284,8 +352,8 @@ if ($serviceExists) {
     Write-Host 'Installing as Windows service...' -ForegroundColor Yellow
     try {
         $hubUrl = '{HUB_URL}'
-        $binPath = "`"$agentExe`" run -u `"$hubUrl`""
-        
+        $binPath = Build-AgentServiceCommandLine -AgentExePath $agentExe -HubUrl $hubUrl
+
         # Install service to run as current user (required for git credentials, dotnet tools, and user environment)
         $currentUser = [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
         Write-Host "Service will run as: $currentUser" -ForegroundColor Cyan
@@ -302,14 +370,9 @@ if ($serviceExists) {
 
             Write-Host 'Granting "Log on as a service" right...' -ForegroundColor Yellow
             Grant-ServiceLogonRight -AccountName $currentUser
-            
-            # Use sc.exe to create service with custom user account (New-Service doesn't support this)
-            # Note: sc.exe is still needed for setting custom user credentials
-            $result = & sc.exe create $serviceName binPath= $binPath start= auto DisplayName= "$serviceDisplayName" obj= "$currentUser" password= "$passwordPlain" 2>&1
-            if ($LASTEXITCODE -ne 0) {
-                $errorMsg = if ($result -is [System.Array]) { ($result | Out-String).Trim() } else { $result.ToString() }
-                throw "sc.exe create failed with exit code ${LASTEXITCODE}: $errorMsg"
-            }
+
+            New-Win32ServiceWithLogon -Name $serviceName -DisplayName $serviceDisplayName -PathName $binPath -StartName $currentUser -StartPassword $passwordPlain
+            Set-ServiceDescriptionRegistry -Name $serviceName -Description $serviceDescription
         }
         finally {
             if ($passwordBstr -ne [IntPtr]::Zero) {
@@ -319,10 +382,7 @@ if ($serviceExists) {
             $password.Dispose()
             [System.GC]::Collect()
         }
-        
-        # Set description using sc.exe
-        & sc.exe description $serviceName "$serviceDescription" | Out-Null
-        
+
         Write-Host 'Service installed successfully.' -ForegroundColor Green
     } catch {
         Write-Host "ERROR: Failed to install service: $_" -ForegroundColor Red

--- a/src/GrayMoon.App/Resources/install-agent.ps1
+++ b/src/GrayMoon.App/Resources/install-agent.ps1
@@ -1,5 +1,6 @@
 # GrayMoon Agent Installation Script
-# This script downloads and installs the GrayMoon Agent as a Windows service
+# Downloads a zip of the framework-dependent agent (graymoon-agent.exe + DLLs), extracts to Program Files, and registers the Windows service.
+# The host must have the .NET 8 runtime (or ASP.NET Core 8 runtime) installed for the same RID as the published agent.
 
 $ErrorActionPreference = 'Stop'
 
@@ -19,6 +20,7 @@ $serviceDescription = 'Host-side agent for GrayMoon: executes git and repository
 $agentPath = Join-Path $env:ProgramFiles 'GrayMoon'
 $agentExe = Join-Path $agentPath 'graymoon-agent.exe'
 $downloadUrl = '{DOWNLOAD_URL}'
+$zipPath = Join-Path $env:TEMP 'graymoon-agent-windows-install.zip'
 
 Add-Type @"
 using System;
@@ -213,17 +215,19 @@ if ($serviceExists -and $existingService.Status -eq 'Running') {
     }
 }
 
-# Create directory
-Write-Host 'Creating installation directory...' -ForegroundColor Yellow
+# Prepare installation directory (clear existing files so the zip extract does not leave stale DLLs)
+Write-Host 'Preparing installation directory...' -ForegroundColor Yellow
 if (-not (Test-Path $agentPath)) {
     New-Item -ItemType Directory -Path $agentPath -Force | Out-Null
+} else {
+    Get-ChildItem -Path $agentPath -Force | Remove-Item -Recurse -Force -ErrorAction Stop
 }
 
-# Download agent (replace existing file if present)
+# Download agent archive, then extract (framework-dependent publish: exe + DLLs)
 Write-Host "Downloading agent from {BASE_URL}..." -ForegroundColor Yellow
 try {
     $webClient = New-Object System.Net.WebClient
-    $webClient.DownloadFile($downloadUrl, $agentExe)
+    $webClient.DownloadFile($downloadUrl, $zipPath)
     Write-Host 'Download completed.' -ForegroundColor Green
 } catch {
     Write-Host "ERROR: Failed to download agent: $_" -ForegroundColor Red
@@ -234,6 +238,27 @@ try {
         } catch {
             Write-Host "Could not restart service. Please restart manually." -ForegroundColor Yellow
         }
+    }
+    return 1
+}
+
+Write-Host 'Extracting agent...' -ForegroundColor Yellow
+try {
+    Expand-Archive -LiteralPath $zipPath -DestinationPath $agentPath -Force
+} catch {
+    Write-Host "ERROR: Failed to extract agent: $_" -ForegroundColor Red
+    if ($wasRunning) {
+        try { Start-Service -Name $serviceName -ErrorAction SilentlyContinue } catch { }
+    }
+    return 1
+} finally {
+    Remove-Item -Path $zipPath -Force -ErrorAction SilentlyContinue
+}
+
+if (-not (Test-Path -Path $agentExe)) {
+    Write-Host "ERROR: graymoon-agent.exe not found under $agentPath after extract. Install .NET 8 Runtime if the app fails to start." -ForegroundColor Red
+    if ($wasRunning) {
+        try { Start-Service -Name $serviceName -ErrorAction SilentlyContinue } catch { }
     }
     return 1
 }

--- a/src/GrayMoon.App/Resources/install-agent.ps1
+++ b/src/GrayMoon.App/Resources/install-agent.ps1
@@ -16,7 +16,7 @@ if (-not $isAdmin) {
 $serviceName = 'GrayMoonAgent'
 $serviceDisplayName = 'GrayMoon Agent'
 $serviceDescription = 'Host-side agent for GrayMoon: executes git and repository I/O operations'
-$agentPath = Join-Path $env:ProgramData 'GrayMoon'
+$agentPath = Join-Path $env:ProgramFiles 'GrayMoon'
 $agentExe = Join-Path $agentPath 'graymoon-agent.exe'
 $downloadUrl = '{DOWNLOAD_URL}'
 
@@ -239,7 +239,21 @@ try {
 }
 
 if ($serviceExists) {
-    Write-Host 'File updated successfully.' -ForegroundColor Green
+    Write-Host 'Agent files updated.' -ForegroundColor Green
+    Write-Host 'Updating service to use the new binary path and hub URL...' -ForegroundColor Yellow
+    try {
+        $hubUrl = '{HUB_URL}'
+        $binPath = "`"$agentExe`" run -u `"$hubUrl`""
+        $result = & sc.exe config $serviceName binPath= $binPath 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            $errorMsg = if ($result -is [System.Array]) { ($result | Out-String).Trim() } else { $result.ToString() }
+            throw "sc.exe config failed with exit code ${LASTEXITCODE}: $errorMsg"
+        }
+        Write-Host 'Service configuration updated successfully.' -ForegroundColor Green
+    } catch {
+        Write-Host "ERROR: Failed to update service binary path: $_" -ForegroundColor Red
+        return 1
+    }
 } else {
     # Service doesn't exist: create it
     Write-Host 'Installing as Windows service...' -ForegroundColor Yellow

--- a/src/GrayMoon.App/Resources/uninstall-agent.ps1
+++ b/src/GrayMoon.App/Resources/uninstall-agent.ps1
@@ -14,7 +14,6 @@ if (-not $isAdmin) {
 
 # Service name
 $serviceName = 'GrayMoonAgent'
-$agentPath = Join-Path $env:ProgramData 'GrayMoon'
 
 Write-Host 'Checking for service...' -ForegroundColor Yellow
 $existingService = Get-Service -Name $serviceName -ErrorAction SilentlyContinue
@@ -38,6 +37,20 @@ if ($existingService) {
     }
 } else {
     Write-Host 'Service not found.' -ForegroundColor Yellow
+}
+
+$agentInstallPath = Join-Path $env:ProgramFiles 'GrayMoon'
+if (Test-Path -Path $agentInstallPath) {
+    Write-Host 'Removing installation directory...' -ForegroundColor Yellow
+    Remove-Item -Path $agentInstallPath -Recurse -Force -ErrorAction Stop
+    Write-Host 'Installation directory removed.' -ForegroundColor Green
+}
+
+$legacyAgentExe = Join-Path $env:ProgramData 'GrayMoon\graymoon-agent.exe'
+if (Test-Path -Path $legacyAgentExe) {
+    Write-Host 'Removing legacy agent executable...' -ForegroundColor Yellow
+    Remove-Item -Path $legacyAgentExe -Force -ErrorAction Stop
+    Write-Host 'Legacy executable removed.' -ForegroundColor Green
 }
 
 Write-Host ''


### PR DESCRIPTION
This change updates how the GrayMoon host agent is published, downloaded, and installed on Windows.

**Install location and upgrade path**  
The Windows install script now deploys under **`%ProgramFiles%\GrayMoon`** instead of `%ProgramData%\GrayMoon`. When the **`GrayMoonAgent`** service already exists, the script updates its binary path and hub URL after deploying files (legacy **`%ProgramData%\GrayMoon\graymoon-agent.exe`** is not removed on upgrade, per earlier intent).

**Distribution: multi-file agent as ZIP**  
The agent is no longer published as a **single-file** executable. It is a **framework-dependent** layout (main exe plus dependent assemblies). The app’s **`/api/agent/download`** endpoint serves **`graymoon-agent-windows.zip`** and **`graymoon-agent-linux.zip`** with **`application/zip`**. The Docker build publishes both RIDs, zips each output directory, and copies the archives into the image **`agent`** folder. The browser “Download agent” flow uses the matching **`.zip`** filenames.

**Install script**  
The embedded **`install-agent.ps1`** downloads the Windows zip to **`%TEMP%`**, clears the install directory, **`Expand-Archive`** into **`%ProgramFiles%\GrayMoon`**, then registers or updates the service. It requires **.NET 8** (or compatible hosting/runtime) on the host for the framework-dependent build.

**Service configuration without `sc.exe`**  
Replacing **`sc config` / `sc create`** avoids fragile **`binPath=`** quoting (e.g. exit **1639**). Service path updates use **`Win32_Service.Change`** via **`Invoke-CimMethod`**; new installs use **`Win32_Service.Create`** with the same logon flow as before; the service description is set in the registry.

**Uninstall**  
**`uninstall-agent.ps1`** removes **`%ProgramFiles%\GrayMoon`** after removing the service and still deletes a legacy **`%ProgramData%\GrayMoon\graymoon-agent.exe`** if present (logs under ProgramData are left alone).

**Docs**  
**`README.md`** Agent section notes the zip download and **.NET 8 runtime** expectation on the host.