### PR TITLE
Branch modal: skip tag-pinned repos on create/switch; move Fetch next to branch search

### DIFF
--- a/src/GrayMoon.App/Components/Modals/BranchModal.razor
+++ b/src/GrayMoon.App/Components/Modals/BranchModal.razor
@@ -119,14 +119,22 @@
                                 <label class="form-label mb-0" for="switch-branch-filter">Branch name</label>
                                 <span class="switch-branch-tab-count">@GetBranchCountText(GetFilteredSwitchBranches().Count(), !string.IsNullOrWhiteSpace(switchBranchFilter))</span>
                             </div>
-                            <input id="switch-branch-filter"
-                                   type="text"
-                                   class="form-control"
-                                   placeholder="search branch..."
-                                   @bind="switchBranchFilter"
-                                   @bind:event="oninput"
-                                   @bind:after="SelectClosestSwitchBranch"
-                                   @ref="switchBranchFilterInput" />
+                            <div class="input-group">
+                                <input id="switch-branch-filter"
+                                       type="text"
+                                       class="form-control"
+                                       placeholder="search branch..."
+                                       @bind="switchBranchFilter"
+                                       @bind:event="oninput"
+                                       @bind:after="SelectClosestSwitchBranch"
+                                       @ref="switchBranchFilterInput" />
+                                <button type="button"
+                                        class="btn btn-outline-secondary"
+                                        title="Fetch branches from remote"
+                                        @onclick="FetchAcrossWorkspaceAsync">
+                                    Fetch
+                                </button>
+                            </div>
                         </div>
                         <div class="branch-list border rounded">
                             @if (GetFilteredSwitchBranches().Count() == 0)
@@ -172,13 +180,17 @@
                 </div>
                 <div class="modal-footer">
                     <div class="d-flex gap-2 align-items-center me-auto">
-                        @if (activeTab == "switchbranch")
+                        @if (HasTaggedRepos)
                         {
-                            <button type="button"
-                                    class="btn btn-outline-secondary"
-                                    @onclick="FetchAcrossWorkspaceAsync">
-                                Fetch
-                            </button>
+                            <div class="form-check mb-0">
+                                <input class="form-check-input" type="checkbox" id="branch-modal-skip-tags"
+                                       style="@(!skipReposOnTags ? "opacity: 0.4;" : "")"
+                                       @bind="skipReposOnTags" />
+                                <label class="form-check-label" for="branch-modal-skip-tags"
+                                       title="Repositories checked out on a tag will not be affected">
+                                    Skip repos on tags
+                                </label>
+                            </div>
                         }
                     </div>
                     @if (activeTab == "newbranch" && !showBranchExistsConfirmation)
@@ -215,14 +227,16 @@
     [Parameter] public string DefaultDisplayText { get; set; } = "multiple";
     /// <summary>Local branch name when every repo in the workspace reports the same current branch; used for Current badge and disabling redundant checkout.</summary>
     [Parameter] public string? WorkspaceUnifiedCurrentBranch { get; set; }
+    [Parameter] public bool HasTaggedRepos { get; set; }
     [Parameter] public EventCallback OnCancel { get; set; }
-    [Parameter] public EventCallback<(string NewBranchName, string BaseBranch)> OnCreateBranch { get; set; }
+    [Parameter] public EventCallback<(string NewBranchName, string BaseBranch, bool SkipReposOnTags)> OnCreateBranch { get; set; }
     [Parameter] public EventCallback OnFetchBranches { get; set; }
-    [Parameter] public EventCallback<string> OnCheckoutBranch { get; set; }
+    [Parameter] public EventCallback<(string BranchName, bool SkipReposOnTags)> OnCheckoutBranch { get; set; }
 
     private string activeTab = "newbranch";
     private string newBranchName = "";
     private string selectedBaseBranch = "__default__";
+    private bool skipReposOnTags = true;
     private bool isCreating = false;
     private string? errorMessage;
     private bool showBranchExistsConfirmation = false;
@@ -361,7 +375,7 @@
             return;
 
         await OnCancel.InvokeAsync();
-        await OnCheckoutBranch.InvokeAsync(selected.BranchName);
+        await OnCheckoutBranch.InvokeAsync((selected.BranchName, skipReposOnTags));
     }
 
     private string GetSelectedBaseDisplayText()
@@ -394,6 +408,7 @@
             switchBranchFilter = "";
             selectedSwitchBranchKey = null;
             _focusSwitchFilterOnNextRender = false;
+            skipReposOnTags = true;
         }
     }
 
@@ -457,7 +472,7 @@
                 return;
             }
 
