### PR TITLE
Workspace chrome: top-bar title, fixed page names, and tighter nav labels

### DIFF
--- a/src/GrayMoon.App/Components/Layout/MainLayout.razor
+++ b/src/GrayMoon.App/Components/Layout/MainLayout.razor
@@ -9,6 +9,7 @@
 @inject CommandTerminalOverlayPreferenceService CommandTerminalOverlayPreference
 @inject LoadingOverlayUiSettingsService LoadingOverlayUiSettings
 @inject IWorkspaceTopBarService WorkspaceTopBarService
+@inject NavigationManager NavigationManager
 
 <Toast />
 
@@ -22,8 +23,12 @@
             <div class="top-row-workspace-title" role="status" aria-live="polite">
                 @if (!string.IsNullOrEmpty(WorkspaceTopBarService.WorkspaceDisplayName))
                 {
-                    <span class="h2 workspace-repos-title top-row-workspace-title__text my-0"
-                          title="@WorkspaceTopBarService.WorkspaceDisplayName">@WorkspaceTopBarService.WorkspaceDisplayName</span>
+                    <a href="@WorkspacesListHref"
+                       class="h2 workspace-repos-title top-row-workspace-title__text top-row-workspace-title__link my-0"
+                       title="@WorkspaceTopBarService.WorkspaceDisplayName"
+                       aria-label="Go to Workspaces">
+                        @WorkspaceTopBarService.WorkspaceDisplayName
+                    </a>
                 }
             </div>
             <div class="top-row-main-trailing">
@@ -78,6 +83,10 @@
 
         await WorkspaceTopBarService.EnsureSynchronizedAsync();
     }
+
+    /// <summary>Root-relative URL to the Workspaces list (correct from /workspaces/{{id}}/… and under virtual paths).</summary>
+    private string WorkspacesListHref =>
+        new Uri(new Uri(NavigationManager.BaseUri), "workspaces").AbsolutePath;
 
     private void OnWorkspaceTopBarChanged() => _ = InvokeAsync(StateHasChanged);
 

--- a/src/GrayMoon.App/Components/Layout/MainLayout.razor
+++ b/src/GrayMoon.App/Components/Layout/MainLayout.razor
@@ -1,4 +1,5 @@
 @inherits LayoutComponentBase
+@implements IDisposable
 @using System.Reflection
 @using GrayMoon.App.Components.Shared
 @using GrayMoon.App.Repositories
@@ -7,6 +8,7 @@
 @inject AppSettingRepository AppSettingRepository
 @inject CommandTerminalOverlayPreferenceService CommandTerminalOverlayPreference
 @inject LoadingOverlayUiSettingsService LoadingOverlayUiSettings
+@inject IWorkspaceTopBarService WorkspaceTopBarService
 
 <Toast />
 
@@ -16,7 +18,14 @@
     </div>
 
     <main>
-        <div class="top-row px-4">
+        <div class="top-row px-4 top-row-main">
+            <div class="top-row-workspace-title" role="status" aria-live="polite">
+                @if (!string.IsNullOrEmpty(WorkspaceTopBarService.WorkspaceDisplayName))
+                {
+                    <span class="top-row-workspace-title__text" title="@WorkspaceTopBarService.WorkspaceDisplayName">@WorkspaceTopBarService.WorkspaceDisplayName</span>
+                }
+            </div>
+            <div class="top-row-main-trailing">
             @if (!string.IsNullOrEmpty(version))
             {
                 <span class="header-version">
@@ -27,6 +36,7 @@
                 </span>
             }
             <AgentStatusBadge />
+            </div>
         </div>
 
         <article class="content px-4">
@@ -46,6 +56,8 @@
 
     protected override async Task OnInitializedAsync()
     {
+        WorkspaceTopBarService.Changed += OnWorkspaceTopBarChanged;
+
         var informationalVersion = typeof(Program).Assembly
             .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
             ?.InformationalVersion;
@@ -62,5 +74,14 @@
         var transparent = await AppSettingRepository.GetBoolAsync(AppSettingRepository.TerminalTransparentBackdropKey, defaultValue: true);
         var scheme = await AppSettingRepository.GetTerminalColorSchemeAsync();
         LoadingOverlayUiSettings.LoadSilently(transparent, scheme);
+
+        await WorkspaceTopBarService.EnsureSynchronizedAsync();
+    }
+
+    private void OnWorkspaceTopBarChanged() => _ = InvokeAsync(StateHasChanged);
+
+    void IDisposable.Dispose()
+    {
+        WorkspaceTopBarService.Changed -= OnWorkspaceTopBarChanged;
     }
 }

