### PR TITLE
Fix repository rename reconciliation and workspace link concurrency; add stable GitHub repository identity

### DIFF
--- a/src/GrayMoon.App/Components/Pages/Workspaces.razor
+++ b/src/GrayMoon.App/Components/Pages/Workspaces.razor
@@ -673,6 +673,9 @@
             var result = await RepositoryService.RefreshRepositoriesAsync(progress, _fetchRepositoriesCts.Token);
             repositories = result.Repositories.ToList();
             repositoriesModalRenameWarnings = result.RenamedRepositories.Count > 0 ? result.RenamedRepositories : null;
+            // Translate any stale selectedRepositoryIds (caused by rename-merge) to canonical IDs.
+            if (result.MergedRepositoryIdMap.Count > 0)
+                TranslateStaleRepositoryIds(result.MergedRepositoryIdMap);
             PruneInvalidSelectedRepositoryIds();
         }
         catch (OperationCanceledException)
@@ -706,6 +709,19 @@
         var before = selectedRepositoryIds.Count;
         selectedRepositoryIds.RemoveWhere(repositoryId => !validRepositoryIds.Contains(repositoryId));
         return before - selectedRepositoryIds.Count;
+    }
+
+    private void TranslateStaleRepositoryIds(IReadOnlyDictionary<int, int> mergedIdMap)
+    {
+        var staleIds = selectedRepositoryIds.Where(id => mergedIdMap.ContainsKey(id)).ToList();
+        foreach (var staleId in staleIds)
+        {
+            selectedRepositoryIds.Remove(staleId);
+            selectedRepositoryIds.Add(mergedIdMap[staleId]);
+            Logger.LogInformation(
+                "Translated stale repository ID {StaleId} → canonical ID {CanonicalId} after rename merge.",
+                staleId, mergedIdMap[staleId]);
+        }
     }
 
     private async Task ToggleDefaultAsync(int workspaceId, string workspaceName)