-            await OnCreateBranch.InvokeAsync((name, baseBranch));
+            await OnCreateBranch.InvokeAsync((name, baseBranch, skipReposOnTags));
         }
         finally
         {
@@ -485,7 +500,7 @@
 
         try
         {
-            await OnCreateBranch.InvokeAsync((_pendingCreateName, _pendingCreateBaseBranch));
+            await OnCreateBranch.InvokeAsync((_pendingCreateName, _pendingCreateBaseBranch, skipReposOnTags));
             DismissBranchExistsConfirmation();
         }
         finally

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor
@@ -187,6 +187,7 @@
 <BranchModal IsVisible="@_branchModal.IsVisible"
                    WorkspaceName="@(workspace?.Name)"
                    WorkspaceId="@WorkspaceId"
+                   HasTaggedRepos="@hasTaggedRepos"
                    CommonBranchNames="@_branchModal.CommonBranchNames"
                    CommonLocalBranchNames="@_branchModal.CommonLocalBranchNames"
                    CommonRemoteBranchNames="@_branchModal.CommonRemoteBranchNames"

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
@@ -34,6 +34,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
     private bool? isOutOfSync = null;
     private bool hasUnmatchedDependencies => workspaceRepositories.Any(wr => !wr.IsOnTag && (wr.UnmatchedDeps ?? 0) > 0);
     private bool isPushRecommended => workspaceRepositories.Any(wr => !wr.IsOnTag && ((wr.OutgoingCommits ?? 0) > 0 || wr.BranchHasUpstream == false));
+    private bool hasTaggedRepos => workspaceRepositories.Any(wr => wr.IsOnTag);
     /// <summary>When true, any repository on its default branch has incoming commits; header shows red Pull button and executes only Pull (commit sync) for those repos. Repos pinned to a tag are excluded.</summary>
     private bool hasIncomingCommits => workspaceRepositories.Any(wr =>
         !wr.IsOnTag
@@ -1951,12 +1952,14 @@ public sealed partial class WorkspaceRepositories : IDisposable
         }
     }
 
-    private async Task CheckoutCommonBranchAcrossWorkspaceAsync(string branchName)
+    private async Task CheckoutCommonBranchAcrossWorkspaceAsync((string BranchName, bool SkipReposOnTags) args)
     {
+        var (branchName, skipReposOnTags) = args;
         if (workspace == null || string.IsNullOrWhiteSpace(branchName) || isWorkspaceBranchesCheckingOut || isSyncing || isUpdating || isCommitSyncing || isCheckingOut)
             return;
 
         var repoIds = workspaceRepositories
+            .Where(wr => !skipReposOnTags || !wr.IsOnTag)
             .Select(wr => wr.RepositoryId)
             .Distinct()
             .ToList();
@@ -2015,9 +2018,9 @@ public sealed partial class WorkspaceRepositories : IDisposable
         }
     }
 
-    private async Task CreateBranchesAsync((string NewBranchName, string BaseBranch) args)
+    private async Task CreateBranchesAsync((string NewBranchName, string BaseBranch, bool SkipReposOnTags) args)
     {
-        var (newBranchName, baseBranch) = args;
+        var (newBranchName, baseBranch, skipReposOnTags) = args;
         if (workspace == null || string.IsNullOrWhiteSpace(newBranchName) || isCreatingBranches || isSyncing || isUpdating)
             return;
 
@@ -2031,6 +2034,10 @@ public sealed partial class WorkspaceRepositories : IDisposable
         errorMessage = null;
         StateHasChanged();
 
+        var tagFilteredRepoIds = skipReposOnTags
+            ? workspaceRepositories.Where(wr => !wr.IsOnTag).Select(wr => wr.RepositoryId).ToHashSet()
+            : (IReadOnlySet<int>?)null;
+
         try
         {
             await Task.Yield();
@@ -2038,6 +2045,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
                 WorkspaceId,
                 newBranchName,
                 baseBranch,
+                tagFilteredRepoIds,
                 (completed, total) =>
                 {
                     SetCreateBranchesProgress($"Created {completed} of {total} branches");

--- a/src/GrayMoon.App/Services/WorkspaceBranchHandler.cs
+++ b/src/GrayMoon.App/Services/WorkspaceBranchHandler.cs
@@ -38,6 +38,7 @@ public sealed class WorkspaceBranchHandler(
         int workspaceId,
         string newBranchName,
         string baseBranch,
+        IReadOnlySet<int>? repositoryIds,
         Action<int, int> reportProgress,
         CancellationToken cancellationToken)
     {
@@ -49,7 +50,7 @@ public sealed class WorkspaceBranchHandler(
             newBranchName,
             baseBranch,
             onProgress: (completed, total) => reportProgress(completed, total),
-            repositoryIds: null,
+            repositoryIds: repositoryIds,
             cancellationToken: cancellationToken);
     }
 


### PR DESCRIPTION
## Summary

- Adds a **Skip repos on tags** option to the workspace Branch modal when any repository is checked out on a tag. It defaults to on so create-branch and switch-branch operations leave tag-pinned repos unchanged.
- Wires the flag through checkout and create flows: checkout filters the repo list; create-branch passes a filtered `repositoryIds` set into `WorkspaceBranchHandler` / `WorkspaceGitService`.
- Moves **Fetch** from the modal footer into the Switch branch tab beside the branch name filter (input group).

## Context

Builds on per-repo tag checkout (#187). Tag-pinned repos should not be moved to a branch unless the user explicitly opts out via the checkbox.

## Test plan

- [ ] Open Branch modal in a workspace with no tag-pinned repos: **Skip repos on tags** is hidden.
- [ ] Open Branch modal with at least one repo on a tag: checkbox is visible, checked by default, with tooltip on the label.
- [ ] **Switch branch** with checkbox checked: only non-tag repos switch; tag-pinned repos stay on the tag.
- [ ] **Switch branch** with checkbox unchecked: all repos in the workspace switch, including tag-pinned ones.
- [ ] **Create branch** with checkbox checked: new branch is created/checked out only on non-tag repos.
- [ ] **Create branch** with checkbox unchecked: all repos participate.
- [ ] Close and reopen the modal: checkbox resets to checked.
- [ ] On Switch branch tab, **Fetch** beside the search box refreshes remote branch lists across the workspace.
- [ ] Branch-exists confirmation path still passes the skip-tags setting through to create.