--- a/src/GrayMoon.App/Components/Layout/MainLayout.razor
+++ b/src/GrayMoon.App/Components/Layout/MainLayout.razor
@@ -22,7 +22,8 @@
             <div class="top-row-workspace-title" role="status" aria-live="polite">
                 @if (!string.IsNullOrEmpty(WorkspaceTopBarService.WorkspaceDisplayName))
                 {
-                    <span class="top-row-workspace-title__text" title="@WorkspaceTopBarService.WorkspaceDisplayName">@WorkspaceTopBarService.WorkspaceDisplayName</span>
+                    <span class="h2 workspace-repos-title top-row-workspace-title__text my-0"
+                          title="@WorkspaceTopBarService.WorkspaceDisplayName">@WorkspaceTopBarService.WorkspaceDisplayName</span>
                 }
             </div>
             <div class="top-row-main-trailing">

--- a/src/GrayMoon.App/Components/Layout/MainLayout.razor.css
+++ b/src/GrayMoon.App/Components/Layout/MainLayout.razor.css
@@ -25,6 +25,45 @@ main {
     align-items: center;
 }
 
+/* Main column only: workspace name + trailing controls; keep sidebar .top-row rules unchanged */
+.top-row.top-row-main {
+    position: relative;
+    justify-content: flex-end;
+}
+
+/* Narrow: title lives in main strip only (sidebar logo row unchanged); small but readable */
+.top-row-workspace-title {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    pointer-events: none;
+    padding-inline: 0.35rem;
+}
+
+.top-row-workspace-title__text {
+    pointer-events: auto;
+    font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+    font-size: clamp(0.72rem, 3.1vw, 0.88rem);
+    font-weight: 600;
+    line-height: 1.15;
+    color: var(--text-primary);
+    max-width: calc(100% - 5.75rem);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.top-row-main-trailing {
+    position: relative;
+    z-index: 2;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-left: auto;
+}
+
     .top-row ::deep a, .top-row ::deep .btn-link {
         white-space: nowrap;
         margin-left: 1.5rem;
@@ -32,14 +71,19 @@ main {
         color: var(--text-primary);
     }
 
+    .top-row-main-trailing ::deep a,
+    .top-row-main-trailing ::deep .btn-link {
+        margin-left: 0;
+    }
+
     .top-row ::deep a:hover, .top-row ::deep .btn-link:hover {
         text-decoration: underline;
         color: var(--accent-blue);
     }
 
-    .top-row ::deep a:first-child {
-        overflow: hidden;
-        text-overflow: ellipsis;
+    .top-row-main-trailing ::deep a:first-of-type {
+        overflow: visible;
+        text-overflow: clip;
     }
 
 .header-version {
@@ -77,12 +121,27 @@ main {
         overflow: hidden;
     }
 
+    /* Main-only: keep a slim header so workspace title + agent stay visible */
+    main .top-row.top-row-main {
+        height: 2.75rem;
+        min-height: 2.75rem;
+        overflow: visible;
+        border-bottom: 1px solid var(--border-color);
+        background-color: var(--bg-tertiary);
+        justify-content: flex-end;
+        align-items: center;
+    }
+
     .header-version {
         display: none;
     }
 
     .top-row ::deep a, .top-row ::deep .btn-link {
         margin-left: 0;
+    }
+
+    main .top-row-main-trailing {
+        z-index: 3;
     }
 }
 
@@ -109,6 +168,32 @@ main {
         position: sticky;
         top: 0;
         z-index: 1;
+    }
+
+    /* Viewport-centered title: geometric center of full page; stays under sidebar (z 101) and above main bg */
+    main .top-row-workspace-title {
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        height: 3.5rem;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        pointer-events: none;
+        padding-inline: 0;
+        z-index: 90;
+        box-sizing: border-box;
+    }
+
+    /* Centered at 50vw: width bounded by sidebar (180px) on the left and header trailing cluster on the right */
+    main .top-row-workspace-title__text {
+        font-size: clamp(0.95rem, 0.28vw + 0.92rem, 1.28rem);
+        max-width: min(38rem, calc(100vw - 360px - 1.5rem), calc(100vw - 24rem));
+    }
+
+    main .top-row-main-trailing {
+        z-index: 91;
     }
 
     .top-row.auth ::deep a:first-child {

--- a/src/GrayMoon.App/Components/Layout/MainLayout.razor.css
+++ b/src/GrayMoon.App/Components/Layout/MainLayout.razor.css
@@ -42,13 +42,15 @@ main {
     padding-inline: 0.35rem;
 }
 
+/* Same family/weight/line-height as page h2 (.h2); smaller scale so it fits the top bar */
 .top-row-workspace-title__text {
     pointer-events: auto;
-    font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
-    font-size: clamp(0.72rem, 3.1vw, 0.88rem);
-    font-weight: 600;
-    line-height: 1.15;
+    display: inline-block;
+    box-sizing: border-box;
     color: var(--text-primary);
+    margin-top: 0;
+    margin-bottom: 0;
+    font-size: calc((1.325rem + 0.9vw) * 0.78);
     max-width: calc(100% - 5.75rem);
     overflow: hidden;
     text-overflow: ellipsis;
@@ -188,7 +190,6 @@ main {
 
     /* Centered at 50vw: width bounded by sidebar (180px) on the left and header trailing cluster on the right */
     main .top-row-workspace-title__text {
-        font-size: clamp(0.95rem, 0.28vw + 0.92rem, 1.28rem);
         max-width: min(38rem, calc(100vw - 360px - 1.5rem), calc(100vw - 24rem));
     }
 
@@ -211,6 +212,12 @@ main {
         padding-top: 2rem !important;
     }
 
+}
+
+@media (min-width: 1200px) {
+    main .top-row-workspace-title__text {
+        font-size: 1.56rem;
+    }
 }
 
 #blazor-error-ui {

--- a/src/GrayMoon.App/Components/Layout/MainLayout.razor.css
+++ b/src/GrayMoon.App/Components/Layout/MainLayout.razor.css
@@ -31,18 +31,18 @@ main {
     justify-content: flex-end;
 }
 
-/* Narrow: title lives in main strip only (sidebar logo row unchanged); small but readable */
+/* Workspace title strip: allow clicks on the link (do not use pointer-events: none here). */
 .top-row-workspace-title {
     position: absolute;
     inset: 0;
     display: flex;
     align-items: center;
     justify-content: center;
-    pointer-events: none;
+    pointer-events: auto;
     padding-inline: 0.35rem;
 }
 
-/* Same family/weight/line-height as page h2 (.h2); smaller scale so it fits the top bar */
+/* Same family/weight/line-height as page h2 (.h2); ~72% scale for top bar */
 .top-row-workspace-title__text {
     pointer-events: auto;
     display: inline-block;
@@ -50,11 +50,28 @@ main {
     color: var(--text-primary);
     margin-top: 0;
     margin-bottom: 0;
-    font-size: calc((1.325rem + 0.9vw) * 0.78);
+    font-size: calc((1.325rem + 0.9vw) * 0.72);
     max-width: calc(100% - 5.75rem);
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+}
+
+.top-row-workspace-title ::deep a.top-row-workspace-title__link {
+    margin-left: 0;
+    text-decoration: none;
+    color: var(--text-primary);
+    cursor: pointer;
+    position: relative;
+    z-index: 1;
+    font-size: calc((1.325rem + 0.9vw) * 0.72);
+}
+
+/* Override generic .top-row ::deep a:hover (blue + underline); workspace title: white, no underline, pointer only */
+.top-row.top-row-main .top-row-workspace-title ::deep a.top-row-workspace-title__link:hover,
+.top-row.top-row-main .top-row-workspace-title ::deep a.top-row-workspace-title__link:focus-visible {
+    color: #fff;
+    text-decoration: none;
 }
 
 .top-row-main-trailing {
@@ -172,7 +189,7 @@ main {
         z-index: 1;
     }
 
-    /* Viewport-centered title: geometric center of full page; stays under sidebar (z 101) and above main bg */
+    /* Full-width strip for layout; must receive hits so the NavLink is clickable (pointer-events: none breaks this). */
     main .top-row-workspace-title {
         position: fixed;
         top: 0;
@@ -182,19 +199,22 @@ main {
         display: flex;
         align-items: center;
         justify-content: center;
-        pointer-events: none;
+        pointer-events: auto;
         padding-inline: 0;
-        z-index: 90;
+        z-index: 94;
         box-sizing: border-box;
     }
 
     /* Centered at 50vw: width bounded by sidebar (180px) on the left and header trailing cluster on the right */
-    main .top-row-workspace-title__text {
+    main .top-row-workspace-title__text,
+    main .top-row-workspace-title ::deep a.top-row-workspace-title__link {
         max-width: min(38rem, calc(100vw - 360px - 1.5rem), calc(100vw - 24rem));
+        font-size: calc((1.325rem + 0.9vw) * 0.72);
+        pointer-events: auto;
     }
 
     main .top-row-main-trailing {
-        z-index: 91;
+        z-index: 95;
     }
 
     .top-row.auth ::deep a:first-child {
@@ -215,8 +235,9 @@ main {
 }
 
 @media (min-width: 1200px) {
-    main .top-row-workspace-title__text {
-        font-size: 1.56rem;
+    main .top-row-workspace-title__text,
+    main .top-row-workspace-title ::deep a.top-row-workspace-title__link {
+        font-size: 1.44rem;
     }
 }
 

--- a/src/GrayMoon.App/Components/Layout/NavMenu.razor
+++ b/src/GrayMoon.App/Components/Layout/NavMenu.razor
@@ -1,7 +1,5 @@
 @implements IDisposable
-@using GrayMoon.App.Repositories
 @inject NavigationManager NavigationManager
-@inject WorkspaceRepository WorkspaceRepository
 
 <div class="top-row navbar navbar-dark">
     <div class="container-fluid d-flex justify-content-center align-items-center">
@@ -28,9 +26,9 @@
             </div>
 
             <div class="nav-item px-3">
-                <NavLink class="nav-link" href="@($"workspaces/{workspaceId}")" Match="NavLinkMatch.All">
+                <NavLink class="nav-link" href="@($"workspaces/{workspaceId}")" Match="NavLinkMatch.All" title="Repositories">
                     <i class="bi bi-grid" aria-hidden="true"></i>
-                    <span class="nav-link-text">@(workspaceName ?? "Workspace")</span>
+                    <span class="nav-link-text">Repos</span>
                 </NavLink>
             </div>
 
@@ -56,9 +54,9 @@
             </div>
 
             <div class="nav-item px-3">
-                <NavLink class="nav-link" href="@($"workspaces/{workspaceId}/dependencies")" Match="NavLinkMatch.All">
+                <NavLink class="nav-link" href="@($"workspaces/{workspaceId}/dependencies")" Match="NavLinkMatch.All" title="Dependencies">
                     <i class="bi bi-share" aria-hidden="true"></i>
-                    <span class="nav-link-text">Graph</span>
+                    <span class="nav-link-text">Deps</span>
                 </NavLink>
             </div>
 
@@ -119,7 +117,6 @@
 @code {
     private bool isWorkspaceView;
     private int? workspaceId;
-    private string? workspaceName;
 
     protected override async Task OnInitializedAsync()
     {
@@ -132,7 +129,7 @@
         _ = UpdateWorkspaceContextAsync();
     }
 
-    private async Task UpdateWorkspaceContextAsync()
+    private Task UpdateWorkspaceContextAsync()
     {
         var relativePath = NavigationManager.ToBaseRelativePath(NavigationManager.Uri);
         var path = relativePath.Split('?', '#')[0];
@@ -143,21 +140,15 @@
             int.TryParse(segments[1], out var parsedId))
         {
             isWorkspaceView = true;
-            if (workspaceId != parsedId || string.IsNullOrWhiteSpace(workspaceName))
-            {
-                workspaceId = parsedId;
-                var workspace = await WorkspaceRepository.GetByIdAsync(parsedId);
-                workspaceName = workspace?.Name ?? "Workspace";
-            }
+            workspaceId = parsedId;
         }
         else
         {
             isWorkspaceView = false;
             workspaceId = null;
-            workspaceName = null;
         }
 
-        await InvokeAsync(StateHasChanged);
+        return InvokeAsync(StateHasChanged);
     }
 
     public void Dispose()

--- a/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor
@@ -5,13 +5,13 @@
 @using Microsoft.AspNetCore.Components.Web
 @using WorkspaceModel = GrayMoon.App.Models.Workspace
 
-<PageTitle>@(workspace?.Name ?? "Workspace") Actions - GrayMoon</PageTitle>
+<PageTitle>Actions - GrayMoon</PageTitle>
 
 <div class="container-fluid page-container grid-page">
     <div class="grid-page-header">
         <div class="workspace-repos-header workspace-actions-header">
             <div class="workspace-repos-title-row">
-                <h2 class="workspace-repos-title">@(workspace?.Name ?? "Workspace") Actions</h2>
+                <h2 class="workspace-repos-title">Actions</h2>
                 <p class="text-muted mb-0 workspace-repos-subtitle workspace-actions__subtitle">
                     @if (!isLoading && rows.Count > 0)
                     {

--- a/src/GrayMoon.App/Components/Pages/WorkspaceDependencies.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceDependencies.razor
@@ -12,13 +12,13 @@
 @using WorkspaceModel = GrayMoon.App.Models.Workspace
 @implements IAsyncDisposable
 
-<PageTitle>@(workspace?.Name ?? "workspace") - Dependency Graph</PageTitle>
+<PageTitle>Dependencies - GrayMoon</PageTitle>
 
 <div class="container-fluid page-container grid-page dependencies-page">
     <div class="grid-page-header">
         <div class="workspace-repos-header workspace-dependencies-header">
             <div class="workspace-repos-title-row">
-                <h2 class="workspace-repos-title">@(workspace?.Name ?? "workspace") Dependency Graph</h2>
+                <h2 class="workspace-repos-title">Dependencies</h2>
                 <p class="text-muted mb-0 workspace-repos-subtitle workspace-dependencies__subtitle">
                     @if (!isLoading && graph != null && graph.Nodes.Count > 0)
                     {

--- a/src/GrayMoon.App/Components/Pages/WorkspaceFiles.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceFiles.razor
@@ -17,13 +17,13 @@
 @inject ILogger<WorkspaceFiles> Logger
 @using WorkspaceModel = GrayMoon.App.Models.Workspace
 
-<PageTitle>@(workspace?.Name ?? "Workspace") - Files</PageTitle>
+<PageTitle>Files - GrayMoon</PageTitle>
 
 <div class="container-fluid page-container grid-page">
     <div class="grid-page-header">
         <div class="workspace-repos-header workspace-files-header">
             <div class="workspace-repos-title-row">
-                <h2 class="workspace-repos-title">@(workspace?.Name ?? "Workspace") Files</h2>
+                <h2 class="workspace-repos-title">Files</h2>
                 <p class="text-muted mb-0 workspace-repos-subtitle workspace-files__subtitle">
                     @if (!isLoading && files.Count > 0)
                     {

--- a/src/GrayMoon.App/Components/Pages/WorkspacePackages.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspacePackages.razor
@@ -11,13 +11,13 @@
 @inject ILogger<WorkspacePackages> Logger
 @using WorkspaceModel = GrayMoon.App.Models.Workspace
 
-<PageTitle>@(workspace?.Name ?? "Workspace") - Packages</PageTitle>
+<PageTitle>Packages - GrayMoon</PageTitle>
 
 <div class="container-fluid page-container grid-page">
     <div class="grid-page-header">
         <div class="workspace-repos-header workspace-packages-header">
             <div class="workspace-repos-title-row">
-                <h2 class="workspace-repos-title">@(workspace?.Name ?? "Workspace") Packages</h2>
+                <h2 class="workspace-repos-title">Packages</h2>
                 <p class="text-muted mb-0 workspace-repos-subtitle workspace-packages__subtitle">
                     @if (!isLoading && packages.Count > 0)
                     {

--- a/src/GrayMoon.App/Components/Pages/WorkspaceProjects.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceProjects.razor
@@ -9,13 +9,13 @@
 @inject ILogger<WorkspaceProjects> Logger
 @using WorkspaceModel = GrayMoon.App.Models.Workspace
 
-<PageTitle>@(workspace?.Name ?? "Workspace") - Projects</PageTitle>
+<PageTitle>Projects - GrayMoon</PageTitle>
 
 <div class="container-fluid page-container grid-page">
     <div class="grid-page-header">
         <div class="workspace-repos-header workspace-projects-header">
             <div class="workspace-repos-title-row">
-                <h2 class="workspace-repos-title">@(workspace?.Name ?? "Workspace") Projects</h2>
+                <h2 class="workspace-repos-title">Projects</h2>
                 <p class="text-muted mb-0 workspace-repos-subtitle workspace-projects__subtitle">
                     @if (!isLoading && projects.Count > 0)
                     {

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor
@@ -25,7 +25,7 @@
 @inject AgentQueueStateService AgentQueueStateService
 @using WorkspaceModel = GrayMoon.App.Models.Workspace
 
-<PageTitle>@PageTitleText</PageTitle>
+<PageTitle>Repositories - GrayMoon</PageTitle>
 
 <div class="container-fluid page-container grid-page">
     <div class="grid-page-header">

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
@@ -54,8 +54,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
             .GroupBy(wr => wr.DependencyLevel)
             .OrderByDescending(g => g.Key ?? int.MinValue);
     private bool HasSearchFilter => !string.IsNullOrWhiteSpace(searchTerm);
-    private string PageTitleText => workspace?.Name ?? "Workspace";
-    private string RepositoriesModalTitle => $"Repositories for {PageTitleText}";
+    private string RepositoriesModalTitle => $"Repositories for {workspace?.Name ?? "Workspace"}";
     private bool ShowRepositoriesFetchOverlay => _repositoriesModal.IsVisible && _repositoriesModal.IsFetching;
     private string RepositoriesFetchOverlayMessage => _repositoriesModal.FetchedRepositoryCount is null || _repositoriesModal.FetchedRepositoryCount == 0
         ? "Fetching repositories..."

--- a/src/GrayMoon.App/Components/Pages/Workspaces.razor
+++ b/src/GrayMoon.App/Components/Pages/Workspaces.razor
@@ -7,6 +7,7 @@
 @using GrayMoon.App.Services
 @using GrayMoon.App.Components.Shared
 @using GrayMoon.App.Components.Modals
+@using Microsoft.AspNetCore.Components.Web
 @inject WorkspaceRepository WorkspaceRepository
 @inject ConnectorRepository ConnectorRepository
 @inject GitHubRepositoryService RepositoryService
@@ -20,20 +21,54 @@
 
 <div class="container-fluid page-container grid-page">
     <div class="grid-page-header">
-        <div class="d-flex justify-content-between align-items-center mb-4">
-            <div>
-                <h2>Workspaces</h2>
-                <p class="text-muted mb-0" style="min-height: 1.5rem;">
-                    @if (workspaces?.Count > 0)
+        <div class="workspace-repos-header workspace-workspaces-header">
+            <div class="workspace-repos-title-row">
+                <h2 class="workspace-repos-title">Workspaces</h2>
+                <p class="text-muted mb-0 workspace-repos-subtitle workspace-workspaces__subtitle">
+                    @if (workspaces != null && workspaces.Count > 0)
                     {
-                        @($"{workspaces.Count} {(workspaces.Count == 1 ? "workspace" : "workspaces")}")
+                        var wsSuffix = HasSearchFilter ? " found" : "";
+                        var wsCount = HasSearchFilter ? FilteredWorkspaceCount : workspaces.Count;
+                        <span>@($"{wsCount} {(wsCount == 1 ? "workspace" : "workspaces")}{wsSuffix}")</span>
                     }
-                    &nbsp;
+                    else if (workspaces != null)
+                    {
+                        <span>0 workspaces</span>
+                    }
+                    else
+                    {
+                        <span>&nbsp;</span>
+                    }
                 </p>
+                <span class="workspace-repos-title-spacer"></span>
             </div>
-            <button class="btn btn-primary" @onclick="ShowCreateModalAsync">
-                Add Workspace
-            </button>
+            <div class="d-flex gap-2 align-items-center workspace-repos-header-actions">
+                <div class="workspace-repos-search-wrapper">
+                    <div class="workspace-repos-search-input-wrap @(HasSearchFilter ? "has-filter" : null)">
+                        <input id="workspaces-list-search"
+                               class="form-control workspace-repos-search"
+                               placeholder="Search workspace name..."
+                               value="@searchTerm"
+                               disabled="@(workspaces == null || workspaces.Count == 0)"
+                               @oninput="OnSearchChanged"
+                               @onkeydown="OnSearchKeyDown" />
+                        @if (HasSearchFilter)
+                        {
+                            <button type="button"
+                                    class="workspace-repos-search-clear"
+                                    title="Clear filter"
+                                    aria-label="Clear search filter"
+                                    @onclick="ClearSearchFilter"
+                                    @onclick:stopPropagation="true">
+                                <i class="bi bi-x-circle" aria-hidden="true"></i>
+                            </button>
+                        }
+                    </div>
+                </div>
+                <button class="btn btn-primary" @onclick="ShowCreateModalAsync">
+                    Add Workspace
+                </button>
+            </div>
         </div>
         @if (errorMessage != null)
         {
@@ -75,9 +110,17 @@
                                     </td>
                                 </tr>
                             }
+                            else if (NoWorkspacesMatchSearch)
+                            {
+                                <tr>
+                                    <td colspan="5" class="text-center text-muted py-4">
+                                        No workspaces match your search.
+                                    </td>
+                                </tr>
+                            }
                             else
                             {
-                                @foreach (var workspace in workspaces)
+                                @foreach (var workspace in FilteredWorkspaces)
                                 {
                                     <tr>
                                         <td class="col-name">
@@ -130,7 +173,7 @@
                 </div>
             </div>
         </div>
-        </div>
+    </div>
     }
 </div>
 
@@ -199,8 +242,59 @@
 
 @code {
     private List<WorkspaceModel>? workspaces;
+    private string searchTerm = string.Empty;
     private List<GitHubRepositoryEntry>? repositories;
     private string? errorMessage;
+
+    private bool HasSearchFilter => !string.IsNullOrWhiteSpace(searchTerm);
+
+    private IReadOnlyList<WorkspaceModel> FilteredWorkspaces => GetFilteredWorkspaces();
+
+    private int FilteredWorkspaceCount => FilteredWorkspaces.Count;
+
+    private bool NoWorkspacesMatchSearch =>
+        workspaces != null && workspaces.Count > 0 && HasSearchFilter && FilteredWorkspaces.Count == 0;
+
+    private IReadOnlyList<WorkspaceModel> GetFilteredWorkspaces()
+    {
+        if (workspaces == null) return Array.Empty<WorkspaceModel>();
+        var words = SplitSearchWords(searchTerm);
+        if (words.Count == 0) return workspaces;
+        return workspaces.Where(w =>
+        {
+            var name = w.Name ?? string.Empty;
+            return words.All(word => name.Contains(word, StringComparison.OrdinalIgnoreCase));
+        }).ToList();
+    }
+
+    private static List<string> SplitSearchWords(string term) =>
+        term
+            .Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(w => w.Trim())
+            .Where(w => w.Length > 0)
+            .ToList();
+
+    private void OnSearchChanged(ChangeEventArgs e)
+    {
+        searchTerm = e.Value?.ToString() ?? string.Empty;
+        StateHasChanged();
+    }
+
+    private void ClearSearchFilter()
+    {
+        searchTerm = string.Empty;
+        StateHasChanged();
+    }
+
+    private void OnSearchKeyDown(KeyboardEventArgs e)
+    {
+        if (e.Key == "Escape")
+        {
+            searchTerm = string.Empty;
+            StateHasChanged();
+        }
+    }
+
     private bool showEditorModal;
     private bool showRepositoriesModal;
     private bool showDeleteModal;

--- a/src/GrayMoon.App/Components/Pages/Workspaces.razor.css
+++ b/src/GrayMoon.App/Components/Pages/Workspaces.razor.css
@@ -1,3 +1,12 @@
+/* Header: match workspace search toolbar */
+.workspace-workspaces-header .workspace-repos-subtitle.workspace-workspaces__subtitle {
+    white-space: normal;
+    overflow: visible;
+    text-overflow: clip;
+    flex: 0 0 auto;
+    min-width: 0;
+}
+
 .workspaces-table {
     table-layout: fixed;
     width: 100%;

--- a/src/GrayMoon.App/Components/Shared/WorkspaceRepositoriesHeader.razor
+++ b/src/GrayMoon.App/Components/Shared/WorkspaceRepositoriesHeader.razor
@@ -2,7 +2,7 @@
 
 <div class="workspace-repos-header">
     <div class="workspace-repos-title-row">
-        <h2 class="workspace-repos-title">@(WorkspaceName ?? "Workspace")</h2>
+        <h2 class="workspace-repos-title">Repositories</h2>
         <p class="text-muted mb-0 workspace-repos-subtitle">
             <NavLink href="workspaces" class="workspaces-breadcrumb-link" style="color: var(--text-muted) !important;">workspace</NavLink><span> | </span>
             @if (RepositoriesCount > 0)

--- a/src/GrayMoon.App/Program.cs
+++ b/src/GrayMoon.App/Program.cs
@@ -85,6 +85,7 @@ try
     builder.Services.AddScoped<WorkspaceDependencyService>();
     builder.Services.AddScoped<WorkspaceBranchHandler>();
     builder.Services.AddScoped<IWorkspacePageService, WorkspacePageService>();
+    builder.Services.AddScoped<IWorkspaceTopBarService, WorkspaceTopBarService>();
 
     builder.Services.AddSingleton<ICommandLineService, CommandLineService>();
 

--- a/src/GrayMoon.App/Services/WorkspaceTopBarService.cs
+++ b/src/GrayMoon.App/Services/WorkspaceTopBarService.cs
@@ -1,0 +1,90 @@
+using System.Threading;
+using GrayMoon.App.Repositories;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Routing;
+
+namespace GrayMoon.App.Services;
+
+/// <summary>
+/// Keeps the main header strip in sync with the current workspace route so the layout can show the workspace name without each page pushing state.</summary>
+public interface IWorkspaceTopBarService
+{
+    /// <summary>Display name for the current workspace route, or null when not under <c>/workspaces/{id}</c>.</summary>
+    string? WorkspaceDisplayName { get; }
+
+    event Action? Changed;
+
+    Task EnsureSynchronizedAsync();
+}
+
+public sealed class WorkspaceTopBarService : IWorkspaceTopBarService, IDisposable
+{
+    private readonly NavigationManager _navigationManager;
+    private readonly WorkspaceRepository _workspaceRepository;
+    private int _refreshGeneration;
+    private int? _cachedWorkspaceId;
+    private string? _workspaceDisplayName;
+
+    public WorkspaceTopBarService(NavigationManager navigationManager, WorkspaceRepository workspaceRepository)
+    {
+        _navigationManager = navigationManager;
+        _workspaceRepository = workspaceRepository;
+        _navigationManager.LocationChanged += OnLocationChanged;
+    }
+
+    public string? WorkspaceDisplayName => _workspaceDisplayName;
+
+    public event Action? Changed;
+
+    public void Dispose()
+    {
+        _navigationManager.LocationChanged -= OnLocationChanged;
+    }
+
+    private void OnLocationChanged(object? sender, LocationChangedEventArgs e)
+    {
+        _ = ApplyNavigationAsync();
+    }
+
+    public Task EnsureSynchronizedAsync() => ApplyNavigationAsync();
+
+    private async Task ApplyNavigationAsync()
+    {
+        var generation = Interlocked.Increment(ref _refreshGeneration);
+
+        var relativePath = _navigationManager.ToBaseRelativePath(_navigationManager.Uri);
+        var path = relativePath.Split('?', '#')[0];
+        var segments = path.Split('/', StringSplitOptions.RemoveEmptyEntries);
+
+        int? workspaceId = null;
+        if (segments.Length >= 2
+            && string.Equals(segments[0], "workspaces", StringComparison.OrdinalIgnoreCase)
+            && int.TryParse(segments[1], out var parsedId))
+        {
+            workspaceId = parsedId;
+        }
+
+        if (workspaceId is null)
+        {
+            if (_workspaceDisplayName is not null || _cachedWorkspaceId is not null)
+            {
+                _cachedWorkspaceId = null;
+                _workspaceDisplayName = null;
+                if (generation == Volatile.Read(ref _refreshGeneration))
+                    Changed?.Invoke();
+            }
+            return;
+        }
+
+        if (_cachedWorkspaceId == workspaceId && _workspaceDisplayName is not null)
+            return;
+
+        var workspace = await _workspaceRepository.GetByIdAsync(workspaceId.Value).ConfigureAwait(false);
+        if (generation != Volatile.Read(ref _refreshGeneration))
+            return;
+
+        _cachedWorkspaceId = workspaceId;
+        _workspaceDisplayName = workspace?.Name ?? "Workspace";
+        Changed?.Invoke();
+    }
+}


### PR DESCRIPTION
This change moves the **workspace name** out of individual workspace headers and into the **main top bar**, centered on the **full viewport** on desktop (with width caps so it does not run under the sidebar or the GitHub / version / agent controls). On **narrow viewports**, the main strip keeps a **compact height** with a **smaller, readable** workspace title and the version string still hidden as before.

Workspace pages now use **fixed** headings and document titles (**Repositories**, **Projects**, **Packages**, **Files**, **Dependencies**, **Actions**) instead of prefixing the workspace name. The repositories grid header matches that pattern; modal copy that still needs the real name continues to use it (e.g. “Repositories for …”).

The sidebar nav under a workspace is shortened for the narrow column: **Repos** (tooltip: Repositories) for the default workspace route and **Deps** (tooltip: Dependencies) for the dependency graph. `NavMenu` no longer queries the database only to show the workspace name in the nav.

A scoped **`IWorkspaceTopBarService`** syncs the displayed name from the current `/workspaces/{id}` URL and repository lookup so the layout stays in sync without each page pushing header state.