### PR TITLE
Workspace Actions: auto GHA terminal, rate-limit errors, archived repos, and overlay level caption

### DIFF
--- a/.cursor/plans/agent_install_path_and_signing_ed1579a8.plan.md
+++ b/.cursor/plans/agent_install_path_and_signing_ed1579a8.plan.md
@@ -29,7 +29,7 @@ isProject: false
 
 - [`src/GrayMoon.App/Resources/install-agent.ps1`](src/GrayMoon.App/Resources/install-agent.ps1) installs `graymoon-agent.exe` under `Join-Path $env:ProgramData 'GrayMoon'`, stops the service if running, downloads over the existing file, and **only** runs `sc create` when the service does not exist. If the service already exists, it never updates `binPath`, so a path change alone would leave the service pointing at the old executable.
 - [`Dockerfile`](Dockerfile) publishes `GrayMoon.Agent` for `win-x64` inside the **Linux** SDK stage (unsigned PE). [`/.github/workflows/docker-build.yml`](.github/workflows/docker-build.yml) is **ubuntu-latest** only.
-- Agent logs remain under `%ProgramData%\GrayMoon\logs` via [`RunCommandHandler.cs`](src/GrayMoon.Agent/Cli/RunCommandHandler.cs) (`CommonApplicationData`) — **no change recommended**; writable data under ProgramData is normal, and avoids permission issues under `Program Files`.
+- Agent logs remain under `%ProgramData%\GrayMoon\logs` via [`RunCommandHandler.cs`](src/GrayMoon.Agent/Cli/RunCommandHandler.cs) (`CommonApplicationData`) - **no change recommended**; writable data under ProgramData is normal, and avoids permission issues under `Program Files`.
 
 ## 1. Install path: `Program Files\GrayMoon`
 
@@ -43,8 +43,8 @@ In [`install-agent.ps1`](src/GrayMoon.App/Resources/install-agent.ps1):
 Update [`uninstall-agent.ps1`](src/GrayMoon.App/Resources/uninstall-agent.ps1) so that **after** the service is removed (or if it was already absent):
 
 - Define `$agentPath = Join-Path $env:ProgramFiles 'GrayMoon'` (same root as install).
-- If that directory exists, remove it recursively (`Remove-Item -Recurse -Force`), or delete only known agent payloads (e.g. `graymoon-agent.exe` and any files the install script drops there) if you prefer a narrower delete — full folder removal is simplest if the directory is dedicated to GrayMoon.
-- **Optional legacy cleanup:** If `%ProgramData%\GrayMoon\graymoon-agent.exe` still exists from older installs, delete that file (or the whole `%ProgramData%\GrayMoon` tree only if safe — today logs live under `%ProgramData%\GrayMoon\logs` from the running agent, so prefer removing **only** `graymoon-agent.exe` under ProgramData unless you confirm nothing else uses that folder). Safer default: remove `ProgramData\GrayMoon\graymoon-agent.exe` only when uninstalling, leave `logs` for user inspection or document manual cleanup.
+- If that directory exists, remove it recursively (`Remove-Item -Recurse -Force`), or delete only known agent payloads (e.g. `graymoon-agent.exe` and any files the install script drops there) if you prefer a narrower delete - full folder removal is simplest if the directory is dedicated to GrayMoon.
+- **Optional legacy cleanup:** If `%ProgramData%\GrayMoon\graymoon-agent.exe` still exists from older installs, delete that file (or the whole `%ProgramData%\GrayMoon` tree only if safe - today logs live under `%ProgramData%\GrayMoon\logs` from the running agent, so prefer removing **only** `graymoon-agent.exe` under ProgramData unless you confirm nothing else uses that folder). Safer default: remove `ProgramData\GrayMoon\graymoon-agent.exe` only when uninstalling, leave `logs` for user inspection or document manual cleanup.
 
 ## 2. Existing service: repoint `binPath` without removing old binaries
 
@@ -54,7 +54,7 @@ After the “stop service if running” block and **successful** download to the
   `"$agentExe" run -u "$hubUrl"`  
   using the script’s existing `{HUB_URL}` placeholder (already substituted by [`AgentEndpoints.cs`](src/GrayMoon.App/Api/Endpoints/AgentEndpoints.cs) when the script is served).
 - Run **`sc.exe config $serviceName binPath= <value>`** with the same `binPath=` spacing rules as `sc create` (space after `binPath=`; outer quoting so the whole executable + arguments is one value). Check `$LASTEXITCODE` and surface errors clearly.
-- Do **not** delete `%ProgramData%\GrayMoon` (or any old exe) — per your request.
+- Do **not** delete `%ProgramData%\GrayMoon` (or any old exe) - per your request.
 - Then start the service (existing logic).
 
 New installs (`-not $serviceExists`): unchanged flow except `$agentPath` / `$agentExe` point to Program Files.
@@ -63,7 +63,7 @@ New installs (`-not $serviceExists`): unchanged flow except `$agentPath` / `$age
 
 ## 3. Pipeline: sign the Windows agent and use it in Docker
 
-The Docker **Linux** stage cannot use Microsoft’s `signtool` without a Windows SDK image, but **Authenticode signing does not require Windows**: you can `dotnet publish -r win-x64` on **Ubuntu** (already works in the Dockerfile today) and sign the PE with **[osslsigncode](https://github.com/mtrojnar/osslsigncode)** or similar using a **PFX** and OpenSSL, or use **AzureSignTool** from a Linux job against **Azure Key Vault** (JWT auth, no exportable key). **Windows is not mandatory** — it is simply the most common choice because `signtool` ships on `windows-latest` and official docs target it.
+The Docker **Linux** stage cannot use Microsoft’s `signtool` without a Windows SDK image, but **Authenticode signing does not require Windows**: you can `dotnet publish -r win-x64` on **Ubuntu** (already works in the Dockerfile today) and sign the PE with **[osslsigncode](https://github.com/mtrojnar/osslsigncode)** or similar using a **PFX** and OpenSSL, or use **AzureSignTool** from a Linux job against **Azure Key Vault** (JWT auth, no exportable key). **Windows is not mandatory** - it is simply the most common choice because `signtool` ships on `windows-latest` and official docs target it.
 
 **Two viable GHA patterns:**
 
@@ -81,8 +81,8 @@ Either way, produce a single **`graymoon-agent.exe`** artifact for the Docker jo
    - **Self-signed / private CA:** You *can* create a self-signed cert (e.g. `New-SelfSignedCertificate` with `Type CodeSigningCert` on Windows, or OpenSSL) and sign with `signtool` / `osslsigncode`. The PE will show as signed, and the pipeline is valid for **learning CI** or **strictly internal** machines where you deploy your own root as trusted. For **end users and AV**, a self-signed signature does **not** substitute for a public CA: the publisher is still “unknown” to the world, SmartScreen may still warn, and **false positives are unlikely to improve** in a meaningful way. Timestamping self-signed builds usually uses a public TSA anyway (fine) but does not fix trust of the publisher identity.
 2. **Private key usable in CI**
    - **PFX path:** Export a `.pfx` (password-protected) from the CA workflow or certificate manager. Store in GitHub as a **secret** (e.g. Base64-encoded `WINDOWS_CODE_SIGNING_PFX_B64`) and a second secret for the **PFX password**. Restrict which branches/workflows can use these secrets (environment protection rules recommended).
-   - **Key Vault path (preferred for production):** Certificate/key non-exportable in Azure Key Vault; GHA uses OIDC (`azure/login`) + AzureSignTool with `-kv` options — no long-lived PFX in secrets.
-3. **Repository settings:** Secrets (and optional **Environments** with required reviewers) available to the workflow; note **fork PRs do not receive secrets** — workflow should `if: secrets... != ''` to skip signing and still upload an unsigned artifact, or fail only on protected branches as you prefer.
+   - **Key Vault path (preferred for production):** Certificate/key non-exportable in Azure Key Vault; GHA uses OIDC (`azure/login`) + AzureSignTool with `-kv` options - no long-lived PFX in secrets.
+3. **Repository settings:** Secrets (and optional **Environments** with required reviewers) available to the workflow; note **fork PRs do not receive secrets** - workflow should `if: secrets... != ''` to skip signing and still upload an unsigned artifact, or fail only on protected branches as you prefer.
 4. **Timestamping (strongly recommended):** A public **RFC3161** timestamp URL (your CA usually documents one, e.g. DigiCert/Sectigo HTTP TS) so the signature stays valid after the signing cert expires.
 5. **For `signtool` on Windows runners:** `windows-latest` already includes the Windows SDK; locate `signtool.exe` under `Program Files (x86)\Windows Kits\10\bin\<version>\x64\` (or use `vswhere`/known version pin). No separate SDK install step is usually required.
 6. **For `osslsigncode` on Linux:** Install the package or download a release binary in a workflow step; ensure OpenSSL can read the PFX (decrypt with password from secret).
@@ -90,22 +90,22 @@ Either way, produce a single **`graymoon-agent.exe`** artifact for the Docker jo
 **Secrets / variables (illustrative names)**
 
 - PFX flow: `CODE_SIGNING_PFX_B64`, `CODE_SIGNING_PFX_PASSWORD`, optional `CODE_SIGNING_TIMESTAMP_URL`.
-- Key Vault flow: Azure service principal or OIDC federated credential, `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_SUBSCRIPTION_ID`, Key Vault URI, certificate name — per AzureSignTool docs.
+- Key Vault flow: Azure service principal or OIDC federated credential, `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_SUBSCRIPTION_ID`, Key Vault URI, certificate name - per AzureSignTool docs.
 
 **Docker build job** (`needs: build-agent-windows` or whatever job produces the exe):
 
 - `actions/download-artifact` into a fixed path (e.g. `docker/agent-windows/graymoon-agent.exe`).
 - [`Dockerfile`](Dockerfile): **remove** in-container `dotnet publish ... win-x64`; **`COPY`** the artifact into `/agent/publish-win/` as before.
 
-**Local `docker build`:** Without the artifact, COPY fails — optional README or `docker-build.ps1` prerequisite (publish win-x64 to the expected folder).
+**Local `docker build`:** Without the artifact, COPY fails - optional README or `docker-build.ps1` prerequisite (publish win-x64 to the expected folder).
 
 ## 4. Further actions to reduce AV false positives (recommendations)
 
 - **Authenticode:** Prefer a **standard code-signing** cert (EV if budget allows); builds reputation faster. Use a **public timestamp** (`/tr` HTTP RFC3161) so signatures stay valid after cert expiry.
 - **Microsoft:** Submit false positives via [Microsoft Security Intelligence](https://www.microsoft.com/en-us/wdsi/filesubmission) when SmartScreen/Defender flags the file.
 - **Bitdefender:** Use their consumer/business false-positive report flow with the **signed** binary hash and version metadata.
-- **Assembly / file metadata:** Ensure [`GrayMoon.Agent.csproj`](src/GrayMoon.Agent/GrayMoon.Agent.csproj) sets `Company`, `Product`, `Copyright`, and optionally `ApplicationIcon` / `AssemblyTitle` — improves heuristics vs generic “unknown .NET single-file”.
+- **Assembly / file metadata:** Ensure [`GrayMoon.Agent.csproj`](src/GrayMoon.Agent/GrayMoon.Agent.csproj) sets `Company`, `Product`, `Copyright`, and optionally `ApplicationIcon` / `AssemblyTitle` - improves heuristics vs generic “unknown .NET single-file”.
 - **Behavior reputation:** Avoid obfuscation; keep download URLs **HTTPS** only in production; versioned, immutable release assets help.
-- **Single-file:** `PublishSingleFile` can look suspicious to some heuristics; if problems persist after signing, consider publishing **non-single-file** for the downloadable Windows agent only (larger payload, often better reputation) — tradeoff to revisit only if needed.
+- **Single-file:** `PublishSingleFile` can look suspicious to some heuristics; if problems persist after signing, consider publishing **non-single-file** for the downloadable Windows agent only (larger payload, often better reputation) - tradeoff to revisit only if needed.
 
-No change required to [`AgentEndpoints.cs`](src/GrayMoon.App/Api/Endpoints/AgentEndpoints.cs) unless you add new placeholders (optional: `{INSTALL_DIR}` for support docs — not necessary for functionality).
+No change required to [`AgentEndpoints.cs`](src/GrayMoon.App/Api/Endpoints/AgentEndpoints.cs) unless you add new placeholders (optional: `{INSTALL_DIR}` for support docs - not necessary for functionality).

--- a/.cursor/plans/agent_queue_per_workspace_ui_cacd7431.plan.md
+++ b/.cursor/plans/agent_queue_per_workspace_ui_cacd7431.plan.md
@@ -5,7 +5,7 @@ todos: []
 isProject: false
 ---
 
-# Agent queue per workspace – UI and state exposure
+# Agent queue per workspace - UI and state exposure
 
 ## Context
 
@@ -41,7 +41,7 @@ flowchart LR
 
 ## Implementation
 
-### 1. SyncBackgroundService – per-workspace pending counts and notification
+### 1. SyncBackgroundService - per-workspace pending counts and notification
 
 **File:** [SyncBackgroundService.cs](src/GrayMoon.App/Services/SyncBackgroundService.cs)
 
@@ -52,7 +52,7 @@ flowchart LR
   - `public int GetPendingCountForWorkspace(int workspaceId)` → `_pendingCountByWorkspace.GetValueOrDefault(workspaceId)`.
 - Keep `GetQueueDepth()` unchanged (channel count only) for existing API if needed; UI will use the new “pending” (queued + in progress) counts.
 
-### 2. AgentStatusBadge – show "running" when any tasks pending
+### 2. AgentStatusBadge - show "running" when any tasks pending
 
 **File:** [AgentStatusBadge.razor](src/GrayMoon.App/Components/Shared/AgentStatusBadge.razor)
 
@@ -61,7 +61,7 @@ flowchart LR
 - **StateLabel**: If `State == AgentConnectionState.Online` and `SyncBackgroundService.GetTotalPendingCount() > 0` → `"running"`; otherwise keep current logic ("online", "update", "offline", etc.).
 - **TitleText**: When showing "running", set title to something like "Agent is running tasks" (and keep existing titles for other states).
 
-### 3. WorkspaceRepositoriesHeader – "Completing x agent tasks..." on the right
+### 3. WorkspaceRepositoriesHeader - "Completing x agent tasks..." on the right
 
 **File:** [WorkspaceRepositoriesHeader.razor](src/GrayMoon.App/Components/Shared/WorkspaceRepositoriesHeader.razor)
 
@@ -71,7 +71,7 @@ flowchart LR
   - When `AgentTasksPendingCount > 0`, add: `<span class="workspace-repos-agent-tasks text-muted">Completing @AgentTasksPendingCount agent task@(AgentTasksPendingCount == 1 ? "" : "s")...</span>`.
 - **Layout**: The title row already uses `display: flex; flex-wrap: wrap`. Use `margin-left: auto` on the agent-tasks span (or rely on the spacer) so it aligns to the right; when the row wraps on narrow viewports, the agent-tasks text will move to the next line so it does not overlap the title/subtitle. Add a small class in [WorkspaceRepositories.razor.css](src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.css) (or [app.css](src/GrayMoon.App/wwwroot/app.css)) for the spacer and agent-tasks span if needed (e.g. `flex-shrink: 0` so the text doesn’t get squashed).
 
-### 4. WorkspaceRepositories page – feed count and subscribe
+### 4. WorkspaceRepositories page - feed count and subscribe
 
 **File:** [WorkspaceRepositories.razor](src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor) and code-behind (or `@code`)
 
@@ -80,7 +80,7 @@ flowchart LR
 - Compute `agentTasksPendingCount = SyncBackgroundService.GetPendingCountForWorkspace(WorkspaceId)` (use the page’s `WorkspaceId`).
 - Pass `AgentTasksPendingCount="@agentTasksPendingCount"` to `<WorkspaceRepositoriesHeader ... />`.
 
-### 5. Optional for later – HasWorkspaceJobsPending
+### 5. Optional for later - HasWorkspaceJobsPending
 
 - Add to **SyncBackgroundService** (or a small facade if you prefer):  
 `public bool HasWorkspaceJobsPending(int workspaceId) => GetPendingCountForWorkspace(workspaceId) > 0;`

--- a/.cursor/plans/agent_queue_ui_agent_side.plan.md
+++ b/.cursor/plans/agent_queue_ui_agent_side.plan.md
@@ -5,7 +5,7 @@ todos: []
 isProject: false
 ---
 
-# Agent queue per workspace – UI (using agent’s job queue)
+# Agent queue per workspace - UI (using agent’s job queue)
 
 ## Clarification
 
@@ -14,9 +14,9 @@ isProject: false
 
 ## Context
 
-- **Agent queue**: [IJobQueue](src/GrayMoon.Agent/Abstractions/IJobQueue.cs) / [JobQueue](src/GrayMoon.Agent/Queue/JobQueue.cs) – a `Channel<JobEnvelope>`. Jobs are either `Command` (from app’s RequestCommand) or `Notify` (from hooks). No count or per-workspace API today.
+- **Agent queue**: [IJobQueue](src/GrayMoon.Agent/Abstractions/IJobQueue.cs) / [JobQueue](src/GrayMoon.Agent/Queue/JobQueue.cs) - a `Channel<JobEnvelope>`. Jobs are either `Command` (from app’s RequestCommand) or `Notify` (from hooks). No count or per-workspace API today.
 - **Workspace on jobs**: `NotifyJob` has `WorkspaceId` ([INotifyJob](src/GrayMoon.Agent/Abstractions/INotifyJob.cs)). Command requests often have `WorkspaceId` (e.g. [SyncRepositoryRequest](src/GrayMoon.Agent/Jobs/Requests/SyncRepositoryRequest.cs), [CommitSyncRepositoryRequest](src/GrayMoon.Agent/Jobs/Requests/CommitSyncRepositoryRequest.cs)); some (e.g. GetHostInfo) do not.
-- **App–agent comms**: Agent connects to app’s [AgentHub](src/GrayMoon.App/Hubs/AgentHub.cs). Agent calls hub methods (e.g. [ReportSemVer](src/GrayMoon.Abstractions/Agent/AgentHubMethods.cs)); app handles them in `AgentHub`. App does not reference GrayMoon.Agent, only GrayMoon.Abstractions.
+- **App-agent comms**: Agent connects to app’s [AgentHub](src/GrayMoon.App/Hubs/AgentHub.cs). Agent calls hub methods (e.g. [ReportSemVer](src/GrayMoon.Abstractions/Agent/AgentHubMethods.cs)); app handles them in `AgentHub`. App does not reference GrayMoon.Agent, only GrayMoon.Abstractions.
 
 ## Architecture
 
@@ -47,14 +47,14 @@ flowchart LR
 
 ## Implementation
 
-### 1. Abstractions – new hub method name
+### 1. Abstractions - new hub method name
 
 **File:** [AgentHubMethods.cs](src/GrayMoon.Abstractions/Agent/AgentHubMethods.cs)
 
 - Add: `public const string ReportQueueStatus = "ReportQueueStatus";`
 - Optional: define a small DTO for the payload (e.g. `AgentQueueStatusDto { int Total; Dictionary<int,int> ByWorkspace; }`) in Abstractions if you want a shared contract; otherwise app and agent can agree on (int total, Dictionary<int,int>? byWorkspace) or (int total, IEnumerable<(int workspaceId, int count)>).
 
-### 2. Agent – extract workspace ID from JobEnvelope
+### 2. Agent - extract workspace ID from JobEnvelope
 
 **File:** New helper in GrayMoon.Agent (e.g. `JobEnvelopeExtensions.cs` or inside the tracker)
 
@@ -63,9 +63,9 @@ flowchart LR
   - If `Kind == Command` and `CommandJob?.Request` has a property `WorkspaceId` (reflection or type checks for known request types) → return its value.
   - Otherwise return `null` (e.g. GetHostInfo). Jobs without a workspace can be counted only in “total”, not in any workspace.
 
-### 3. Agent – queue tracker and reporting
+### 3. Agent - queue tracker and reporting
 
-**Option A – Wrapper around the channel (recommended)**
+**Option A - Wrapper around the channel (recommended)**
 
 - New type `TrackedJobQueue : IJobQueue` in the Agent project. It holds the real `Channel<JobEnvelope>` (or the existing `JobQueue` as a dependency if you refactor it to expose the channel).
 - **EnqueueAsync**: Resolve workspace ID with `TryGetWorkspaceId(envelope)`. Increment total and, if workspace is not null, increment per-workspace count. Write to the inner channel. Then notify the app (see below).
@@ -73,11 +73,11 @@ flowchart LR
 - **Notify app**: When counts change, get `IHubConnectionProvider` (or the connection from the hosted service), and if connected, call `InvokeAsync(AgentHubMethods.ReportQueueStatus, total, byWorkspace)`. Pass a serializable representation of byWorkspace (e.g. `Dictionary<int,int>` or list of key-value pairs). Fire-and-forget (e.g. `_ = NotifyAppAsync()`) so the worker thread doesn’t block.
 - Register `TrackedJobQueue` as `IJobQueue` in the agent’s DI; remove or replace the previous `JobQueue` registration so the rest of the agent (SignalRConnectionHostedService, JobBackgroundService, HookListenerHostedService) uses the tracked queue.
 
-**Option B – Instrument existing JobQueue**
+**Option B - Instrument existing JobQueue**
 
 - If the agent’s `JobQueue` is a simple wrapper around a channel, add counting and reporting inside it (increment on write, decrement when the reader advances). Same idea as above, but without a separate “TrackedJobQueue” type.
 
-### 4. App – receive and store agent queue state
+### 4. App - receive and store agent queue state
 
 - **New singleton**: `AgentQueueStateService` (or extend `AgentConnectionTracker`). It holds:
   - `int _totalPending`
@@ -87,7 +87,7 @@ flowchart LR
 - **On agent disconnect**: In `AgentHub.OnDisconnectedAsync`, when the disconnecting client is the agent, clear queue state (total = 0, byWorkspace empty) and raise the event so the badge and page update.
 - **Expose**: `GetTotalPendingCount()`, `GetPendingCountForWorkspace(int workspaceId)`, `HasWorkspaceJobsPending(int workspaceId)`, and a way for components to subscribe (e.g. `OnQueueStateChanged(Action callback)` that invokes the callback when `QueueStateChanged` fires).
 
-### 5. App – UI (badge and workspace page)
+### 5. App - UI (badge and workspace page)
 
 - **AgentStatusBadge**: Inject `AgentQueueStateService` (or the service that holds queue state). Subscribe to queue state changes and call `InvokeAsync(StateHasChanged)`. **StateLabel**: If `State == AgentConnectionState.Online` and `GetTotalPendingCount() > 0` → `"running"`; otherwise keep current labels. **TitleText**: When showing “running”, use e.g. “Agent is running tasks”. Unsubscribe on `Dispose`.
 - **WorkspaceRepositoriesHeader**: Keep parameter `AgentTasksPendingCount` and the “Completing x agent tasks…” block (right-aligned, same row, no overlap when narrow). No change to layout/CSS.

--- a/.cursor/plans/decouple_dependency_update_logic.plan.md
+++ b/.cursor/plans/decouple_dependency_update_logic.plan.md
@@ -8,7 +8,7 @@
 
 ## Current state
 
-- **Update flow** is driven from [WorkspaceRepositories.razor.cs](src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs) and implemented in [WorkspaceGitService.RunUpdateAsync](src/GrayMoon.App/Services/WorkspaceGitService.cs) (lines 504–679), which mixes refresh, plan, multi/single-level branching, sync, commit, and refresh version in one long method.
+- **Update flow** is driven from [WorkspaceRepositories.razor.cs](src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs) and implemented in [WorkspaceGitService.RunUpdateAsync](src/GrayMoon.App/Services/WorkspaceGitService.cs) (lines 504-679), which mixes refresh, plan, multi/single-level branching, sync, commit, and refresh version in one long method.
 - **Progress** is reported via `Action<string> setProgress`; the page shows it in [LoadingOverlay](src/GrayMoon.App/Components/Shared/LoadingOverlay.razor) with "Running x tasks…" when awaiting agent tasks.
 - **Csproj commits**: Paths in [CommitDependencyUpdatesAsync](src/GrayMoon.App/Services/WorkspaceGitService.cs) should be normalized (repo-relative, forward slashes) to avoid commit bugs.
 
@@ -44,11 +44,11 @@ flowchart LR
 - **Location**: New file `src/GrayMoon.App/Services/DependencyUpdateOrchestrator.cs`.
 - **Signature**: `RunAsync(workspaceId, cancellationToken, setProgress, onRepoError, onAppSideComplete, repoIdsToUpdate?)` returning `Task` (no payload return).
 - **Steps** (clear, commented):
-  1. **Refresh projects** — `RefreshWorkspaceProjectsAsync`; stop on error.
-  2. **Get update plan** — `GetUpdatePlanAsync`. If empty, `RecomputeAndBroadcastWorkspaceSyncedAsync`, invoke `onAppSideComplete`, return.
+  1. **Refresh projects** - `RefreshWorkspaceProjectsAsync`; stop on error.
+  2. **Get update plan** - `GetUpdatePlanAsync`. If empty, `RecomputeAndBroadcastWorkspaceSyncedAsync`, invoke `onAppSideComplete`, return.
   3. **Multi-level**: For each level (ascending): sync deps for that level → commit for that level (required before next level) → refresh version for that level; invoke `onAppSideComplete` where appropriate; stop on error.
   4. **Single-level**: Sync all → commit all → refresh version for all; then `onAppSideComplete` and `RecomputeAndBroadcastWorkspaceSyncedAsync`.
-  5. **Finalize** — `RecomputeAndBroadcastWorkspaceSyncedAsync`; invoke `onAppSideComplete`.
+  5. **Finalize** - `RecomputeAndBroadcastWorkspaceSyncedAsync`; invoke `onAppSideComplete`.
 
 ### 2. Fix csproj commit path handling
 
@@ -75,11 +75,11 @@ flowchart LR
 
 ## Files to change
 
-- [WorkspaceGitService.cs](src/GrayMoon.App/Services/WorkspaceGitService.cs) — Path normalization in `CommitDependencyUpdatesAsync`; delegate `RunUpdateAsync` to orchestrator or remove.
-- [WorkspaceUpdateHandler.cs](src/GrayMoon.App/Services/WorkspaceUpdateHandler.cs) — Call orchestrator; remove payload return and "update only" handling.
-- [WorkspaceRepositories.razor.cs](src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs) — Use orchestrator only; remove "Update only" and "commit later" flows.
-- [UpdateDependenciesModal.razor](src/GrayMoon.App/Components/Modals/UpdateDependenciesModal.razor) — Remove "Update only" button and related parameters.
-- DI registration — Register `DependencyUpdateOrchestrator`.
+- [WorkspaceGitService.cs](src/GrayMoon.App/Services/WorkspaceGitService.cs) - Path normalization in `CommitDependencyUpdatesAsync`; delegate `RunUpdateAsync` to orchestrator or remove.
+- [WorkspaceUpdateHandler.cs](src/GrayMoon.App/Services/WorkspaceUpdateHandler.cs) - Call orchestrator; remove payload return and "update only" handling.
+- [WorkspaceRepositories.razor.cs](src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs) - Use orchestrator only; remove "Update only" and "commit later" flows.
+- [UpdateDependenciesModal.razor](src/GrayMoon.App/Components/Modals/UpdateDependenciesModal.razor) - Remove "Update only" button and related parameters.
+- DI registration - Register `DependencyUpdateOrchestrator`.
 
 ## Result
 

--- a/.cursor/plans/multi-workflow_actions_grid_b201ec86.plan.md
+++ b/.cursor/plans/multi-workflow_actions_grid_b201ec86.plan.md
@@ -22,7 +22,7 @@ isProject: false
 ## Current behavior (problem)
 
 - [`GitHubActionsService.GetAggregateActionStatusForBranchAsync`](src/GrayMoon.App/Services/GitHubActionsService.cs) loads all runs for the branch, groups by `WorkflowId`, then **picks one “primary” run** and returns a single [`ActionStatusInfo`](src/GrayMoon.App/Models/ActionStatusInfo.cs). The UI in [`WorkspaceActions.razor`](src/GrayMoon.App/Components/Pages/WorkspaceActions.razor) / [`WorkspaceActions.razor.cs`](src/GrayMoon.App/Components/Pages/WorkspaceActions.razor.cs) binds one status and one Run/Re-run button to that aggregate.
-- Persistence in [`WorkspaceActionRepository`](src/GrayMoon.App/Repositories/WorkspaceActionRepository.cs) / [`WorkspaceRepositoryAction`](src/GrayMoon.App/Models/WorkspaceRepositoryAction.cs) is **one row per workspace–repository link**, storing only one workflow’s fields.
+- Persistence in [`WorkspaceActionRepository`](src/GrayMoon.App/Repositories/WorkspaceActionRepository.cs) / [`WorkspaceRepositoryAction`](src/GrayMoon.App/Models/WorkspaceRepositoryAction.cs) is **one row per workspace-repository link**, storing only one workflow’s fields.
 
 ## Target behavior
 
@@ -33,7 +33,7 @@ isProject: false
 - **Striping**: remove `table-striped` and apply **one background per repository group** (first + continuation rows share the same class), matching your option “sub-rows same bg as the first” / “colors only change when new repository.” Implement via CSS classes (e.g. `actions-group-0` / `actions-group-1`) in [`WorkspaceActions.razor.css`](src/GrayMoon.App/Components/Pages/WorkspaceActions.razor.css), with colors that work on the existing table body (avoid hard-coded light-only grays if the app supports dark tables; prefer `rgba` overlays or Bootstrap CSS variables where possible).
 - **Header counts** (`FailedCount`, `RunningCount`, etc.): count **workflow lines**, not repos, so badges stay meaningful.
 - **Sorting**: sort **repository groups** by worst status across their workflows (failed &lt; running &lt; success &lt; none), same priority as today’s `GetStatusSortOrder`; stable secondary sort by repo name.
-- **Errors** (GitHub fetch failure): treat as **repo-level**; show [`ActionBadge`](src/GrayMoon.App/Components/Shared/ActionBadge.razor) with `ErrorMessage` only on the **first** line of the group; other lines get no duplicate error badge (empty status or “—” as you prefer).
+- **Errors** (GitHub fetch failure): treat as **repo-level**; show [`ActionBadge`](src/GrayMoon.App/Components/Shared/ActionBadge.razor) with `ErrorMessage` only on the **first** line of the group; other lines get no duplicate error badge (empty status or “-” as you prefer).
 
 ## Backend / GitHub API
 
@@ -45,7 +45,7 @@ isProject: false
    - Load branch runs via existing `GetWorkflowRunsForBranchAsync`.
    - Build **latest run per `WorkflowId`** (reuse the existing grouping logic).
    - For **each** listed workflow (sorted by name): emit an `ActionStatusInfo` with `BranchName = branch`, `WorkflowId` / `WorkflowName` from the workflow definition, and if a latest run exists set `Status` / `HtmlUrl` / `UpdatedAt` / `RunId` from **that run only** (map conclusion/status using the same rules as today: failure conclusions → `failed`, non-completed → `running`, else `success`; no run → `none`).
-   - Optionally include runs whose `WorkflowId` is **not** in the workflow list (deleted/renamed workflow files) as extra rows—nice-to-have, not required for the first iteration.
+   - Optionally include runs whose `WorkflowId` is **not** in the workflow list (deleted/renamed workflow files) as extra rows-nice-to-have, not required for the first iteration.
 
 3. **Deprecate or narrow** `GetAggregateActionStatusForBranchAsync`: either remove if unused after the change or keep as a thin wrapper only if something else needs it (today only [`WorkspaceActionService`](src/GrayMoon.App/Services/WorkspaceActionService.cs) calls it).
 
@@ -59,7 +59,7 @@ isProject: false
 ## Workspace UI state model
 
 - Extend [`WorkspaceActionRow`](src/GrayMoon.App/Components/Pages/WorkspaceActions.razor.cs) with a **`List<WorkflowActionLine>`** (name TBD) holding `ActionStatusInfo` (or equivalent) and **`RunInProgress` per workflow** (move off the repo row).
-- Replace repo-level `Action` with the list (or keep `Action` only during transition—prefer removing to avoid ambiguity).
+- Replace repo-level `Action` with the list (or keep `Action` only during transition-prefer removing to avoid ambiguity).
 - **`RefreshRowAsync`**: call updated `FetchAndPersistAsync` that returns `IReadOnlyList<ActionStatusInfo>`, assign to the row’s lines.
 - **`RunWorkflowAsync` / `RerunWorkflowAsync`**: take the **line** (or `workflowId` + row) so `BuildActionEntry` uses **that** workflow’s ids; after success, refresh the **whole repo** row once (same as today).
 - **`RerunAllFailedAsync`**: iterate **failed workflow lines** that have `RunId`, not one row per repo.
@@ -68,7 +68,7 @@ isProject: false
 
 ## Razor / CSS
 
-- Table columns: **Repository | Branch | Workflow | Status | Actions** (drop Last checked; [`WorkspaceActions.razor.css`](src/GrayMoon.App/Components/Pages/WorkspaceActions.razor.css) already defines `.col-workflow`—wire it to the new column and rebalance widths vs `.col-repo`).
+- Table columns: **Repository | Branch | Workflow | Status | Actions** (drop Last checked; [`WorkspaceActions.razor.css`](src/GrayMoon.App/Components/Pages/WorkspaceActions.razor.css) already defines `.col-workflow`-wire it to the new column and rebalance widths vs `.col-repo`).
 - Remove `table-striped` from the `<table>` class list; add **group index** classes on each `<tr>`.
 - Adjust **colspan** for loading/empty rows from 5 → **4**.
 

--- a/.cursor/plans/overlay_awaiting_tasks_toggle_6b061748.plan.md
+++ b/.cursor/plans/overlay_awaiting_tasks_toggle_6b061748.plan.md
@@ -11,17 +11,17 @@ isProject: false
 
 Show **"Awaiting x tasks"** in the overlay only when **all three** are true:
 
-1. **All app-side tasks are completed** – the progress message is in the form "X of Y" with **X == Y** (e.g. "Committed 9 of 9", "Pushed 2 of 2", "Synchronized 10 of 10"), not "3 of 9".
-2. **There are agent tasks still to complete** – `AgentTasksPendingCount > 0` for the current workspace.
-3. **Toggle is on** – `UseAwaitingTasksMessageInOverlay` is true (default false).
+1. **All app-side tasks are completed** - the progress message is in the form "X of Y" with **X == Y** (e.g. "Committed 9 of 9", "Pushed 2 of 2", "Synchronized 10 of 10"), not "3 of 9".
+2. **There are agent tasks still to complete** - `AgentTasksPendingCount > 0` for the current workspace.
+3. **Toggle is on** - `UseAwaitingTasksMessageInOverlay` is true (default false).
 
 So while the app is still doing its part (e.g. "Committed 3 of 9"), the overlay keeps showing "Committed 3 of 9". Only when we reach "Committed 9 of 9" and the overlay is still visible because we're waiting on the agent do we switch the text to "Awaiting x tasks".
 
 ## Key files
 
-- [WorkspaceRepositories.razor](src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor) – LoadingOverlay usages
-- [WorkspaceRepositories.razor.cs](src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs) – progress state, `AgentTasksPendingCount`, `OnQueueStateChanged`
-- [LoadingOverlay.razor](src/GrayMoon.App/Components/Shared/LoadingOverlay.razor) – spinner, optional count in ring, Message display
+- [WorkspaceRepositories.razor](src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor) - LoadingOverlay usages
+- [WorkspaceRepositories.razor.cs](src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs) - progress state, `AgentTasksPendingCount`, `OnQueueStateChanged`
+- [LoadingOverlay.razor](src/GrayMoon.App/Components/Shared/LoadingOverlay.razor) - spinner, optional count in ring, Message display
 
 ## Implementation
 
@@ -32,7 +32,7 @@ So while the app is still doing its part (e.g. "Committed 3 of 9"), the overlay 
 - Add `**GetOverlayMessage(string progressMessage, bool overlayVisible)`**:
   - If overlay not visible, return `progressMessage`.
   - If `!UseAwaitingTasksMessageInOverlay`, return `progressMessage`.
-  - If `!IsCompletedNOfNProgressMessage(progressMessage)`, return `progressMessage` (app still working – e.g. "3 of 9").
+  - If `!IsCompletedNOfNProgressMessage(progressMessage)`, return `progressMessage` (app still working - e.g. "3 of 9").
   - If `AgentTasksPendingCount == 0`, return `progressMessage` (no agent tasks to wait for).
   - Otherwise return **"Awaiting {AgentTasksPendingCount} task(s)"**.
 - Use `GetOverlayMessage(...)` for the Message passed to LoadingOverlay for: sync, push, update, commit sync, sync-to-default. Other overlays keep their static message.

--- a/.cursor/plans/overlay_command_terminal_927bf869.plan.md
+++ b/.cursor/plans/overlay_command_terminal_927bf869.plan.md
@@ -25,7 +25,7 @@ isProject: false
 ## Concurrency and labeling
 
 - **Order**: The terminal does **not** guarantee global chronological ordering across concurrent agent jobs. When multiple repositories run commands in parallel (e.g. parallel sync), stdout/stderr lines may **interleave** in whatever order they arrive over SignalR; that is acceptable.
-- **Repository prefix**: Each displayed line should start with a **repository label** when the command’s request includes a repository identity (e.g. `[RepositoryName]` or `[repo:Name]`), so mixed streams stay readable. When no repo applies (e.g. `GetHostInfo`, `EnsureWorkspace`), use a short fallback such as `[agent]` or omit the bracket and show the hub command name only—pick one convention and apply it consistently.
+- **Repository prefix**: Each displayed line should start with a **repository label** when the command’s request includes a repository identity (e.g. `[RepositoryName]` or `[repo:Name]`), so mixed streams stay readable. When no repo applies (e.g. `GetHostInfo`, `EnsureWorkspace`), use a short fallback such as `[agent]` or omit the bracket and show the hub command name only-pick one convention and apply it consistently.
 - **Implementation note**: Resolve the label in the agent from the **typed job request** already deserialized in `ICommandJob` / `ProcessCommandAsync` (e.g. `repositoryName` on sync/push/checkout requests). Pass `repositoryName` (nullable) alongside `requestId` on each `CommandOutput` hub call so the app can format the prefix without re-parsing JSON.
 
 ## Architecture
@@ -68,25 +68,25 @@ sequenceDiagram
 
 - Add a static `AsyncLocal` + `IDisposable` scope in **GrayMoon.Common** (e.g. `CommandLineStreamScope` / `CommandLineStreamAmbient`) and a small `record` for `{ Kind, Text }` (command line vs stdout vs stderr).
 - Extend [`CommandLineService.RunAsync`](src/GrayMoon.Common/CommandLineService.cs): after the existing DEBUG log line for “Command starting…”, report a **command echo** line to the ambient sink (use existing `LogSafe.ForLog` for arguments); in each `FlushSegment` for stdout/stderr, invoke the ambient sink with the appropriate kind.
-- **Agent** [`JobBackgroundService`](src/GrayMoon.Agent/Hosted/JobBackgroundService.cs): on entering `ProcessCommandAsync`, `Push` a sink that maps ambient events to `connection.InvokeAsync(AgentHubMethods.CommandOutput, requestId, repositoryName, kind, truncatedText)`. Truncate each line (e.g. 2–4K chars) to protect SignalR and UI.
+- **Agent** [`JobBackgroundService`](src/GrayMoon.Agent/Hosted/JobBackgroundService.cs): on entering `ProcessCommandAsync`, `Push` a sink that maps ambient events to `connection.InvokeAsync(AgentHubMethods.CommandOutput, requestId, repositoryName, kind, truncatedText)`. Truncate each line (e.g. 2-4K chars) to protect SignalR and UI.
 - **Non-blocking concern**: avoid `await InvokeAsync` on the same thread that reads the process stdout if that risks pipe backpressure; prefer enqueue + background sender (channel + single worker) if a quick prototype shows stalls. Document this in implementation.
 
 ## 4. In-memory terminal buffer + Blazor updates
 
-- Add a **singleton** service, e.g. `OverlayCommandTerminalService`, registered in [`Program.cs`](src/GrayMoon.App/Program.cs): thread-safe bounded list (e.g. max 500–1000 lines), `IReadOnlyList` snapshot or immutable updates for UI, and `event EventHandler? Changed`. Store each row as `{ RepositoryLabel?, Kind, Text }` or a single **preformatted display string** that already includes the `[repo]` prefix for simplicity.
+- Add a **singleton** service, e.g. `OverlayCommandTerminalService`, registered in [`Program.cs`](src/GrayMoon.App/Program.cs): thread-safe bounded list (e.g. max 500-1000 lines), `IReadOnlyList` snapshot or immutable updates for UI, and `event EventHandler? Changed`. Store each row as `{ RepositoryLabel?, Kind, Text }` or a single **preformatted display string** that already includes the `[repo]` prefix for simplicity.
 - `AgentBridge` appends lines when `ReportStreamLine` fires. **Do not** clear the buffer on every `SendCommandAsync` if multiple agent calls can be in flight (parallel repos); that would drop other repos’ output. Prefer **clear when the loading overlay becomes visible** (transition to shown) or a manual/user reset, and otherwise use a **rolling cap** on total lines only.
 - [`LoadingOverlay.razor`](src/GrayMoon.App/Components/Shared/LoadingOverlay.razor): inject the service; when `IsVisible`, render a terminal region; subscribe to `Changed` and call `InvokeAsync(StateHasChanged)` (mirror existing `AgentQueueStateService` subscription pattern).
 
 ## 5. UI / CSS: look, layering, scroll
 
-- **Layout**: Dock a terminal panel to the **bottom** (~25–35vh), full width, **below** `.loading-overlay-content` in stacking order so the spinner, message, and Abort stay visually dominant. Suggested z-index: above matrix canvas + veil, **below** `.loading-overlay-content` (currently `z-index: 1` in [`loading-overlay.css`](src/GrayMoon.App/wwwroot/css/loading-overlay.css)).
+- **Layout**: Dock a terminal panel to the **bottom** (~25-35vh), full width, **below** `.loading-overlay-content` in stacking order so the spinner, message, and Abort stay visually dominant. Suggested z-index: above matrix canvas + veil, **below** `.loading-overlay-content` (currently `z-index: 1` in [`loading-overlay.css`](src/GrayMoon.App/wwwroot/css/loading-overlay.css)).
 - **Visual**: Dark translucent panel (e.g. `rgba(12, 14, 18, 0.72)` with a subtle top border / inner shadow), **monospace** stack (e.g. `Consolas`, `Cascadia Mono`), muted green/amber for stdout/stderr, slightly brighter/dimmed prompt line for the command echo; optional subtle **dim styling for the `[repo]` prefix** so the rest of the line stays easy to scan when logs are interleaved.
-- **Scroll**: `overflow-y: auto` on the inner container; `@ref` + `OnAfterRenderAsync`: when line count changes and overlay is visible, set `scrollTop = scrollHeight` (JS interop) or scroll last element into view—same pattern as typical chat logs.
+- **Scroll**: `overflow-y: auto` on the inner container; `@ref` + `OnAfterRenderAsync`: when line count changes and overlay is visible, set `scrollTop = scrollHeight` (JS interop) or scroll last element into view-same pattern as typical chat logs.
 - **Accessibility**: `aria-hidden="true"` on the decorative terminal (or `role="log"` with `aria-live="off"` to avoid noisy screen readers during long git output).
 
 ## 6. Edge cases
 
-- **Install/uninstall CLI** and any `RunAsync` before hub is connected: ambient sink unset—no stream; behavior unchanged.
+- **Install/uninstall CLI** and any `RunAsync` before hub is connected: ambient sink unset-no stream; behavior unchanged.
 - **Notify jobs** that might run processes without `ProcessCommandAsync` scope: no stream unless you later extend scope there (optional follow-up).
 - **Multiple `LoadingOverlay` instances** (e.g. [`WorkspaceRepositories.razor`](src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor)): each visible overlay can render the same singleton buffer; typically only one overlay is visible.
 
@@ -96,7 +96,7 @@ sequenceDiagram
 |------|--------|
 | Contracts | [`AgentHubMethods.cs`](src/GrayMoon.Abstractions/Agent/AgentHubMethods.cs), new stream line type/enum in Abstractions |
 | Common | [`CommandLineService.cs`](src/GrayMoon.Common/CommandLineService.cs), new ambient scope type |
-| Agent | [`JobBackgroundService.cs`](src/GrayMoon.Agent/Hosted/JobBackgroundService.cs), [`SignalRConnectionHostedService.cs`](src/GrayMoon.Agent/Hosted/SignalRConnectionHostedService.cs) only if hub client needs to know new method (server invokes from agent—no client `On` needed) |
+| Agent | [`JobBackgroundService.cs`](src/GrayMoon.Agent/Hosted/JobBackgroundService.cs), [`SignalRConnectionHostedService.cs`](src/GrayMoon.Agent/Hosted/SignalRConnectionHostedService.cs) only if hub client needs to know new method (server invokes from agent-no client `On` needed) |
 | App hub + delivery | [`AgentHub.cs`](src/GrayMoon.App/Hubs/AgentHub.cs), [`AgentResponseDelivery.cs`](src/GrayMoon.App/Services/AgentResponseDelivery.cs), [`AgentBridge.cs`](src/GrayMoon.App/Services/AgentBridge.cs) |
 | UI | [`LoadingOverlay.razor`](src/GrayMoon.App/Components/Shared/LoadingOverlay.razor), [`loading-overlay.css`](src/GrayMoon.App/wwwroot/css/loading-overlay.css) |
 

--- a/.cursor/plans/push_modal_and_dependency_service_e671b1b4.plan.md
+++ b/.cursor/plans/push_modal_and_dependency_service_e671b1b4.plan.md
@@ -25,9 +25,9 @@ So the modal appears whenever there are dependencies, even if all dependency rep
 
 | Role                          | File                                                                                                                                                                       |
 | ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Push flow (badge + header)    | [WorkspaceRepositories.razor.cs](src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs) — `OnPushBadgeClickAsync`, `OnPushClickAsync`                           |
-| Push handler (plan + execute) | [WorkspacePushHandler.cs](src/GrayMoon.App/Services/WorkspacePushHandler.cs) — get dep info today; will stop returning dep info for modal decision                         |
-| Push dependency data          | [WorkspaceProjectRepository.cs](src/GrayMoon.App/Repositories/WorkspaceProjectRepository.cs) — `GetPushDependencyInfoForRepoAsync`, `GetPushDependencyInfoForRepoSetAsync` |
+| Push flow (badge + header)    | [WorkspaceRepositories.razor.cs](src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs) - `OnPushBadgeClickAsync`, `OnPushClickAsync`                           |
+| Push handler (plan + execute) | [WorkspacePushHandler.cs](src/GrayMoon.App/Services/WorkspacePushHandler.cs) - get dep info today; will stop returning dep info for modal decision                         |
+| Push dependency data          | [WorkspaceProjectRepository.cs](src/GrayMoon.App/Repositories/WorkspaceProjectRepository.cs) - `GetPushDependencyInfoForRepoAsync`, `GetPushDependencyInfoForRepoSetAsync` |
 | “Needs push” definition       | Same as existing: `(OutgoingCommits ?? 0) > 0                                                                                                                              |
 
 