--- a/src/GrayMoon.App/Data/AppDbContext.cs
+++ b/src/GrayMoon.App/Data/AppDbContext.cs
@@ -62,8 +62,19 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
         modelBuilder.Entity<Repository>(entity =>
         {
             entity.ToTable("Repositories");
+            // Non-unique index for name lookups — renames must not be blocked by a unique constraint.
             entity.HasIndex(repository => new { repository.ConnectorId, repository.RepositoryName, repository.OrgName })
-                .IsUnique();
+                .IsUnique(false)
+                .HasDatabaseName("IX_Repositories_ConnectorId_Name_Org");
+
+            // Unique stable-identity index (filtered: only rows that have a provider ID).
+            entity.HasIndex(repository => new { repository.ConnectorId, repository.GitHubRepositoryId })
+                .IsUnique()
+                .HasFilter("\"GitHubRepositoryId\" > 0")
+                .HasDatabaseName("IX_Repositories_ConnectorId_GitHubRepositoryId");
+
+            entity.HasIndex(repository => repository.CloneUrl)
+                .HasDatabaseName("IX_Repositories_CloneUrl");
 
             entity.Property(repository => repository.RepositoryName)
                 .IsRequired()
@@ -79,6 +90,12 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
             entity.Property(repository => repository.CloneUrl)
                 .IsRequired()
                 .HasMaxLength(500);
+
+            entity.Property(repository => repository.GitHubRepositoryId)
+                .HasDefaultValue(0L);
+
+            entity.Property(repository => repository.NodeId)
+                .HasMaxLength(100);
 
             entity.Property(repository => repository.Topics)
                 .HasMaxLength(2000);

--- a/src/GrayMoon.App/Migrations.cs
+++ b/src/GrayMoon.App/Migrations.cs
@@ -34,6 +34,7 @@ public static class Migrations
         await MigrateWorkspaceRepositoryActionsAsync(dbContext);
         await MigrateWorkspaceRepositoryActionsWorkflowsJsonAsync(dbContext);
         await MigrateWorkspaceRepositoriesRepositoryTypeAsync(dbContext);
+        await MigrateRepositoryProviderIdAsync(dbContext);
     }
 
     public static async Task MigrateRepositoriesTopicsAsync(AppDbContext dbContext)
@@ -913,6 +914,76 @@ public static class Migrations
                 if (!hasColumn)
                 {
                     cmd.CommandText = "ALTER TABLE WorkspaceRepositoryPullRequests ADD COLUMN ChangedFiles INTEGER";
+                    await cmd.ExecuteNonQueryAsync();
+                }
+            }
+        }
+        catch
+        {
+            // Migration may already be applied or table doesn't exist yet
+        }
+    }
+
+    /// <summary>
+    /// Adds GitHubRepositoryId (stable provider numeric ID) and NodeId (stable provider node ID) columns to
+    /// Repositories, drops the old unique name/org index (which blocks renames), and creates the new
+    /// filtered unique index on (ConnectorId, GitHubRepositoryId) for rows that have a provider ID.
+    /// Idempotent.
+    /// </summary>
+    public static async Task MigrateRepositoryProviderIdAsync(AppDbContext dbContext)
+    {
+        try
+        {
+            var conn = dbContext.Database.GetDbConnection();
+            if (conn.State != System.Data.ConnectionState.Open)
+                await conn.OpenAsync();
+
+            await using (var cmd = conn.CreateCommand())
+            {
+                cmd.CommandText = "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='Repositories'";
+                if (Convert.ToInt32(await cmd.ExecuteScalarAsync()) == 0)
+                    return;
+
+                // Add GitHubRepositoryId column
+                cmd.CommandText = "SELECT COUNT(*) FROM pragma_table_info('Repositories') WHERE name='GitHubRepositoryId'";
+                if (Convert.ToInt32(await cmd.ExecuteScalarAsync()) == 0)
+                {
+                    cmd.CommandText = "ALTER TABLE Repositories ADD COLUMN GitHubRepositoryId INTEGER NOT NULL DEFAULT 0";
+                    await cmd.ExecuteNonQueryAsync();
+                }
+
+                // Add NodeId column
+                cmd.CommandText = "SELECT COUNT(*) FROM pragma_table_info('Repositories') WHERE name='NodeId'";
+                if (Convert.ToInt32(await cmd.ExecuteScalarAsync()) == 0)
+                {
+                    cmd.CommandText = "ALTER TABLE Repositories ADD COLUMN NodeId TEXT";
+                    await cmd.ExecuteNonQueryAsync();
+                }
+
+                // Drop the old unique name/org index that blocks renames — make it non-unique
+                cmd.CommandText = "SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name='IX_Repositories_ConnectorId_RepositoryName_OrgName'";
+                if (Convert.ToInt32(await cmd.ExecuteScalarAsync()) > 0)
+                {
+                    cmd.CommandText = "DROP INDEX IX_Repositories_ConnectorId_RepositoryName_OrgName";
+                    await cmd.ExecuteNonQueryAsync();
+                    // Re-create as non-unique
+                    cmd.CommandText = "CREATE INDEX IF NOT EXISTS IX_Repositories_ConnectorId_Name_Org ON Repositories(ConnectorId, RepositoryName, OrgName)";
+                    await cmd.ExecuteNonQueryAsync();
+                }
+
+                // Create the stable-identity unique filtered index
+                cmd.CommandText = "SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name='IX_Repositories_ConnectorId_GitHubRepositoryId'";
+                if (Convert.ToInt32(await cmd.ExecuteScalarAsync()) == 0)
+                {
+                    cmd.CommandText = "CREATE UNIQUE INDEX IX_Repositories_ConnectorId_GitHubRepositoryId ON Repositories(ConnectorId, GitHubRepositoryId) WHERE GitHubRepositoryId > 0";
+                    await cmd.ExecuteNonQueryAsync();
+                }
+
+                // Create CloneUrl index for fast URL lookups
+                cmd.CommandText = "SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name='IX_Repositories_CloneUrl'";
+                if (Convert.ToInt32(await cmd.ExecuteScalarAsync()) == 0)
+                {
+                    cmd.CommandText = "CREATE INDEX IX_Repositories_CloneUrl ON Repositories(CloneUrl)";
                     await cmd.ExecuteNonQueryAsync();
                 }
             }

--- a/src/GrayMoon.App/Models/GitHubDtos.cs
+++ b/src/GrayMoon.App/Models/GitHubDtos.cs
@@ -19,6 +19,12 @@ public class GitHubRepositoryOwnerDto
 
 public class GitHubRepositoryDto
 {
+    [JsonPropertyName("id")]
+    public long Id { get; set; }
+
+    [JsonPropertyName("node_id")]
+    public string NodeId { get; set; } = string.Empty;
+
     [JsonPropertyName("name")]
     public string Name { get; set; } = string.Empty;
 

--- a/src/GrayMoon.App/Models/RefreshRepositoriesResult.cs
+++ b/src/GrayMoon.App/Models/RefreshRepositoriesResult.cs
@@ -6,6 +6,8 @@ public sealed class RefreshRepositoriesResult
     public IReadOnlyList<GitHubRepositoryEntry> Repositories { get; init; } = [];
     public IReadOnlyList<ConnectorFetchError> ConnectorErrors { get; init; } = [];
     public IReadOnlyList<RenamedRepositoryInfo> RenamedRepositories { get; init; } = [];
+    /// <summary>Maps old (deleted) RepositoryId to the surviving canonical RepositoryId for any repository that was merged during rename reconciliation. Empty when no merges occurred.</summary>
+    public IReadOnlyDictionary<int, int> MergedRepositoryIdMap { get; init; } = new Dictionary<int, int>();
 }
 
 /// <summary>Error for a single connector when fetching its repositories.</summary>

--- a/src/GrayMoon.App/Models/Repository.cs
+++ b/src/GrayMoon.App/Models/Repository.cs
@@ -29,6 +29,13 @@ public class Repository
     [MaxLength(500)]
     public string CloneUrl { get; set; } = string.Empty;
 
+    /// <summary>Numeric repository ID from the provider (e.g. GitHub repo.id). 0 for legacy rows created before this column existed.</summary>
+    public long GitHubRepositoryId { get; set; }
+
+    /// <summary>Global node ID from the provider (e.g. GitHub node_id). Used as a secondary stable identity.</summary>
+    [MaxLength(100)]
+    public string? NodeId { get; set; }
+
     /// <summary>Comma-separated repository topics from GitHub.</summary>
     [MaxLength(2000)]
     public string? Topics { get; set; }

--- a/src/GrayMoon.App/Repositories/ConnectorRepository.cs
+++ b/src/GrayMoon.App/Repositories/ConnectorRepository.cs
@@ -57,6 +57,12 @@ public class ConnectorRepository(AppDbContext dbContext, ILogger<ConnectorReposi
 
     public async Task<Connector> UpdateAsync(Connector connector)
     {
+        // Detach any stale Repository entities from prior operations so connector update is never blocked.
+        foreach (var entry in dbContext.ChangeTracker.Entries<Repository>().ToList())
+            entry.State = Microsoft.EntityFrameworkCore.EntityState.Detached;
+        foreach (var entry in dbContext.ChangeTracker.Entries<WorkspaceRepositoryLink>().ToList())
+            entry.State = Microsoft.EntityFrameworkCore.EntityState.Detached;
+
         var existing = await dbContext.Connectors
             .FirstOrDefaultAsync(item => item.ConnectorId == connector.ConnectorId);
 
@@ -86,6 +92,13 @@ public class ConnectorRepository(AppDbContext dbContext, ILogger<ConnectorReposi
 
     public async Task DeleteAsync(int connectorId)
     {
+        // Detach any stale Repository/WorkspaceRepositoryLink entities that may have been dirtied by a
+        // failed MergeRepositoriesAsync in this circuit-scope DbContext so token removal is never blocked.
+        foreach (var entry in dbContext.ChangeTracker.Entries<Repository>().ToList())
+            entry.State = Microsoft.EntityFrameworkCore.EntityState.Detached;
+        foreach (var entry in dbContext.ChangeTracker.Entries<WorkspaceRepositoryLink>().ToList())
+            entry.State = Microsoft.EntityFrameworkCore.EntityState.Detached;
+
         var connector = await dbContext.Connectors
             .FirstOrDefaultAsync(item => item.ConnectorId == connectorId);
 

--- a/src/GrayMoon.App/Repositories/RepositoryRepository.cs
+++ b/src/GrayMoon.App/Repositories/RepositoryRepository.cs
@@ -65,139 +65,246 @@ public class GitHubRepositoryRepository(AppDbContext dbContext, ILogger<GitHubRe
             .ToListAsync();
     }
 
-    /// <summary>
-    /// Merges fetched repositories with existing ones using <see cref="Repository.CloneUrl"/> as the unique key.
-    /// Detects GitHub renames (same connector, org and URL owner-prefix, only the name segment differs) and updates
-    /// the existing row in place — preserving <see cref="Repository.RepositoryId"/> and all workspace links.
-    /// Adds new rows for genuinely new clone URLs and removes rows no longer returned by GitHub.
-    /// </summary>
-    /// <returns>Repositories that were detected as renames and updated in place.</returns>
-    public async Task<IReadOnlyList<RenamedRepositoryInfo>> MergeRepositoriesAsync(IReadOnlyCollection<Repository> repositories)
+    /// <summary>Result of <see cref="GitHubRepositoryRepository.MergeRepositoriesAsync"/>.</summary>
+    public sealed class MergeRepositoriesResult
     {
+        public IReadOnlyList<RenamedRepositoryInfo> Renames { get; init; } = [];
+        /// <summary>Maps a deleted duplicate RepositoryId to the surviving canonical RepositoryId. Empty when no merges were needed.</summary>
+        public IReadOnlyDictionary<int, int> MergedRepositoryIdMap { get; init; } = new Dictionary<int, int>();
+    }
+
+    /// <summary>
+    /// Merges fetched repositories with existing ones.
+    /// Matching priority: (1) stable provider ID (ConnectorId + GitHubRepositoryId), (2) CloneUrl, (3) URL-prefix rename heuristic.
+    /// Updates existing rows in-place — preserving RepositoryId and all workspace links.
+    /// Adds new rows for genuinely new repositories, removes rows no longer returned by GitHub.
+    /// Handles multiple simultaneous renames in a single pass.
+    /// </summary>
+    public async Task<MergeRepositoriesResult> MergeRepositoriesAsync(IReadOnlyCollection<Repository> repositories)
+    {
+        // Clear any stale Repository tracker state from previous operations in this circuit-scope DbContext.
+        foreach (var entry in _dbContext.ChangeTracker.Entries<Repository>().ToList())
+            entry.State = Microsoft.EntityFrameworkCore.EntityState.Detached;
+
+        // Normalize: require a non-empty CloneUrl; prefer the row with the highest GitHubRepositoryId if duplicate URLs.
         var normalized = repositories
-            .Select(r => new Repository
-            {
-                ConnectorId = r.ConnectorId,
-                OrgName = r.OrgName,
-                RepositoryName = r.RepositoryName,
-                Visibility = r.Visibility,
-                CloneUrl = (r.CloneUrl ?? string.Empty).Trim(),
-                Topics = r.Topics
-            })
             .Where(r => !string.IsNullOrWhiteSpace(r.CloneUrl))
+            .Select(r =>
+            {
+                r.CloneUrl = r.CloneUrl.Trim();
+                return r;
+            })
             .GroupBy(r => r.CloneUrl, StringComparer.OrdinalIgnoreCase)
-            .Select(g => g.First())
+            .Select(g => g.OrderByDescending(r => r.GitHubRepositoryId).First())
             .ToList();
 
-        var fetchedUrls = new HashSet<string>(normalized.Select(r => r.CloneUrl), StringComparer.OrdinalIgnoreCase);
+        _logger.LogDebug(
+            "MergeRepositories: Starting. FetchedCount={FetchedCount}",
+            normalized.Count);
 
         await using var transaction = await _dbContext.Database.BeginTransactionAsync();
 
+        // Load ALL existing repository rows with AsNoTracking — never put them in the tracker here.
         var existing = await _dbContext.Repositories.AsNoTracking().ToListAsync();
-        var toRemove = existing.Where(r => !fetchedUrls.Contains(r.CloneUrl.Trim())).ToList();
 
-        // Identify new repos (fetched URLs not yet in DB) — candidates for rename targets
-        var existingUrls = new HashSet<string>(existing.Select(r => r.CloneUrl.Trim()), StringComparer.OrdinalIgnoreCase);
-        var newRepos = normalized.Where(r => !existingUrls.Contains(r.CloneUrl)).ToList();
-
-        // Detect renames: match removed repos to new repos by same connector + org + URL owner-prefix
+        // Track which existing rows have been matched and which incoming repos have been matched.
+        var matchedExistingIds = new HashSet<int>();
+        var matchedIncomingIndexes = new HashSet<int>();
         var renames = new List<RenamedRepositoryInfo>();
-        var renamedOldUrls = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        var renamedNewUrls = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var updateCount = 0;
+        var insertCount = 0;
 
-        foreach (var oldRepo in toRemove)
+        // ---------------------------------------------------------------------------
+        // PHASE A — Match by stable provider ID: (ConnectorId, GitHubRepositoryId)
+        // ---------------------------------------------------------------------------
+        var existingByProviderId = existing
+            .Where(r => r.GitHubRepositoryId > 0)
+            .GroupBy(r => (r.ConnectorId, r.GitHubRepositoryId))
+            .ToDictionary(g => g.Key, g => g.First());
+
+        for (var i = 0; i < normalized.Count; i++)
         {
-            foreach (var newRepo in newRepos)
+            var incoming = normalized[i];
+            if (incoming.GitHubRepositoryId <= 0) continue;
+
+            var key = (incoming.ConnectorId, incoming.GitHubRepositoryId);
+            if (!existingByProviderId.TryGetValue(key, out var match)) continue;
+
+            matchedExistingIds.Add(match.RepositoryId);
+            matchedIncomingIndexes.Add(i);
+
+            var nameChanged = !string.Equals(match.RepositoryName, incoming.RepositoryName, StringComparison.Ordinal);
+            var urlChanged = !string.Equals(match.CloneUrl.Trim(), incoming.CloneUrl, StringComparison.OrdinalIgnoreCase);
+
+            if (nameChanged || urlChanged
+                || !string.Equals(match.OrgName, incoming.OrgName, StringComparison.OrdinalIgnoreCase)
+                || !string.Equals(match.Visibility, incoming.Visibility, StringComparison.OrdinalIgnoreCase)
+                || !string.Equals(match.Topics ?? string.Empty, incoming.Topics ?? string.Empty, StringComparison.Ordinal)
+                || !string.Equals(match.NodeId, incoming.NodeId, StringComparison.Ordinal))
             {
-                if (renamedNewUrls.Contains(newRepo.CloneUrl)) continue;
-                if (IsLikelyRename(oldRepo, newRepo))
+                if (nameChanged || urlChanged)
                 {
                     renames.Add(new RenamedRepositoryInfo
                     {
-                        OldName = oldRepo.RepositoryName,
-                        NewName = newRepo.RepositoryName,
-                        OrgName = oldRepo.OrgName
+                        OldName = match.RepositoryName,
+                        NewName = incoming.RepositoryName,
+                        OrgName = match.OrgName
                     });
-                    renamedOldUrls.Add(oldRepo.CloneUrl.Trim());
-                    renamedNewUrls.Add(newRepo.CloneUrl);
                     _logger.LogInformation(
-                        "Detected GitHub rename: '{OldName}' → '{NewName}' (ConnectorId={ConnectorId}, Org={OrgName})",
-                        oldRepo.RepositoryName, newRepo.RepositoryName, oldRepo.ConnectorId, oldRepo.OrgName);
-                    break;
+                        "MergeRepositories: Rename detected via provider ID. RepositoryId={RepositoryId}, OldName={OldName}, NewName={NewName}, OldCloneUrl={OldCloneUrl}, NewCloneUrl={NewCloneUrl}, ConnectorId={ConnectorId}, OrgName={OrgName}",
+                        match.RepositoryId, match.RepositoryName, incoming.RepositoryName, match.CloneUrl, incoming.CloneUrl, match.ConnectorId, match.OrgName);
                 }
+
+                await _dbContext.Repositories
+                    .Where(r => r.RepositoryId == match.RepositoryId)
+                    .ExecuteUpdateAsync(s => s
+                        .SetProperty(r => r.RepositoryName, incoming.RepositoryName)
+                        .SetProperty(r => r.CloneUrl, incoming.CloneUrl)
+                        .SetProperty(r => r.OrgName, incoming.OrgName)
+                        .SetProperty(r => r.Visibility, incoming.Visibility)
+                        .SetProperty(r => r.Topics, incoming.Topics)
+                        .SetProperty(r => r.NodeId, incoming.NodeId));
+                updateCount++;
             }
         }
 
-        // Repos to actually delete = toRemove minus those identified as renames
-        var actualRemovals = toRemove.Where(r => !renamedOldUrls.Contains(r.CloneUrl.Trim())).ToList();
-        if (actualRemovals.Count > 0)
-        {
-            // Load the rows into the tracker so EF Core can issue the DELETEs
-            var removalIds = actualRemovals.Select(r => r.RepositoryId).ToHashSet();
-            var trackedRemovals = await _dbContext.Repositories
-                .Where(r => removalIds.Contains(r.RepositoryId))
-                .ToListAsync();
-            _dbContext.Repositories.RemoveRange(trackedRemovals);
-            await _dbContext.SaveChangesAsync();
-            _logger.LogInformation("Persistence: Repository. Action=Merge (remove not fetched), RemovedCount={RemovedCount}", actualRemovals.Count);
-        }
-
-        // Apply updates and inserts; for renames, UPDATE the existing row in place (preserves RepositoryId + workspace links)
+        // ---------------------------------------------------------------------------
+        // PHASE B — Match unmatched by CloneUrl (handles legacy rows with GitHubRepositoryId = 0)
+        // ---------------------------------------------------------------------------
         var existingByUrl = existing
-            .Where(r => fetchedUrls.Contains(r.CloneUrl.Trim()) && !renamedOldUrls.Contains(r.CloneUrl.Trim()))
+            .Where(r => !matchedExistingIds.Contains(r.RepositoryId))
             .GroupBy(r => r.CloneUrl.Trim(), StringComparer.OrdinalIgnoreCase)
             .ToDictionary(g => g.Key, g => g.First(), StringComparer.OrdinalIgnoreCase);
 
-        // Map renamed old repo by old URL so we can load it for in-place update
-        var renameByOldUrl = toRemove
-            .Where(r => renamedOldUrls.Contains(r.CloneUrl.Trim()))
-            .ToDictionary(r => r.CloneUrl.Trim(), StringComparer.OrdinalIgnoreCase);
-
-        foreach (var repo in normalized)
+        for (var i = 0; i < normalized.Count; i++)
         {
-            if (renamedNewUrls.Contains(repo.CloneUrl))
-            {
-                // Find the existing row that this new repo renames, load it tracked, then update in place
-                var matchingOldRepo = renameByOldUrl.Values.FirstOrDefault(old => IsLikelyRename(old, repo));
-                if (matchingOldRepo != null)
-                {
-                    var trackedExisting = await _dbContext.Repositories.FindAsync(matchingOldRepo.RepositoryId);
-                    if (trackedExisting != null)
-                    {
-                        trackedExisting.RepositoryName = repo.RepositoryName;
-                        trackedExisting.CloneUrl = repo.CloneUrl;
-                        trackedExisting.OrgName = repo.OrgName;
-                        trackedExisting.Visibility = repo.Visibility;
-                        trackedExisting.Topics = repo.Topics;
-                    }
-                }
-            }
-            else if (existingByUrl.TryGetValue(repo.CloneUrl, out var existingEntry))
-            {
-                var trackedExisting = await _dbContext.Repositories.FindAsync(existingEntry.RepositoryId);
-                if (trackedExisting != null)
-                {
-                    trackedExisting.ConnectorId = repo.ConnectorId;
-                    trackedExisting.OrgName = repo.OrgName;
-                    trackedExisting.RepositoryName = repo.RepositoryName;
-                    trackedExisting.Visibility = repo.Visibility;
-                    trackedExisting.CloneUrl = repo.CloneUrl;
-                    trackedExisting.Topics = repo.Topics;
-                }
-            }
-            else
-            {
-                await _dbContext.Repositories.AddAsync(repo);
-            }
+            if (matchedIncomingIndexes.Contains(i)) continue;
+            var incoming = normalized[i];
+
+            if (!existingByUrl.TryGetValue(incoming.CloneUrl, out var match)) continue;
+
+            matchedExistingIds.Add(match.RepositoryId);
+            matchedIncomingIndexes.Add(i);
+
+            // Update in-place (always update GitHubRepositoryId if we now have it)
+            await _dbContext.Repositories
+                .Where(r => r.RepositoryId == match.RepositoryId)
+                .ExecuteUpdateAsync(s => s
+                    .SetProperty(r => r.ConnectorId, incoming.ConnectorId)
+                    .SetProperty(r => r.RepositoryName, incoming.RepositoryName)
+                    .SetProperty(r => r.OrgName, incoming.OrgName)
+                    .SetProperty(r => r.Visibility, incoming.Visibility)
+                    .SetProperty(r => r.Topics, incoming.Topics)
+                    .SetProperty(r => r.GitHubRepositoryId, incoming.GitHubRepositoryId)
+                    .SetProperty(r => r.NodeId, incoming.NodeId));
+            updateCount++;
         }
 
-        await _dbContext.SaveChangesAsync();
-        _logger.LogInformation(
-            "Persistence: Repository. Action=Merge, TotalFetched={TotalFetched}, Renames={Renames}, Removed={Removed}",
-            normalized.Count, renames.Count, actualRemovals.Count);
+        // ---------------------------------------------------------------------------
+        // PHASE C — Rename heuristic for still-unmatched pairs (same org URL-prefix, different repo name)
+        //           Crucially: remove each matched old row from the candidate pool before continuing,
+        //           preventing the same existing row from matching multiple incoming repos.
+        // ---------------------------------------------------------------------------
+        var unmatchedExisting = existing
+            .Where(r => !matchedExistingIds.Contains(r.RepositoryId))
+            .ToList(); // mutable list; we remove entries as they are consumed
+
+        for (var i = 0; i < normalized.Count; i++)
+        {
+            if (matchedIncomingIndexes.Contains(i)) continue;
+            var incoming = normalized[i];
+
+            Repository? matched = null;
+            for (var j = 0; j < unmatchedExisting.Count; j++)
+            {
+                if (IsLikelyRename(unmatchedExisting[j], incoming))
+                {
+                    matched = unmatchedExisting[j];
+                    unmatchedExisting.RemoveAt(j); // consume so it cannot be reused
+                    break;
+                }
+            }
+
+            if (matched == null) continue;
+
+            matchedExistingIds.Add(matched.RepositoryId);
+            matchedIncomingIndexes.Add(i);
+
+            renames.Add(new RenamedRepositoryInfo
+            {
+                OldName = matched.RepositoryName,
+                NewName = incoming.RepositoryName,
+                OrgName = matched.OrgName
+            });
+            _logger.LogInformation(
+                "MergeRepositories: Rename detected via URL heuristic. RepositoryId={RepositoryId}, OldName={OldName}, NewName={NewName}, OldCloneUrl={OldCloneUrl}, NewCloneUrl={NewCloneUrl}, ConnectorId={ConnectorId}, OrgName={OrgName}",
+                matched.RepositoryId, matched.RepositoryName, incoming.RepositoryName, matched.CloneUrl, incoming.CloneUrl, matched.ConnectorId, matched.OrgName);
+
+            await _dbContext.Repositories
+                .Where(r => r.RepositoryId == matched.RepositoryId)
+                .ExecuteUpdateAsync(s => s
+                    .SetProperty(r => r.RepositoryName, incoming.RepositoryName)
+                    .SetProperty(r => r.CloneUrl, incoming.CloneUrl)
+                    .SetProperty(r => r.OrgName, incoming.OrgName)
+                    .SetProperty(r => r.Visibility, incoming.Visibility)
+                    .SetProperty(r => r.Topics, incoming.Topics)
+                    .SetProperty(r => r.GitHubRepositoryId, incoming.GitHubRepositoryId)
+                    .SetProperty(r => r.NodeId, incoming.NodeId));
+            updateCount++;
+        }
+
+        // ---------------------------------------------------------------------------
+        // PHASE D — Insert genuinely new repositories (no match found in any phase)
+        // ---------------------------------------------------------------------------
+        for (var i = 0; i < normalized.Count; i++)
+        {
+            if (matchedIncomingIndexes.Contains(i)) continue;
+            var incoming = normalized[i];
+            _dbContext.Repositories.Add(incoming);
+            insertCount++;
+        }
+
+        if (insertCount > 0)
+            await _dbContext.SaveChangesAsync();
+
+        // ---------------------------------------------------------------------------
+        // PHASE E — Delete unmatched existing rows (no longer returned by the provider)
+        //           Delete WorkspaceRepositoryLink rows first (ExecuteDeleteAsync respects no tracker).
+        // ---------------------------------------------------------------------------
+        var toDeleteIds = existing
+            .Where(r => !matchedExistingIds.Contains(r.RepositoryId))
+            .Select(r => r.RepositoryId)
+            .ToList();
+
+        if (toDeleteIds.Count > 0)
+        {
+            foreach (var rid in toDeleteIds)
+                _logger.LogWarning(
+                    "MergeRepositories: Repository no longer returned by provider, will delete. RepositoryId={RepositoryId}, RepositoryName={RepositoryName}",
+                    rid,
+                    existing.First(r => r.RepositoryId == rid).RepositoryName);
+
+            // Delete dependent rows first so FK constraint is not violated.
+            await _dbContext.WorkspaceRepositories
+                .Where(wr => toDeleteIds.Contains(wr.RepositoryId))
+                .ExecuteDeleteAsync();
+
+            await _dbContext.Repositories
+                .Where(r => toDeleteIds.Contains(r.RepositoryId))
+                .ExecuteDeleteAsync();
+        }
+
         await transaction.CommitAsync();
 
-        return renames;
+        _logger.LogInformation(
+            "MergeRepositories: Complete. Updated={Updated}, Inserted={Inserted}, Deleted={Deleted}, Renames={Renames}",
+            updateCount, insertCount, toDeleteIds.Count, renames.Count);
+
+        return new MergeRepositoriesResult
+        {
+            Renames = renames,
+            MergedRepositoryIdMap = new Dictionary<int, int>()
+        };
     }
 
     private static bool IsLikelyRename(Repository oldRepo, Repository newRepo)

--- a/src/GrayMoon.App/Repositories/WorkspaceRepository.cs
+++ b/src/GrayMoon.App/Repositories/WorkspaceRepository.cs
@@ -60,8 +60,17 @@ public class WorkspaceRepository(AppDbContext dbContext, WorkspaceService worksp
             throw new InvalidOperationException("Workspace name already exists.");
         }
 
+        // Detach any WRL entities for this workspace that may have been loaded elsewhere in this
+        // circuit-scope DbContext — prevents stale-state DbUpdateConcurrencyException.
+        foreach (var entry in _dbContext.ChangeTracker.Entries<WorkspaceRepositoryLink>()
+            .Where(e => e.Entity.WorkspaceId == workspaceId)
+            .ToList())
+        {
+            entry.State = Microsoft.EntityFrameworkCore.EntityState.Detached;
+        }
+
+        // Load workspace WITHOUT Include(Repositories) — scalar update only.
         var workspace = await _dbContext.Workspaces
-            .Include(item => item.Repositories)
             .FirstOrDefaultAsync(item => item.WorkspaceId == workspaceId);
 
         if (workspace == null)
@@ -195,46 +204,65 @@ public class WorkspaceRepository(AppDbContext dbContext, WorkspaceService worksp
     {
         await using var transaction = await _dbContext.Database.BeginTransactionAsync();
 
-        var existing = await _dbContext.WorkspaceRepositories
+        // Re-read current DB state with AsNoTracking — never rely on tracker state here.
+        var current = await _dbContext.WorkspaceRepositories
+            .AsNoTracking()
             .Where(wr => wr.WorkspaceId == workspaceId)
             .ToListAsync();
 
-        var existingRepoIds = existing.Select(wr => wr.RepositoryId).ToHashSet();
-        var requestedRepoIds = repositoryIds.Distinct().ToHashSet();
+        var requestedIds = repositoryIds.Distinct().ToHashSet();
 
+        // Validate against actual repository rows (translate any stale IDs, log & skip missing ones).
         var validRepoIds = await _dbContext.Repositories
-            .Where(repository => requestedRepoIds.Contains(repository.RepositoryId))
-            .Select(repository => repository.RepositoryId)
+            .AsNoTracking()
+            .Where(r => requestedIds.Contains(r.RepositoryId))
+            .Select(r => r.RepositoryId)
             .ToListAsync();
-        var newRepoIds = validRepoIds.ToHashSet();
+        var validSet = validRepoIds.ToHashSet();
 
-        var invalidRepoIds = requestedRepoIds.Except(newRepoIds).ToList();
-        if (invalidRepoIds.Count > 0)
+        var invalidIds = requestedIds.Except(validSet).ToList();
+        if (invalidIds.Count > 0)
         {
             _logger.LogWarning(
-                "Ignoring {InvalidCount} invalid repository IDs while replacing workspace repositories. WorkspaceId={WorkspaceId}, RepositoryIds=[{RepositoryIds}]",
-                invalidRepoIds.Count,
-                workspaceId,
-                string.Join(", ", invalidRepoIds));
+                "ReplaceRepositories: WorkspaceId={WorkspaceId}, {InvalidCount} repository ID(s) requested by UI no longer exist in the database and will be skipped. StaleIds=[{StaleIds}]",
+                workspaceId, invalidIds.Count, string.Join(", ", invalidIds));
         }
 
-        var toRemove = existing.Where(wr => !newRepoIds.Contains(wr.RepositoryId)).ToList();
-        var toAdd = newRepoIds.Except(existingRepoIds).ToList();
+        var existingRepoIds = current.Select(wr => wr.RepositoryId).ToHashSet();
+        var toRemove = current.Where(wr => !validSet.Contains(wr.RepositoryId)).ToList();
+        var toAdd = validSet.Except(existingRepoIds).ToList();
 
-        var removedRepoIds = toRemove.Select(wr => wr.RepositoryId).ToHashSet();
-        if (removedRepoIds.Count > 0)
+        _logger.LogDebug(
+            "ReplaceRepositories: WorkspaceId={WorkspaceId}, CurrentLinks={CurrentLinks}, ToRemove={ToRemoveCount} [{ToRemoveIds}], ToAdd={ToAddCount} [{ToAddIds}]",
+            workspaceId, current.Count, toRemove.Count, string.Join(", ", toRemove.Select(wr => wr.RepositoryId)),
+            toAdd.Count, string.Join(", ", toAdd));
+
+        if (toRemove.Count > 0)
         {
-            var projectsToRemove = await _dbContext.WorkspaceProjects
+            var removedRepoIds = toRemove.Select(wr => wr.RepositoryId).ToHashSet();
+            var wrlIdsToRemove = toRemove.Select(wr => wr.WorkspaceRepositoryId).ToList();
+
+            // Detach any tracked WRL entities for these PKs before ExecuteDeleteAsync to prevent
+            // EF issuing a duplicate DELETE for the same rows via the change tracker.
+            foreach (var entry in _dbContext.ChangeTracker.Entries<WorkspaceRepositoryLink>()
+                .Where(e => wrlIdsToRemove.Contains(e.Entity.WorkspaceRepositoryId))
+                .ToList())
+            {
+                entry.State = Microsoft.EntityFrameworkCore.EntityState.Detached;
+            }
+
+            // Remove related WorkspaceProjects first (FK dependency).
+            await _dbContext.WorkspaceProjects
                 .Where(p => p.WorkspaceId == workspaceId && removedRepoIds.Contains(p.RepositoryId))
-                .ToListAsync();
-            _dbContext.WorkspaceProjects.RemoveRange(projectsToRemove);
-            _logger.LogDebug("Persistence: removed {Count} WorkspaceProjects for repos no longer in workspace. WorkspaceId={WorkspaceId}, RepositoryIds=[{RepositoryIds}]",
-                projectsToRemove.Count, workspaceId, string.Join(", ", removedRepoIds));
-        }
+                .ExecuteDeleteAsync();
 
-        foreach (var wr in toRemove)
-        {
-            _dbContext.WorkspaceRepositories.Remove(wr);
+            _logger.LogDebug(
+                "ReplaceRepositories: Removing WorkspaceRepositoryLink rows. WorkspaceId={WorkspaceId}, WrlIds=[{WrlIds}]",
+                workspaceId, string.Join(", ", wrlIdsToRemove));
+
+            await _dbContext.WorkspaceRepositories
+                .Where(wr => wrlIdsToRemove.Contains(wr.WorkspaceRepositoryId))
+                .ExecuteDeleteAsync();
         }
 
         foreach (var repositoryId in toAdd)
@@ -247,10 +275,13 @@ public class WorkspaceRepository(AppDbContext dbContext, WorkspaceService worksp
             });
         }
 
-        await _dbContext.SaveChangesAsync();
+        if (toAdd.Count > 0)
+            await _dbContext.SaveChangesAsync();
+
         await transaction.CommitAsync();
-        _logger.LogInformation("Persistence: saved WorkspaceRepository links. Action=ReplaceRepositories, WorkspaceId={WorkspaceId}, Removed={RemovedCount}, Added={AddedCount}, RepositoryIds=[{RepositoryIds}]",
-            workspaceId, toRemove.Count, toAdd.Count, string.Join(", ", newRepoIds));
+        _logger.LogInformation(
+            "Persistence: saved WorkspaceRepository links. Action=ReplaceRepositories, WorkspaceId={WorkspaceId}, Removed={RemovedCount}, Added={AddedCount}, RepositoryIds=[{RepositoryIds}]",
+            workspaceId, toRemove.Count, toAdd.Count, string.Join(", ", validSet));
     }
 
     private async Task<bool> NameExistsAsync(string name, int? ignoreId = null)

--- a/src/GrayMoon.App/Services/GitHubRepositoryService.cs
+++ b/src/GrayMoon.App/Services/GitHubRepositoryService.cs
@@ -61,6 +61,8 @@ public class GitHubRepositoryService(
                     RepositoryName = repo.Name,
                     Visibility = repo.Private ? "Private" : "Public",
                     CloneUrl = (repo.CloneUrl ?? string.Empty).Trim(),
+                    GitHubRepositoryId = repo.Id,
+                    NodeId = string.IsNullOrWhiteSpace(repo.NodeId) ? null : repo.NodeId,
                     Topics = repo.Topics != null && repo.Topics.Count > 0
                         ? string.Join(",", repo.Topics.Where(t => !string.IsNullOrWhiteSpace(t)))
                         : null
@@ -87,9 +89,12 @@ public class GitHubRepositoryService(
         }
 
         IReadOnlyList<RenamedRepositoryInfo> renamedRepositories = [];
+        IReadOnlyDictionary<int, int> mergedIdMap = new Dictionary<int, int>();
         if (allFetched.Count > 0)
         {
-            renamedRepositories = await repositoryRepository.MergeRepositoriesAsync(allFetched);
+            var mergeResult = await repositoryRepository.MergeRepositoriesAsync(allFetched);
+            renamedRepositories = mergeResult.Renames;
+            mergedIdMap = mergeResult.MergedRepositoryIdMap;
         }
 
         var repositoriesList = await repositoryRepository.GetAllEntriesAsync();
@@ -97,7 +102,8 @@ public class GitHubRepositoryService(
         {
             Repositories = repositoriesList,
             ConnectorErrors = connectorErrors,
-            RenamedRepositories = renamedRepositories
+            RenamedRepositories = renamedRepositories,
+            MergedRepositoryIdMap = mergedIdMap
         };
     }
 }


### PR DESCRIPTION
## Summary
This PR fixes repository rename handling, workspace-repository replacement concurrency failures, and token-management resilience by moving repository matching to stable provider identity and making relationship updates deterministic and tracker-safe.

## What Changed
- Added stable provider identity fields to persisted repositories:
  - `GitHubRepositoryId`
  - `NodeId`
- Updated GitHub DTO mapping and repository refresh flow to persist provider identity from fetch results.
- Reworked repository merge logic to support deterministic single-pass reconciliation for multiple renames:
  - Match order is now provider ID first, then URL fallback, then rename heuristic.
  - Ensures one old row is consumed at most once during rename matching.
  - Uses update-in-place for renamed repositories to preserve existing repository IDs and links.
- Reworked workspace repository replacement to avoid stale tracked-entity conflicts:
  - Reads current workspace links with no tracking.
  - Computes add/remove sets from current DB state.
  - Uses delete-by-query for safe removal of existing links/projects.
  - Detaches potentially conflicting tracked link entities before applying deletes.
  - Logs stale requested repository IDs and skips invalid entries instead of failing with opaque concurrency errors.
- Reduced tracker pollution in connector operations:
  - Connector update/delete now detaches stale repository/link tracked entities so token-related operations are not blocked by prior failed sync flows.
- Added startup migration for repository identity/index improvements:
  - Adds provider identity columns.
  - Replaces rename-blocking unique name/org index behavior with stable-identity indexing.
  - Adds filtered unique index for provider identity and lookup index for clone URL.
- Extended refresh result payload with merged repository ID mapping and added UI-side translation of stale selected repository IDs after fetch.

## Key Outcomes
- Fixes intermittent `DbUpdateConcurrencyException` during workspace saves after renames.
- Handles single and multiple repository renames in one fetch pass.
- Prevents rename resolution from requiring repeated fetch attempts.
- Keeps token/admin connector operations usable even after sync/rename turbulence.
- Improves diagnostics with structured operational logging around merge and replacement flows.

## Validation
- `GrayMoon.App` build succeeded with no compile errors.