--- a/.cursor/rules/hyphens-not-em-en-dashes.mdc
+++ b/.cursor/rules/hyphens-not-em-en-dashes.mdc
@@ -1,0 +1,20 @@
+---
+description: Use ASCII hyphen (-) only; never em dash or en dash in project text.
+alwaysApply: true
+---
+
+# Hyphens only (no em dash or en dash)
+
+Do **not** use Unicode **em dash** (U+2014) or **en dash** (U+2013). Always use the regular **ASCII hyphen-minus** (`-`, U+002D).
+
+Applies to user-visible strings, UI markup, comments, XML docs, logs, CSS comments, Markdown, and internal docs (including `.cursor/plans/`). Do not introduce smart-quote typography that substitutes hyphens for em/en dashes.
+
+**Examples**
+
+- Prefer: `Step 1 - overview` (ASCII hyphen)
+- Avoid: `Step 1` + em dash + `overview`
+- Numeric spans in prose or docs: `0.1-2` not an en dash between numbers
+- Compound terms: `workspace-repository link` not an en dash between words
+- Empty table cells may use `-` as a placeholder
+
+Third-party vendored sources (e.g. `bootstrap.min.css`, icon fonts) are excluded from edits unless the project intentionally forks them.

--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ docker pull jandini/graymoon:latest && docker stop graymoon || true && docker rm
 
 The app runs in a container and does not run git or access your workspace filesystem. A **host-side agent** does that: it runs on the machine where your repos live, connects to the app via SignalR, and runs git, GitVersion, and workspace I/O.
 
-1. **Download** — On the home page, use **Download Agent**. Your browser gets a **zip** of the framework-dependent build (Windows or Linux): extract it and run `graymoon-agent` / `graymoon-agent.exe`. The host needs the **.NET 8 runtime** installed for that RID.
-2. **Run on the host** — Run the agent on the same machine (or network) as your repositories, e.g. as a console app or Windows/Linux service.
+1. **Download** - On the home page, use **Download Agent**. Your browser gets a **zip** of the framework-dependent build (Windows or Linux): extract it and run `graymoon-agent` / `graymoon-agent.exe`. The host needs the **.NET 8 runtime** installed for that RID.
+2. **Run on the host** - Run the agent on the same machine (or network) as your repositories, e.g. as a console app or Windows/Linux service.
 
 When the agent is connected, the app shows an **online** badge; sync and repository operations use the agent.
 

--- a/docs/Commit-Divergence-Design.md
+++ b/docs/Commit-Divergence-Design.md
@@ -1,4 +1,4 @@
-# Commit Divergence – Design Document
+# Commit Divergence - Design Document
 
 ## Overview
 
@@ -15,13 +15,13 @@ All counts are relative to the **default branch** (e.g. `origin/main` or `origin
 - **Behind:** Commits on the default branch that are not in the current branch. (Current branch is behind default.)
 - **Ahead:** Commits on the current branch that are not in the default branch. (Current branch is ahead of default.)
 
-When the default branch cannot be determined, show `—` or `— | —`. The existing **Commits** column keeps its role (colored badge + push/pull vs tracking branch); this column is a compact, read-only display of divergence vs default branch.
+When the default branch cannot be determined, show `-` or `- | -`. The existing **Commits** column keeps its role (colored badge + push/pull vs tracking branch); this column is a compact, read-only display of divergence vs default branch.
 
 ---
 
 ## 2. How the Information Is Obtained
 
-### 2.1 Agent (Git) side – vs default branch
+### 2.1 Agent (Git) side - vs default branch
 
 The agent must compute **behind** and **ahead** against the **default branch** (e.g. `main`/`master`), not the tracking branch.
 
@@ -38,21 +38,21 @@ The agent must compute **behind** and **ahead** against the **default branch** (
 - **A) Extend `GetCommitCountsAsync`** to also return default-branch counts (e.g. `defaultBehind`, `defaultAhead`), in addition to existing tracking-branch counts (for the Commits badge). One round-trip; sync/refresh/hooks all get both.
 - **B) New method** `GetCommitCountsVsDefaultAsync` (or a dedicated command) that returns only default-branch behind/ahead. App calls it when building the divergence column (or in parallel with existing GetCommitCounts).
 
-Recommendation: **A** – extend the existing response so sync, refresh, and every hook flow automatically get default-branch counts without extra calls.
+Recommendation: **A** - extend the existing response so sync, refresh, and every hook flow automatically get default-branch counts without extra calls.
 
 **Response shape (add to existing commit-counts response):**
 
-- `DefaultBranchBehind` (int?) – commits on default not in current branch.
-- `DefaultBranchAhead` (int?) – commits on current branch not in default.
+- `DefaultBranchBehind` (int?) - commits on default not in current branch.
+- `DefaultBranchAhead` (int?) - commits on current branch not in default.
 
 When default branch cannot be resolved or rev-list fails, return null for both.
 
 ### 2.2 Who uses the data
 
-- **GetCommitCountsCommand** – extend to return default-branch counts.
-- **SyncRepositoryCommand** – include default-branch counts in response.
-- **RefreshRepositoryVersionCommand** – include default-branch counts.
-- **Hook sync commands** – include default-branch counts in SyncCommand payload.
+- **GetCommitCountsCommand** - extend to return default-branch counts.
+- **SyncRepositoryCommand** - include default-branch counts in response.
+- **RefreshRepositoryVersionCommand** - include default-branch counts.
+- **Hook sync commands** - include default-branch counts in SyncCommand payload.
 
 ### 2.3 App side
 
@@ -66,7 +66,7 @@ When default branch cannot be resolved or rev-list fails, return null for both.
 
 - **Model:** `WorkspaceRepositoryLink`:
   - **Existing** (unchanged for Commits badge): `OutgoingCommits`, `IncomingCommits` (vs tracking branch), `BranchHasUpstream`.
-  - **New:** `DefaultBranchBehindCommits` (int?), `DefaultBranchAheadCommits` (int?) – used only by the Divergence column (vs default branch).
+  - **New:** `DefaultBranchBehindCommits` (int?), `DefaultBranchAheadCommits` (int?) - used only by the Divergence column (vs default branch).
 - **When persisted:** Same as today for sync/refresh/push/hooks; in addition, persist the new default-branch fields whenever the agent includes them in the response or SyncCommand.
 - **Migration:** Add two nullable int columns to `WorkspaceRepositories`.
 
@@ -82,12 +82,12 @@ When default branch cannot be resolved or rev-list fails, return null for both.
 
 ### 4.2 Display Format
 
-**Option A – Simple (recommended for first version)**  
+**Option A - Simple (recommended for first version)**  
 - Format: `behind | ahead` (e.g. `0 | 12`, `2 | 0`).
 - Pipe `|` in gray (e.g. `color: #6c757d` or Bootstrap `text-muted`).
-- When unknown (no upstream and no counts): show `—` or `— | —`.
+- When unknown (no upstream and no counts): show `-` or `- | -`.
 
-**Option B – GitHub-style**  
+**Option B - GitHub-style**  
 - Same semantics, with a small visual indicator:
   - “Behind” has a short line under the number when behind &gt; 0 (e.g. `2̣` or `2_` with underline).
   - “Ahead” has a short line under the number when ahead &gt; 0 (e.g. `1̣` or `_1`).
@@ -95,7 +95,7 @@ When default branch cannot be resolved or rev-list fails, return null for both.
 - Implement with a small inline element (e.g. `span` with `border-bottom` or a tiny SVG line) so it looks like a minimal branch diagram.
 
 **Empty / no branch:**  
-- If `BranchName` is empty or repo not cloned, show `—` in the divergence cell.
+- If `BranchName` is empty or repo not cloned, show `-` in the divergence cell.
 
 **Data source:** Use `DefaultBranchBehindCommits` and `DefaultBranchAheadCommits` (not `IncomingCommits`/`OutgoingCommits`, which remain for the Commits badge).
 

--- a/docs/Dependency-Level-Sync-Analysis.md
+++ b/docs/Dependency-Level-Sync-Analysis.md
@@ -64,7 +64,7 @@ So **sync-all** both **refreshes** project dependencies from disk for every repo
 - **One level:** `SyncLevelAsync` → same with a list of repo IDs, `skipDependencyLevelPersistence: true`.
 
 **Reason (code comment / behavior):**  
-`MergeWorkspaceProjectDependenciesAsync` is documented to skip recomputing levels when `persistDependencyLevel` is false—*e.g. when syncing only selected repos*.
+`MergeWorkspaceProjectDependenciesAsync` is documented to skip recomputing levels when `persistDependencyLevel` is false-*e.g. when syncing only selected repos*.
 
 **Technical reason:**  
 `MergeWorkspaceProjectDependenciesAsync` only **builds `uniqueEdges` from the `syncResults` passed in**. For a **partial** sync:
@@ -72,7 +72,7 @@ So **sync-all** both **refreshes** project dependencies from disk for every repo
 - It still **updates DB** correctly for the synced repo(s): it removes old `ProjectDependencies` for those repos’ dependent projects and inserts new edges from the fresh `ProjectsDetail`.
 - If **`persistDependencyLevel: true`** were passed with **only** that repo in `syncResults`, **`uniqueEdges` would only contain edges derived from that repo’s projects**. Calling `PersistRepositoryDependencyLevelAndDependenciesAsync` with that **partial** edge list would **omit edges from other repos**, so the **topological sort and level assignment would be wrong** for the whole workspace.
 
-Therefore the UI **deliberately** passes `skipDependencyLevelPersistence: true` so levels are **not** overwritten with a partial graph. Side effect: after single-repo sync, **`DependencyLevel` is not recalculated** even though that repo’s `ProjectDependencies` and `GitVersion` may have changed—grid grouping and push/update plans can stay stale until a full sync or another operation that recomputes stats.
+Therefore the UI **deliberately** passes `skipDependencyLevelPersistence: true` so levels are **not** overwritten with a partial graph. Side effect: after single-repo sync, **`DependencyLevel` is not recalculated** even though that repo’s `ProjectDependencies` and `GitVersion` may have changed-grid grouping and push/update plans can stay stale until a full sync or another operation that recomputes stats.
 
 ---
 
@@ -95,11 +95,11 @@ So **the full edge set for leveling** can be **reloaded from the database** afte
 
 Goal: **Keep current behavior** (sync one repo only via agent) but **refresh `DependencyLevel` / `Dependencies` / `UnmatchedDeps`** using **all** workspace repos’ **already-persisted** graph + updated versions for the synced repo.
 
-### Option A — Recompute after partial sync (implemented)
+### Option A - Recompute after partial sync (implemented)
 
 After `PersistVersionsAsync` when `persistDependencyLevel` was false (partial sync):
 
-1. **`MergeWorkspaceProjectDependenciesAsync(..., persistDependencyLevel: false)`** — already happens today; updates `ProjectDependencies` for synced repo only and saves.
+1. **`MergeWorkspaceProjectDependenciesAsync(..., persistDependencyLevel: false)`** - already happens today; updates `ProjectDependencies` for synced repo only and saves.
 2. Immediately call **`WorkspaceProjectRepository.RecomputeAndPersistRepositoryDependencyStatsAsync(workspaceId)`**.
 
 `RecomputeAndPersistRepositoryDependencyStatsAsync`:
@@ -108,23 +108,23 @@ After `PersistVersionsAsync` when `persistDependencyLevel` was false (partial sy
 - Rebuilds `uniqueEdges` from that full set.
 - Calls `PersistRepositoryDependencyLevelAndDependenciesAsync` with the **complete** graph.
 
-**Pros:** No second agent sync; uses existing repos as stored. **Cons:** Other repos’ `ProjectDependencies` are only as fresh as their last sync/refresh—if their `.csproj` changed on disk but wasn’t synced, edges for those repos remain stale (same as today until they sync).
+**Pros:** No second agent sync; uses existing repos as stored. **Cons:** Other repos’ `ProjectDependencies` are only as fresh as their last sync/refresh-if their `.csproj` changed on disk but wasn’t synced, edges for those repos remain stale (same as today until they sync).
 
-**Implementation:** In `WorkspaceGitService.PersistVersionsAsync`, whenever `persistDependencyLevel` is false, after `MergeWorkspaceProjectDependenciesAsync` the service calls `RecomputeAndBroadcastWorkspaceSyncedAsync` (recompute from full DB + `WorkspaceSynced` hub). Applies to **single-repo sync** and **level sync** (multiple repos in one call)—both use `skipDependencyLevelPersistence: true`, so one code path covers both.
+**Implementation:** In `WorkspaceGitService.PersistVersionsAsync`, whenever `persistDependencyLevel` is false, after `MergeWorkspaceProjectDependenciesAsync` the service calls `RecomputeAndBroadcastWorkspaceSyncedAsync` (recompute from full DB + `WorkspaceSynced` hub). Applies to **single-repo sync** and **level sync** (multiple repos in one call)-both use `skipDependencyLevelPersistence: true`, so one code path covers both.
 
-### Option B — Merge always persists from DB after save
+### Option B - Merge always persists from DB after save
 
 Change `MergeWorkspaceProjectDependenciesAsync` so that when `persistDependencyLevel` is true, **after** saving `ProjectDependencies`, **reload** all dependency rows into `uniqueEdges` (same query as in `RecomputeAndPersistRepositoryDependencyStatsAsync`) and then call `PersistRepositoryDependencyLevelAndDependenciesAsync`. That way partial sync could pass `persistDependencyLevel: true` safely.
 
 **Pros:** Single code path. **Cons:** Extra DB read on every merge; still need to decide whether partial sync should trigger persist (may want explicit flag).
 
-### Option C — Optional “refresh levels only” action
+### Option C - Optional “refresh levels only” action
 
 Expose a lightweight action that only runs `RecomputeAndPersistRepositoryDependencyStatsAsync` (and broadcast `WorkspaceSynced`). Users run it after partial syncs if levels look wrong.
 
 **Pros:** No change to sync semantics. **Cons:** Manual step.
 
-### Option D — Refresh projects for all repos without full git sync
+### Option D - Refresh projects for all repos without full git sync
 
 If staleness of other repos’ edges is the main issue, **`RefreshWorkspaceProjectsAsync`** (agent `RefreshRepositoryProjects`, no fetch) could be run periodically or once after single sync to refresh `ProjectsDetail` for everyone, then merge with `persistDependencyLevel: true`. That **does** touch every repo on disk (not a git sync, but still agent work per repo).
 
@@ -132,10 +132,10 @@ If staleness of other repos’ edges is the main issue, **`RefreshWorkspaceProje
 
 | Option | Effort | Touch points | Risk | Testing |
 |--------|--------|--------------|------|--------|
-| **A — Recompute after partial sync** | **Low** | One call site: `WorkspaceGitService.PersistVersionsAsync` after `MergeWorkspaceProjectDependenciesAsync(..., false)` when partial; optional UI unchanged if done only in service. | Low: recompute is already used elsewhere (`RecomputeAndPersistRepositoryDependencyStatsAsync`); must ensure partial merge completed and saved before recompute. | Sync single repo → assert `DependencyLevel` updates; workspace with cycles still gets null levels; full sync unchanged. |
-| **B — Merge reloads edges then persist** | **Medium** | `WorkspaceProjectRepository.MergeWorkspaceProjectDependenciesAsync`: after `SaveChanges`, load all `ProjectDependencies` for workspace (duplicate query shape from `RecomputeAndPersistRepositoryDependencyStatsAsync`), then call persist. Possibly flip `SyncSingleRepoAsync` / `SyncLevelAsync` to `skipDependencyLevelPersistence: false` or remove flag for partial if merge always safe. | Medium: every merge pays extra read; must not regress full-sync path (behavior should match today). Regression if reload logic diverges from recompute’s edge load. | Full sync + single sync both; large workspace perf smoke test. |
-| **C — Manual “refresh levels” action** | **Low–Medium** | New UI control (header or menu) + handler calling `RecomputeAndPersistRepositoryDependencyStatsAsync` + `WorkspaceSynced` broadcast (same as `RecomputeAndBroadcastWorkspaceSyncedAsync` without dependency sync). Authorization if needed. | Low for backend; UX risk if users don’t know when to click. | Manual click after partial sync; no agent required if DB already consistent. |
-| **D — Refresh projects for all repos** | **High** | Orchestration in `WorkspaceGitService` (or UI) to call `RefreshWorkspaceProjectsAsync` for all repo IDs, then merge with persist — similar to full refresh flow. Progress/cancel semantics; agent must stay connected for duration. | High: N agent round-trips, failure mid-way leaves mixed freshness; timeouts on large workspaces. | Staging with many repos; cancel mid-refresh; compare edge counts before/after. |
+| **A - Recompute after partial sync** | **Low** | One call site: `WorkspaceGitService.PersistVersionsAsync` after `MergeWorkspaceProjectDependenciesAsync(..., false)` when partial; optional UI unchanged if done only in service. | Low: recompute is already used elsewhere (`RecomputeAndPersistRepositoryDependencyStatsAsync`); must ensure partial merge completed and saved before recompute. | Sync single repo → assert `DependencyLevel` updates; workspace with cycles still gets null levels; full sync unchanged. |
+| **B - Merge reloads edges then persist** | **Medium** | `WorkspaceProjectRepository.MergeWorkspaceProjectDependenciesAsync`: after `SaveChanges`, load all `ProjectDependencies` for workspace (duplicate query shape from `RecomputeAndPersistRepositoryDependencyStatsAsync`), then call persist. Possibly flip `SyncSingleRepoAsync` / `SyncLevelAsync` to `skipDependencyLevelPersistence: false` or remove flag for partial if merge always safe. | Medium: every merge pays extra read; must not regress full-sync path (behavior should match today). Regression if reload logic diverges from recompute’s edge load. | Full sync + single sync both; large workspace perf smoke test. |
+| **C - Manual “refresh levels” action** | **Low-Medium** | New UI control (header or menu) + handler calling `RecomputeAndPersistRepositoryDependencyStatsAsync` + `WorkspaceSynced` broadcast (same as `RecomputeAndBroadcastWorkspaceSyncedAsync` without dependency sync). Authorization if needed. | Low for backend; UX risk if users don’t know when to click. | Manual click after partial sync; no agent required if DB already consistent. |
+| **D - Refresh projects for all repos** | **High** | Orchestration in `WorkspaceGitService` (or UI) to call `RefreshWorkspaceProjectsAsync` for all repo IDs, then merge with persist - similar to full refresh flow. Progress/cancel semantics; agent must stay connected for duration. | High: N agent round-trips, failure mid-way leaves mixed freshness; timeouts on large workspaces. | Staging with many repos; cancel mid-refresh; compare edge counts before/after. |
 
 **Effort scale (rough):** Low = small localized change, existing APIs; Medium = refactor or new branch in merge + caller updates; High = new flows, perf/cancel, and operational concerns.
 
@@ -145,11 +145,11 @@ If staleness of other repos’ edges is the main issue, **`RefreshWorkspaceProje
 
 | Scenario | Agent work | ProjectDependencies update | DependencyLevel update |
 |----------|------------|------------------------------|------------------------|
-| Sync all | All repos | Full replace per repo from full sync results | Yes — full `uniqueEdges` |
-| Sync one / level | Subset only | Only synced repos’ dependents replaced in DB | No — skipped to avoid partial `uniqueEdges` |
-| Single sync / level sync (Option A) | Subset only | Same as today | Yes — after merge, recompute loads **full** edges from DB |
+| Sync all | All repos | Full replace per repo from full sync results | Yes - full `uniqueEdges` |
+| Sync one / level | Subset only | Only synced repos’ dependents replaced in DB | No - skipped to avoid partial `uniqueEdges` |
+| Single sync / level sync (Option A) | Subset only | Same as today | Yes - after merge, recompute loads **full** edges from DB |
 
-**Recommended direction:** **Option A** — after partial `PersistVersionsAsync`, call **`RecomputeAndPersistRepositoryDependencyStatsAsync`** so the workspace grid and push/update logic see consistent levels without syncing other repositories.
+**Recommended direction:** **Option A** - after partial `PersistVersionsAsync`, call **`RecomputeAndPersistRepositoryDependencyStatsAsync`** so the workspace grid and push/update logic see consistent levels without syncing other repositories.
 
 ---
 
@@ -161,5 +161,5 @@ If staleness of other repos’ edges is the main issue, **`RefreshWorkspaceProje
 | Merge + persist flag | `WorkspaceProjectRepository.MergeWorkspaceProjectDependenciesAsync` |
 | Level algorithm | `WorkspaceProjectRepository.PersistRepositoryDependencyLevelAndDependenciesAsync` |
 | Recompute from DB | `WorkspaceProjectRepository.RecomputeAndPersistRepositoryDependencyStatsAsync` |
-| UI full sync | `WorkspaceRepositories.razor` — `SyncAsync` (no `repositoryIds`) |
-| UI single / level sync | `WorkspaceRepositories.razor` — `SyncSingleRepoAsync`, `SyncLevelAsync` |
+| UI full sync | `WorkspaceRepositories.razor` - `SyncAsync` (no `repositoryIds`) |
+| UI single / level sync | `WorkspaceRepositories.razor` - `SyncSingleRepoAsync`, `SyncLevelAsync` |

--- a/docs/File-Configuration-Dependencies-Design.md
+++ b/docs/File-Configuration-Dependencies-Design.md
@@ -1,4 +1,4 @@
-# File Configuration Dependencies — Design Plan
+# File Configuration Dependencies - Design Plan
 
 This document describes how to extend GrayMoon’s dependency computation so that **file configuration** (version patterns with `{repositoryname}` tokens) contributes to repository dependencies, using the **existing dependency persistence** (WorkspaceRepositoryLink: DependencyLevel, Dependencies, UnmatchedDeps).
 
@@ -29,7 +29,7 @@ This document describes how to extend GrayMoon’s dependency computation so tha
 
 ### 1.3 File configuration (already in the app)
 
-- **WorkspaceFile**: FileId, WorkspaceId, RepositoryId, FilePath — a file belongs to one repository in a workspace.
+- **WorkspaceFile**: FileId, WorkspaceId, RepositoryId, FilePath - a file belongs to one repository in a workspace.
 - **WorkspaceFileVersionConfig**: ConfigId, FileId, VersionPattern (multi-line, each line `KEY={repositoryname}`).
 - **WorkspaceFileVersionService.ExtractTokens(pattern)** returns all `{token}` names from the pattern; these are **repository names** (matched to workspace repos by name).
 - **WorkspaceFileVersionConfigRepository.GetByWorkspaceIdAsync(workspaceId)** returns configs with File and Repository loaded (so we know file → RepositoryId).
@@ -40,7 +40,7 @@ This document describes how to extend GrayMoon’s dependency computation so tha
 ## 2. Goal
 
 - **If the repository has configured files:** for each such file, take all **matching repository tokens** from its version pattern (i.e. `{repositoryname}` tokens that resolve to a workspace repository) and treat those repositories as **dependencies of the repository that owns the file**.
-- **Use existing persistence:** do **not** add a new persistence table for “file-config dependencies.” Reuse WorkspaceRepositoryLink (DependencyLevel, Dependencies, UnmatchedDeps) by merging file-config–derived repo edges with project-derived repo edges when computing and persisting stats.
+- **Use existing persistence:** do **not** add a new persistence table for “file-config dependencies.” Reuse WorkspaceRepositoryLink (DependencyLevel, Dependencies, UnmatchedDeps) by merging file-config-derived repo edges with project-derived repo edges when computing and persisting stats.
 - **Downstream behavior:** Push order, sync order, dependency graph UI, and any logic that uses DependencyLevel or Dependencies should automatically respect file-config dependencies because they are folded into the same persisted fields.
 
 ---
@@ -108,7 +108,7 @@ This document describes how to extend GrayMoon’s dependency computation so tha
 
 ### 4.1 WorkspaceProjectRepository
 
-- **Inject** **WorkspaceFileVersionConfigRepository** (and ensure it can be used from the same DbContext / scope as WorkspaceProjectRepository, which it can — both are scoped and use AppDbContext).
+- **Inject** **WorkspaceFileVersionConfigRepository** (and ensure it can be used from the same DbContext / scope as WorkspaceProjectRepository, which it can - both are scoped and use AppDbContext).
 - **PersistRepositoryDependencyLevelAndDependenciesAsync** (private):
   - After loading workspaceProjects and building project-based repo edges:
     1. Load `WorkspaceRepositories` for workspaceId with `Include(wr => wr.Repository)`.

--- a/docs/Git-Improvements-Implementation-Plan.md
+++ b/docs/Git-Improvements-Implementation-Plan.md
@@ -1,4 +1,4 @@
-## Git Improvements – Implementation Plan
+## Git Improvements - Implementation Plan
 
 This document describes how to standardize git operations in GrayMoon so that all remote git commands are executed through a single, token-aware service used by the agent and any hook-triggered flows.
 
@@ -59,7 +59,7 @@ This document describes how to standardize git operations in GrayMoon so that al
 
 ## 3. Supported scenarios and flows
 
-### 3.1 Scenario 1 – Direct agent calls with token
+### 3.1 Scenario 1 - Direct agent calls with token
 
 - **Use case**
   - The app initiates an agent command (e.g. sync, push, clone) and already has a token from the connector.
@@ -82,7 +82,7 @@ This document describes how to standardize git operations in GrayMoon so that al
      - If git returns **unauthorized** for a provided token:
        - GitService surfaces the failure **without** retrying or re-fetching a token (the app is responsible for providing a fresh token).
 
-### 3.2 Scenario 2 – Hook-triggered / no token provided
+### 3.2 Scenario 2 - Hook-triggered / no token provided
 
 - **Use case**
   - A git hook fires (e.g. pre-push, post-receive) and calls into the agent, but does **not** have a token available.

--- a/docs/GrayMoon-Architecture-Design.md
+++ b/docs/GrayMoon-Architecture-Design.md
@@ -1,4 +1,4 @@
-# GrayMoon — Architecture & Design Reference
+# GrayMoon - Architecture & Design Reference
 
 **Version:** 0.1.0-main.177  
 **Target runtime:** .NET 8, ASP.NET Core 8, Blazor Server, EF Core 8 (SQLite)
@@ -11,8 +11,8 @@
 2. [Two-Process Architecture](#2-two-process-architecture)
 3. [Data Model](#3-data-model)
 4. [Communication Layer](#4-communication-layer)
-5. [GrayMoon.App — Service Layer](#5-graymoonapp--service-layer)
-6. [GrayMoon.Agent — Command Pipeline](#6-graymoonagent--command-pipeline)
+5. [GrayMoon.App - Service Layer](#5-graymoonapp--service-layer)
+6. [GrayMoon.Agent - Command Pipeline](#6-graymoonagent--command-pipeline)
 7. [Feature Workflows](#7-feature-workflows)
 8. [Concurrency Model](#8-concurrency-model)
 9. [Security Design](#9-security-design)
@@ -24,7 +24,7 @@
 
 ## 1. What GrayMoon Is
 
-GrayMoon is a **workspace orchestration tool for multi-repository .NET development**. It is designed for teams and individuals working across many repositories simultaneously — microservices, shared libraries, NuGet packages — where a single feature typically requires coordinated changes in several places.
+GrayMoon is a **workspace orchestration tool for multi-repository .NET development**. It is designed for teams and individuals working across many repositories simultaneously - microservices, shared libraries, NuGet packages - where a single feature typically requires coordinated changes in several places.
 
 ### Core problem solved
 
@@ -251,7 +251,7 @@ App AgentHub.SyncCommand
         └── hubContext.Clients.All.SendAsync("WorkspaceSynced", workspaceId)
 ```
 
-`SyncCommandHandler` uses **`HasValue` guards**: null fields in the incoming notification do not overwrite existing DB values. This is important — it allows partial-update notifications (e.g. the pre-push hook now only sends Version + Branch, leaving commit counts untouched).
+`SyncCommandHandler` uses **`HasValue` guards**: null fields in the incoming notification do not overwrite existing DB values. This is important - it allows partial-update notifications (e.g. the pre-push hook now only sends Version + Branch, leaving commit counts untouched).
 
 ### 4.4 HTTP Hook Listener (Agent)
 
@@ -270,7 +270,7 @@ Each POST carries a JSON body: `{ "repositoryId", "workspaceId", "repositoryPath
 
 ---
 
-## 5. GrayMoon.App — Service Layer
+## 5. GrayMoon.App - Service Layer
 
 ### 5.1 Agent communication
 
@@ -278,14 +278,14 @@ Each POST carries a JSON body: `{ "repositoryId", "workspaceId", "repositoryPath
 |---------|----------------|
 | `AgentBridge` | Sends commands to the Agent; wraps SignalR `RequestCommand` with `requestId` tracking via `AgentResponseDelivery`. |
 | `AgentConnectionTracker` | Tracks current Agent SignalR connection ID; used by `AgentBridge` to find the target. |
-| `AgentResponseDelivery` | Static `ConcurrentDictionary<string, TCS>` — bridges async hub callbacks back to calling code. |
+| `AgentResponseDelivery` | Static `ConcurrentDictionary<string, TCS>` - bridges async hub callbacks back to calling code. |
 | `AgentQueueStateService` | Reports agent job-queue depth for diagnostics. |
 
 ### 5.2 Workspace orchestration
 
 | Service | Responsibility |
 |---------|----------------|
-| `WorkspaceGitService` | Core fanout service — sync, refresh projects, push, update, commit-sync, create branches, and dependency sync. Uses `SemaphoreSlim(MaxParallelOperations)` for all parallel work. |
+| `WorkspaceGitService` | Core fanout service - sync, refresh projects, push, update, commit-sync, create branches, and dependency sync. Uses `SemaphoreSlim(MaxParallelOperations)` for all parallel work. |
 | `WorkspaceService` | Workspace CRUD + root path resolution. `GetRootPathForWorkspaceAsync` returns `workspace.RootPath ?? Settings.RootPath`. |
 | `WorkspaceSyncHandler` | Thin wrapper around `WorkspaceGitService.SyncAsync` with error handling and broadcast. |
 | `WorkspacePushService` | Push business logic: builds push plan, runs parallel or level-ordered push, calls `UpdateCommitCountsAndUpstreamAfterPushAsync` which resets commit counts in DB and sends `WorkspaceSynced`. |
@@ -326,14 +326,14 @@ Each POST carries a JSON body: `{ "repositoryId", "workspaceId", "repositoryPath
 
 ---
 
-## 6. GrayMoon.Agent — Command Pipeline
+## 6. GrayMoon.Agent - Command Pipeline
 
 ### 6.1 Job kinds
 
 Two job kinds flow through a single bounded `Channel<JobEnvelope>`:
 
-- **Command jobs** — initiated by App `RequestCommand`; have a `requestId`; must send `ResponseCommand` back.
-- **Notify jobs** — initiated by git hook HTTP POST; fire-and-forget; may send `SyncCommand` back to App.
+- **Command jobs** - initiated by App `RequestCommand`; have a `requestId`; must send `ResponseCommand` back.
+- **Notify jobs** - initiated by git hook HTTP POST; fire-and-forget; may send `SyncCommand` back to App.
 
 ### 6.2 Agent command catalog
 
@@ -368,14 +368,14 @@ Hook commands (Notify job path):
 
 | Command | Hook | Does |
 |---------|------|------|
-| `PushHookSyncCommand` | pre-push | GitVersion only; sends `SyncCommand` with Version + Branch (no commit counts — push not yet complete) |
+| `PushHookSyncCommand` | pre-push | GitVersion only; sends `SyncCommand` with Version + Branch (no commit counts - push not yet complete) |
 | `CommitHookSyncCommand` | post-commit | GitVersion + commit counts; sends `SyncCommand` |
 | `CheckoutHookSyncCommand` | post-checkout | GitVersion + commit counts; sends `SyncCommand` |
 | `MergeHookSyncCommand` | post-merge | GitVersion + commit counts; sends `SyncCommand` |
 
 ### 6.3 Job concurrency (agent side)
 
-`JobBackgroundService` maintains up to `MaxConcurrentCommands` (default 8) parallel workers reading from the job queue. All workers share the same `Channel<JobEnvelope>`. There is no per-command serialization — the agent can run 8 jobs concurrently against different repositories without coordination. Callers that require serialization (e.g. dependency-level push ordering) must enforce it on the App side.
+`JobBackgroundService` maintains up to `MaxConcurrentCommands` (default 8) parallel workers reading from the job queue. All workers share the same `Channel<JobEnvelope>`. There is no per-command serialization - the agent can run 8 jobs concurrently against different repositories without coordination. Callers that require serialization (e.g. dependency-level push ordering) must enforce it on the App side.
 
 ### 6.4 Git hook registration
 
@@ -449,7 +449,7 @@ User clicks Push
 All repos pushed in parallel in one pass; no NuGet polling.
 
 **Pre-push hook interaction:**
-Git's pre-push hook fires before the actual push data transfer. `PushHookSyncCommand` intentionally sends only `Version` and `Branch` — no commit counts — because they would be stale (push not yet complete). The authoritative post-push counts come from `UpdateCommitCountsAndUpstreamAfterPushAsync` via explicit `GetCommitCounts` commands.
+Git's pre-push hook fires before the actual push data transfer. `PushHookSyncCommand` intentionally sends only `Version` and `Branch` - no commit counts - because they would be stale (push not yet complete). The authoritative post-push counts come from `UpdateCommitCountsAndUpstreamAfterPushAsync` via explicit `GetCommitCounts` commands.
 
 ### 7.3 Dependency Update Workflow
 
@@ -481,7 +481,7 @@ Single-repo and workspace-wide branch operations:
 - **Create branch:** `CreateBranch` command; optionally pattern-based across workspace.
 - **Checkout:** `CheckoutBranch` command; post-checkout hook fires and sends `SyncCommand`.
 - **Set upstream:** `SetUpstreamBranch` after first push of a new branch.
-- **Sync to default:** `SyncToDefaultBranch` — checkout default branch, prune feature branch if no drift, pull latest. Used after a PR is merged.
+- **Sync to default:** `SyncToDefaultBranch` - checkout default branch, prune feature branch if no drift, pull latest. Used after a PR is merged.
 - **Delete branch:** `DeleteBranch` with safety checks.
 - **Refresh branches:** `RefreshBranches` command; updates `RepositoryBranch` rows.
 
@@ -513,9 +513,9 @@ PR state is persisted in `WorkspaceRepositoryPullRequest` and refreshed whenever
 
 A single `Workspace:MaxParallelOperations` setting (default 16) governs all parallel workspace work in the App:
 
-- `WorkspaceGitService` — all parallel agent command fan-outs.
-- `PackageRegistrySyncService` — parallel NuGet package lookups.
-- `SyncBackgroundService` — default worker count (overridden by `Sync:MaxConcurrency`).
+- `WorkspaceGitService` - all parallel agent command fan-outs.
+- `PackageRegistrySyncService` - parallel NuGet package lookups.
+- `SyncBackgroundService` - default worker count (overridden by `Sync:MaxConcurrency`).
 
 All parallelism uses `SemaphoreSlim(_maxConcurrent)` + `Task.WhenAll`.
 
@@ -542,7 +542,7 @@ After the push bug fix in this version:
 
 ## 9. Security Design
 
-### 9.1 Token storage (Level 2 — AES-256-GCM)
+### 9.1 Token storage (Level 2 - AES-256-GCM)
 
 Connector tokens (`Connector.UserToken`) are stored encrypted using AES-256-GCM via `AesGcmTokenProtector`, which is backed by ASP.NET Core Data Protection. The key store is in the volume-mounted `/app/db/DataProtection-Keys/` directory so keys survive container restarts.
 
@@ -645,7 +645,7 @@ Currently command args are serialized as `JsonElement` and deserialized per comm
 Track which repos in a push plan were successfully pushed vs. failed. Allow the user to retry only the failed repos without re-pushing the successful ones.
 
 **Per-workspace agent (future)**  
-For team deployments, multiple agents per workspace (or per machine) would allow the App to orchestrate work across machines. The current single-agent model is a design constraint, not a fundamental limitation — `AgentConnectionTracker` would need to become a multi-entry registry.
+For team deployments, multiple agents per workspace (or per machine) would allow the App to orchestrate work across machines. The current single-agent model is a design constraint, not a fundamental limitation - `AgentConnectionTracker` would need to become a multi-entry registry.
 
 ### Performance
 

--- a/docs/GrayMoon.Agent-Design.md
+++ b/docs/GrayMoon.Agent-Design.md
@@ -4,8 +4,8 @@
 
 GrayMoon.Agent is a host-side executable that executes all git and repository I/O operations on behalf of GrayMoon.App (which runs in Docker). It receives commands via SignalR from the app and pushes responses (and sync notifications) back. This design simplifies the app by removing git, GitVersion, and workspace filesystem access from the container.
 
-- **GrayMoon.App** (Docker): Web UI, DB, orchestration, SignalR hub — no git/filesystem.
-- **GrayMoon.Agent** (Host): All git commands, hooks, workspace I/O — runs as console app or Windows/Linux service.
+- **GrayMoon.App** (Docker): Web UI, DB, orchestration, SignalR hub - no git/filesystem.
+- **GrayMoon.Agent** (Host): All git commands, hooks, workspace I/O - runs as console app or Windows/Linux service.
 
 ---
 
@@ -31,9 +31,9 @@ When offline: sync operations fail with a clear message. No silent failures.
 
 ## 2. Concurrency & Queuing
 
-- **One agent per host** — single process, single connection to the app
-- **Up to 8 concurrent jobs** — configurable parallelism (`MaxConcurrentCommands`)
-- **Single shared queue** — both UI commands (SignalR `RequestCommand`) and hook notifications (`/notify`) are enqueued to the same queue
+- **One agent per host** - single process, single connection to the app
+- **Up to 8 concurrent jobs** - configurable parallelism (`MaxConcurrentCommands`)
+- **Single shared queue** - both UI commands (SignalR `RequestCommand`) and hook notifications (`/notify`) are enqueued to the same queue
 - When a slot frees, the next job is processed (FIFO within the queue)
 
 ```
@@ -78,7 +78,7 @@ Environment variables override: `GrayMoon__AppHubUrl`, `GrayMoon__ListenPort`, e
 post-commit → curl http://127.0.0.1:9191/notify → Agent enqueues to same queue → Worker runs GitVersion → Agent pushes workspaceId, repositoryId, version, branch to App → App persists
 ```
 
-- Hooks always use `http://127.0.0.1:{ListenPort}/notify` — no Docker URL config
+- Hooks always use `http://127.0.0.1:{ListenPort}/notify` - no Docker URL config
 - Agent runs on the host where repos live; hooks run in the same environment
 - `/notify` enqueues a job to the **same queue** as UI commands; a worker picks it up (up to 8 concurrent)
 - Single network concern: agent must reach the app; hooks only reach localhost
@@ -117,7 +117,7 @@ GrayMoon.sln
 
 ### Hub: `AgentHub` (path: `/agent`)
 
-Hub path is `/agent` (no `hubs/` prefix required — map via `MapHub<AgentHub>("/agent")`).
+Hub path is `/agent` (no `hubs/` prefix required - map via `MapHub<AgentHub>("/agent")`).
 
 **Server → Agent (invoke on agent client):**
 
@@ -144,9 +144,9 @@ The app sends all required data in each command. **AddSafeDirectory is called on
 | **GetWorkspaceRepositories** | `workspaceName` | `{ repositories: string[] }` |
 | **GetRepositoryVersion** | `workspaceName`, `repositoryName` | `{ exists, version?, branch? }` |
 
-**SyncRepository** — Full sync for one repo (used by workspace sync): ensures workspace dir exists, clones if repo missing. **AddSafeDirectory is called only immediately after CloneAsync** (when a clone was performed). Then runs GitVersion, writes post-commit/post-checkout hooks. Hooks curl `http://127.0.0.1:{ListenPort}/notify` with `{ repositoryId, workspaceId, repositoryPath }` (repositoryPath embedded at hook-creation time so the agent can run GitVersion directly when the hook fires).
+**SyncRepository** - Full sync for one repo (used by workspace sync): ensures workspace dir exists, clones if repo missing. **AddSafeDirectory is called only immediately after CloneAsync** (when a clone was performed). Then runs GitVersion, writes post-commit/post-checkout hooks. Hooks curl `http://127.0.0.1:{ListenPort}/notify` with `{ repositoryId, workspaceId, repositoryPath }` (repositoryPath embedded at hook-creation time so the agent can run GitVersion directly when the hook fires).
 
-**RefreshRepositoryVersion** — Manual/API-triggered single-repo refresh: runs GitVersion only (no AddSafeDirectory; repo was cloned earlier). Hook flow uses `/notify` instead (agent runs GitVersion and pushes result directly).
+**RefreshRepositoryVersion** - Manual/API-triggered single-repo refresh: runs GitVersion only (no AddSafeDirectory; repo was cloned earlier). Hook flow uses `/notify` instead (agent runs GitVersion and pushes result directly).
 
 ---
 

--- a/docs/GrayMoon.Agent-Jobs-Design.md
+++ b/docs/GrayMoon.Agent-Jobs-Design.md
@@ -1,4 +1,4 @@
-# GrayMoon.Agent — Jobs: Separate Services, Interfaces & JSON Handling
+# GrayMoon.Agent - Jobs: Separate Services, Interfaces & JSON Handling
 
 ## 1. Goals
 
@@ -15,8 +15,8 @@
 
 All enqueued work is represented as a **job**. Two kinds:
 
-- **Command jobs** — originate from SignalR `RequestCommand`; have a request ID and require a `ResponseCommand` back.
-- **Notify jobs** — originate from HTTP `/notify`; no request ID; agent pushes `SyncCommand` to the app.
+- **Command jobs** - originate from SignalR `RequestCommand`; have a request ID and require a `ResponseCommand` back.
+- **Notify jobs** - originate from HTTP `/notify`; no request ID; agent pushes `SyncCommand` to the app.
 
 Introduce a small type hierarchy and shared model location:
 

--- a/docs/GrayMoon.Agent-Parallel-Jobs.md
+++ b/docs/GrayMoon.Agent-Parallel-Jobs.md
@@ -1,4 +1,4 @@
-# GrayMoon.Agent — Parallel Jobs System
+# GrayMoon.Agent - Parallel Jobs System
 
 ## Overview
 
@@ -77,7 +77,7 @@ The Agent processes work through a single shared **job queue** consumed by a con
 public enum JobKind { Command = 0, Notify = 1 }
 ```
 
-### `JobEnvelope` — Queue Unit of Work
+### `JobEnvelope` - Queue Unit of Work
 
 The `JobEnvelope` is the single type that flows through `JobQueue`. It's a discriminated union with factory statics:
 
@@ -97,7 +97,7 @@ JobEnvelope.Notify(notifyJob)     // hook-initiated fire-and-forget
 
 ## Job Types
 
-### 1. Command Job — `ICommandJob` / `CommandJob`
+### 1. Command Job - `ICommandJob` / `CommandJob`
 
 **Origin**: App → SignalR `RequestCommand`
 
@@ -122,7 +122,7 @@ JobEnvelope.Notify(notifyJob)     // hook-initiated fire-and-forget
 
 ---
 
-### 2. Notify Job — `INotifyJob` / `NotifySyncJob`
+### 2. Notify Job - `INotifyJob` / `NotifySyncJob`
 
 **Origin**: External git post-receive hook → HTTP POST `/notify`
 
@@ -161,7 +161,7 @@ Backpressure: producers (`SignalRConnectionHostedService`, `HookListenerHostedSe
 
 ### `JobBackgroundService`
 
-Spawns exactly `MaxConcurrentCommands` independent workers (default **8**), each reading from the shared `IAsyncEnumerable<JobEnvelope>` provided by `JobQueue.ReadAllAsync()`. Because `Channel` is multi-reader-safe, all workers compete for the next available envelope — work is distributed automatically.
+Spawns exactly `MaxConcurrentCommands` independent workers (default **8**), each reading from the shared `IAsyncEnumerable<JobEnvelope>` provided by `JobQueue.ReadAllAsync()`. Because `Channel` is multi-reader-safe, all workers compete for the next available envelope - work is distributed automatically.
 
 ```
 Worker count = Math.Max(1, AgentOptions.MaxConcurrentCommands)   // default 8
@@ -212,7 +212,7 @@ App HTTP request
 
 Multiple HTTP requests can be in-flight simultaneously; each gets its own `requestId` and `TaskCompletionSource`. The workers process them concurrently up to `MaxConcurrentCommands`.
 
-Notify jobs compete for the same worker pool as command jobs. A heavy burst of git hooks will not starve command jobs — they interleave in FIFO order as workers free up.
+Notify jobs compete for the same worker pool as command jobs. A heavy burst of git hooks will not starve command jobs - they interleave in FIFO order as workers free up.
 
 ---
 

--- a/docs/PR-Badge-Mergeability-Design.md
+++ b/docs/PR-Badge-Mergeability-Design.md
@@ -1,4 +1,4 @@
-# PR Badge Mergeability – Design Document (Not Implemented)
+# PR Badge Mergeability - Design Document (Not Implemented)
 
 ## Overview
 
@@ -24,24 +24,24 @@ GitHub’s REST API exposes mergeability on pull request resources:
 - **Get a pull request:** `GET /repos/{owner}/{repo}/pulls/{pull_number}`  
   Returns the full pull request object, including:
   - **`mergeable`** (boolean or null)  
-    - `true` – can be merged without conflicts  
-    - `false` – has merge conflicts  
-    - `null` – GitHub is still computing mergeability (background job)
+    - `true` - can be merged without conflicts  
+    - `false` - has merge conflicts  
+    - `null` - GitHub is still computing mergeability (background job)
   - **`mergeable_state`** (string)  
     More detailed state; see below.
 
 - **List pull requests:** `GET /repos/{owner}/{repo}/pulls?state=all&head=owner:branch&per_page=1`  
-  The response schema includes the same top-level fields, so **list responses can include `mergeable` and `mergeable_state`** when the API returns the full pull request shape. In practice, list and get often return these fields; the **single-PR endpoint is the one that guarantees** them (see [REST API – Get a pull request](https://docs.github.com/en/rest/pulls/pulls#get-a-pull-request)).
+  The response schema includes the same top-level fields, so **list responses can include `mergeable` and `mergeable_state`** when the API returns the full pull request shape. In practice, list and get often return these fields; the **single-PR endpoint is the one that guarantees** them (see [REST API - Get a pull request](https://docs.github.com/en/rest/pulls/pulls#get-a-pull-request)).
 
 ### 1.2 `mergeable` (boolean | null)
 
-From [GitHub Docs – Checking mergeability of pull requests](https://docs.github.com/en/rest/pulls/pulls#get-a-pull-request):
+From [GitHub Docs - Checking mergeability of pull requests](https://docs.github.com/en/rest/pulls/pulls#get-a-pull-request):
 
 - When you get, create, or edit a pull request, GitHub may create a test merge commit to see if it can be merged.
 - **`mergeable`** can be:
-  - **`true`** – No conflicts; if applicable, `merge_commit_sha` is the test merge commit.
-  - **`false`** – There are merge conflicts.
-  - **`null`** – A background job is computing mergeability; after a short delay, a second request can return a non-null value.
+  - **`true`** - No conflicts; if applicable, `merge_commit_sha` is the test merge commit.
+  - **`false`** - There are merge conflicts.
+  - **`null`** - A background job is computing mergeability; after a short delay, a second request can return a non-null value.
 
 So the API **does deliver** “mergeable”, “conflict”, and “don’t know yet” via this single field (plus null).
 
@@ -106,8 +106,8 @@ On the object that represents a pull request (list item or single PR), ensure:
 
 Add to the display model used for the PR badge:
 
-- **`Mergeable`** (bool?) – null = unknown, true = mergeable, false = conflict (or blocked).
-- **`MergeableState`** (string?) – raw value from API for mapping to badge color.
+- **`Mergeable`** (bool?) - null = unknown, true = mergeable, false = conflict (or blocked).
+- **`MergeableState`** (string?) - raw value from API for mapping to badge color.
 
 ---
 
@@ -138,7 +138,7 @@ So:
 GitHub often returns `mergeable: null` and `mergeable_state: "unknown"` on first load and fills them in after a background job. Options:
 
 - **A)** Show gray “unknown” and do **not** retry; next page load or manual refresh will get the updated value.
-- **B)** After a short delay (e.g. 2–3 seconds), **retry** once per PR that is still null/unknown, then update the badge (good for real-time feel; more logic and one extra request per such PR).
+- **B)** After a short delay (e.g. 2-3 seconds), **retry** once per PR that is still null/unknown, then update the badge (good for real-time feel; more logic and one extra request per such PR).
 
 Recommendation: start with **A**; add **B** later if desired.
 

--- a/docs/Parallelism-Analysis.md
+++ b/docs/Parallelism-Analysis.md
@@ -12,7 +12,7 @@ A single value controls parallelism for all workspace-level operations in the ap
 
 | Consumer | Use |
 |----------|-----|
-| **WorkspaceGitService** | Git batch operations (sync, refresh projects, push, create branches), commit-sync batches, post–commit-sync refresh, and push-wait dependency checks. |
+| **WorkspaceGitService** | Git batch operations (sync, refresh projects, push, create branches), commit-sync batches, post-commit-sync refresh, and push-wait dependency checks. |
 | **PackageRegistrySyncService** | Parallel package lookups when matching workspace packages to NuGet connectors. |
 | **SyncBackgroundService** | Number of sync workers when `Sync:MaxConcurrency` is not set (defaults to `MaxParallelOperations`). |
 | **Agent (when app passes it)** | `GetWorkspaceRepositories` (parallel repo discovery) and `RefreshRepositoryProjects` (parallel .csproj discovery/parsing) use `maxParallelOperations` from the request; when omitted, agent uses its default (e.g. 8). |
@@ -46,12 +46,12 @@ So one appsetting (`Workspace:MaxParallelOperations`) drives Git concurrency, pa
 
 Uses `_maxConcurrent = MaxParallelOperations` (from `WorkspaceOptions`) for:
 
-1. **SyncAsync** – parallel `SyncRepository` commands.
-2. **RefreshWorkspaceProjectsAsync** – parallel `RefreshRepositoryProjects` commands (and passes `maxParallelOperations` to the agent).
-3. **PushReposAsync** – parallel `PushRepository` commands.
-4. **CreateBranchesAsync** – parallel `CreateBranch` commands.
+1. **SyncAsync** - parallel `SyncRepository` commands.
+2. **RefreshWorkspaceProjectsAsync** - parallel `RefreshRepositoryProjects` commands (and passes `maxParallelOperations` to the agent).
+3. **PushReposAsync** - parallel `PushRepository` commands.
+4. **CreateBranchesAsync** - parallel `CreateBranch` commands.
 5. Commit-sync batch (parallel `StageAndCommit`).
-6. Post–commit-sync refresh (parallel `SyncSingleRepositoryAsync`).
+6. Post-commit-sync refresh (parallel `SyncSingleRepositoryAsync`).
 7. Push wait loop (parallel NuGet “package exists” checks per round).
 
 All of these use the same `MaxParallelOperations` value; there are no separate local constants for workspace operations.
@@ -60,8 +60,8 @@ All of these use the same `MaxParallelOperations` value; there are no separate l
 
 ## 4. App: Other parallelism
 
-- **PackageRegistrySyncService** – Uses `WorkspaceOptions.MaxParallelOperations` for `MaxDegreeOfParallelism` when syncing workspace package registries or selected package IDs.
-- **WorkspaceService** – Single `SemaphoreSlim(1, 1)` for workspace root path cache access.
+- **PackageRegistrySyncService** - Uses `WorkspaceOptions.MaxParallelOperations` for `MaxDegreeOfParallelism` when syncing workspace package registries or selected package IDs.
+- **WorkspaceService** - Single `SemaphoreSlim(1, 1)` for workspace root path cache access.
 
 ---
 
@@ -76,8 +76,8 @@ All of these use the same `MaxParallelOperations` value; there are no separate l
 
 ## 6. Agent: Commands that use maxParallelOperations
 
-- **GetWorkspaceRepositoriesCommand** – When the request includes `maxParallelOperations`, uses it for the semaphore that limits parallel repo discovery; otherwise uses default 8.
-- **RefreshRepositoryProjectsCommand** – When the request includes `maxParallelOperations`, passes it to `ICsProjFileService.FindAsync` for parallel .csproj discovery and parsing; otherwise the service uses default 8.
+- **GetWorkspaceRepositoriesCommand** - When the request includes `maxParallelOperations`, uses it for the semaphore that limits parallel repo discovery; otherwise uses default 8.
+- **RefreshRepositoryProjectsCommand** - When the request includes `maxParallelOperations`, passes it to `ICsProjFileService.FindAsync` for parallel .csproj discovery and parsing; otherwise the service uses default 8.
 
 The base request type `WorkspaceCommandRequest` defines optional `MaxParallelOperations`; the app sets it from `WorkspaceOptions.MaxParallelOperations` when calling these commands.
 
@@ -88,8 +88,8 @@ The base request type `WorkspaceCommandRequest` defines optional `MaxParallelOpe
 | Limit | Where | Why |
 |-------|--------|-----|
 | **Workspace:MaxParallelOperations** | App (and passed to agent) | Single knob for all workspace operation parallelism: Git batches, package registry sync, sync workers (if not overridden), and agent workspace commands that do parallel work. |
-| **Sync:MaxConcurrency** | App – SyncBackgroundService | Optional override for sync worker count; when not set, uses `MaxParallelOperations`. |
-| **AgentOptions.MaxConcurrentCommands** | Agent – JobBackgroundService | How many jobs (commands + notify syncs) the agent processes at once. |
-| **Job queue capacity** | Agent – JobQueue | Bounded channel; back-pressure when enqueue is faster than workers. |
+| **Sync:MaxConcurrency** | App - SyncBackgroundService | Optional override for sync worker count; when not set, uses `MaxParallelOperations`. |
+| **AgentOptions.MaxConcurrentCommands** | Agent - JobBackgroundService | How many jobs (commands + notify syncs) the agent processes at once. |
+| **Job queue capacity** | Agent - JobQueue | Bounded channel; back-pressure when enqueue is faster than workers. |
 
 Together, this keeps a single appsetting for workspace parallelism while still allowing an optional override for sync workers and a separate agent concurrency setting for total job throughput.

--- a/docs/Performance-Analysis.md
+++ b/docs/Performance-Analysis.md
@@ -4,7 +4,7 @@ This document provides a high-level performance analysis of GrayMoon (app + agen
 
 ---
 
-## 1. System overview – what matters for performance
+## 1. System overview - what matters for performance
 
 - **App (`GrayMoon.App`)**: ASP.NET Core 8 + Razor Components front-end, SQLite + EF Core persistence, background workers (sync, token health), and HTTP/SignalR endpoints.
 - **Agent (`GrayMoon.Agent`)**: Long-running host process that performs git and filesystem operations and some package-registry work, with background workers and a bounded job queue.
@@ -26,9 +26,9 @@ See `Parallelism-Analysis.md` for detailed concurrency mechanics; this document 
 ### 2.1 Workspace sync and refresh
 
 - **Main classes**:
-  - `WorkspaceGitService` – orchestrates sync, refresh projects, dependency sync, push, and branch creation across many repositories.
-  - `SyncBackgroundService` – reads sync requests from an unbounded channel and runs `SyncSingleRepositoryAsync` with a configurable worker count.
-  - `WorkspaceService` – resolves and manages workspace root paths, and forwards workspace-level commands to the agent.
+  - `WorkspaceGitService` - orchestrates sync, refresh projects, dependency sync, push, and branch creation across many repositories.
+  - `SyncBackgroundService` - reads sync requests from an unbounded channel and runs `SyncSingleRepositoryAsync` with a configurable worker count.
+  - `WorkspaceService` - resolves and manages workspace root paths, and forwards workspace-level commands to the agent.
 - **Characteristics**:
   - Heavy use of **parallelism** (SemaphoreSlim + `Task.WhenAll`) to fan out per-repository work.
   - Mix of **agent commands**, **EF Core persistence**, and **external HTTP calls** (for package registries) inside these flows.
@@ -37,7 +37,7 @@ See `Parallelism-Analysis.md` for detailed concurrency mechanics; this document 
 ### 2.2 Git and dependency operations
 
 - **Main classes**:
-  - `WorkspaceGitService` – `SyncAsync`, `RefreshWorkspaceProjectsAsync`, `SyncDependenciesAsync`, `RunUpdateAsync`, `RunPushAsync`, `CreateBranchesAsync`.
+  - `WorkspaceGitService` - `SyncAsync`, `RefreshWorkspaceProjectsAsync`, `SyncDependenciesAsync`, `RunUpdateAsync`, `RunPushAsync`, `CreateBranchesAsync`.
   - Agent-side commands for `SyncRepository`, `RefreshRepositoryProjects`, `SyncRepositoryDependencies`, `PushRepository`, etc.
 - **Characteristics**:
   - Uses a single **`MaxParallelOperations`** setting for workspace operations (see `WorkspaceOptions`).
@@ -49,9 +49,9 @@ See `Parallelism-Analysis.md` for detailed concurrency mechanics; this document 
 ### 2.3 Data access and workspace loading
 
 - **Main classes**:
-  - `AppDbContext` – SQLite-backed EF Core context with multiple indexed entities: connectors, repositories, workspaces, workspace repositories, branches, projects, dependencies, files, settings.
-  - `WorkspaceRepository` – reads and writes workspace graphs, including navigation properties and related entities.
-  - `WorkspaceProjectRepository` and related repositories – manage projects, dependency levels, and associated data.
+  - `AppDbContext` - SQLite-backed EF Core context with multiple indexed entities: connectors, repositories, workspaces, workspace repositories, branches, projects, dependencies, files, settings.
+  - `WorkspaceRepository` - reads and writes workspace graphs, including navigation properties and related entities.
+  - `WorkspaceProjectRepository` and related repositories - manage projects, dependency levels, and associated data.
 - **Characteristics**:
   - Many read paths (especially in UI) load **entire workspace graphs** with eager includes for repositories, connectors, pull requests, and branches.
   - Writes often occur in **per-repository loops**, sometimes with batched pre-loading and then per-repository updates.
@@ -59,17 +59,17 @@ See `Parallelism-Analysis.md` for detailed concurrency mechanics; this document 
 ### 2.4 UI rendering and SignalR updates
 
 - **Main components**:
-  - `WorkspaceRepositories` page (`.razor` + `.razor.cs`) – primary UI for viewing and managing workspace repositories, dependencies, and operations.
+  - `WorkspaceRepositories` page (`.razor` + `.razor.cs`) - primary UI for viewing and managing workspace repositories, dependencies, and operations.
   - SignalR hubs for workspace sync and agent events.
 - **Characteristics**:
   - Uses a **debounced** handler for `WorkspaceSynced` and `RepositoryError` events, but still reloads workspace data from a new `DbContext` scope on each (expensive for large workspaces).
-  - Client-side filtering, grouping, and overlay state are maintained in memory over a list of `workspaceRepositories` entries – trivial with small counts, but can become noticeable for very large workspaces.
+  - Client-side filtering, grouping, and overlay state are maintained in memory over a list of `workspaceRepositories` entries - trivial with small counts, but can become noticeable for very large workspaces.
 
 ### 2.5 Agent job processing
 
 - **Main components**:
-  - `JobBackgroundService` – agent-side background service with `MaxConcurrentCommands` workers consuming a bounded queue.
-  - `HookListenerHostedService` – receives local hook HTTP requests and enqueues jobs.
+  - `JobBackgroundService` - agent-side background service with `MaxConcurrentCommands` workers consuming a bounded queue.
+  - `HookListenerHostedService` - receives local hook HTTP requests and enqueues jobs.
 - **Characteristics**:
   - Uses a bounded channel to maintain backpressure on agent work.
   - Tracks job latencies with `Stopwatch` and logs them, which provides a useful **performance signal** for command-level timing.

--- a/docs/Pull-Request-Column-Design.md
+++ b/docs/Pull-Request-Column-Design.md
@@ -1,4 +1,4 @@
-# Pull Request Column – Design Document
+# Pull Request Column - Design Document
 
 ## Overview
 
@@ -25,8 +25,8 @@ Use GitHub REST API:
 
 - **List Pull Requests:** `GET /repos/{owner}/{repo}/pulls`
 - **Query parameters:**
-  - `state=open` – only open PRs (fast, one call per repo).
-  - `head={owner}:{branch}` – filter by source branch. For same-repo PRs this is the repo owner and current branch name.
+  - `state=open` - only open PRs (fast, one call per repo).
+  - `head={owner}:{branch}` - filter by source branch. For same-repo PRs this is the repo owner and current branch name.
 
 So the request is:
 
@@ -42,7 +42,7 @@ To support **merged** state (badge “merged” in purple), either:
 - **Option A:** Use `state=all` and take the first result; check `state` and `merged_at` to decide open vs merged. Slightly more data but still one request per repo.
 - **Option B:** First call with `state=open`; if empty, call again with `state=closed` and `head=owner:branch`, then inspect `merged_at` on the first result. Two calls only when there is no open PR.
 
-**Recommendation:** **Option A** – single request with `state=all`, `per_page=1`. If the single result’s head ref matches the current branch, use it and derive state (open / merged) from `state` and `merged_at`; otherwise treat as no PR.
+**Recommendation:** **Option A** - single request with `state=all`, `per_page=1`. If the single result’s head ref matches the current branch, use it and derive state (open / merged) from `state` and `merged_at`; otherwise treat as no PR.
 
 ### 1.2 Head ref format
 
@@ -63,12 +63,12 @@ So: **no new agent commands for PR**. PR data is fetched in the app via GitHub A
 
 ### 2.1 GitHub API (App)
 
-- **Option 1 – Extend `GitHubService`:** Add a method such as:
+- **Option 1 - Extend `GitHubService`:** Add a method such as:
   - `GetPullRequestForBranchAsync(Connector connector, string owner, string repo, string branch, CancellationToken ct)`
   - Returns a DTO with: `Number`, `State` (open/closed), `MergedAt` (nullable), `HtmlUrl`, `Title` (optional).
   - Implementation: `GET repos/{owner}/{repo}/pulls?state=all&head={owner}:{branch}&per_page=1`, then map first item to DTO; if empty or head ref doesn’t match, return “no PR”.
 
-- **Option 2 – New `GitHubPullRequestService`:** Thin service that takes `GitHubService`, `ConnectorRepository`, and exposes e.g. `GetPullRequestForBranchAsync(Repository repo, Connector connector, string branchName, CancellationToken ct)`. It would resolve owner/repo from the repository (see §2.2) and call `GitHubService` (which gets the new `GetPullRequestForBranchAsync` or a low-level `GetPullsAsync`).
+- **Option 2 - New `GitHubPullRequestService`:** Thin service that takes `GitHubService`, `ConnectorRepository`, and exposes e.g. `GetPullRequestForBranchAsync(Repository repo, Connector connector, string branchName, CancellationToken ct)`. It would resolve owner/repo from the repository (see §2.2) and call `GitHubService` (which gets the new `GetPullRequestForBranchAsync` or a low-level `GetPullsAsync`).
 
 **Recommendation:** Add **one new method on `GitHubService`** for the raw API call (`GetPullRequestForBranchAsync(Connector, owner, repo, branch)`), then either call it from a small **`GitHubPullRequestService`** that resolves owner/repo and connector per repo, or from the page/component that builds the PR column. Prefer a small **`GitHubPullRequestService`** so workspace page stays simple and we have a single place for “get PR for this workspace repo”.
 
@@ -78,28 +78,28 @@ So: **no new agent commands for PR**. PR data is fetched in the app via GitHub A
 - **Helper:** Extend **`RepositoryUrlHelper`** (or add a small static helper) to parse **owner** and **repo** from a GitHub clone URL:
   - `git@github.com:owner/repo.git` → `owner`, `repo`
   - `https://github.com/owner/repo.git` → `owner`, `repo`
-- If the URL is not GitHub, the repo is skipped for PR (no API call, show “—” or “none” in the PR column).
+- If the URL is not GitHub, the repo is skipped for PR (no API call, show “-” or “none” in the PR column).
 
 ### 2.3 Connector and token
 
 - Each `Repository` has `ConnectorId`. Use **`ConnectorRepository.GetByIdAsync(Repository.ConnectorId)`** to get the Connector.
 - Use that Connector’s `UserToken` (and optional `ApiBaseUrl`) in the existing `GitHubService.GetAsync(Connector, requestUri)` pattern.
-- If the connector is not GitHub or token is missing, skip PR fetch for that repo and show a neutral badge (“none” or “—”).
+- If the connector is not GitHub or token is missing, skip PR fetch for that repo and show a neutral badge (“none” or “-”).
 
 ---
 
 ## 3. When to Fetch PR Data
 
-### 3.1 Option A – On workspace page load (recommended for v1)
+### 3.1 Option A - On workspace page load (recommended for v1)
 
 - When the user opens the workspace repositories page, after the list of `WorkspaceRepositoryLink` (with Repository and branch) is available, **fetch PR in the app** for each repo that has a GitHub clone URL and a branch name.
-- **Parallelism:** Run requests in parallel with a **bounded concurrency** (e.g. 3–5 at a time) to avoid rate limits and avoid overwhelming the client.
+- **Parallelism:** Run requests in parallel with a **bounded concurrency** (e.g. 3-5 at a time) to avoid rate limits and avoid overwhelming the client.
 - **Caching:** Keep results in component state (e.g. `Dictionary<int, PullRequestInfo>` keyed by `RepositoryId`). No persistence in v1.
 
 **Pros:** Simple, always up-to-date when opening the page, no agent changes, no DB schema change.  
 **Cons:** Small delay on first load; no PR data when offline.
 
-### 3.2 Option B – Persist and refresh
+### 3.2 Option B - Persist and refresh
 
 - Add fields to **`WorkspaceRepositoryLink`**: e.g. `PullRequestNumber` (int?), `PullRequestState` (string or enum: Open, Merged, Closed), `PullRequestHtmlUrl` (string), `LastPrCheckAt` (DateTime?).
 - **When to set:** (1) After a full sync or refresh, the app calls the GitHub API for each repo and persists the result; and/or (2) on workspace page load, fetch and then persist.
@@ -108,7 +108,7 @@ So: **no new agent commands for PR**. PR data is fetched in the app via GitHub A
 **Pros:** Can show PR without a new API call; can show “last known” state.  
 **Cons:** Schema change, migration, and more logic; risk of stale data.
 
-**Recommendation for v1:** **Option A** – fetch on page load, in-memory only. Option B can be a follow-up if you want persisted PR state and fewer API calls on load.
+**Recommendation for v1:** **Option A** - fetch on page load, in-memory only. Option B can be a follow-up if you want persisted PR state and fewer API calls on load.
 
 ---
 
@@ -152,17 +152,17 @@ Non-GitHub repo or missing connector/token: show **none** (dark gray).
 ### 6.2 Cell content
 
 - **Component:** `PRBadge` (new shared component).
-- **Parameters:** e.g. `PullRequestNumber`, `PullRequestState` (open/merged/closed), `PullRequestUrl`, `DefaultBranchAheadCommits`, `HasPrData` (so we can show loading or “—” when fetch didn’t run).
+- **Parameters:** e.g. `PullRequestNumber`, `PullRequestState` (open/merged/closed), `PullRequestUrl`, `DefaultBranchAheadCommits`, `HasPrData` (so we can show loading or “-” when fetch didn’t run).
 - **Links:** When there is a PR, the badge can link to `PullRequestUrl` (GitHub PR page). “create” can link to the compare URL (same as used elsewhere: `{repoUrl}/compare/main...{branch}`).
 
 ### 6.3 Styling
 
 - Reuse existing badge patterns from the table (e.g. `.badge`, existing column alignment).
 - New classes, e.g.:
-  - `.pr-badge-none` – dark gray background.
-  - `.pr-badge-create` – yellow.
-  - `.pr-badge-open` – green.
-  - `.pr-badge-merged` – background #8957E5, color white.
+  - `.pr-badge-none` - dark gray background.
+  - `.pr-badge-create` - yellow.
+  - `.pr-badge-open` - green.
+  - `.pr-badge-merged` - background #8957E5, color white.
 
 Define these in `app.css` (or scoped CSS) under `.repositories-table td.col-pr`.
 
@@ -170,7 +170,7 @@ Define these in `app.css` (or scoped CSS) under `.repositories-table td.col-pr`.
 
 ## 7. Implementation Outline
 
-### 7.1 App – GitHub API
+### 7.1 App - GitHub API
 
 1. **GitHub API model:** Add a small DTO for the PR list response item (e.g. `GitHubPullRequestDto`) with `Number`, `State`, `MergedAt`, `HtmlUrl`, `Title`, and head ref info so we can confirm the branch matches.
 2. **`GitHubService`:** Add `GetPullRequestForBranchAsync(Connector connector, string owner, string repo, string branch, CancellationToken ct)`:
@@ -185,7 +185,7 @@ Define these in `app.css` (or scoped CSS) under `.repositories-table td.col-pr`.
      - Call `GitHubService.GetPullRequestForBranchAsync(connector, owner, repo, branchName, ct)`.
      - Return a simple app-side model (e.g. `PullRequestInfo { Number, State, MergedAt, HtmlUrl }`).
 
-### 7.2 App – Workspace page
+### 7.2 App - Workspace page
 
 1. **WorkspaceRepositories.razor:**
    - Inject `GitHubPullRequestService` and `ConnectorRepository` (if not already).
@@ -197,7 +197,7 @@ Define these in `app.css` (or scoped CSS) under `.repositories-table td.col-pr`.
    - Add `<td class="col-pr">` with `<PRBadge ... />` after the Divergence `<td>`, passing PR data and `DefaultBranchAheadCommits`.
    - Increment `colSpan` to 8.
 
-### 7.3 App – PRBadge component
+### 7.3 App - PRBadge component
 
 1. **Components/Shared/PRBadge.razor:**
    - Parameters: `PullRequestNumber`, `PullRequestState` (enum or string: Open, Merged, Closed), `PullRequestUrl`, `DefaultBranchAheadCommits`, and e.g. `IsLoading` / `IsGitHubRepo`.
@@ -219,8 +219,8 @@ Define these in `app.css` (or scoped CSS) under `.repositories-table td.col-pr`.
 | Non-GitHub repo | Do not call API; show “none” (dark gray). |
 | Missing or invalid connector/token | Skip API call; show “none”. |
 | Branch name with special characters | Use `Uri.EscapeDataString(branch)` in `head=` parameter. |
-| Rate limiting (403/429) | Log and show “—” or “none” for affected repos; optional: retry with backoff or show a “rate limited” message. |
-| Network error | Log; show “—” or “none” for that repo. |
+| Rate limiting (403/429) | Log and show “-” or “none” for affected repos; optional: retry with backoff or show a “rate limited” message. |
+| Network error | Log; show “-” or “none” for that repo. |
 | Repo not yet synced / no branch | Show “none”. |
 
 ---

--- a/docs/Pull-Request-Persistence-Design.md
+++ b/docs/Pull-Request-Persistence-Design.md
@@ -1,4 +1,4 @@
-# Pull Request Persistence – Design Document
+# Pull Request Persistence - Design Document
 
 ## Overview
 
@@ -32,7 +32,7 @@ Use a **dedicated table** so PR concerns stay in one place and `WorkspaceReposit
 | MergedAt               | datetime?| When merged (for "merged" badge) |
 | LastCheckedAt          | datetime | When we last fetched from API |
 
-- **PK:** `WorkspaceRepositoryId` (one row per workspace–repo link).
+- **PK:** `WorkspaceRepositoryId` (one row per workspace-repo link).
 - **FK:** `WorkspaceRepositoryId` → `WorkspaceRepositories(WorkspaceRepositoryId)` ON DELETE CASCADE.
 - When there is no PR, store a row with `PullRequestNumber = null` (and other fields null) so we know "we checked, no PR"; or delete the row. Prefer **upsert: if no PR, write null number and state** so `LastCheckedAt` is still set.
 

--- a/docs/Push-Hook-Implementation.md
+++ b/docs/Push-Hook-Implementation.md
@@ -1,4 +1,4 @@
-# Push Hook — Implementation Document
+# Push Hook - Implementation Document
 
 ## Purpose
 
@@ -16,7 +16,7 @@ Notify the GrayMoon app when a **push** is about to happen (or has been triggere
 ### 2. Dedicated push handler
 
 - **`PushHookSyncCommand`** was added in `GrayMoon.Agent/Commands/PushHookSyncCommand.cs`. It implements the push notify flow:
-  - **No fetch** — uses current local state only.
+  - **No fetch** - uses current local state only.
   - Runs **GitVersion** and **commit counts** (outgoing/incoming vs upstream, and vs default branch).
   - Optionally resolves **has upstream** via token + remote branches.
   - Builds a **`RepositorySyncNotification`** (same type as commit/checkout/merge) and sends it to the app via **SignalR `SyncCommand`**.
@@ -56,7 +56,7 @@ No new app-side handler was added; the existing **SyncCommand** / **SyncCommandH
 |----------|--------|
 | `GrayMoon.Agent/Abstractions/NotifyHookKind.cs` | Added `Push = 3`. |
 | `GrayMoon.Agent/Hosted/HookListenerHostedService.cs` | Map `/hook/push` → `NotifyHookKind.Push`. |
-| `GrayMoon.Agent/Commands/PushHookSyncCommand.cs` | **New** — push notify handler (version + commit counts only, no fetch). |
+| `GrayMoon.Agent/Commands/PushHookSyncCommand.cs` | **New** - push notify handler (version + commit counts only, no fetch). |
 | `GrayMoon.Agent/Commands/HookSyncDispatcher.cs` | Route `NotifyHookKind.Push` to `PushHookSyncCommand`. |
 | `GrayMoon.Agent/Cli/RunCommandHandler.cs` | Register `PushHookSyncCommand` in DI. |
 | `GrayMoon.Agent/Services/GitService.cs` | In `WriteSyncHooks`, add `pushCurl` and write **pre-push** hook. |

--- a/docs/SignalR-Agent-Code-Analysis.md
+++ b/docs/SignalR-Agent-Code-Analysis.md
@@ -65,7 +65,7 @@ This document summarizes the **SignalR and agent notification flow**, identifies
 **Findings:**
 
 - **Single subscription**: Only one `On("WorkspaceSynced")` registration; no duplicate handlers.
-- **Rapid events**: Multiple WorkspaceSynced events in quick succession (e.g. from API + hook) each trigger `RefreshFromSync`, so the page can do multiple full DB reloads and re-renders for one user action. **Debouncing** the SignalR callback (e.g. 150–200 ms) so that only one refresh runs after the last event in a burst keeps behavior correct and makes the UI feel snappier.
+- **Rapid events**: Multiple WorkspaceSynced events in quick succession (e.g. from API + hook) each trigger `RefreshFromSync`, so the page can do multiple full DB reloads and re-renders for one user action. **Debouncing** the SignalR callback (e.g. 150-200 ms) so that only one refresh runs after the last event in a burst keeps behavior correct and makes the UI feel snappier.
 - **Dispose**: The component disposes the hub connection and various CTSs; cancelling any pending debounce timer in `Dispose` avoids running refresh after the component is disposed.
 
 ---

--- a/docs/Token-Encryption-Design.md
+++ b/docs/Token-Encryption-Design.md
@@ -109,8 +109,8 @@ We want a single string column that:
 Suggested format:
 
 - `v2:KEYID:BASE64(IV || CIPHERTEXT || TAG)`
-  - `v2` – identifies the AES-GCM scheme (Level 2).
-  - `KEYID` – optional; allows multiple keys (e.g. `"v1"`, `"2026-03"`). If not used, we can set it to a fixed default such as `"default"`.
+  - `v2` - identifies the AES-GCM scheme (Level 2).
+  - `KEYID` - optional; allows multiple keys (e.g. `"v1"`, `"2026-03"`). If not used, we can set it to a fixed default such as `"default"`.
   - The final portion is one Base64 string containing **IV (12 bytes) + ciphertext (N) + tag (16 bytes)**.
 
 This string is what we store in `Connectors.UserToken`.
@@ -240,9 +240,9 @@ If we cannot inject into all existing call sites easily, we can keep the existin
 
 We need to handle **three formats** during migration:
 
-1. **Legacy plain text** (pre-Level 1) – theoretically no longer present after `MigrateConnectorUserTokenBase64Async`, but we handle it defensively if found.
-2. **Level 1 Base64-only** – strings that are valid Base64 but have **no `v2:` prefix**.
-3. **Level 2 AES-GCM** – strings starting with `v2:` as defined above.
+1. **Legacy plain text** (pre-Level 1) - theoretically no longer present after `MigrateConnectorUserTokenBase64Async`, but we handle it defensively if found.
+2. **Level 1 Base64-only** - strings that are valid Base64 but have **no `v2:` prefix**.
+3. **Level 2 AES-GCM** - strings starting with `v2:` as defined above.
 
 `ITokenProtector.Unprotect` is responsible for:
 

--- a/docs/Workspace-Root-Path-Analysis.md
+++ b/docs/Workspace-Root-Path-Analysis.md
@@ -16,16 +16,16 @@
 ### How it is used today
 
 1. **WorkspaceService**
-   - **`GetRootPathAsync()`** – Reads from Settings (with in-memory cache). Used as the "global" default.
-   - **`GetRootPathForWorkspaceAsync(workspace)`** – Returns `workspace.RootPath` if set, otherwise falls back to `GetRootPathAsync()` (Settings). This is the **correct** source for command execution when a workspace is known.
+   - **`GetRootPathAsync()`** - Reads from Settings (with in-memory cache). Used as the "global" default.
+   - **`GetRootPathForWorkspaceAsync(workspace)`** - Returns `workspace.RootPath` if set, otherwise falls back to `GetRootPathAsync()` (Settings). This is the **correct** source for command execution when a workspace is known.
 
 2. **WorkspaceRepository**
-   - **AddAsync** – Sets `workspace.RootPath = await _workspaceService.GetRootPathAsync()`. New workspaces get the **current Settings value** (intended as default).
-   - **UpdateAsync** – Updates only `Name` and repository links. **Does not update `RootPath`.** So any edited "root path" in the UI is not persisted.
+   - **AddAsync** - Sets `workspace.RootPath = await _workspaceService.GetRootPathAsync()`. New workspaces get the **current Settings value** (intended as default).
+   - **UpdateAsync** - Updates only `Name` and repository links. **Does not update `RootPath`.** So any edited "root path" in the UI is not persisted.
 
-3. **Settings page** – Edits and saves the global Setting only. On save it calls `WorkspaceService.ClearCachedRootPath()` so the next `GetRootPathAsync()` re-reads from DB.
+3. **Settings page** - Edits and saves the global Setting only. On save it calls `WorkspaceService.ClearCachedRootPath()` so the next `GetRootPathAsync()` re-reads from DB.
 
-4. **AgentHub** – On agent connect: `RefreshRootPathAsync()` (refreshes cache from Settings). On disconnect: `ClearCachedRootPath()`. This only affects the **global** cache, not per-workspace `RootPath`.
+4. **AgentHub** - On agent connect: `RefreshRootPathAsync()` (refreshes cache from Settings). On disconnect: `ClearCachedRootPath()`. This only affects the **global** cache, not per-workspace `RootPath`.
 
 ---
 
@@ -34,7 +34,7 @@
 - **Commands** receive `WorkspaceRoot` from the app. The app is supposed to pass the root for the **specific workspace**. Most call sites use `GetRootPathForWorkspaceAsync(workspace)`, which is correct.
 - **One bug:** In **BranchEndpoints.cs** (Sync-to-default flow), the code uses `GetRootPathAsync(CancellationToken.None)` instead of `GetRootPathForWorkspaceAsync(workspace, ...)`. So that endpoint uses the **Settings** root, not the workspace’s `RootPath`. If the workspace has a different root (or Settings was changed), the repo can’t be found.
 - **Workspaces with `RootPath == null`** (e.g. created before the column existed, or never set) always fall back to Settings. If the user then changes the Settings path, those workspaces effectively "move" to the new path and existing repos are no longer found.
-- **Edit workspace** – The Workspaces page has `editingWorkspaceRootPath` and uses it for validation and display, but **UpdateAsync does not persist RootPath**, so changes to root path in the edit modal are never saved.
+- **Edit workspace** - The Workspaces page has `editingWorkspaceRootPath` and uses it for validation and display, but **UpdateAsync does not persist RootPath**, so changes to root path in the edit modal are never saved.
 
 ---
 
@@ -51,7 +51,7 @@
 | WorkspaceFileVersionService.cs | File versions | `GetRootPathForWorkspaceAsync(workspace)` | ✓ correct |
 | WorkspaceFiles.razor | ViewFileModal | `GetRootPathForWorkspaceAsync(workspace)` | ✓ correct |
 | **WorkspaceRepository.cs** | AddAsync | `GetRootPathAsync()` → set `workspace.RootPath` | ✓ correct (Settings as default for new workspace) |
-| **WorkspaceRepository.cs** | UpdateAsync | — | Should persist `RootPath` if we allow editing it |
+| **WorkspaceRepository.cs** | UpdateAsync | - | Should persist `RootPath` if we allow editing it |
 | Workspaces.razor | Create modal default / validation | `GetRootPathAsync()`, `editingWorkspaceRootPath` | ✓ Settings as default for new; edit should persist RootPath |
 | Settings.razor | Single global root path | AppSettingRepository | ✓ only default for new workspace |
 

--- a/docs/design/dependency-update-orchestration.md
+++ b/docs/design/dependency-update-orchestration.md
@@ -11,15 +11,15 @@ This document describes how **csproj dependencies** and **version file dependenc
 **What they are:** PackageReference versions in `.csproj` files. A project in repo A references a package produced by a project in repo B; the version in A’s `.csproj` should match the current version (e.g. GitVersion) of B.
 
 **Data sources:**
-- **WorkspaceProjects** — projects and their `ProjectFilePath` (path to `.csproj`), `PackageId`, `ProjectName`
-- **ProjectDependencies** — dependent project → referenced project, and current `Version` in the `.csproj`
-- **WorkspaceRepositoryLink.GitVersion** — current version of each repo (source of truth for “new” version)
+- **WorkspaceProjects** - projects and their `ProjectFilePath` (path to `.csproj`), `PackageId`, `ProjectName`
+- **ProjectDependencies** - dependent project → referenced project, and current `Version` in the `.csproj`
+- **WorkspaceRepositoryLink.GitVersion** - current version of each repo (source of truth for “new” version)
 
 **Mismatch rule:** For each dependency edge, `ProjectDependency.Version` ≠ referenced repo’s `GitVersion` ⇒ needs update.
 
 | Layer | Responsibility |
 |-------|----------------|
-| **WorkspaceProjectRepository** | Builds update plan: `GetSyncDependenciesPayloadAsync` — which repos/projects/packages need version bumps and to what version. |
+| **WorkspaceProjectRepository** | Builds update plan: `GetSyncDependenciesPayloadAsync` - which repos/projects/packages need version bumps and to what version. |
 | **WorkspaceGitService** | Refresh projects from disk (`RefreshWorkspaceProjectsAsync`), get plan (`GetUpdatePlanAsync`), sync `.csproj` on disk (`SyncDependenciesAsync`), commit `.csproj` changes (`CommitDependencyUpdatesAsync`), refresh repo version and broadcast. |
 | **DependencyUpdateOrchestrator** | Runs the **csproj-only** workflow: refresh → plan → (multi/single level) sync → commit → refresh version. Stateless; no UI. |
 | **WorkspaceUpdateHandler** | Thin wrapper: calls orchestrator with progress/error callbacks. |
@@ -38,9 +38,9 @@ This document describes how **csproj dependencies** and **version file dependenc
 **What they are:** Arbitrary files (e.g. `Directory.Build.props`, `version.json`) that contain version placeholders. The user configures a **version pattern** per file (e.g. `Version="{RepoA}"`). At update time, placeholders are replaced with current repo versions from workspace links (no GitVersion run).
 
 **Data sources:**
-- **WorkspaceFileVersionConfig** — `FileId`, `VersionPattern` (multi-line: `KEY={repositoryName}`)
-- **WorkspaceRepositoryLink.GitVersion** — current version per repo (same as for csproj)
-- **WorkspaceFile** — file path and repository
+- **WorkspaceFileVersionConfig** - `FileId`, `VersionPattern` (multi-line: `KEY={repositoryName}`)
+- **WorkspaceRepositoryLink.GitVersion** - current version per repo (same as for csproj)
+- **WorkspaceFile** - file path and repository
 
 **“Mismatch” rule:** There is no explicit mismatch. The operation is “update all configured files with current workspace repo versions.” So it’s always “run update” if there are configs.
 
@@ -50,7 +50,7 @@ This document describes how **csproj dependencies** and **version file dependenc
 | **WorkspaceGitService** | Commit updated paths: `CommitFilePathsAsync` (generic “stage these paths and commit” with message e.g. `chore(deps): update versions (N)`). |
 | **Orchestrator** | **None.** Version-file update is not part of `DependencyUpdateOrchestrator`. |
 | **UI (WorkspaceRepositories.razor.cs)** | After csproj update completes: call `RunFileVersionUpdateAndGetUpdatedFilesAsync()`; if any files updated, either auto-commit (`CommitFileVersionUpdatesAsync`) or show `VersionFilesCommitModal`. When Update is clicked and **no** csproj updates: run version-file update and show modal if there are updated files. Same for single-repo update. |
-| **Agent** | `UpdateFileVersions` — in-place substitution in one file using pattern + `repoVersions`. |
+| **Agent** | `UpdateFileVersions` - in-place substitution in one file using pattern + `repoVersions`. |
 
 **Flow (high level):**
 1. No plan step: all configured files are candidates.
@@ -360,7 +360,7 @@ So:
 Current:
 
 - `DependencyUpdateOrchestrator.RunAsync(workspaceId, cancellationToken, setProgress, onRepoError, onAppSideComplete, repoIdsToUpdate?)`  
-  — runs only the **csproj** flow.
+  - runs only the **csproj** flow.
 
 Proposed:
 
@@ -390,7 +390,7 @@ Recommendation: **Option B** for backward compatibility with “confirm before c
 ### 6.4 Dependency Injection
 
 - `DependencyUpdateOrchestrator` today depends on `WorkspaceGitService` and `IOptions<WorkspaceOptions>`.
-- Add `WorkspaceFileVersionService` (and, for Option B, no extra dependency for modal — just a callback).
+- Add `WorkspaceFileVersionService` (and, for Option B, no extra dependency for modal - just a callback).
 - Orchestrator stays in App layer; no UI types. Callback `onVersionFilesUpdated(byRepo)` can be a simple delegate so the page can pass a method that opens the modal and stores `byRepo` for commit on confirm.
 
 ### 6.5 UI Changes
@@ -421,7 +421,7 @@ Recommendation: **Option B** for backward compatibility with “confirm before c
 ### 6.7 Backward Compatibility
 
 - If there are no version configs, step 6 returns no updated files; step 7 is skipped. Behavior matches “csproj only.”
-- If there are no csproj updates but there are version configs, step 4 is skipped, step 6 runs, step 7 runs — “version files only” is just a subset of the same flow.
+- If there are no csproj updates but there are version configs, step 4 is skipped, step 6 runs, step 7 runs - “version files only” is just a subset of the same flow.
 - Single-repo: same orchestrator with `repoIdsToUpdate: { id }`; version-file update can be scoped to that repo in `UpdateAllVersionsAsync(selectedRepositoryIds: repoIdsToUpdate)`.
 
 ---

--- a/docs/obsolete/Sync-Push-Implementation-Analysis.md
+++ b/docs/obsolete/Sync-Push-Implementation-Analysis.md
@@ -9,7 +9,7 @@ This document describes how **dependency-synchronized push** (sync push) is impl
 - **Purpose:** Push multiple repositories in a workspace while respecting inter-repo dependencies. Lower-level repos (packages consumed by others) are pushed first; the app can wait until their packages are visible in the configured NuGet registries before pushing higher-level repos.
 - **Entry point:** UI "Push" button on the Workspace Repositories page.
 - **Main orchestration:** `WorkspaceGitService.RunPushAsync` (App) and agent command `PushRepository` (Agent).
-- **Key data:** Push plan from `WorkspaceProjectRepository.GetPushPlanPayloadAsync` — one payload per repo with dependency level and list of required packages (from lower-level repos) that must be in the registry before that repo is pushed.
+- **Key data:** Push plan from `WorkspaceProjectRepository.GetPushPlanPayloadAsync` - one payload per repo with dependency level and list of required packages (from lower-level repos) that must be in the registry before that repo is pushed.
 
 ---
 
@@ -66,13 +66,13 @@ So the UI only pushes repos that have unpushed commits (and optionally only sele
 
 ## 4. App Service: `WorkspaceGitService.RunPushAsync`
 
-**Location:** `GrayMoon.App/Services/WorkspaceGitService.cs` (approx. lines 541–664).
+**Location:** `GrayMoon.App/Services/WorkspaceGitService.cs` (approx. lines 541-664).
 
 ### 4.1 Prerequisites and setup
 
 - Requires `IAgentBridge.IsAgentConnected`; throws if not.
 - Loads workspace; creates workspace directory if needed.
-- **Step 1 — Sync package registries:**  
+- **Step 1 - Sync package registries:**  
   If `PackageRegistrySyncService` is registered, calls `SyncWorkspacePackageRegistriesAsync(workspaceId)`. This updates `MatchedConnectorId` for workspace packages by checking active NuGet connectors so the push plan’s “required package → registry” is up to date.
 
 ### 4.2 Push plan and filtering
@@ -95,7 +95,7 @@ So the UI only pushes repos that have unpushed commits (and optionally only sele
   - Process **one dependency level at a time** (levels ascending).
   - For each level:
     1. **Wait for required packages:** Collect all `RequiredPackages` for repos at this level (with `MatchedConnectorId`). For each, poll `NuGetService.PackageVersionExistsAsync(connector, packageId, version)` until all are found or timeout. Timeout = `totalDeps * PushWaitDependencyTimeoutMinutesPerDependency` (from `WorkspaceOptions`, default 1.0 minute per dependency). Progress message shows “Waiting for N dependencies...” and countdown.
-    2. **Push repos at this level:** `PushReposAsync(workspace, reposAtLevel, ...)` — all repos at this level pushed in parallel (throttled by `_maxConcurrent`).
+    2. **Push repos at this level:** `PushReposAsync(workspace, reposAtLevel, ...)` - all repos at this level pushed in parallel (throttled by `_maxConcurrent`).
     3. **Refresh versions:** `RefreshVersionsAfterPushAsync(workspaceId, reposAtLevel)` so the UI sees updated versions after push.
 
 - After all levels (or after single-step push): broadcast `WorkspaceSynced` if hub is available.

--- a/docs/obsolete/WorkspaceRepositories-Analysis.md
+++ b/docs/obsolete/WorkspaceRepositories-Analysis.md
@@ -1,4 +1,4 @@
-# WorkspaceRepositories.razor – Analysis and Optimization Plan
+# WorkspaceRepositories.razor - Analysis and Optimization Plan
 
 This document analyzes the **GrayMoon** codebase purpose, the **WorkspaceRepositories** page in detail, and proposes **breakdown and optimizations** to improve maintainability without changing behavior.
 
@@ -19,7 +19,7 @@ The **WorkspaceRepositories** page is the main workspace view: it lists reposito
 
 ---
 
-## 2. WorkspaceRepositories.razor – Current State
+## 2. WorkspaceRepositories.razor - Current State
 
 ### 2.1 Size and structure
 
@@ -101,7 +101,7 @@ The project does not use `.razor.cs` today; introducing it for this one page is 
 
 Instead of 55 flat fields, group by concern so the file is easier to reason about:
 
-- **Modal state**: e.g. `RepositoriesModalState`, `BranchModalState`, `SwitchBranchModalState`, `UpdateModalState`, `PushWithDependenciesModalState`, `ConfirmModalState` (each with the 3–6 fields for that modal).
+- **Modal state**: e.g. `RepositoriesModalState`, `BranchModalState`, `SwitchBranchModalState`, `UpdateModalState`, `PushWithDependenciesModalState`, `ConfirmModalState` (each with the 3-6 fields for that modal).
 - **Operation state**: e.g. `SyncState`, `UpdateState`, `PushState`, `CommitSyncState`, `CheckoutState`, `CreateBranchesState` (progress message, CTS, bool flags).
 
 Refactor one modal or one operation at a time; behavior stays the same.

--- a/docs/obsolete/WorkspaceRepositories-CSS-Fix-Plan.md
+++ b/docs/obsolete/WorkspaceRepositories-CSS-Fix-Plan.md
@@ -4,7 +4,7 @@ This plan addresses the regressions after moving the Workspace Repositories grid
 
 ---
 
-### Step 1 – Restore dependency level header layout and background
+### Step 1 - Restore dependency level header layout and background
 
 - **Goal**: Make the dependency level header row look exactly like before:
   - Dark background (black / near-black).
@@ -26,7 +26,7 @@ This plan addresses the regressions after moving the Workspace Repositories grid
 
 ---
 
-### Step 2 – Fix dependency level header icon colors
+### Step 2 - Fix dependency level header icon colors
 
 - **Goal**: Use the same icon colors as before (dedicated gray tones, not global text variables).
 - **Files**:
@@ -49,7 +49,7 @@ This plan addresses the regressions after moving the Workspace Repositories grid
 
 ---
 
-### Step 3 – Restore dependency column badge (background + text color)
+### Step 3 - Restore dependency column badge (background + text color)
 
 - **Goal**: Make the dependency badge cells look like before:
   - Solid background color per state (none/ok/mismatch).
@@ -73,7 +73,7 @@ This plan addresses the regressions after moving the Workspace Repositories grid
 
 ---
 
-### Step 4 – Restore ellipsis behavior for Repository / Version / Branch columns
+### Step 4 - Restore ellipsis behavior for Repository / Version / Branch columns
 
 - **Goal**:
   - `Repository`, `Version`, and `Branch` **never wrap**; they truncate with `...` when too long.
@@ -101,7 +101,7 @@ This plan addresses the regressions after moving the Workspace Repositories grid
 
 ---
 
-### Step 5 – Restore hover “frame” (pill) for Version and Branch
+### Step 5 - Restore hover “frame” (pill) for Version and Branch
 
 - **Goal**: When hovering Version and Branch:
   - Show the pill‑like frame and background, identical to Divergence/Commits badges behavior.
@@ -121,7 +121,7 @@ This plan addresses the regressions after moving the Workspace Repositories grid
 
 ---
 
-### Step 6 – Fix Repository link hover color (underline should match text color)
+### Step 6 - Fix Repository link hover color (underline should match text color)
 
 - **Goal**:
   - Repository names remain white (or current text color).

--- a/docs/obsolete/WorkspaceRepositories-Refactoring-Plan.md
+++ b/docs/obsolete/WorkspaceRepositories-Refactoring-Plan.md
@@ -1,4 +1,4 @@
-# WorkspaceRepositories.razor — Refactoring Plan
+# WorkspaceRepositories.razor - Refactoring Plan
 
 **Goal:** Make the page safe, maintainable, and optimized without breaking UX or functionality.  
 **Reference:** [WorkspaceRepositories-razor-Analysis.md](WorkspaceRepositories-razor-Analysis.md) (method inventory and best practices).
@@ -16,39 +16,39 @@ This plan applies **all 10 best practices** in a phased order so each step is sm
 
 ---
 
-## Phase 0 — Preparation (no UX change)
+## Phase 0 - Preparation (no UX change)
 
 **Purpose:** Add missing shared types and a URL helper so later phases don’t depend on the page.
 
-### 0.1 — Point 9: Extract API and DTOs
+### 0.1 - Point 9: Extract API and DTOs
 
 | Action | Detail |
 |--------|--------|
 | **Add DTO** | In `Models/Api/BranchesApiModels.cs` add `CreateBranchApiResult` with `Success` and `Error` (or align with existing `CreateBranchResponse` if the API returns `errorMessage`). |
 | **Update page** | In `WorkspaceRepositories.razor` remove the nested `CreateBranchApiResult` class and use the type from `GrayMoon.App.Models.Api`. |
-| **Verify** | Build; run; create branch from Switch Branch modal — response still deserializes. |
+| **Verify** | Build; run; create branch from Switch Branch modal - response still deserializes. |
 
 **Risk:** Low. Only moves a type and updates a using.
 
 ---
 
-### 0.2 — Point 7: Centralize URLs and navigation
+### 0.2 - Point 7: Centralize URLs and navigation
 
 | Action | Detail |
 |--------|--------|
 | **Add helper** | Create `Services/WorkspaceUrlHelper.cs` (or extend an existing route helper) with: `GetDependencyGraphUrl(int workspaceId, int? repositoryId = null, int? level = null)` returning `/workspaces/{id}/dependencies?repo={repo}` or `?level={level}`. |
 | **Update page** | Replace `GetDependencyGraphUrl(repoId)` and `GetDependencyGraphUrlForLevel(level)` with calls to the helper (pass `WorkspaceId`). |
-| **Verify** | Build; click dependency graph links for repo and level — same URLs and navigation. |
+| **Verify** | Build; click dependency graph links for repo and level - same URLs and navigation. |
 
 **Risk:** Low. Pure URL generation; no state or UI change.
 
 ---
 
-## Phase 1 — Code-behind and shared orchestration
+## Phase 1 - Code-behind and shared orchestration
 
 **Purpose:** Move logic out of the `.razor` file and deduplicate sync/commit-sync/sync-to-default so the page stays stable while we add structure.
 
-### 1.1 — Point 1: Move logic to a code-behind or view model
+### 1.1 - Point 1: Move logic to a code-behind or view model
 
 | Action | Detail |
 |--------|--------|
@@ -60,7 +60,7 @@ This plan applies **all 10 best practices** in a phased order so each step is sm
 
 ---
 
-### 1.2 — Point 4: Reuse sync/update/push orchestration
+### 1.2 - Point 4: Reuse sync/update/push orchestration
 
 | Action | Detail |
 |--------|--------|
@@ -74,28 +74,28 @@ This plan applies **all 10 best practices** in a phased order so each step is sm
 
 ---
 
-## Phase 2 — Feature handlers and modal state
+## Phase 2 - Feature handlers and modal state
 
 **Purpose:** Isolate feature logic and modal state so the page only coordinates.
 
-### 2.1 — Point 2: Extract feature-based services or handlers
+### 2.1 - Point 2: Extract feature-based services or handlers
 
 | Action | Detail |
 |--------|--------|
 | **Handlers** | Create stateless handler classes (or scoped services) that take dependencies in the constructor and expose async methods. Page creates them via factory or gets them from DI. Suggested split: |
-| | **WorkspaceSyncHandler** — `SyncAsync`, `SyncLevelAsync`, `SyncSingleRepoAsync` (call `RunSyncCoreAsync`); progress/CTS/errors reported via callbacks or a context object provided by the page. |
-| | **WorkspaceUpdateHandler** — Update plan, `RunUpdateCoreAsync`, single-repo update, commit payload, file-version update; page passes `WorkspaceId`, progress/error callbacks, and cancellation. |
-| | **WorkspacePushHandler** — Push plan, push with deps, single-repo push with upstream; page passes workspace id, progress, errors. |
-| | **WorkspaceCommitSyncHandler** — `CommitSyncAsync`, `CommitSyncLevelAsync` (calls API); page passes base URL, HTTP client, progress, errors. |
-| | **WorkspaceBranchHandler** — Create branches (all/single), checkout, sync to default (single/level); page passes workspace id, progress, errors. |
+| | **WorkspaceSyncHandler** - `SyncAsync`, `SyncLevelAsync`, `SyncSingleRepoAsync` (call `RunSyncCoreAsync`); progress/CTS/errors reported via callbacks or a context object provided by the page. |
+| | **WorkspaceUpdateHandler** - Update plan, `RunUpdateCoreAsync`, single-repo update, commit payload, file-version update; page passes `WorkspaceId`, progress/error callbacks, and cancellation. |
+| | **WorkspacePushHandler** - Push plan, push with deps, single-repo push with upstream; page passes workspace id, progress, errors. |
+| | **WorkspaceCommitSyncHandler** - `CommitSyncAsync`, `CommitSyncLevelAsync` (calls API); page passes base URL, HTTP client, progress, errors. |
+| | **WorkspaceBranchHandler** - Create branches (all/single), checkout, sync to default (single/level); page passes workspace id, progress, errors. |
 | **Page** | Page keeps: loading state, `workspaceRepositories`, `errorMessage`, `repositoryErrors`, modal visibility flags, and high-level actions that call the handlers and then set state / refresh. Handlers do not hold component state; they receive everything they need. |
 | **Verify** | Same flows as before: sync, update, push, pull, branch create/checkout/sync-to-default. |
 
-**Risk:** Medium–high. Start with one handler (e.g. `WorkspaceCommitSyncHandler`) and wire it; then replicate the pattern for sync, update, push, branch.
+**Risk:** Medium-high. Start with one handler (e.g. `WorkspaceCommitSyncHandler`) and wire it; then replicate the pattern for sync, update, push, branch.
 
 ---
 
-### 2.2 — Point 3: Extract modal state and commands
+### 2.2 - Point 3: Extract modal state and commands
 
 | Action | Detail |
 |--------|--------|
@@ -108,11 +108,11 @@ This plan applies **all 10 best practices** in a phased order so each step is sm
 
 ---
 
-## Phase 3 — Markup and components
+## Phase 3 - Markup and components
 
 **Purpose:** Shrink the Razor file and isolate table structure.
 
-### 3.1 — Point 5: Keep markup focused on structure and binding
+### 3.1 - Point 5: Keep markup focused on structure and binding
 
 | Action | Detail |
 |--------|--------|
@@ -124,7 +124,7 @@ This plan applies **all 10 best practices** in a phased order so each step is sm
 
 ---
 
-### 3.2 — Point 6: Use partials or subcomponents for table sections
+### 3.2 - Point 6: Use partials or subcomponents for table sections
 
 | Action | Detail |
 |--------|--------|
@@ -137,11 +137,11 @@ This plan applies **all 10 best practices** in a phased order so each step is sm
 
 ---
 
-## Phase 4 — Service surface and responsibility
+## Phase 4 - Service surface and responsibility
 
 **Purpose:** Reduce what the page injects and does so it acts as a coordinator.
 
-### 4.1 — Point 8: Limit injected services in the page
+### 4.1 - Point 8: Limit injected services in the page
 
 | Action | Detail |
 |--------|--------|
@@ -153,15 +153,15 @@ This plan applies **all 10 best practices** in a phased order so each step is sm
 
 ---
 
-### 4.2 — Point 10: Single responsibility per component
+### 4.2 - Point 10: Single responsibility per component
 
 | Action | Detail |
 |--------|--------|
-| **Optional split** | If the page is still large or has distinct “zones,” consider splitting into: (1) **WorkspaceRepositoriesPage** — route, layout, header, one main child; (2) **WorkspaceRepositoriesGrid** — table, level headers, rows, loading/empty states, search filter applied to data; (3) **WorkspaceRepositoriesHeader** — already exists; reuse. The page would own workspace load, errors, and modal/overlay state and pass data + callbacks into the grid. |
+| **Optional split** | If the page is still large or has distinct “zones,” consider splitting into: (1) **WorkspaceRepositoriesPage** - route, layout, header, one main child; (2) **WorkspaceRepositoriesGrid** - table, level headers, rows, loading/empty states, search filter applied to data; (3) **WorkspaceRepositoriesHeader** - already exists; reuse. The page would own workspace load, errors, and modal/overlay state and pass data + callbacks into the grid. |
 | **Responsibility** | Page: load workspace, manage errors and global state, show/hide modals and overlays, delegate actions to handlers. Grid: display and filter repos, emit row/level events. Handlers: run sync, update, push, commit-sync, branch operations. |
 | **Verify** | No UX or URL change; only file boundaries and responsibility boundaries clarified. |
 
-**Risk:** Low to medium. Can be done last and only if the team wants a clearer split; otherwise Phase 1–3 already achieve most of the maintainability gain.
+**Risk:** Low to medium. Can be done last and only if the team wants a clearer split; otherwise Phase 1-3 already achieve most of the maintainability gain.
 
 ---
 
@@ -184,15 +184,15 @@ This plan applies **all 10 best practices** in a phased order so each step is sm
 
 ## Suggested order of implementation
 
-1. **Phase 0** — DTO and URL helper (quick wins, no behavior change).  
-2. **Phase 1.1** — Code-behind (enables all other refactors).  
-3. **Phase 1.2** — Sync/commit-sync/sync-to-default consolidation (fewer bugs, easier to change).  
-4. **Phase 2.2** — Modal state (one modal at a time; reduces field sprawl).  
-5. **Phase 2.1** — Handlers (one handler at a time; e.g. CommitSync → Sync → Update → Push → Branch).  
-6. **Phase 3.2** — Level header and row components (biggest markup reduction).  
-7. **Phase 3.1** — Cleanup markup and bindings.  
-8. **Phase 4.1** — Facade service (after handlers exist).  
-9. **Phase 4.2** — Optional page/grid split.
+1. **Phase 0** - DTO and URL helper (quick wins, no behavior change).  
+2. **Phase 1.1** - Code-behind (enables all other refactors).  
+3. **Phase 1.2** - Sync/commit-sync/sync-to-default consolidation (fewer bugs, easier to change).  
+4. **Phase 2.2** - Modal state (one modal at a time; reduces field sprawl).  
+5. **Phase 2.1** - Handlers (one handler at a time; e.g. CommitSync → Sync → Update → Push → Branch).  
+6. **Phase 3.2** - Level header and row components (biggest markup reduction).  
+7. **Phase 3.1** - Cleanup markup and bindings.  
+8. **Phase 4.1** - Facade service (after handlers exist).  
+9. **Phase 4.2** - Optional page/grid split.
 
 ---
 

--- a/docs/obsolete/WorkspaceRepositories-razor-Analysis.md
+++ b/docs/obsolete/WorkspaceRepositories-razor-Analysis.md
@@ -1,4 +1,4 @@
-# WorkspaceRepositories.razor — Deep Analysis
+# WorkspaceRepositories.razor - Deep Analysis
 
 **File:** `src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor`  
 **Approximate size:** ~2,845 lines (markup + @code)  
@@ -229,16 +229,16 @@
 
 ## 2. Properties / Computed (used like methods)
 
-- **FilteredWorkspaceRepositories** — calls `GetFilteredWorkspaceRepositories()`.
-- **LevelGroups** — groups `workspaceRepositories` by dependency level, ordered.
-- **FilteredLevelGroups** — same grouping on filtered list.
-- **ApiBaseUrl** — `NavigationManager.BaseUri` trimmed.
+- **FilteredWorkspaceRepositories** - calls `GetFilteredWorkspaceRepositories()`.
+- **LevelGroups** - groups `workspaceRepositories` by dependency level, ordered.
+- **FilteredLevelGroups** - same grouping on filtered list.
+- **ApiBaseUrl** - `NavigationManager.BaseUri` trimmed.
 
 ---
 
 ## 3. Nested Type
 
-- **CreateBranchApiResult** — DTO for `/api/branches/create` (and set-upstream) response: `Success`, `Error`.
+- **CreateBranchApiResult** - DTO for `/api/branches/create` (and set-upstream) response: `Success`, `Error`.
 
 ---
 

--- a/src/GrayMoon.Agent/Abstractions/NotifyHookKind.cs
+++ b/src/GrayMoon.Agent/Abstractions/NotifyHookKind.cs
@@ -9,6 +9,6 @@ public enum NotifyHookKind
     Checkout = 1,
     /// <summary>post-merge: re-runs GitVersion and commit counts. No fetch needed.</summary>
     Merge = 2,
-    /// <summary>pre-push: re-runs GitVersion and commit counts. No fetch — uses current local state only.</summary>
+    /// <summary>pre-push: re-runs GitVersion and commit counts. No fetch - uses current local state only.</summary>
     Push = 3
 }

--- a/src/GrayMoon.Agent/Commands/CommitHookSyncCommand.cs
+++ b/src/GrayMoon.Agent/Commands/CommitHookSyncCommand.cs
@@ -8,7 +8,7 @@ namespace GrayMoon.Agent.Commands;
 
 /// <summary>
 /// Handles post-commit and post-update hooks: re-runs GitVersion and gets commit counts.
-/// No git fetch — uses the existing remote tracking refs from the last checkout/sync.
+/// No git fetch - uses the existing remote tracking refs from the last checkout/sync.
 /// </summary>
 public sealed class CommitHookSyncCommand(IGitService git, IAgentTokenProvider tokenProvider, IHubConnectionProvider hubProvider, ILogger<CommitHookSyncCommand> logger)
 {

--- a/src/GrayMoon.Agent/Commands/MergeHookSyncCommand.cs
+++ b/src/GrayMoon.Agent/Commands/MergeHookSyncCommand.cs
@@ -8,7 +8,7 @@ namespace GrayMoon.Agent.Commands;
 
 /// <summary>
 /// Handles post-merge hooks: re-runs GitVersion and gets commit counts.
-/// No git fetch — the merge already brought remote changes in; existing remote tracking refs are current enough.
+/// No git fetch - the merge already brought remote changes in; existing remote tracking refs are current enough.
 /// </summary>
 public sealed class MergeHookSyncCommand(IGitService git, ICsProjFileService csProjFileService, IAgentTokenProvider tokenProvider, IHubConnectionProvider hubProvider, ILogger<MergeHookSyncCommand> logger)
 {

--- a/src/GrayMoon.Agent/Commands/PushHookSyncCommand.cs
+++ b/src/GrayMoon.Agent/Commands/PushHookSyncCommand.cs
@@ -30,7 +30,7 @@ public sealed class PushHookSyncCommand(IGitService git, IHubConnectionProvider 
         if (connection?.State == HubConnectionState.Connected)
         {
             // Send an immediate notification with Version+Branch so the UI updates right away.
-            // Commit counts are intentionally omitted here — this hook fires BEFORE the push
+            // Commit counts are intentionally omitted here - this hook fires BEFORE the push
             // data is transferred, so any counts read now are stale.
             // SyncCommandHandler's HasValue guards ensure null fields do not overwrite DB values.
             var notification = new RepositorySyncNotification
@@ -87,7 +87,7 @@ public sealed class PushHookSyncCommand(IGitService git, IHubConnectionProvider 
                     continue;
                 }
 
-                // Push done (outgoing == 0 or null) or max attempts reached — send final notification
+                // Push done (outgoing == 0 or null) or max attempts reached - send final notification
                 var (defaultBehind, defaultAhead, _) = await git.GetCommitCountsVsDefaultAsync(repoPath, defaultRef, CancellationToken.None);
                 var (versionResult, _) = await git.GetVersionAsync(repoPath, CancellationToken.None);
                 var finalVersion = versionResult?.InformationalVersion ?? "-";

--- a/src/GrayMoon.Agent/Commands/PushRepositoryCommand.cs
+++ b/src/GrayMoon.Agent/Commands/PushRepositoryCommand.cs
@@ -74,7 +74,7 @@ public sealed class PushRepositoryCommand(IGitService git, IHubConnectionProvide
         if (success)
         {
             // Fire-and-forget: send actual post-push commit counts to the app so DB is updated
-            // immediately after push — for both GrayMoon-initiated and any downstream refresh path.
+            // immediately after push - for both GrayMoon-initiated and any downstream refresh path.
             _ = SendPostPushSyncAsync(request.WorkspaceId, request.RepositoryId, repoPath, branch);
         }
 

--- a/src/GrayMoon.Agent/Commands/UpdateFileVersionsCommand.cs
+++ b/src/GrayMoon.Agent/Commands/UpdateFileVersionsCommand.cs
@@ -24,7 +24,7 @@ public sealed class UpdateFileVersionsCommand(IGitService git) : ICommandHandler
         if (!File.Exists(fullFilePath))
             return new UpdateFileVersionsResponse { UpdatedCount = 0, ErrorMessage = $"File not found: {filePath}" };
 
-        // Parse pattern lines: each is PREFIX={reponame}SUFFIX — extract (prefix, repoName, suffix) tuples
+        // Parse pattern lines: each is PREFIX={reponame}SUFFIX - extract (prefix, repoName, suffix) tuples
         var patternEntries = ParsePatternLines(versionPattern);
         if (patternEntries.Count == 0)
             return new UpdateFileVersionsResponse { UpdatedCount = 0 };

--- a/src/GrayMoon.Agent/Commands/ValidatePathCommand.cs
+++ b/src/GrayMoon.Agent/Commands/ValidatePathCommand.cs
@@ -18,7 +18,7 @@ public sealed class ValidatePathCommand : ICommandHandler<ValidatePathRequest, V
             // Validates path syntax (throws on invalid chars, relative paths, etc.)
             var fullPath = Path.GetFullPath(path);
 
-            // Try to create the directory if it doesn't exist — leave it in place once created
+            // Try to create the directory if it doesn't exist - leave it in place once created
             Directory.CreateDirectory(fullPath);
 
             return Task.FromResult(new ValidatePathResponse { IsValid = true });

--- a/src/GrayMoon.Agent/Services/CsProjFileParser.cs
+++ b/src/GrayMoon.Agent/Services/CsProjFileParser.cs
@@ -8,7 +8,7 @@ namespace GrayMoon.Agent.Services;
 
 public sealed class CsProjFileParser : ICsProjFileParser
 {
-    // Matches a complete PackageReference element — self-closing (<PackageReference ... />) or with child
+    // Matches a complete PackageReference element - self-closing (<PackageReference ... />) or with child
     // elements (<PackageReference ...>...</PackageReference>). Singleline so . spans newlines, which lets
     // a single match cover attributes spread across multiple lines.
     private static readonly Regex PackageReferenceElementRegex = new(

--- a/src/GrayMoon.App/Components/Modals/BranchModal.razor.css
+++ b/src/GrayMoon.App/Components/Modals/BranchModal.razor.css
@@ -1,4 +1,4 @@
-/* Branch Modal – width a bit narrower than modal-lg */
+/* Branch Modal - width a bit narrower than modal-lg */
 .branch-modal-dialog {
     max-width: 600px;
 }

--- a/src/GrayMoon.App/Components/Modals/VersionConfigModal.razor
+++ b/src/GrayMoon.App/Components/Modals/VersionConfigModal.razor
@@ -17,7 +17,7 @@
                     <p class="text-muted small mb-3">
                         Enter one version pattern per line. Each pattern is a line prefix followed by a <code>{repositoryname}</code> token.
                         For example: <code>MY_SERVICE_VERSION={repositoryname}</code> will match any line starting with <code>MY_SERVICE_VERSION=</code> and replace the rest with the repository's current version.
-                        The repository name should match a workspace repository — unknown tokens are silently ignored during update.
+                        The repository name should match a workspace repository - unknown tokens are silently ignored during update.
                         Type <kbd>@@</kbd> to autocomplete a repository name.
                     </p>
 
@@ -107,7 +107,7 @@
     private List<string> filteredRepos = new();
     private int suggestionIndex;
     private int _atPos;
-    private int _queryEnd;  // pre-computed end of @query — stable across Enter default-action timing
+    private int _queryEnd;  // pre-computed end of @query - stable across Enter default-action timing
     private double _dropdownX;
     private double _dropdownY;
     private int _pendingCaret = -1;

--- a/src/GrayMoon.App/Components/Modals/VersionConfigModal.razor.css
+++ b/src/GrayMoon.App/Components/Modals/VersionConfigModal.razor.css
@@ -90,7 +90,7 @@
     overflow-y: auto;
     min-width: 180px;
     width: max-content;
-    /* Gray scrollbar — standard */
+    /* Gray scrollbar - standard */
     scrollbar-width: thin;
     scrollbar-color: #5a5a5a #2a2a2a;
 }

--- a/src/GrayMoon.App/Components/Modals/ViewFileModal.razor
+++ b/src/GrayMoon.App/Components/Modals/ViewFileModal.razor
@@ -44,7 +44,7 @@
                         <button type="button" class="btn btn-outline-secondary"
                                 disabled="@IsConfigured"
                                 @onclick="ConfigureAsync"
-                                title="@(IsConfigured ? "Already configured — edit via Configure in the files table" : "Configure versioning for this file")">
+                                title="@(IsConfigured ? "Already configured - edit via Configure in the files table" : "Configure versioning for this file")">
                             Configure
                         </button>
                     </div>

--- a/src/GrayMoon.App/Components/Pages/Connectors.razor
+++ b/src/GrayMoon.App/Components/Pages/Connectors.razor
@@ -583,7 +583,7 @@
         catch (Exception ex)
         {
             Logger.LogError(ex, "Error testing connector.");
-            // Unexpected app exception — not a connector fault; do not deactivate
+            // Unexpected app exception - not a connector fault; do not deactivate
             await ConnectorRepository.UpdateStatusAsync(connector.ConnectorId, "Error",
                 "An unexpected error occurred while testing the connector.");
             return false;

--- a/src/GrayMoon.App/Components/Pages/Connectors.razor.css
+++ b/src/GrayMoon.App/Components/Pages/Connectors.razor.css
@@ -27,7 +27,7 @@
     table-layout: fixed;
 }
 
-/* Active column: fit toggle only – fixed width so it stays visible */
+/* Active column: fit toggle only - fixed width so it stays visible */
 .connectors-table th.col-active,
 .connectors-table td.col-active {
     text-align: center;
@@ -37,7 +37,7 @@
     box-sizing: content-box;
 }
 
-/* Status column: fit badge only – fixed width so it stays visible */
+/* Status column: fit badge only - fixed width so it stays visible */
 .connectors-table th.status-col,
 .connectors-table td.status-col {
     text-align: center;
@@ -52,7 +52,7 @@
     text-align: center;
 }
 
-/* Actions column: fit all three buttons – fixed width so it stays visible */
+/* Actions column: fit all three buttons - fixed width so it stays visible */
 .connectors-table th.col-actions,
 .connectors-table td.col-actions {
     width: 160px;

--- a/src/GrayMoon.App/Components/Pages/Repositories.razor
+++ b/src/GrayMoon.App/Components/Pages/Repositories.razor
@@ -158,9 +158,16 @@
                                         </td>
                                         <td class="col-connector">@repository.ConnectorName</td>
                                         <td class="col-visibility col-status-badge">
-                                            <span class="badge @(repository.Visibility == "Private" ? "badge-private" : "badge-public")">
-                                                @repository.Visibility.ToLowerInvariant()
-                                            </span>
+                                            @if (repository.Archived)
+                                            {
+                                                <span class="badge badge-archived">archived</span>
+                                            }
+                                            else
+                                            {
+                                                <span class="badge @(repository.Visibility == "Private" ? "badge-private" : "badge-public")">
+                                                    @repository.Visibility.ToLowerInvariant()
+                                                </span>
+                                            }
                                         </td>
                                     </tr>
                                 }

--- a/src/GrayMoon.App/Components/Pages/Repositories.razor.css
+++ b/src/GrayMoon.App/Components/Pages/Repositories.razor.css
@@ -96,3 +96,14 @@
     background-color: #b58900;
     color: #000000;
 }
+
+.badge-archived {
+    display: inline-block;
+    width: auto;
+    min-width: 0;
+    padding-left: 0.65em;
+    padding-right: 0.65em;
+    text-align: center;
+    background-color: #8b6fc7;
+    color: #000000;
+}

--- a/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor
@@ -287,7 +287,7 @@
                                                     }
                                                     else
                                                     {
-                                                        <span class="text-muted">—</span>
+                                                        <span class="text-muted">-</span>
                                                     }
                                                 </td>
                                                 <td class="col-actions ps-3">

--- a/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor.cs
@@ -63,6 +63,8 @@ public sealed partial class WorkspaceActions : IDisposable
     private CancellationTokenSource _cts = new();
     private HubConnection? _hubConnection;
     private CancellationTokenSource? _syncDebounceCts;
+    private CancellationTokenSource? _repositorySyncDebounceCts;
+    private readonly HashSet<int> _pendingRepositorySyncIds = [];
     private bool _autoPollRunning;
     private const int SyncDebounceMs = 500;
     private const int AutoPollIntervalMs = 5000;
@@ -228,6 +230,33 @@ public sealed partial class WorkspaceActions : IDisposable
                 }
             });
 
+            _hubConnection.On<int, int>("RepositorySynced", async (workspaceId, repositoryId) =>
+            {
+                if (workspaceId != WorkspaceId) return;
+
+                lock (_pendingRepositorySyncIds)
+                    _pendingRepositorySyncIds.Add(repositoryId);
+
+                _repositorySyncDebounceCts?.Cancel();
+                _repositorySyncDebounceCts?.Dispose();
+                _repositorySyncDebounceCts = new CancellationTokenSource();
+                var cts = _repositorySyncDebounceCts;
+                try
+                {
+                    await Task.Delay(SyncDebounceMs, cts.Token);
+                    await InvokeAsync(RefreshFromRepositorySyncAsync);
+                }
+                catch (OperationCanceledException) { /* debounced */ }
+                finally
+                {
+                    if (cts == _repositorySyncDebounceCts)
+                    {
+                        _repositorySyncDebounceCts?.Dispose();
+                        _repositorySyncDebounceCts = null;
+                    }
+                }
+            });
+
             await _hubConnection.StartAsync();
         }
     }
@@ -304,46 +333,154 @@ public sealed partial class WorkspaceActions : IDisposable
     {
         try
         {
-            await using var scope = ServiceScopeFactory.CreateAsyncScope();
-            var repo = scope.ServiceProvider.GetRequiredService<WorkspaceRepository>();
-            var freshWorkspace = await repo.GetByIdAsync(WorkspaceId);
-            if (freshWorkspace == null) return;
-
-            workspace = freshWorkspace;
-
-            var freshLinks = freshWorkspace.Repositories
-                .Where(l => l.Repository != null && l.Repository.Connector != null)
-                .ToDictionary(l => l.RepositoryId);
-
-            var rowsToRefresh = new List<WorkspaceActionRow>();
-
-            foreach (var row in rows)
-            {
-                if (!freshLinks.TryGetValue(row.Repo.RepositoryId, out var freshLink)) continue;
-
-                var branchChanged = !string.Equals(row.Link.BranchName, freshLink.BranchName, StringComparison.OrdinalIgnoreCase);
-                row.Link = freshLink;
-
-                if (branchChanged)
-                {
-                    row.WorkflowLines = [new WorkflowActionLine()];
-                    row.ActionLatches.Clear();
-                    row.IsVerified = false;
-                    rowsToRefresh.Add(row);
-                }
-            }
-
+            var rowsToRefresh = await ApplyFreshWorkspaceLinksAsync();
             await InvokeAsync(StateHasChanged);
 
             foreach (var row in rowsToRefresh.Where(r => !string.IsNullOrWhiteSpace(r.Link.BranchName)))
-            {
                 _ = RefreshRowAsync(row, _cts.Token);
-            }
         }
         catch (Exception ex)
         {
             Logger.LogError(ex, "Error refreshing from sync for workspace {WorkspaceId}", WorkspaceId);
         }
+    }
+
+    /// <summary>
+    /// After agent hook sync (e.g. push hook): refresh GitHub Actions for affected repos so running workflows and the live terminal appear.
+    /// </summary>
+    private async Task RefreshFromRepositorySyncAsync()
+    {
+        List<int> repositoryIds;
+        lock (_pendingRepositorySyncIds)
+        {
+            repositoryIds = _pendingRepositorySyncIds.ToList();
+            _pendingRepositorySyncIds.Clear();
+        }
+
+        if (repositoryIds.Count == 0)
+            return;
+
+        try
+        {
+            await ApplyFreshWorkspaceLinksAsync();
+            await InvokeAsync(StateHasChanged);
+
+            foreach (var repositoryId in repositoryIds)
+            {
+                var row = rows.FirstOrDefault(r => r.Repo.RepositoryId == repositoryId);
+                if (row == null || string.IsNullOrWhiteSpace(row.Link.BranchName))
+                    continue;
+
+                _ = RefreshRowAfterHookSyncAsync(row, _cts.Token);
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error refreshing actions after repository sync for workspace {WorkspaceId}", WorkspaceId);
+        }
+    }
+
+    /// <summary>Reloads workspace links from DB; returns rows whose branch changed (need full workflow reset).</summary>
+    private async Task<List<WorkspaceActionRow>> ApplyFreshWorkspaceLinksAsync()
+    {
+        var rowsToRefresh = new List<WorkspaceActionRow>();
+
+        await using var scope = ServiceScopeFactory.CreateAsyncScope();
+        var repo = scope.ServiceProvider.GetRequiredService<WorkspaceRepository>();
+        var freshWorkspace = await repo.GetByIdAsync(WorkspaceId);
+        if (freshWorkspace == null)
+            return rowsToRefresh;
+
+        workspace = freshWorkspace;
+
+        var freshLinks = freshWorkspace.Repositories
+            .Where(l => l.Repository != null && l.Repository.Connector != null)
+            .ToDictionary(l => l.RepositoryId);
+
+        foreach (var row in rows)
+        {
+            if (!freshLinks.TryGetValue(row.Repo.RepositoryId, out var freshLink))
+                continue;
+
+            var branchChanged = !string.Equals(row.Link.BranchName, freshLink.BranchName, StringComparison.OrdinalIgnoreCase);
+            row.Link = freshLink;
+
+            if (branchChanged)
+            {
+                row.WorkflowLines = [new WorkflowActionLine()];
+                row.ActionLatches.Clear();
+                row.IsVerified = false;
+                rowsToRefresh.Add(row);
+            }
+        }
+
+        return rowsToRefresh;
+    }
+
+    private async Task RefreshRowAfterHookSyncAsync(WorkspaceActionRow row, CancellationToken cancellationToken)
+    {
+        await TryRefreshUntilAnyWorkflowRunningAsync(row, cancellationToken);
+    }
+
+    /// <summary>GitHub may lag listing a new run after a push; retry until any workflow line is running with a run id.</summary>
+    private async Task<bool> TryRefreshUntilAnyWorkflowRunningAsync(
+        WorkspaceActionRow row,
+        CancellationToken cancellationToken)
+    {
+        const string operationLabel = "PushHookGhaVisibility";
+
+        for (var attempt = 1; attempt <= RunWorkflowVisibilityMaxAttempts; attempt++)
+        {
+            var delayMs = attempt == 1 ? RunWorkflowVisibilityFirstDelayMs : RunWorkflowVisibilityRetryDelayMs;
+            try
+            {
+                await Task.Delay(delayMs, cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                return false;
+            }
+
+            await RefreshRowAsync(row, cancellationToken);
+
+            if (!string.IsNullOrWhiteSpace(row.ErrorMessage))
+            {
+                Logger.LogWarning(
+                    "{Operation}: refresh failed for {Repo} after attempt {Attempt}",
+                    operationLabel,
+                    row.Repo.RepositoryName,
+                    attempt);
+                return false;
+            }
+
+            if (row.WorkflowLines.Any(line => IsLineRunningForBranch(row, line) && (line.Action?.RunId ?? 0) > 0))
+            {
+                Logger.LogInformation(
+                    "{Operation}: running workflow visible after attempt {Attempt}/{Max} for {Repo}",
+                    operationLabel,
+                    attempt,
+                    RunWorkflowVisibilityMaxAttempts,
+                    row.Repo.RepositoryName);
+                return true;
+            }
+
+            if (attempt < RunWorkflowVisibilityMaxAttempts)
+            {
+                Logger.LogDebug(
+                    "{Operation}: attempt {Attempt}/{Max} - no running workflow in API yet for {Repo}",
+                    operationLabel,
+                    attempt,
+                    RunWorkflowVisibilityMaxAttempts,
+                    row.Repo.RepositoryName);
+            }
+        }
+
+        Logger.LogDebug(
+            "{Operation}: no running workflow after {Max} attempts for {Repo} (may still be queued)",
+            operationLabel,
+            RunWorkflowVisibilityMaxAttempts,
+            row.Repo.RepositoryName);
+        return false;
     }
 
     private void StartBackgroundRefresh()
@@ -480,7 +617,7 @@ public sealed partial class WorkspaceActions : IDisposable
             if (attempt < RunWorkflowVisibilityMaxAttempts)
             {
                 Logger.LogDebug(
-                    "{Operation}: attempt {Attempt}/{Max} — workflow not running in API yet WorkflowId={WorkflowId}",
+                    "{Operation}: attempt {Attempt}/{Max} - workflow not running in API yet WorkflowId={WorkflowId}",
                     operationLabel,
                     attempt,
                     RunWorkflowVisibilityMaxAttempts,
@@ -548,7 +685,7 @@ public sealed partial class WorkspaceActions : IDisposable
             if (attempt < RunWorkflowVisibilityMaxAttempts)
             {
                 Logger.LogDebug(
-                    "{Operation}: attempt {Attempt}/{Max} — run still in progress in API WorkflowId={WorkflowId} RunId={RunId}",
+                    "{Operation}: attempt {Attempt}/{Max} - run still in progress in API WorkflowId={WorkflowId} RunId={RunId}",
                     operationLabel,
                     attempt,
                     RunWorkflowVisibilityMaxAttempts,
@@ -1173,6 +1310,10 @@ public sealed partial class WorkspaceActions : IDisposable
         _cts.Dispose();
         _syncDebounceCts?.Cancel();
         _syncDebounceCts?.Dispose();
+        _repositorySyncDebounceCts?.Cancel();
+        _repositorySyncDebounceCts?.Dispose();
+        lock (_pendingRepositorySyncIds)
+            _pendingRepositorySyncIds.Clear();
         _ = _hubConnection?.StopAsync();
         _ = _hubConnection?.DisposeAsync().AsTask();
     }

--- a/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor.cs
@@ -309,6 +309,7 @@ public sealed partial class WorkspaceActions : IDisposable
                             OrgName = link.Repository.OrgName,
                             RepositoryName = link.Repository.RepositoryName,
                             Visibility = link.Repository.Visibility,
+                                Archived = link.Repository.Archived,
                             CloneUrl = link.Repository.CloneUrl
                         },
                         WorkflowLines = workflowLines,

--- a/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor.cs
@@ -1102,26 +1102,7 @@ public sealed partial class WorkspaceActions : IDisposable
     private static string GetFriendlyErrorMessage(Exception ex) =>
         ex switch
         {
-            HttpRequestException { StatusCode: HttpStatusCode.Unauthorized } =>
-                "Unauthorized (401). Check the connector token on the Connectors page.",
-            HttpRequestException { StatusCode: HttpStatusCode.Forbidden } =>
-                "Forbidden (403). The token does not have permission to access GitHub Actions.",
-            HttpRequestException { StatusCode: HttpStatusCode.NotFound } =>
-                "Not found (404). The repository or workflow was not found.",
-            HttpRequestException { StatusCode: HttpStatusCode.Conflict } =>
-                "Conflict (409). The workflow run may already be finished.",
-            HttpRequestException { StatusCode: HttpStatusCode.UnprocessableEntity } http422 =>
-                string.IsNullOrWhiteSpace(http422.Message)
-                    ? "GitHub rejected the workflow request (422). It may not support manual runs on this branch, or required workflow inputs are missing."
-                    : http422.Message,
-            HttpRequestException { StatusCode: HttpStatusCode.TooManyRequests } =>
-                "Rate limited (429). Too many requests to GitHub. Try again later.",
-            HttpRequestException { StatusCode: HttpStatusCode.ServiceUnavailable } =>
-                "GitHub service unavailable (503). Try again later.",
-            HttpRequestException httpEx =>
-                string.IsNullOrWhiteSpace(httpEx.Message)
-                    ? "GitHub API request failed."
-                    : httpEx.Message,
+            HttpRequestException httpEx => GitHubApiErrorHelper.FormatFriendlyGitHubHttpError(httpEx),
             OperationCanceledException =>
                 "The operation was cancelled (for example, refresh was interrupted). Try Run again or use Refresh.",
             _ => ex.Message

--- a/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor.css
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor.css
@@ -1,6 +1,6 @@
 /*
  * Title row: use same baseline alignment as app.css .workspace-repos-header .workspace-repos-title-row
- * (do not override with flex-end — that sat the subtitle lower than the h2 text).
+ * (do not override with flex-end - that sat the subtitle lower than the h2 text).
  * Workflow count stays in <p> like WorkspaceRepositories; status chips are siblings so they don't stretch the subtitle.
  */
 .workspace-actions-header .workspace-repos-subtitle.workspace-actions__subtitle {
@@ -85,7 +85,7 @@
     border-color: var(--border-color, #3e3e42);
 }
 
-/* Count pill colors when filter is on — match wwwroot/app.css .action-badge-* */
+/* Count pill colors when filter is on - match wwwroot/app.css .action-badge-* */
 .gha-status-filter--on .gha-status-filter__count--errors,
 .gha-status-filter--on .gha-status-filter__count--failed {
     background-color: #da3633;

--- a/src/GrayMoon.App/Components/Pages/WorkspaceFiles.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceFiles.razor
@@ -387,7 +387,7 @@
             if (error != null)
                 errorMessage = error;
             else if (failed > 0)
-                errorMessage = $"Updated {updated} line(s). {failed} file(s) could not be updated — check logs.";
+                errorMessage = $"Updated {updated} line(s). {failed} file(s) could not be updated - check logs.";
             else
                 ToastService.Show("Versions updated in configured files.");
         }

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
@@ -261,7 +261,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
         ProjectType.Executable => 2,
         ProjectType.Library    => 3,
         ProjectType.Test       => 4,
-        _                      => 5 // null — no projects yet
+        _                      => 5 // null - no projects yet
     };
 
     private static IReadOnlyDictionary<int, PullRequestInfo?> BuildPrByRepositoryIdFromLinks(List<WorkspaceRepositoryLink> links)

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.css
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.css
@@ -649,7 +649,7 @@
     border-color: #5a6268;
 }
 
-/* Workspaces breadcrumb link – same gray as "X repositories", override global a color */
+/* Workspaces breadcrumb link - same gray as "X repositories", override global a color */
 .grid-page-header .text-muted a.workspaces-breadcrumb-link,
 .grid-page-header .text-muted a.workspaces-breadcrumb-link:hover,
 .grid-page-header .text-muted a.workspaces-breadcrumb-link:visited,

--- a/src/GrayMoon.App/Components/Pages/Workspaces.razor
+++ b/src/GrayMoon.App/Components/Pages/Workspaces.razor
@@ -769,7 +769,7 @@
         }
         catch (OperationCanceledException)
         {
-            // Swallow – a new name change will schedule a new check
+            // Swallow - a new name change will schedule a new check
         }
     }
 

--- a/src/GrayMoon.App/Components/Shared/GhaWorkflowLiveTerminal.razor
+++ b/src/GrayMoon.App/Components/Shared/GhaWorkflowLiveTerminal.razor
@@ -1,5 +1,6 @@
 @using GrayMoon.App.Models
 @using GrayMoon.App.Repositories
+@using GrayMoon.App.Services
 @inject GitHubService GitHubService
 @inject ConnectorRepository ConnectorRepository
 @inject LoadingOverlayUiSettingsService OverlayUiSettings
@@ -178,7 +179,10 @@
         catch (Exception ex) when (!cancellationToken.IsCancellationRequested)
         {
             Logger.LogDebug(ex, "GHA live feed poll failed for run {RunId}", RunId);
-            AppendUnique($"Update failed: {ex.Message}");
+            var failureText = ex is HttpRequestException httpEx
+                ? GitHubApiErrorHelper.FormatFriendlyGitHubHttpError(httpEx)
+                : ex.Message;
+            AppendUnique($"Update failed: {failureText}");
             return PollIntervalWaitingJobsMs;
         }
     }

--- a/src/GrayMoon.App/Components/Shared/GhaWorkflowLiveTerminal.razor
+++ b/src/GrayMoon.App/Components/Shared/GhaWorkflowLiveTerminal.razor
@@ -21,8 +21,9 @@
                     }
                 </div>
                 <div class="loading-overlay-terminal__inner actions-gha-terminal__scroll" aria-live="polite">
-                    @foreach (var line in _visibleLines)
+                    @for (var i = 0; i < BodyLineCount; i++)
                     {
+                        var line = _visibleLineSlots[i];
                         <p class="loading-overlay-terminal__line loading-overlay-terminal__line--out actions-gha-terminal__line">
                             @if (string.IsNullOrWhiteSpace(line))
                             {
@@ -49,28 +50,23 @@
 
     private readonly List<string> _buffer = [];
     private readonly Dictionary<string, string> _stepSignatures = new(StringComparer.Ordinal);
+    private readonly string[] _visibleLineSlots = new string[BodyLineCount];
+    private Connector? _cachedConnector;
+    private string? _cachedConnectorName;
     private bool _snapshottedSteps;
     private string _caption = "Workflow · Connecting to GitHub Actions…";
     private string? _stepProgress;
     private CancellationTokenSource? _cts;
     private Task? _pollTask;
+    private bool _needsRender;
 
     private const int BodyLineCount = 8;
-
-    private IReadOnlyList<string> _visibleLines
-    {
-        get
-        {
-            List<string> take;
-            if (_buffer.Count >= BodyLineCount)
-                take = _buffer.Skip(_buffer.Count - BodyLineCount).ToList();
-            else
-                take = _buffer.ToList();
-            while (take.Count < BodyLineCount)
-                take.Insert(0, "");
-            return take;
-        }
-    }
+    /// <summary>Delay while jobs/steps are active — balances responsiveness vs API rate limits when many rows poll.</summary>
+    private const int PollIntervalActiveMs = 1_200;
+    /// <summary>Delay when waiting for GitHub to attach jobs to the run.</summary>
+    private const int PollIntervalWaitingJobsMs = 2_000;
+    /// <summary>Delay when all jobs report completed (terminal tail).</summary>
+    private const int PollIntervalIdleMs = 4_000;
 
     private string _captionTooltip =>
         string.IsNullOrWhiteSpace(_stepProgress) ? _caption : $"{_caption} · {_stepProgress}";
@@ -79,6 +75,7 @@
     {
         OverlayUiSettings.Changed += OnOverlayUiSettingsChanged;
         _buffer.Add($"Run #{RunId} · Subscribing to job updates…");
+        RefreshVisibleLineSlots();
     }
 
     private void OnOverlayUiSettingsChanged(object? sender, EventArgs e) =>
@@ -101,9 +98,14 @@
         {
             while (!cancellationToken.IsCancellationRequested)
             {
-                await PollOnceAsync(cancellationToken);
-                await InvokeAsync(StateHasChanged);
-                await Task.Delay(3000, cancellationToken);
+                var delayMs = await PollOnceAsync(cancellationToken);
+                if (_needsRender)
+                {
+                    _needsRender = false;
+                    await InvokeAsync(StateHasChanged);
+                }
+
+                await Task.Delay(delayMs, cancellationToken);
             }
         }
         catch (OperationCanceledException)
@@ -112,27 +114,35 @@
         }
     }
 
-    private async Task PollOnceAsync(CancellationToken cancellationToken)
+    /// <returns>Milliseconds to wait before the next poll.</returns>
+    private async Task<int> PollOnceAsync(CancellationToken cancellationToken)
     {
         try
         {
-            var connector = await ConnectorRepository.GetByNameAsync(ConnectorName);
+            var connector = await ResolveConnectorAsync(cancellationToken);
             if (connector == null)
             {
                 AppendUnique("Connector not found — cannot load job status.");
-                return;
+                return PollIntervalWaitingJobsMs;
             }
 
             var response = await GitHubService.GetWorkflowRunJobsAsync(connector, Owner, RepositoryName, RunId, cancellationToken);
             var jobs = response?.Jobs ?? [];
-            _caption = BuildCaption(jobs, WorkflowDisplayName);
-            _stepProgress = BuildStepProgressForCaptionJob(jobs);
+
+            var caption = BuildCaption(jobs, WorkflowDisplayName);
+            var stepProgress = BuildStepProgressForCaptionJob(jobs);
+            if (!string.Equals(_caption, caption, StringComparison.Ordinal) || !string.Equals(_stepProgress, stepProgress, StringComparison.Ordinal))
+            {
+                _caption = caption;
+                _stepProgress = stepProgress;
+                _needsRender = true;
+            }
 
             if (jobs.Count == 0)
             {
                 _stepProgress = null;
                 AppendUnique("Waiting for GitHub to assign jobs to this run…");
-                return;
+                return PollIntervalWaitingJobsMs;
             }
 
             if (!_snapshottedSteps)
@@ -146,7 +156,7 @@
 
                 var stepCount = jobs.Sum(j => j.Steps?.Count ?? 0);
                 AppendUnique($"Live · {jobs.Count} job(s), {stepCount} step(s) — streaming updates…");
-                return;
+                return DeterminePollDelayMs(jobs);
             }
 
             foreach (var job in jobs.OrderBy(j => j.Id))
@@ -162,11 +172,64 @@
                     AppendUnique(FormatStepTransition(job.Name, step));
                 }
             }
+
+            return DeterminePollDelayMs(jobs);
         }
         catch (Exception ex) when (!cancellationToken.IsCancellationRequested)
         {
             Logger.LogDebug(ex, "GHA live feed poll failed for run {RunId}", RunId);
             AppendUnique($"Update failed: {ex.Message}");
+            return PollIntervalWaitingJobsMs;
+        }
+    }
+
+    private async Task<Connector?> ResolveConnectorAsync(CancellationToken cancellationToken)
+    {
+        if (_cachedConnector != null
+            && string.Equals(_cachedConnectorName, ConnectorName, StringComparison.Ordinal))
+            return _cachedConnector;
+
+        cancellationToken.ThrowIfCancellationRequested();
+        var connector = await ConnectorRepository.GetByNameAsync(ConnectorName);
+        if (connector != null)
+        {
+            _cachedConnector = connector;
+            _cachedConnectorName = ConnectorName;
+        }
+
+        return connector;
+    }
+
+    private static int DeterminePollDelayMs(IReadOnlyList<GitHubWorkflowJobDto> jobs)
+    {
+        foreach (var job in jobs)
+        {
+            var js = job.Status ?? "";
+            if (js.Equals("in_progress", StringComparison.OrdinalIgnoreCase)
+                || js.Equals("queued", StringComparison.OrdinalIgnoreCase)
+                || js.Equals("waiting", StringComparison.OrdinalIgnoreCase))
+            {
+                return PollIntervalActiveMs;
+            }
+
+            var steps = job.Steps;
+            if (steps == null) continue;
+            foreach (var step in steps)
+            {
+                if (string.Equals(step.Status, "in_progress", StringComparison.OrdinalIgnoreCase))
+                    return PollIntervalActiveMs;
+            }
+        }
+
+        return PollIntervalIdleMs;
+    }
+
+    private void RefreshVisibleLineSlots()
+    {
+        for (var i = 0; i < BodyLineCount; i++)
+        {
+            var bufIdx = _buffer.Count - BodyLineCount + i;
+            _visibleLineSlots[i] = bufIdx >= 0 ? _buffer[bufIdx] : "";
         }
     }
 
@@ -177,6 +240,8 @@
         _buffer.Add(line);
         while (_buffer.Count > 120)
             _buffer.RemoveAt(0);
+        RefreshVisibleLineSlots();
+        _needsRender = true;
     }
 
     private static string BuildCaption(IReadOnlyList<GitHubWorkflowJobDto> jobs, string? workflowName)

--- a/src/GrayMoon.App/Components/Shared/GhaWorkflowLiveTerminal.razor
+++ b/src/GrayMoon.App/Components/Shared/GhaWorkflowLiveTerminal.razor
@@ -61,7 +61,7 @@
     private bool _needsRender;
 
     private const int BodyLineCount = 8;
-    /// <summary>Delay while jobs/steps are active — balances responsiveness vs API rate limits when many rows poll.</summary>
+    /// <summary>Delay while jobs/steps are active - balances responsiveness vs API rate limits when many rows poll.</summary>
     private const int PollIntervalActiveMs = 1_200;
     /// <summary>Delay when waiting for GitHub to attach jobs to the run.</summary>
     private const int PollIntervalWaitingJobsMs = 2_000;
@@ -122,7 +122,7 @@
             var connector = await ResolveConnectorAsync(cancellationToken);
             if (connector == null)
             {
-                AppendUnique("Connector not found — cannot load job status.");
+                AppendUnique("Connector not found - cannot load job status.");
                 return PollIntervalWaitingJobsMs;
             }
 
@@ -155,7 +155,7 @@
                 }
 
                 var stepCount = jobs.Sum(j => j.Steps?.Count ?? 0);
-                AppendUnique($"Live · {jobs.Count} job(s), {stepCount} step(s) — streaming updates…");
+                AppendUnique($"Live · {jobs.Count} job(s), {stepCount} step(s) - streaming updates…");
                 return DeterminePollDelayMs(jobs);
             }
 
@@ -314,13 +314,13 @@
                 return $"⊘ {jobName} › {step.Name} (skipped)";
             if (string.Equals(c, "failure", StringComparison.OrdinalIgnoreCase) || string.Equals(c, "cancelled", StringComparison.OrdinalIgnoreCase))
                 return $"✗ {jobName} › {step.Name} ({c})";
-            return $"• {jobName} › {step.Name} — {c}";
+            return $"• {jobName} › {step.Name} - {c}";
         }
 
         if (string.Equals(step.Status, "in_progress", StringComparison.OrdinalIgnoreCase))
             return $"⧗ {jobName} › {step.Name}…";
 
-        return $"… {jobName} › {step.Name} — {step.Status}";
+        return $"… {jobName} › {step.Name} - {step.Status}";
     }
 
     public async ValueTask DisposeAsync()

--- a/src/GrayMoon.App/Components/Shared/LoadingOverlay.razor
+++ b/src/GrayMoon.App/Components/Shared/LoadingOverlay.razor
@@ -118,7 +118,7 @@
     [Parameter] public double FadeAlpha { get; set; } = 0.08;
     /// <summary>Matrix rain: character opacity (e.g. 0.65).</summary>
     [Parameter] public double CharacterOpacity { get; set; } = 0.65;
-    /// <summary>Matrix rain: fall speed (0.1–2, default 0.6 = slower).</summary>
+    /// <summary>Matrix rain: fall speed (0.1-2, default 0.6 = slower).</summary>
     [Parameter] public double DropSpeed { get; set; } = 0.6;
 
     private readonly string _canvasId = "matrixOverlay_" + Guid.NewGuid().ToString("N");

--- a/src/GrayMoon.App/Components/Shared/LoadingOverlay.razor
+++ b/src/GrayMoon.App/Components/Shared/LoadingOverlay.razor
@@ -49,37 +49,39 @@
             var hasMessage = !string.IsNullOrEmpty(Message);
             var parsed = hasMessage ? ParseOverlayMessage(Message!) : default;
         }
-        @if (hasMessage && !string.IsNullOrEmpty(parsed.LevelCaption))
-        {
-            <p class="loading-overlay-level">@parsed.LevelCaption</p>
-        }
-        <div class="loading-overlay-spinner-wrap">
-            <div class="spinner-border" role="status">
-                <span class="visually-hidden">Loading...</span>
-            </div>
-            @if (IsVisible && ShowTaskCountInSpinner && DisplayTaskCount > 0)
+        <div class="loading-overlay-body">
+            @if (hasMessage && !string.IsNullOrEmpty(parsed.LevelCaption))
             {
-                <span class="loading-overlay-spinner-count" aria-hidden="true">@DisplayTaskCount</span>
+                <p class="loading-overlay-level">@parsed.LevelCaption</p>
             }
-        </div>
-        @if (hasMessage)
-        {
-            @if (!string.IsNullOrEmpty(parsed.CountdownBody))
-            {
-                @foreach (var countdownLine in parsed.CountdownBody.Split('\n'))
+            <div class="loading-overlay-spinner-wrap">
+                <div class="spinner-border" role="status">
+                    <span class="visually-hidden">Loading...</span>
+                </div>
+                @if (IsVisible && ShowTaskCountInSpinner && DisplayTaskCount > 0)
                 {
-                    if (!string.IsNullOrWhiteSpace(countdownLine))
+                    <span class="loading-overlay-spinner-count" aria-hidden="true">@DisplayTaskCount</span>
+                }
+            </div>
+            @if (hasMessage)
+            {
+                @if (!string.IsNullOrEmpty(parsed.CountdownBody))
+                {
+                    @foreach (var countdownLine in parsed.CountdownBody.Split('\n'))
                     {
-                        <p class="loading-overlay-countdown">@countdownLine.Trim()</p>
+                        if (!string.IsNullOrWhiteSpace(countdownLine))
+                        {
+                            <p class="loading-overlay-countdown">@countdownLine.Trim()</p>
+                        }
                     }
                 }
+                <p class="loading-overlay-message">@parsed.Primary</p>
             }
-            <p class="loading-overlay-message">@parsed.Primary</p>
-        }
-        @if (OnAbort.HasDelegate)
-        {
-            <button type="button" class="btn btn-outline-light btn-sm" @onclick="AbortClicked">Abort</button>
-        }
+            @if (OnAbort.HasDelegate)
+            {
+                <button type="button" class="btn btn-outline-light btn-sm" @onclick="AbortClicked">Abort</button>
+            }
+        </div>
     </div>
     <button type="button" class="loading-overlay__rabbit" aria-label="Toggle overlay style" @onclick="ToggleMatrixOverlay">🐇</button>
 </div>

--- a/src/GrayMoon.App/Components/Shared/LoadingOverlay.razor
+++ b/src/GrayMoon.App/Components/Shared/LoadingOverlay.razor
@@ -45,6 +45,14 @@
         }
     </div>
     <div class="loading-overlay-content">
+        @{
+            var hasMessage = !string.IsNullOrEmpty(Message);
+            var parsed = hasMessage ? ParseOverlayMessage(Message!) : default;
+        }
+        @if (hasMessage && !string.IsNullOrEmpty(parsed.LevelCaption))
+        {
+            <p class="loading-overlay-level">@parsed.LevelCaption</p>
+        }
         <div class="loading-overlay-spinner-wrap">
             <div class="spinner-border" role="status">
                 <span class="visually-hidden">Loading...</span>
@@ -54,14 +62,11 @@
                 <span class="loading-overlay-spinner-count" aria-hidden="true">@DisplayTaskCount</span>
             }
         </div>
-        @if (!string.IsNullOrEmpty(Message))
+        @if (hasMessage)
         {
-            var idx = Message.IndexOf('\n');
-            var countdown = idx >= 0 ? Message[(idx + 1)..].Trim() : null;
-            var messageText = idx >= 0 ? Message[..idx].Trim() : Message;
-            @if (!string.IsNullOrEmpty(countdown))
+            @if (!string.IsNullOrEmpty(parsed.CountdownBody))
             {
-                @foreach (var countdownLine in countdown.Split('\n'))
+                @foreach (var countdownLine in parsed.CountdownBody.Split('\n'))
                 {
                     if (!string.IsNullOrWhiteSpace(countdownLine))
                     {
@@ -69,7 +74,7 @@
                     }
                 }
             }
-            <p class="loading-overlay-message">@messageText</p>
+            <p class="loading-overlay-message">@parsed.Primary</p>
         }
         @if (OnAbort.HasDelegate)
         {
@@ -208,6 +213,44 @@
                 // circuit / JS unavailable
             }
         }
+    }
+
+    private readonly record struct OverlayMessageParts(string Primary, string? LevelCaption, string? CountdownBody);
+
+    private static OverlayMessageParts ParseOverlayMessage(string message)
+    {
+        var idx = message.IndexOf('\n');
+        if (idx < 0)
+            return new OverlayMessageParts(message.Trim(), null, null);
+
+        var primary = message[..idx].Trim();
+        var remainder = message[(idx + 1)..];
+        string? level = null;
+        var otherLines = new List<string>();
+        foreach (var raw in remainder.Split('\n'))
+        {
+            var t = raw.Trim();
+            if (string.IsNullOrWhiteSpace(t))
+                continue;
+            if (IsDependencyLevelCaption(t))
+                level = t;
+            else
+                otherLines.Add(t);
+        }
+
+        var countdown = otherLines.Count > 0 ? string.Join("\n", otherLines) : null;
+        return new OverlayMessageParts(primary, level, countdown);
+    }
+
+    /// <summary>Matches lines like "Level 2" from dependency-level progress (update, push, etc.).</summary>
+    private static bool IsDependencyLevelCaption(string trimmedLine)
+    {
+        ReadOnlySpan<char> s = trimmedLine.AsSpan().Trim();
+        const string prefix = "Level ";
+        if (!s.StartsWith(prefix, StringComparison.Ordinal))
+            return false;
+        s = s[prefix.Length..].Trim();
+        return !s.IsEmpty && int.TryParse(s, out _);
     }
 
     private static string KindCss(AgentCommandStreamKind kind) => kind switch

--- a/src/GrayMoon.App/Components/Shared/LoadingOverlay.razor.css
+++ b/src/GrayMoon.App/Components/Shared/LoadingOverlay.razor.css
@@ -24,9 +24,6 @@
 
 .loading-overlay-level {
     color: #858585 !important;
-    margin: 0 0 0.25rem 0;
-    font-size: 1.1rem;
-    text-align: center;
 }
 
 .loading-overlay-message {

--- a/src/GrayMoon.App/Components/Shared/LoadingOverlay.razor.css
+++ b/src/GrayMoon.App/Components/Shared/LoadingOverlay.razor.css
@@ -22,6 +22,13 @@
     text-align: center;
 }
 
+.loading-overlay-level {
+    color: #858585 !important;
+    margin: 0 0 0.25rem 0;
+    font-size: 1.1rem;
+    text-align: center;
+}
+
 .loading-overlay-message {
     color: #cccccc !important;
     margin: 0;

--- a/src/GrayMoon.App/Components/Shared/PRBadge.razor
+++ b/src/GrayMoon.App/Components/Shared/PRBadge.razor
@@ -101,15 +101,15 @@ else
     {
         var state = pr.MergeableState ?? string.Empty;
         if (pr.Mergeable == null || string.Equals(state, "unknown", StringComparison.OrdinalIgnoreCase))
-            return "PR #" + pr.Number + " – mergeability unknown";
+            return "PR #" + pr.Number + " - mergeability unknown";
         if (pr.Mergeable == false || string.Equals(state, "dirty", StringComparison.OrdinalIgnoreCase))
-            return "PR #" + pr.Number + " – merge conflicts";
+            return "PR #" + pr.Number + " - merge conflicts";
         if (string.Equals(state, "unstable", StringComparison.OrdinalIgnoreCase))
-            return "PR #" + pr.Number + " – checks running";
+            return "PR #" + pr.Number + " - checks running";
         if (string.Equals(state, "blocked", StringComparison.OrdinalIgnoreCase))
-            return "PR #" + pr.Number + " – Cannot merge (review or requirements)";
+            return "PR #" + pr.Number + " - Cannot merge (review or requirements)";
         if (pr.Mergeable == true || string.Equals(state, "clean", StringComparison.OrdinalIgnoreCase))
-            return "PR #" + pr.Number + " – mergeable";
+            return "PR #" + pr.Number + " - mergeable";
         return "PR #" + pr.Number;
     }
 }

--- a/src/GrayMoon.App/Components/Shared/Toast.razor.css
+++ b/src/GrayMoon.App/Components/Shared/Toast.razor.css
@@ -1,4 +1,4 @@
-/* Toast bubble – matches app dark theme, non-intrusive */
+/* Toast bubble - matches app dark theme, non-intrusive */
 .toast-bubble {
     position: fixed;
     top: calc(3.5rem + 1rem); /* Below top-row (3.5rem) + spacing (1rem) */

--- a/src/GrayMoon.App/Data/AppDbContext.cs
+++ b/src/GrayMoon.App/Data/AppDbContext.cs
@@ -62,7 +62,7 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
         modelBuilder.Entity<Repository>(entity =>
         {
             entity.ToTable("Repositories");
-            // Non-unique index for name lookups — renames must not be blocked by a unique constraint.
+            // Non-unique index for name lookups - renames must not be blocked by a unique constraint.
             entity.HasIndex(repository => new { repository.ConnectorId, repository.RepositoryName, repository.OrgName })
                 .IsUnique(false)
                 .HasDatabaseName("IX_Repositories_ConnectorId_Name_Org");

--- a/src/GrayMoon.App/Data/AppDbContext.cs
+++ b/src/GrayMoon.App/Data/AppDbContext.cs
@@ -87,6 +87,9 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
                 .IsRequired()
                 .HasMaxLength(20);
 
+            entity.Property(repository => repository.Archived)
+                .HasDefaultValue(false);
+
             entity.Property(repository => repository.CloneUrl)
                 .IsRequired()
                 .HasMaxLength(500);

--- a/src/GrayMoon.App/Hubs/WorkspaceSyncHub.cs
+++ b/src/GrayMoon.App/Hubs/WorkspaceSyncHub.cs
@@ -4,5 +4,5 @@ namespace GrayMoon.App.Hubs;
 
 public sealed class WorkspaceSyncHub : Hub
 {
-    // Hub exists for IHubContext<T>; clients subscribe via .On("WorkspaceSynced", ...)
+    // Hub exists for IHubContext<T>; clients subscribe via .On("WorkspaceSynced", ...) and .On("RepositorySynced", ...)
 }

--- a/src/GrayMoon.App/Migrations.cs
+++ b/src/GrayMoon.App/Migrations.cs
@@ -9,6 +9,7 @@ public static class Migrations
     public static async Task RunAllAsync(AppDbContext dbContext)
     {
         await MigrateRepositoriesTopicsAsync(dbContext);
+        await MigrateRepositoriesArchivedAsync(dbContext);
         await MigrateWorkspaceSyncMetadataAsync(dbContext);
         await MigrateConnectorUserNameAsync(dbContext);
         await MigrateConnectorTypeAndTokenAsync(dbContext);
@@ -52,6 +53,32 @@ public static class Migrations
                 if (count == 0)
                 {
                     cmd.CommandText = "ALTER TABLE Repositories ADD COLUMN Topics TEXT";
+                    await cmd.ExecuteNonQueryAsync();
+                }
+            }
+        }
+        catch
+        {
+            // Migration may already be applied or table doesn't exist yet
+        }
+    }
+
+    /// <summary>Adds Archived column to Repositories for marking GitHub archived repositories.</summary>
+    public static async Task MigrateRepositoriesArchivedAsync(AppDbContext dbContext)
+    {
+        try
+        {
+            var conn = dbContext.Database.GetDbConnection();
+            if (conn.State != System.Data.ConnectionState.Open)
+                await conn.OpenAsync();
+
+            await using (var cmd = conn.CreateCommand())
+            {
+                cmd.CommandText = "SELECT COUNT(*) FROM pragma_table_info('Repositories') WHERE name='Archived'";
+                var count = Convert.ToInt32(await cmd.ExecuteScalarAsync());
+                if (count == 0)
+                {
+                    cmd.CommandText = "ALTER TABLE Repositories ADD COLUMN Archived INTEGER NOT NULL DEFAULT 0";
                     await cmd.ExecuteNonQueryAsync();
                 }
             }

--- a/src/GrayMoon.App/Migrations.cs
+++ b/src/GrayMoon.App/Migrations.cs
@@ -798,7 +798,7 @@ public static class Migrations
         }
     }
 
-    /// <summary>Creates WorkspaceRepositoryActions table for persisted CI action status per workspace–repository link.</summary>
+    /// <summary>Creates WorkspaceRepositoryActions table for persisted CI action status per workspace-repository link.</summary>
     public static async Task MigrateWorkspaceRepositoryActionsAsync(AppDbContext dbContext)
     {
         try
@@ -960,7 +960,7 @@ public static class Migrations
                     await cmd.ExecuteNonQueryAsync();
                 }
 
-                // Drop the old unique name/org index that blocks renames — make it non-unique
+                // Drop the old unique name/org index that blocks renames - make it non-unique
                 cmd.CommandText = "SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name='IX_Repositories_ConnectorId_RepositoryName_OrgName'";
                 if (Convert.ToInt32(await cmd.ExecuteScalarAsync()) > 0)
                 {

--- a/src/GrayMoon.App/Models/GitHubDtos.cs
+++ b/src/GrayMoon.App/Models/GitHubDtos.cs
@@ -34,6 +34,9 @@ public class GitHubRepositoryDto
     [JsonPropertyName("private")]
     public bool Private { get; set; }
 
+    [JsonPropertyName("archived")]
+    public bool Archived { get; set; }
+
     [JsonPropertyName("clone_url")]
     public string CloneUrl { get; set; } = string.Empty;
 

--- a/src/GrayMoon.App/Models/GitHubRepositoryEntry.cs
+++ b/src/GrayMoon.App/Models/GitHubRepositoryEntry.cs
@@ -7,6 +7,7 @@ public class GitHubRepositoryEntry
     public string? OrgName { get; set; }
     public string RepositoryName { get; set; } = string.Empty;
     public string Visibility { get; set; } = "Public";
+    public bool Archived { get; set; }
     public string CloneUrl { get; set; } = string.Empty;
     public string? Topics { get; set; }
 }

--- a/src/GrayMoon.App/Models/Repository.cs
+++ b/src/GrayMoon.App/Models/Repository.cs
@@ -25,6 +25,8 @@ public class Repository
     [MaxLength(20)]
     public string Visibility { get; set; } = "Public";
 
+    public bool Archived { get; set; }
+
     [Required]
     [MaxLength(500)]
     public string CloneUrl { get; set; } = string.Empty;

--- a/src/GrayMoon.App/Models/RepositoryActionsPersistedState.cs
+++ b/src/GrayMoon.App/Models/RepositoryActionsPersistedState.cs
@@ -1,6 +1,6 @@
 namespace GrayMoon.App.Models;
 
-/// <summary>CI action status loaded from persistence for one workspace–repository link (multiple workflows).</summary>
+/// <summary>CI action status loaded from persistence for one workspace-repository link (multiple workflows).</summary>
 public sealed class RepositoryActionsPersistedState
 {
     public string? BranchName { get; init; }

--- a/src/GrayMoon.App/Models/WorkspaceRepositoryLink.cs
+++ b/src/GrayMoon.App/Models/WorkspaceRepositoryLink.cs
@@ -6,7 +6,7 @@ namespace GrayMoon.App.Models;
 [Table("WorkspaceRepositories")]
 public class WorkspaceRepositoryLink
 {
-    /// <summary>Primary key for the workspace–repository link row.</summary>
+    /// <summary>Primary key for the workspace-repository link row.</summary>
     public int WorkspaceRepositoryId { get; set; }
 
     [Required]
@@ -64,9 +64,9 @@ public class WorkspaceRepositoryLink
     /// <summary>Dominant project type for this repository (Service &gt; Package &gt; Executable &gt; Library &gt; Test). Null when no projects are known. Set during sync and project refresh.</summary>
     public ProjectType? RepositoryType { get; set; }
 
-    /// <summary>Persisted pull request state for this workspace–repo link. 1:1 optional.</summary>
+    /// <summary>Persisted pull request state for this workspace-repo link. 1:1 optional.</summary>
     public WorkspaceRepositoryPullRequest? PullRequest { get; set; }
 
-    /// <summary>Persisted CI action status for this workspace–repo link. 1:1 optional.</summary>
+    /// <summary>Persisted CI action status for this workspace-repo link. 1:1 optional.</summary>
     public WorkspaceRepositoryAction? Action { get; set; }
 }

--- a/src/GrayMoon.App/Repositories/RepositoryRepository.cs
+++ b/src/GrayMoon.App/Repositories/RepositoryRepository.cs
@@ -76,7 +76,7 @@ public class GitHubRepositoryRepository(AppDbContext dbContext, ILogger<GitHubRe
     /// <summary>
     /// Merges fetched repositories with existing ones.
     /// Matching priority: (1) stable provider ID (ConnectorId + GitHubRepositoryId), (2) CloneUrl, (3) URL-prefix rename heuristic.
-    /// Updates existing rows in-place — preserving RepositoryId and all workspace links.
+    /// Updates existing rows in-place - preserving RepositoryId and all workspace links.
     /// Adds new rows for genuinely new repositories, removes rows no longer returned by GitHub.
     /// Handles multiple simultaneous renames in a single pass.
     /// </summary>
@@ -104,7 +104,7 @@ public class GitHubRepositoryRepository(AppDbContext dbContext, ILogger<GitHubRe
 
         await using var transaction = await _dbContext.Database.BeginTransactionAsync();
 
-        // Load ALL existing repository rows with AsNoTracking — never put them in the tracker here.
+        // Load ALL existing repository rows with AsNoTracking - never put them in the tracker here.
         var existing = await _dbContext.Repositories.AsNoTracking().ToListAsync();
 
         // Track which existing rows have been matched and which incoming repos have been matched.
@@ -115,7 +115,7 @@ public class GitHubRepositoryRepository(AppDbContext dbContext, ILogger<GitHubRe
         var insertCount = 0;
 
         // ---------------------------------------------------------------------------
-        // PHASE A — Match by stable provider ID: (ConnectorId, GitHubRepositoryId)
+        // PHASE A - Match by stable provider ID: (ConnectorId, GitHubRepositoryId)
         // ---------------------------------------------------------------------------
         var existingByProviderId = existing
             .Where(r => r.GitHubRepositoryId > 0)
@@ -169,7 +169,7 @@ public class GitHubRepositoryRepository(AppDbContext dbContext, ILogger<GitHubRe
         }
 
         // ---------------------------------------------------------------------------
-        // PHASE B — Match unmatched by CloneUrl (handles legacy rows with GitHubRepositoryId = 0)
+        // PHASE B - Match unmatched by CloneUrl (handles legacy rows with GitHubRepositoryId = 0)
         // ---------------------------------------------------------------------------
         var existingByUrl = existing
             .Where(r => !matchedExistingIds.Contains(r.RepositoryId))
@@ -201,7 +201,7 @@ public class GitHubRepositoryRepository(AppDbContext dbContext, ILogger<GitHubRe
         }
 
         // ---------------------------------------------------------------------------
-        // PHASE C — Rename heuristic for still-unmatched pairs (same org URL-prefix, different repo name)
+        // PHASE C - Rename heuristic for still-unmatched pairs (same org URL-prefix, different repo name)
         //           Crucially: remove each matched old row from the candidate pool before continuing,
         //           preventing the same existing row from matching multiple incoming repos.
         // ---------------------------------------------------------------------------
@@ -254,7 +254,7 @@ public class GitHubRepositoryRepository(AppDbContext dbContext, ILogger<GitHubRe
         }
 
         // ---------------------------------------------------------------------------
-        // PHASE D — Insert genuinely new repositories (no match found in any phase)
+        // PHASE D - Insert genuinely new repositories (no match found in any phase)
         // ---------------------------------------------------------------------------
         for (var i = 0; i < normalized.Count; i++)
         {
@@ -268,7 +268,7 @@ public class GitHubRepositoryRepository(AppDbContext dbContext, ILogger<GitHubRe
             await _dbContext.SaveChangesAsync();
 
         // ---------------------------------------------------------------------------
-        // PHASE E — Delete unmatched existing rows (no longer returned by the provider)
+        // PHASE E - Delete unmatched existing rows (no longer returned by the provider)
         //           Delete WorkspaceRepositoryLink rows first (ExecuteDeleteAsync respects no tracker).
         // ---------------------------------------------------------------------------
         var toDeleteIds = existing

--- a/src/GrayMoon.App/Repositories/RepositoryRepository.cs
+++ b/src/GrayMoon.App/Repositories/RepositoryRepository.cs
@@ -22,6 +22,7 @@ public class GitHubRepositoryRepository(AppDbContext dbContext, ILogger<GitHubRe
                 OrgName = repository.OrgName,
                 RepositoryName = repository.RepositoryName,
                 Visibility = repository.Visibility,
+                Archived = repository.Archived,
                 CloneUrl = repository.CloneUrl,
                 Topics = repository.Topics
             })
@@ -59,6 +60,7 @@ public class GitHubRepositoryRepository(AppDbContext dbContext, ILogger<GitHubRe
                 OrgName = repository.OrgName,
                 RepositoryName = repository.RepositoryName,
                 Visibility = repository.Visibility,
+                Archived = repository.Archived,
                 CloneUrl = repository.CloneUrl,
                 Topics = repository.Topics
             })
@@ -139,6 +141,7 @@ public class GitHubRepositoryRepository(AppDbContext dbContext, ILogger<GitHubRe
             if (nameChanged || urlChanged
                 || !string.Equals(match.OrgName, incoming.OrgName, StringComparison.OrdinalIgnoreCase)
                 || !string.Equals(match.Visibility, incoming.Visibility, StringComparison.OrdinalIgnoreCase)
+                || match.Archived != incoming.Archived
                 || !string.Equals(match.Topics ?? string.Empty, incoming.Topics ?? string.Empty, StringComparison.Ordinal)
                 || !string.Equals(match.NodeId, incoming.NodeId, StringComparison.Ordinal))
             {
@@ -162,6 +165,7 @@ public class GitHubRepositoryRepository(AppDbContext dbContext, ILogger<GitHubRe
                         .SetProperty(r => r.CloneUrl, incoming.CloneUrl)
                         .SetProperty(r => r.OrgName, incoming.OrgName)
                         .SetProperty(r => r.Visibility, incoming.Visibility)
+                    .SetProperty(r => r.Archived, incoming.Archived)
                         .SetProperty(r => r.Topics, incoming.Topics)
                         .SetProperty(r => r.NodeId, incoming.NodeId));
                 updateCount++;
@@ -194,6 +198,7 @@ public class GitHubRepositoryRepository(AppDbContext dbContext, ILogger<GitHubRe
                     .SetProperty(r => r.RepositoryName, incoming.RepositoryName)
                     .SetProperty(r => r.OrgName, incoming.OrgName)
                     .SetProperty(r => r.Visibility, incoming.Visibility)
+                    .SetProperty(r => r.Archived, incoming.Archived)
                     .SetProperty(r => r.Topics, incoming.Topics)
                     .SetProperty(r => r.GitHubRepositoryId, incoming.GitHubRepositoryId)
                     .SetProperty(r => r.NodeId, incoming.NodeId));
@@ -247,6 +252,7 @@ public class GitHubRepositoryRepository(AppDbContext dbContext, ILogger<GitHubRe
                     .SetProperty(r => r.CloneUrl, incoming.CloneUrl)
                     .SetProperty(r => r.OrgName, incoming.OrgName)
                     .SetProperty(r => r.Visibility, incoming.Visibility)
+                    .SetProperty(r => r.Archived, incoming.Archived)
                     .SetProperty(r => r.Topics, incoming.Topics)
                     .SetProperty(r => r.GitHubRepositoryId, incoming.GitHubRepositoryId)
                     .SetProperty(r => r.NodeId, incoming.NodeId));

--- a/src/GrayMoon.App/Repositories/WorkspaceActionRepository.cs
+++ b/src/GrayMoon.App/Repositories/WorkspaceActionRepository.cs
@@ -5,7 +5,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace GrayMoon.App.Repositories;
 
-/// <summary>Persistence for CI action status per workspace–repository link. Single place for all action table read/write.</summary>
+/// <summary>Persistence for CI action status per workspace-repository link. Single place for all action table read/write.</summary>
 public sealed class WorkspaceActionRepository(AppDbContext dbContext, ILogger<WorkspaceActionRepository> logger)
 {
     private static readonly JsonSerializerOptions JsonOptions = new()
@@ -48,7 +48,7 @@ public sealed class WorkspaceActionRepository(AppDbContext dbContext, ILogger<Wo
         return result;
     }
 
-    /// <summary>Inserts or updates the action row for the given workspace–repo link. JSON is the source of truth; legacy scalar columns are cleared.</summary>
+    /// <summary>Inserts or updates the action row for the given workspace-repo link. JSON is the source of truth; legacy scalar columns are cleared.</summary>
     public async Task UpsertAsync(int workspaceRepositoryId, IReadOnlyList<ActionStatusInfo> workflows, string? branchName, CancellationToken cancellationToken = default)
     {
         var now = DateTime.UtcNow;

--- a/src/GrayMoon.App/Repositories/WorkspacePullRequestRepository.cs
+++ b/src/GrayMoon.App/Repositories/WorkspacePullRequestRepository.cs
@@ -4,7 +4,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace GrayMoon.App.Repositories;
 
-/// <summary>Persistence for pull request state per workspace–repository link. Single place for all PR table read/write.</summary>
+/// <summary>Persistence for pull request state per workspace-repository link. Single place for all PR table read/write.</summary>
 public sealed class WorkspacePullRequestRepository(AppDbContext dbContext, ILogger<WorkspacePullRequestRepository> logger)
 {
     /// <summary>Returns persisted PR state for all repositories in the workspace, keyed by RepositoryId. Missing row yields null (no PR or not yet checked).</summary>
@@ -27,7 +27,7 @@ public sealed class WorkspacePullRequestRepository(AppDbContext dbContext, ILogg
         return result;
     }
 
-    /// <summary>Inserts or updates the PR row for the given workspace–repo link. Pass null to persist "no PR" with LastCheckedAt.</summary>
+    /// <summary>Inserts or updates the PR row for the given workspace-repo link. Pass null to persist "no PR" with LastCheckedAt.</summary>
     public async Task UpsertAsync(int workspaceRepositoryId, PullRequestInfo? pr, CancellationToken cancellationToken = default)
     {
         var now = DateTime.UtcNow;

--- a/src/GrayMoon.App/Repositories/WorkspaceRepository.cs
+++ b/src/GrayMoon.App/Repositories/WorkspaceRepository.cs
@@ -61,7 +61,7 @@ public class WorkspaceRepository(AppDbContext dbContext, WorkspaceService worksp
         }
 
         // Detach any WRL entities for this workspace that may have been loaded elsewhere in this
-        // circuit-scope DbContext — prevents stale-state DbUpdateConcurrencyException.
+        // circuit-scope DbContext - prevents stale-state DbUpdateConcurrencyException.
         foreach (var entry in _dbContext.ChangeTracker.Entries<WorkspaceRepositoryLink>()
             .Where(e => e.Entity.WorkspaceId == workspaceId)
             .ToList())
@@ -69,7 +69,7 @@ public class WorkspaceRepository(AppDbContext dbContext, WorkspaceService worksp
             entry.State = Microsoft.EntityFrameworkCore.EntityState.Detached;
         }
 
-        // Load workspace WITHOUT Include(Repositories) — scalar update only.
+        // Load workspace WITHOUT Include(Repositories) - scalar update only.
         var workspace = await _dbContext.Workspaces
             .FirstOrDefaultAsync(item => item.WorkspaceId == workspaceId);
 
@@ -204,7 +204,7 @@ public class WorkspaceRepository(AppDbContext dbContext, WorkspaceService worksp
     {
         await using var transaction = await _dbContext.Database.BeginTransactionAsync();
 
-        // Re-read current DB state with AsNoTracking — never rely on tracker state here.
+        // Re-read current DB state with AsNoTracking - never rely on tracker state here.
         var current = await _dbContext.WorkspaceRepositories
             .AsNoTracking()
             .Where(wr => wr.WorkspaceId == workspaceId)

--- a/src/GrayMoon.App/Services/GitHubApiErrorHelper.cs
+++ b/src/GrayMoon.App/Services/GitHubApiErrorHelper.cs
@@ -1,0 +1,225 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+
+namespace GrayMoon.App.Services;
+
+/// <summary>Maps GitHub REST API failures to accurate user-facing messages (rate limits vs token/scopes).</summary>
+public static class GitHubApiErrorHelper
+{
+    private const string ResetEpochMarker = "X-RateLimit-Reset:";
+
+    private static readonly Regex RateLimitIndicatorsRegex = new(
+        @"rate\s*limit|secondary\s+rate|abuse|too many requests",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+    private static readonly Regex GenericHttpClientMessageRegex = new(
+        @"^Response status code does not indicate success",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+    /// <summary>Extracts the user-visible <c>message</c> field from a GitHub API JSON error body.</summary>
+    public static string? TryParseGitHubApiUserMessage(string? jsonBody)
+    {
+        if (string.IsNullOrWhiteSpace(jsonBody))
+            return null;
+        try
+        {
+            using var doc = JsonDocument.Parse(jsonBody);
+            if (doc.RootElement.TryGetProperty("message", out var m) && m.ValueKind == JsonValueKind.String)
+                return m.GetString();
+        }
+        catch (JsonException)
+        {
+            /* not JSON */
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Parses <c>x-ratelimit-limit</c>, <c>x-ratelimit-remaining</c>, <c>x-ratelimit-used</c>, and
+    /// <c>x-ratelimit-reset</c> (UTC epoch seconds) from a GitHub REST response.
+    /// </summary>
+    public static GitHubRateLimitSnapshot? TryParseRateLimitHeaders(HttpResponseMessage response)
+    {
+        return TryParseRateLimitHeaders(response.Headers)
+               ?? (response.Content != null ? TryParseRateLimitHeaders(response.Content.Headers) : null);
+    }
+
+    public static bool LooksLikeRateLimit(HttpStatusCode? statusCode, string? githubMessage)
+    {
+        if (statusCode == HttpStatusCode.TooManyRequests)
+            return true;
+        return !string.IsNullOrWhiteSpace(githubMessage) && RateLimitIndicatorsRegex.IsMatch(githubMessage);
+    }
+
+    public static bool IsRateLimitExhausted(HttpResponseMessage response)
+    {
+        var snapshot = TryParseRateLimitHeaders(response);
+        if (snapshot?.Remaining is int remaining)
+            return remaining <= 0;
+        return false;
+    }
+
+    public static HttpRequestException CreateHttpRequestException(
+        HttpStatusCode statusCode,
+        string? errorContent,
+        HttpResponseMessage? response = null)
+    {
+        var rateLimit = response != null ? TryParseRateLimitHeaders(response) : null;
+        var detail = TryParseGitHubApiUserMessage(errorContent);
+        var core = !string.IsNullOrWhiteSpace(detail)
+            ? detail.Trim()
+            : $"GitHub returned {(int)statusCode} ({statusCode}).";
+        var message = AppendRateLimitReset(core, rateLimit);
+        return new GitHubHttpRequestException(message, statusCode, rateLimit);
+    }
+
+    /// <summary>User-facing text for Actions error badges and connector tests.</summary>
+    public static string FormatFriendlyGitHubHttpError(HttpRequestException ex)
+    {
+        var rateLimit = ex is GitHubHttpRequestException githubEx ? githubEx.RateLimit : null;
+        var status = ex.StatusCode;
+        var detail = GetActionableDetail(ex.Message);
+
+        var core = LooksLikeRateLimit(status, detail)
+            ? BuildRateLimitUserMessage(status, detail)
+            : status switch
+            {
+                HttpStatusCode.Unauthorized =>
+                    string.IsNullOrWhiteSpace(detail)
+                        ? "Unauthorized (401). Check the connector token on the Connectors page."
+                        : $"Unauthorized (401). {detail}",
+                HttpStatusCode.Forbidden => BuildForbiddenUserMessage(detail),
+                HttpStatusCode.NotFound =>
+                    string.IsNullOrWhiteSpace(detail)
+                        ? "Not found (404). The repository or workflow was not found."
+                        : $"Not found (404). {detail}",
+                HttpStatusCode.Conflict =>
+                    string.IsNullOrWhiteSpace(detail)
+                        ? "Conflict (409). The workflow run may already be finished."
+                        : detail,
+                HttpStatusCode.UnprocessableEntity =>
+                    string.IsNullOrWhiteSpace(detail)
+                        ? "GitHub rejected the workflow request (422). It may not support manual runs on this branch, or required workflow inputs are missing."
+                        : detail,
+                HttpStatusCode.TooManyRequests => BuildRateLimitUserMessage(status, detail),
+                HttpStatusCode.ServiceUnavailable =>
+                    string.IsNullOrWhiteSpace(detail)
+                        ? "GitHub service unavailable (503). Try again later."
+                        : $"GitHub service unavailable (503). {detail}",
+                _ =>
+                    string.IsNullOrWhiteSpace(detail)
+                        ? "GitHub API request failed."
+                        : detail
+            };
+
+        return AppendRateLimitReset(core, rateLimit);
+    }
+
+    /// <summary>
+    /// Appends when <c>x-ratelimit-reset</c> is present so users know when the token may call the API again.
+    /// </summary>
+    public static string AppendRateLimitReset(string message, GitHubRateLimitSnapshot? snapshot)
+    {
+        if (snapshot?.ResetEpochUtcSeconds is not long epoch)
+            return message;
+
+        if (message.Contains(ResetEpochMarker, StringComparison.Ordinal))
+            return message;
+
+        var resetUtc = DateTimeOffset.FromUnixTimeSeconds(epoch);
+        var usage = FormatUsageClause(snapshot.Value);
+
+        return $"{message.TrimEnd()} GitHub will allow API requests again after {resetUtc:yyyy-MM-dd HH:mm:ss} UTC "
+               + $"({ResetEpochMarker} {epoch}, Unix epoch UTC seconds){usage}";
+    }
+
+    private static string FormatUsageClause(GitHubRateLimitSnapshot snapshot)
+    {
+        if (snapshot.Used.HasValue && snapshot.Limit.HasValue)
+        {
+            return $" X-RateLimit-Used: {snapshot.Used.Value} of {snapshot.Limit.Value} in the current window.";
+        }
+
+        if (snapshot.Remaining.HasValue && snapshot.Limit.HasValue)
+        {
+            return $" X-RateLimit-Remaining: {snapshot.Remaining.Value} of {snapshot.Limit.Value}.";
+        }
+
+        return string.Empty;
+    }
+
+    private static GitHubRateLimitSnapshot? TryParseRateLimitHeaders(HttpHeaders? headers)
+    {
+        if (headers == null)
+            return null;
+
+        var limit = TryParseHeaderInt(headers, "X-RateLimit-Limit");
+        var remaining = TryParseHeaderInt(headers, "X-RateLimit-Remaining");
+        var used = TryParseHeaderInt(headers, "X-RateLimit-Used");
+        var reset = TryParseHeaderLong(headers, "X-RateLimit-Reset");
+
+        if (!limit.HasValue && !remaining.HasValue && !used.HasValue && !reset.HasValue)
+            return null;
+
+        return new GitHubRateLimitSnapshot(limit, remaining, used, reset);
+    }
+
+    private static int? TryParseHeaderInt(HttpHeaders headers, string name)
+    {
+        if (!headers.TryGetValues(name, out var values))
+            return null;
+        return int.TryParse(values.FirstOrDefault(), out var n) ? n : null;
+    }
+
+    private static long? TryParseHeaderLong(HttpHeaders headers, string name)
+    {
+        if (!headers.TryGetValues(name, out var values))
+            return null;
+        return long.TryParse(values.FirstOrDefault(), out var n) ? n : null;
+    }
+
+    private static string? GetActionableDetail(string? exceptionMessage)
+    {
+        if (string.IsNullOrWhiteSpace(exceptionMessage))
+            return null;
+        var trimmed = exceptionMessage.Trim();
+        if (GenericHttpClientMessageRegex.IsMatch(trimmed))
+            return null;
+
+        var resetIdx = trimmed.IndexOf(" GitHub will allow API requests again after ", StringComparison.Ordinal);
+        if (resetIdx > 0)
+            trimmed = trimmed[..resetIdx];
+
+        return trimmed;
+    }
+
+    private static string BuildForbiddenUserMessage(string? githubDetail)
+    {
+        if (!string.IsNullOrWhiteSpace(githubDetail))
+        {
+            return $"Forbidden (403). {githubDetail} "
+                   + "If the same token works outside GrayMoon, this is often API rate limiting (GitHub returns 403, not only 429), not a bad token. "
+                   + "Wait until the reset time below (if shown), use Refresh, and avoid many repos refreshing at once on Actions.";
+        }
+
+        return "Forbidden (403). GitHub denied the request. "
+               + "This is not always a bad token: GitHub uses 403 for rate and abuse limits, and also for missing scopes (repo, workflow) or org SSO. "
+               + "Check Connectors; if a reset time is shown below, wait until then and refresh.";
+    }
+
+    private static string BuildRateLimitUserMessage(HttpStatusCode? status, string? githubDetail)
+    {
+        var statusLabel = status.HasValue ? $" ({(int)status.Value})" : "";
+        if (!string.IsNullOrWhiteSpace(githubDetail))
+        {
+            return $"GitHub rate limit{statusLabel}. {githubDetail} "
+                   + "Wait until the reset time below, then use Refresh. Actions polls workflows and live job logs; large workspaces hit limits faster than a single manual API call.";
+        }
+
+        return $"GitHub rate limit{statusLabel}. Too many API requests. "
+               + "Wait until the reset time below, then refresh. Actions polls workflows and live logs; many repositories refreshing together can exhaust the token limit quickly.";
+    }
+}

--- a/src/GrayMoon.App/Services/GitHubHttpRequestException.cs
+++ b/src/GrayMoon.App/Services/GitHubHttpRequestException.cs
@@ -1,0 +1,30 @@
+using System.Net;
+
+namespace GrayMoon.App.Services;
+
+/// <summary>GitHub REST failure with optional rate-limit headers from the response.</summary>
+public sealed class GitHubHttpRequestException : HttpRequestException
+{
+    public GitHubRateLimitSnapshot? RateLimit { get; }
+
+    public GitHubHttpRequestException(
+        string message,
+        HttpStatusCode statusCode,
+        GitHubRateLimitSnapshot? rateLimit)
+        : base(message, inner: null, statusCode: statusCode)
+    {
+        RateLimit = rateLimit;
+    }
+}
+
+/// <summary>Values from GitHub <c>x-ratelimit-*</c> response headers (reset is UTC epoch seconds).</summary>
+public readonly record struct GitHubRateLimitSnapshot(
+    int? Limit,
+    int? Remaining,
+    int? Used,
+    long? ResetEpochUtcSeconds)
+{
+    public DateTimeOffset? ResetUtc => ResetEpochUtcSeconds.HasValue
+        ? DateTimeOffset.FromUnixTimeSeconds(ResetEpochUtcSeconds.Value)
+        : null;
+}

--- a/src/GrayMoon.App/Services/GitHubRepositoryService.cs
+++ b/src/GrayMoon.App/Services/GitHubRepositoryService.cs
@@ -60,6 +60,7 @@ public class GitHubRepositoryService(
                     OrgName = repo.Owner?.Login,
                     RepositoryName = repo.Name,
                     Visibility = repo.Private ? "Private" : "Public",
+                    Archived = repo.Archived,
                     CloneUrl = (repo.CloneUrl ?? string.Empty).Trim(),
                     GitHubRepositoryId = repo.Id,
                     NodeId = string.IsNullOrWhiteSpace(repo.NodeId) ? null : repo.NodeId,

--- a/src/GrayMoon.App/Services/GitHubService.cs
+++ b/src/GrayMoon.App/Services/GitHubService.cs
@@ -161,7 +161,7 @@ public class GitHubService : IConnectorService
                 response.StatusCode,
                 response.RequestMessage?.RequestUri,
                 errorContent);
-            response.EnsureSuccessStatusCode();
+            ThrowGitHubApiFailure(response, errorContent);
         }
 
         return await response.Content.ReadFromJsonAsync<GitHubWorkflowDto>(_jsonOptions, cancellationToken);
@@ -189,7 +189,7 @@ public class GitHubService : IConnectorService
                 response.StatusCode,
                 response.RequestMessage?.RequestUri,
                 errorContent);
-            response.EnsureSuccessStatusCode();
+            ThrowGitHubApiFailure(response, errorContent);
         }
 
         var dto = await response.Content.ReadFromJsonAsync<GitHubContentResponse>(_jsonOptions, cancellationToken);
@@ -333,11 +333,7 @@ public class GitHubService : IConnectorService
             new Uri(new Uri(baseUrl), requestUri),
             errorContent);
 
-        var detail = TryParseGitHubApiUserMessage(errorContent);
-        var summary = string.IsNullOrWhiteSpace(detail)
-            ? $"GitHub returned {(int)response.StatusCode} ({response.ReasonPhrase})."
-            : detail.Trim();
-        throw new HttpRequestException(summary, inner: null, statusCode: response.StatusCode);
+        throw GitHubApiErrorHelper.CreateHttpRequestException(response.StatusCode, errorContent, response);
     }
 
     public async Task DispatchWorkflowAsync(Connector connector, string owner, string repo, long workflowId, string branch, CancellationToken cancellationToken = default)
@@ -381,7 +377,7 @@ public class GitHubService : IConnectorService
         }
         catch (HttpRequestException ex)
         {
-            var message = MapHttpStatusToMessage(ex.StatusCode, "GitHub");
+            var message = GitHubApiErrorHelper.FormatFriendlyGitHubHttpError(ex);
             _logger.LogError(ex, "Failed to test GitHub connector connection. Status={StatusCode}", ex.StatusCode);
             var isConnectorFault = ex.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden or HttpStatusCode.NotFound;
             return isConnectorFault ? ConnectorTestResult.Fault(message) : ConnectorTestResult.Fail(message);
@@ -392,25 +388,6 @@ public class GitHubService : IConnectorService
             return ConnectorTestResult.Fail($"Connection error: {ex.Message}");
         }
     }
-
-    private static string MapHttpStatusToMessage(HttpStatusCode? statusCode, string service) =>
-        statusCode switch
-        {
-            HttpStatusCode.Unauthorized =>
-                $"Unauthorized (401). Your {service} token is invalid or has expired. Update it on the Connectors page.",
-            HttpStatusCode.Forbidden =>
-                $"Forbidden (403). Your {service} token does not have sufficient permissions.",
-            HttpStatusCode.NotFound =>
-                $"Not found (404). Check the API base URL for connector '{service}'.",
-            HttpStatusCode.TooManyRequests =>
-                $"Rate limited (429). Too many requests to {service}. Try again later.",
-            HttpStatusCode.ServiceUnavailable =>
-                $"{service} service is unavailable (503). Try again later.",
-            null =>
-                $"Could not connect to {service}. Check your network and API base URL.",
-            _ =>
-                $"HTTP {(int)statusCode} error connecting to {service}."
-        };
 
     public async Task<(int OrganizationCount, int RepositoryCount)> TestConnectionDetailedAsync(Connector connector)
     {
@@ -537,7 +514,7 @@ public class GitHubService : IConnectorService
                 response.StatusCode,
                 new Uri(_httpClient.BaseAddress ?? new Uri("https://api.github.com/"), requestUri),
                 errorContent);
-            response.EnsureSuccessStatusCode();
+            ThrowGitHubApiFailure(response, errorContent);
         }
 
         return await response.Content.ReadFromJsonAsync<T>(_jsonOptions);
@@ -553,7 +530,7 @@ public class GitHubService : IConnectorService
                 response.StatusCode,
                 response.RequestMessage?.RequestUri,
                 errorContent);
-            response.EnsureSuccessStatusCode();
+            ThrowGitHubApiFailure(response, errorContent);
         }
 
         return await response.Content.ReadFromJsonAsync<T>(_jsonOptions, cancellationToken);
@@ -601,39 +578,30 @@ public class GitHubService : IConnectorService
             new Uri(new Uri(baseUrl), requestUri),
             errorContent);
 
-        var detail = TryParseGitHubApiUserMessage(errorContent);
-        var summary = string.IsNullOrWhiteSpace(detail)
-            ? $"GitHub returned {(int)response.StatusCode} ({response.ReasonPhrase})."
-            : detail.Trim();
-        throw new HttpRequestException(summary, inner: null, statusCode: response.StatusCode);
+        throw GitHubApiErrorHelper.CreateHttpRequestException(response.StatusCode, errorContent, response);
+    }
+
+    private static void ThrowGitHubApiFailure(HttpResponseMessage response, string errorContent)
+    {
+        if (GitHubApiErrorHelper.IsRateLimitExhausted(response)
+            && !GitHubApiErrorHelper.LooksLikeRateLimit(response.StatusCode, GitHubApiErrorHelper.TryParseGitHubApiUserMessage(errorContent)))
+        {
+            throw GitHubApiErrorHelper.CreateHttpRequestException(
+                response.StatusCode,
+                "API rate limit exceeded. X-RateLimit-Remaining is 0.",
+                response);
+        }
+
+        throw GitHubApiErrorHelper.CreateHttpRequestException(response.StatusCode, errorContent, response);
     }
 
     private static bool IsCancelWorkflowRunAlreadyCompleted(HttpStatusCode status, string errorContent)
     {
         if (status != HttpStatusCode.Conflict)
             return false;
-        var msg = TryParseGitHubApiUserMessage(errorContent);
+        var msg = GitHubApiErrorHelper.TryParseGitHubApiUserMessage(errorContent);
         return msg != null
                && msg.Contains("Cannot cancel a workflow run that is completed", StringComparison.OrdinalIgnoreCase);
-    }
-
-    /// <summary>Extracts the user-visible <c>message</c> field from a GitHub API JSON error body.</summary>
-    private static string? TryParseGitHubApiUserMessage(string jsonBody)
-    {
-        if (string.IsNullOrWhiteSpace(jsonBody))
-            return null;
-        try
-        {
-            using var doc = JsonDocument.Parse(jsonBody);
-            if (doc.RootElement.TryGetProperty("message", out var m) && m.ValueKind == JsonValueKind.String)
-                return m.GetString();
-        }
-        catch (JsonException)
-        {
-            /* not JSON */
-        }
-
-        return null;
     }
 
     private async Task<List<GitHubRepositoryDto>> GetRepositoriesPagedAsync(string requestUri)

--- a/src/GrayMoon.App/Services/GitHubService.cs
+++ b/src/GrayMoon.App/Services/GitHubService.cs
@@ -291,7 +291,7 @@ public class GitHubService : IConnectorService
         await PostAsync(connector, $"repos/{owner}/{repo}/actions/runs/{runId}/rerun", payload: null, cancellationToken: cancellationToken);
     }
 
-    /// <summary>POST /repos/{owner}/{repo}/actions/runs/{run_id}/cancel — cancels an in-progress workflow run.</summary>
+    /// <summary>POST /repos/{owner}/{repo}/actions/runs/{run_id}/cancel - cancels an in-progress workflow run.</summary>
     /// <remarks>409 when the run already finished is treated as success (UI/API lag vs GitHub).</remarks>
     public async Task CancelWorkflowRunAsync(Connector connector, string owner, string repo, long runId, CancellationToken cancellationToken = default)
     {

--- a/src/GrayMoon.App/Services/SyncCommandHandler.cs
+++ b/src/GrayMoon.App/Services/SyncCommandHandler.cs
@@ -93,6 +93,7 @@ public sealed class SyncCommandHandler(
         var workspacePullRequestService = scope.ServiceProvider.GetRequiredService<WorkspacePullRequestService>();
         await workspacePullRequestService.RefreshPullRequestsAsync(n.WorkspaceId, [n.RepositoryId]);
 
+        await hubContext.Clients.All.SendAsync("RepositorySynced", n.WorkspaceId, n.RepositoryId);
         await hubContext.Clients.All.SendAsync("WorkspaceSynced", n.WorkspaceId);
         if (!string.IsNullOrWhiteSpace(n.ErrorMessage))
             await hubContext.Clients.All.SendAsync("RepositoryError", n.WorkspaceId, n.RepositoryId, n.ErrorMessage);

--- a/src/GrayMoon.App/wwwroot/app.css
+++ b/src/GrayMoon.App/wwwroot/app.css
@@ -1,4 +1,4 @@
-/* Local font files (no internet required) – latin subset only */
+/* Local font files (no internet required) - latin subset only */
 @font-face {
   font-family: 'Cinzel';
   font-style: normal;
@@ -243,7 +243,7 @@ a.workspaces-breadcrumb-link:hover {
     box-shadow: 0 0 0 1px var(--focus-ring-outer);
 }
 
-/* Text inputs / selects: border-only focus like workspace repository search — no glow */
+/* Text inputs / selects: border-only focus like workspace repository search - no glow */
 .form-control:focus,
 .form-select:focus,
 .form-check-input:focus {
@@ -251,7 +251,7 @@ a.workspaces-breadcrumb-link:hover {
     box-shadow: none !important;
 }
 
-/* Plain links (not Bootstrap .btn) — thin frame to match buttons */
+/* Plain links (not Bootstrap .btn) - thin frame to match buttons */
 a:focus-visible:not(.btn) {
     outline: none;
     box-shadow: 0 0 0 1px var(--focus-ring-outer);
@@ -270,7 +270,7 @@ h1:focus {
     outline: none;
 }
 
-/* Form Controls – dark gray frame (global; !important so Bootstrap cannot override) */
+/* Form Controls - dark gray frame (global; !important so Bootstrap cannot override) */
 .form-control,
 .form-select,
 .new-branch-based-on-trigger,
@@ -1024,7 +1024,7 @@ table.resizable-columns th:hover .resize-handle::after {
     box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
 }
 
-/* PR column badges – white text except create (black on yellow) */
+/* PR column badges - white text except create (black on yellow) */
 .repositories-table td.col-pr .pr-badge {
     font-weight: 400;
 }
@@ -1069,7 +1069,7 @@ table.resizable-columns th:hover .resize-handle::after {
     margin-left: 0.25rem;
 }
 
-/* Actions page run/re-run button – fixed size so spinner swap never causes resize */
+/* Actions page run/re-run button - fixed size so spinner swap never causes resize */
 .action-run-btn {
     display: inline-flex;
     align-items: center;
@@ -1080,7 +1080,7 @@ table.resizable-columns th:hover .resize-handle::after {
     white-space: nowrap;
 }
 
-/* Action status column badges – same color palette as PR badges */
+/* Action status column badges - same color palette as PR badges */
 .action-badge {
     font-weight: 400;
     text-decoration: none;
@@ -1136,7 +1136,7 @@ table.resizable-columns th:hover .resize-handle::after {
     text-decoration: none;
 }
 
-/* GitHub level-header dropdown — appended to <body>, position: fixed escapes table overflow */
+/* GitHub level-header dropdown - appended to <body>, position: fixed escapes table overflow */
 .gm-gh-dropdown {
     position: fixed;
     background: #1e1e1e;

--- a/src/GrayMoon.App/wwwroot/css/loading-overlay.css
+++ b/src/GrayMoon.App/wwwroot/css/loading-overlay.css
@@ -36,7 +36,7 @@
 }
 
 /*
- * Opaque + Matrix: do not set veil dim to 1 — that paints solid black over the canvas and hides the rain.
+ * Opaque + Matrix: do not set veil dim to 1 - that paints solid black over the canvas and hides the rain.
  * Black fills the overlay behind the canvas so transparent canvas pixels do not reveal the app; veil keeps
  * using --overlay-dim from matrixOverlay.setDim (e.g. 0.45) so the effect stays visible.
  */
@@ -117,19 +117,19 @@
   padding: 0.06rem 0;
 }
 
-/* Stream/repo label — neutral gray in both themes (not tinted green or yellow) */
+/* Stream/repo label - neutral gray in both themes (not tinted green or yellow) */
 .loading-overlay-terminal__prefix {
   color: rgba(148, 152, 158, 0.62);
   font-weight: 400;
   margin-right: 0.35rem;
 }
 
-/* Command echo — muted light gray (darker than centered overlay message text) */
+/* Command echo - muted light gray (darker than centered overlay message text) */
 .loading-overlay-terminal__line--cmd .loading-overlay-terminal__text {
   color: rgba(168, 182, 176, 0.92);
 }
 
-/* Stdout — green theme */
+/* Stdout - green theme */
 .loading-overlay-terminal__line--out .loading-overlay-terminal__text {
   color: rgba(120, 210, 150, 0.78);
 }
@@ -144,7 +144,7 @@
 }
 
 /*
- * Yellow scheme: same structure as green — gray [label], whiteish commands, stdout yellow instead of green.
+ * Yellow scheme: same structure as green - gray [label], whiteish commands, stdout yellow instead of green.
  * Prefix stays base gray; stderr unchanged.
  */
 .loading-overlay-terminal--scheme-yellow .loading-overlay-terminal__line--cmd .loading-overlay-terminal__text {
@@ -157,7 +157,7 @@
 
 /*
  * Workspace Actions: embedded GHA live terminal (GhaWorkflowLiveTerminal).
- * Global selectors — Blazor scoped CSS from the component bundle does not reliably override these rules.
+ * Global selectors - Blazor scoped CSS from the component bundle does not reliably override these rules.
  */
 .actions-gha-terminal .actions-gha-terminal__caption-text,
 .actions-gha-terminal .actions-gha-terminal__caption-steps {
@@ -190,7 +190,7 @@
   color: rgba(220, 190, 72, 0.9) !important;
 }
 
-/* Brand at top-left of overlay – same position and font as sidebar header; above full-height terminal */
+/* Brand at top-left of overlay - same position and font as sidebar header; above full-height terminal */
 .loading-overlay__brand {
   position: absolute;
   top: 0;
@@ -234,7 +234,7 @@
   filter: drop-shadow(0 0 1px #000) drop-shadow(0 0 4px rgba(0, 0, 0, 0.75));
 }
 
-/* Content (spinner, message, abort) above canvas and veil – no panel, transparent */
+/* Content (spinner, message, abort) above canvas and veil - no panel, transparent */
 .loading-overlay-content {
   position: absolute;
   left: 50%;
@@ -290,7 +290,7 @@
   margin: 0;
 }
 
-/* Live command log toggle — beside GrayMoon in brand row; bright = hidden, dark = log visible */
+/* Live command log toggle - beside GrayMoon in brand row; bright = hidden, dark = log visible */
 .loading-overlay__terminal-toggle {
   position: relative;
   display: inline-flex;

--- a/src/GrayMoon.App/wwwroot/css/loading-overlay.css
+++ b/src/GrayMoon.App/wwwroot/css/loading-overlay.css
@@ -241,14 +241,32 @@
   top: 50%;
   transform: translate(-50%, -50%);
   z-index: 3;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 1rem;
   padding: 1rem;
   background: transparent;
   user-select: none;
+}
+
+/* Spinner stack: level is out of flow so appearing/disappearing does not shift the spinner */
+.loading-overlay-body {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+}
+
+.loading-overlay-level {
+  position: absolute;
+  bottom: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  margin: 0;
+  padding-bottom: 1rem;
+  white-space: nowrap;
+  text-align: center;
+  color: #858585;
+  font-size: 1.1rem;
+  line-height: 1.1rem;
 }
 
 /* Spinner with optional pending-agent-tasks count inside the ring */

--- a/src/GrayMoon.App/wwwroot/js/resizable-columns.js
+++ b/src/GrayMoon.App/wwwroot/js/resizable-columns.js
@@ -48,7 +48,7 @@
         if (savedWidths && savedWidths.length === ths.length) {
             ths.forEach((th, i) => {
                 if (th.classList.contains('no-resize')) {
-                    /* width controlled entirely by CSS — clear any stale inline styles */
+                    /* width controlled entirely by CSS - clear any stale inline styles */
                     th.style.width = '';
                     th.style.minWidth = '';
                     th.style.maxWidth = '';
@@ -68,7 +68,7 @@
             if (tableWidth > 0) {
                 ths.forEach(th => {
                     if (th.classList.contains('no-resize')) {
-                        /* width controlled entirely by CSS — do not set inline styles */
+                        /* width controlled entirely by CSS - do not set inline styles */
                     } else {
                         const px = th.getBoundingClientRect().width;
                         const pct = (px / tableWidth) * 100;
@@ -136,7 +136,7 @@
                 const w = th.style.width || '';
                 const mw = th.style.minWidth || '';
                 if (th.classList.contains('no-resize')) {
-                    /* width controlled entirely by CSS — clear inline styles on td too */
+                    /* width controlled entirely by CSS - clear inline styles on td too */
                     tds[i].style.width = '';
                     tds[i].style.minWidth = '';
                     tds[i].style.maxWidth = '';

--- a/src/GrayMoon.App/wwwroot/js/versionPatternEditor.js
+++ b/src/GrayMoon.App/wwwroot/js/versionPatternEditor.js
@@ -41,7 +41,7 @@ window.versionPatternEditor = {
                 e.key === 'ArrowUp' || e.key === 'ArrowDown') {
                 e.preventDefault();
             }
-        }, true /* capture — fires before Blazor's listener and before browser default */);
+        }, true /* capture - fires before Blazor's listener and before browser default */);
     },
 
     // Activates or deactivates the keydown guard. Call whenever suggestion visibility changes.
@@ -90,7 +90,7 @@ window.versionPatternEditor = {
         document.body.appendChild(mirror);
         mirror.appendChild(document.createTextNode(el.value.substring(0, atPos)));
         const marker = document.createElement('span');
-        marker.textContent = '\u200b'; // zero-width space – just marks the position
+        marker.textContent = '\u200b'; // zero-width space - just marks the position
         mirror.appendChild(marker);
 
         const mRect = marker.getBoundingClientRect();


### PR DESCRIPTION
## Summary

- **Workspace Actions / GHA live terminal:** After agent push-hook sync, the page listens for `RepositorySynced`, debounces refreshes, and retries until GitHub exposes a running workflow with a run id so the live terminal opens without a manual refresh. `GhaWorkflowLiveTerminal` polls with adaptive intervals (active / waiting / idle), caches the connector, and re-renders only when caption or log lines change. Running rows keep auto-polling until workflows finish.
- **GitHub API errors:** Adds `GitHubApiErrorHelper` and `GitHubHttpRequestException` to parse `x-ratelimit-*` headers, detect exhausted limits on 403, and show clear rate-limit vs token/scope messages in connector tests, Actions error badges, and the live terminal.
- **Archived repositories:** Persists `Repository.Archived` from GitHub (DTO + migration), syncs on connector refresh, and shows an **archived** badge on the Repositories grid instead of public/private when applicable.
- **Loading overlay:** Parses multi-line overlay messages so dependency **Level N** captions appear with the spinner and primary message (layout tuned so level stays aligned with the rest of the overlay body).
- **Docs / style:** Adds `.cursor/rules/hyphens-not-em-en-dashes.mdc` and normalizes em/en dashes to ASCII hyphens across docs, plans, and UI strings.

`SyncCommandHandler` now broadcasts `RepositorySynced` (workspace + repository id) so Actions can react to per-repo hook syncs, not only full workspace sync.

## Test plan

- [ ] Push to a linked repo (or trigger push-hook sync) and confirm Workspace Actions shows the running workflow and embedded GHA terminal without manual refresh.
- [ ] Run / rerun / cancel a workflow from Actions; confirm status updates and terminal stream behave as before.
- [ ] With a token near GitHub rate limit, confirm Actions errors and connector test show rate-limit wording (including reset time when headers are present), not a generic 403.
- [ ] Sync connectors with an archived GitHub repo; confirm **archived** badge on Repositories and data persisted after restart.
- [ ] Start a multi-level dependency sync; confirm loading overlay shows **Level N** above the spinner with the main message unchanged.
- [ ] Fresh DB / existing DB: confirm `Repositories.Archived` migration applies cleanly.
