### PR TITLE
Fix sync-to-default reliability - per-repo locking and skip hooks on checkout

### DIFF
--- a/.cursor/plans/fix_sync-to-default_bfae17ba.plan.md
+++ b/.cursor/plans/fix_sync-to-default_bfae17ba.plan.md
@@ -1,0 +1,136 @@
+---
+name: Fix sync-to-default
+overview: "The sync-to-default flow matches your log: remote delete fails harmlessly (GitHub already deleted the branch), checkout tries `checkout -b` before falling back to `checkout main`, and the real failure is a race between the post-checkout hook's fetch and `git pull` updating `refs/remotes/origin/main`."
+todos:
+  - id: checkout-order
+    content: Fix CheckoutBranchAsync to prefer existing local branch before checkout -b origin/branch
+    status: completed
+  - id: idempotent-remote-delete
+    content: Treat 'remote ref does not exist' as success in DeleteBranchAsync for remote deletes
+    status: completed
+  - id: repo-git-lock
+    content: Add per-repo SemaphoreSlim lock in GitService.RunProcessAsync to serialize git commands
+    status: completed
+  - id: sync-skip-hooks
+    content: "SyncToDefaultBranchCommand: checkout with core.hooksPath disabled to avoid post-checkout fetch race"
+    status: completed
+  - id: verify-manual
+    content: Manual verify sync-to-default on merged-PR repo with GitHub head-branch auto-delete enabled
+    status: completed
+isProject: false
+---
+
+# Fix sync-to-default branch race and checkout logic
+
+## What your log shows (mapped to code)
+
+```mermaid
+sequenceDiagram
+    participant App as WorkspaceBranchHandler
+    participant Agent as SyncToDefaultBranchCommand
+    participant Hook as CheckoutHookSyncCommand
+    participant Git as git
+
+    App->>Git: push origin --delete tape-device
+    Note over Git: fails: remote ref does not exist (expected if GitHub auto-deleted head)
+    App->>Agent: POST sync-to-default
+    Agent->>Git: checkout -b main origin/main
+    Git-->>Agent: fatal: branch main already exists
+    Agent->>Git: checkout main (fallback)
+    Git->>Hook: post-checkout hook (async curl)
+    Hook->>Git: fetch origin main (FetchMinimalAsync)
+    Agent->>Git: branch -D tape-device
+    Agent->>Git: pull origin main
+    Git-->>Agent: incorrect old value provided (race on origin/main ref)
+    Note over Git: PullRetryPipeline retries, same error
+```
+
+| Log line | Source | Severity |
+|----------|--------|----------|
+| `unable to delete 'tape-device': remote ref does not exist` | [`WorkspaceBranchHandler.SyncToDefaultSingleAsync`](src/GrayMoon.App/Services/WorkspaceBranchHandler.cs) calls delete API when `hasUpstream`; agent runs `git push origin --delete` in [`DeleteBranchAsync`](src/GrayMoon.Agent/Services/GitService.cs) | Expected/noisy — App already ignores "not exist"/"not found" in the delete response, but agent still logs errors |
+| `checkout -b main origin/main` then `fatal: branch named 'main' already exists` | [`CheckoutBranchAsync`](src/GrayMoon.Agent/Services/GitService.cs) lines 728-737: if `origin/main` exists, always tries `-b` first, then falls back to `checkout main` | Harmless noise — fallback succeeds (`Switched to branch 'main'`) |
+| `pull origin main` → `incorrect old value provided` | [`SyncToDefaultBranchCommand`](src/GrayMoon.Agent/Commands/SyncToDefaultBranchCommand.cs) line 57 calls `PullAsync` immediately after checkout; **post-checkout hook** ([`CheckoutHookSyncCommand`](src/GrayMoon.Agent/Commands/CheckoutHookSyncCommand.cs) line 39) concurrently runs `FetchMinimalAsync` on `main` | **Real bug** — two git processes race to atomically update `refs/remotes/origin/main` |
+| Duplicate error lines | [`CreatePullPipeline`](src/GrayMoon.Agent/Services/GitResiliencePipelines.cs) retries up to 3 times on any non-zero exit; checkout fatals may also appear twice via git stderr mirroring in the terminal overlay | Symptom, not root cause |
+
+## Why `checkout -b main origin/main` is used
+
+[`CheckoutBranchAsync`](src/GrayMoon.Agent/Services/GitService.cs) was written for the "local branch doesn't exist yet, but remote does" case (e.g. first checkout of a remote branch). Sync-to-default almost always has a local `main` already, so the `-b` path is wrong-first.
+
+Your instinct is correct: **prefer `git checkout main` when `refs/heads/main` exists**, and only use `-b`/tracking when the local branch is missing.
+
+## Why pull fails (not the remote delete)
+
+The delete-remote step completes (with expected failure) before checkout. Checkout succeeds. The failure happens because:
+
+1. `git checkout main` triggers the GrayMoon **post-checkout hook** ([`WriteSyncHooks`](src/GrayMoon.Agent/Services/GitService.cs) — fire-and-forget `curl` to `/hook/checkout`).
+2. That enqueues [`CheckoutHookSyncCommand`](src/GrayMoon.Agent/Commands/CheckoutHookSyncCommand.cs), which fetches `main`.
+3. In parallel, `SyncToDefaultBranchCommand` runs `git pull origin main` (fetch + merge).
+4. Both try to update `refs/remotes/origin/main` using Git's atomic ref update; one loses with **"incorrect old value provided"**.
+
+There is **no per-repo git lock** today — command jobs and notify (hook) jobs share the worker pool ([`GrayMoon.Agent-Parallel-Jobs.md`](docs/GrayMoon.Agent-Parallel-Jobs.md)).
+
+## Proposed fixes (minimal, targeted)
+
+### 1. Fix checkout order in `CheckoutBranchAsync` (reduce noise, safer default)
+
+In [`GitService.CheckoutBranchAsync`](src/GrayMoon.Agent/Services/GitService.cs):
+
+```
+if refs/heads/{branchName} exists  →  git checkout {branchName}
+else if origin/{branchName} exists →  git checkout -b {branchName} origin/{branchName}  (or --track)
+else                               →  git checkout {branchName}  (local-only fallback)
+```
+
+This matches what you suggested and eliminates the double-fatal on every sync-to-default where local default already exists.
+
+### 2. Treat missing remote branch as success on delete (expected GitHub behavior)
+
+In [`DeleteBranchAsync`](src/GrayMoon.Agent/Services/GitService.cs) when `isRemote == true`, if stderr contains phrases like `remote ref does not exist` or `does not exist`, return `(true, null)` instead of failure. Makes delete idempotent when GitHub "Delete head branches" already removed the branch.
+
+No change needed in [`WorkspaceBranchHandler`](src/GrayMoon.App/Services/WorkspaceBranchHandler.cs) — it already swallows those API errors, but this cleans agent logs and returns consistent success.
+
+### 3. Fix the pull race (primary bug)
+
+**Recommended: per-repo git lock in `GitService`**
+
+Add a `ConcurrentDictionary<string, SemaphoreSlim>` keyed by normalized repo path. Acquire the semaphore at the start of `RunProcessAsync` when `workingDirectory` is set (all git commands for that repo serialize).
+
+- Fixes sync-to-default pull vs hook fetch race
+- Fixes similar races elsewhere (e.g. hook fetch during manual pull/push)
+- Small, localized change in one service
+
+**Additionally for sync-to-default checkout:** pass `-c core.hooksPath=<empty>` on the checkout git invocation used by `SyncToDefaultBranchCommand` only (new optional `skipHooks` parameter on `CheckoutBranchAsync`, or a dedicated internal checkout helper). This prevents the hook from firing during an orchestrated multi-step operation, so sync-to-default does not depend on hook timing even under load.
+
+Use an empty hooks directory (cross-platform) rather than `/dev/null`.
+
+### 4. Optional hardening of the update step in `SyncToDefaultBranchCommand`
+
+After fetch succeeds, prefer **`git merge --ff-only origin/{defaultBranch}`** (or `reset --hard` when PR was merged and local default should exactly match remote) instead of a full `pull`. This separates fetch from merge and avoids a second implicit fetch inside `pull`. Only valuable once the race is fixed; not sufficient alone.
+
+## Files to change
+
+| File | Change |
+|------|--------|
+| [`src/GrayMoon.Agent/Services/GitService.cs`](src/GrayMoon.Agent/Services/GitService.cs) | Repo lock in `RunProcessAsync`; fix `CheckoutBranchAsync` order; idempotent remote delete |
+| [`src/GrayMoon.Agent/Commands/SyncToDefaultBranchCommand.cs`](src/GrayMoon.Agent/Commands/SyncToDefaultBranchCommand.cs) | Checkout with hooks disabled; optionally replace `PullAsync` with fetch + ff-merge |
+| [`src/GrayMoon.Agent/Abstractions/IGitService.cs`](src/GrayMoon.Agent/Abstractions/IGitService.cs) | Add `skipHooks` (or similar) to checkout signature if needed |
+
+## Verification
+
+Manual repro on a repo like MezzoRecovery.TapeTools:
+
+1. Be on feature branch with upstream; merge PR on GitHub (head branch auto-deleted).
+2. Run sync-to-default from GrayMoon UI.
+3. Confirm:
+   - No `checkout -b` fatal when local `main` exists
+   - Remote delete either succeeds or is silently treated as already-deleted (no error surfaced to user)
+   - `pull`/update completes; local `main` at latest `origin/main`
+   - No `incorrect old value provided` in agent/terminal log
+
+Optional: run two concurrent git operations on same repo (checkout hook + pull) to confirm lock prevents the race.
+
+## Out of scope
+
+- Skipping remote delete when PR is merged (nice optimization, but idempotent delete is sufficient)
+- Changing GitHub "delete head branches" setting
+- Adding automated tests (none exist for this path today; manual verification is the practical first step)

--- a/src/GrayMoon.Agent/Abstractions/IGitService.cs
+++ b/src/GrayMoon.Agent/Abstractions/IGitService.cs
@@ -40,8 +40,8 @@ public interface IGitService
     Task<IReadOnlyList<string>> GetRemoteBranchesFromRefsAsync(string repoPath, CancellationToken ct);
     /// <summary>Gets all remote branch names (without 'origin/' prefix). Uses ls-remote; for post-fetch use <see cref="GetRemoteBranchesFromRefsAsync"/>.</summary>
     Task<IReadOnlyList<string>> GetRemoteBranchesAsync(string repoPath, string? bearerToken, CancellationToken ct);
-    /// <summary>Checks out the specified branch. Returns (success, errorMessage).</summary>
-    Task<(bool Success, string? ErrorMessage)> CheckoutBranchAsync(string repoPath, string branchName, CancellationToken ct);
+    /// <summary>Checks out the specified branch. Returns (success, errorMessage). When <paramref name="skipHooks"/> is true, hooks are disabled for the checkout (orchestrated flows such as sync-to-default).</summary>
+    Task<(bool Success, string? ErrorMessage)> CheckoutBranchAsync(string repoPath, string branchName, CancellationToken ct, bool skipHooks = false);
     /// <summary>Creates a new branch from the given base branch and checks it out. Returns (success, errorMessage).</summary>
     Task<(bool Success, string? ErrorMessage)> CreateBranchAsync(string repoPath, string newBranchName, string baseBranchName, CancellationToken ct);
     /// <summary>Deletes a local branch. Returns true if successful. Only deletes if branch is not current and is merged or force flag is set.</summary>

--- a/src/GrayMoon.Agent/Commands/SyncToDefaultBranchCommand.cs
+++ b/src/GrayMoon.Agent/Commands/SyncToDefaultBranchCommand.cs
@@ -35,8 +35,8 @@ public sealed class SyncToDefaultBranchCommand(IGitService git) : ICommandHandle
             };
         }
 
-        // Checkout default branch
-        var (checkoutSuccess, checkoutError) = await git.CheckoutBranchAsync(repoPath, defaultBranch, cancellationToken);
+        // Checkout default branch without firing post-checkout hook (orchestrated fetch/pull follows).
+        var (checkoutSuccess, checkoutError) = await git.CheckoutBranchAsync(repoPath, defaultBranch, cancellationToken, skipHooks: true);
         if (!checkoutSuccess)
         {
             return new SyncToDefaultBranchResponse

--- a/src/GrayMoon.Agent/Services/GitService.cs
+++ b/src/GrayMoon.Agent/Services/GitService.cs
@@ -18,6 +18,8 @@ public sealed class GitService(IOptions<AgentOptions> options, ILogger<GitServic
     private readonly int _listenPort = options.Value.ListenPort;
     private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
     private readonly ConcurrentDictionary<string, byte> _safeRepoCache = new(StringComparer.OrdinalIgnoreCase);
+    private static readonly ConcurrentDictionary<string, SemaphoreSlim> RepoLocks = new(StringComparer.OrdinalIgnoreCase);
+    private static string? _emptyHooksPath;
 
     public string GetWorkspacePath(string root, string workspaceName)
     {
@@ -711,7 +713,7 @@ public sealed class GitService(IOptions<AgentOptions> options, ILogger<GitServic
         return branches!;
     }
 
-    public async Task<(bool Success, string? ErrorMessage)> CheckoutBranchAsync(string repoPath, string branchName, CancellationToken ct)
+    public async Task<(bool Success, string? ErrorMessage)> CheckoutBranchAsync(string repoPath, string branchName, CancellationToken ct, bool skipHooks = false)
     {
         if (string.IsNullOrWhiteSpace(repoPath) || !Directory.Exists(repoPath) || string.IsNullOrWhiteSpace(branchName))
             return (false, "Invalid repository path or branch name");
@@ -725,18 +727,13 @@ public sealed class GitService(IOptions<AgentOptions> options, ILogger<GitServic
                  : $"{outStr}\n{errStr}";
         }
 
-        // First check if it's a remote branch that needs to be tracked locally
-        var (exitCheckRemote, _, _) = await RunProcessAsync("git", $"rev-parse --verify origin/{branchName}", repoPath, ct);
-        if (exitCheckRemote == 0)
-        {
-            // Remote branch exists, checkout with tracking
-            var (exitCode, stdout, stderr) = await RunProcessAsync("git", $"checkout -b {branchName} origin/{branchName}", repoPath, ct);
-            if (exitCode != 0)
-            {
-                // Try regular checkout in case branch already exists locally
-                (exitCode, stdout, stderr) = await RunProcessAsync("git", $"checkout {branchName}", repoPath, ct);
-            }
+        var hooksPrefix = GetHooksConfigPrefix(skipHooks);
 
+        // Prefer an existing local branch; only create a tracking branch when local is missing.
+        var (exitCheckLocal, _, _) = await RunProcessAsync("git", $"rev-parse --verify refs/heads/{branchName}", repoPath, ct);
+        if (exitCheckLocal == 0)
+        {
+            var (exitCode, stdout, stderr) = await RunProcessAsync("git", $"{hooksPrefix}checkout {branchName}", repoPath, ct);
             if (exitCode != 0)
             {
                 var combined = CombineOutput(stdout, stderr);
@@ -746,13 +743,26 @@ public sealed class GitService(IOptions<AgentOptions> options, ILogger<GitServic
         }
         else
         {
-            // Local branch only
-            var (exitCode, stdout, stderr) = await RunProcessAsync("git", $"checkout {branchName}", repoPath, ct);
-            if (exitCode != 0)
+            var (exitCheckRemote, _, _) = await RunProcessAsync("git", $"rev-parse --verify origin/{branchName}", repoPath, ct);
+            if (exitCheckRemote == 0)
             {
-                var combined = CombineOutput(stdout, stderr);
-                logger.LogError("Git checkout failed for {RepoPath}. Branch={Branch}, ExitCode={ExitCode}, Stdout={Stdout}, Stderr={Stderr}", repoPath, branchName, exitCode, stdout, stderr);
-                return (false, combined);
+                var (exitCode, stdout, stderr) = await RunProcessAsync("git", $"{hooksPrefix}checkout -b {branchName} origin/{branchName}", repoPath, ct);
+                if (exitCode != 0)
+                {
+                    var combined = CombineOutput(stdout, stderr);
+                    logger.LogError("Git checkout failed for {RepoPath}. Branch={Branch}, ExitCode={ExitCode}, Stdout={Stdout}, Stderr={Stderr}", repoPath, branchName, exitCode, stdout, stderr);
+                    return (false, combined);
+                }
+            }
+            else
+            {
+                var (exitCode, stdout, stderr) = await RunProcessAsync("git", $"{hooksPrefix}checkout {branchName}", repoPath, ct);
+                if (exitCode != 0)
+                {
+                    var combined = CombineOutput(stdout, stderr);
+                    logger.LogError("Git checkout failed for {RepoPath}. Branch={Branch}, ExitCode={ExitCode}, Stdout={Stdout}, Stderr={Stderr}", repoPath, branchName, exitCode, stdout, stderr);
+                    return (false, combined);
+                }
             }
         }
 
@@ -873,6 +883,11 @@ public sealed class GitService(IOptions<AgentOptions> options, ILogger<GitServic
             if (exitCode != 0)
             {
                 var combined = CombineOutput(stdout, stderr);
+                if (IsRemoteBranchAlreadyDeleted(combined))
+                {
+                    logger.LogInformation("Git remote branch already deleted for {RepoPath}. Branch={Branch}", repoPath, name);
+                    return (true, null);
+                }
                 logger.LogWarning("Git push --delete failed for {RepoPath}. Branch={Branch}, ExitCode={ExitCode}", repoPath, name, exitCode);
                 return (false, combined);
             }
@@ -1211,6 +1226,32 @@ public sealed class GitService(IOptions<AgentOptions> options, ILogger<GitServic
         bool? streamStderrAsStdout = null,
         bool? mirrorFailureOutputAsStderr = null)
     {
+        if (string.Equals(fileName, "git", StringComparison.OrdinalIgnoreCase) &&
+            !string.IsNullOrWhiteSpace(workingDirectory))
+        {
+            var repoLock = GetRepoLock(workingDirectory);
+            await repoLock.WaitAsync(ct);
+            try
+            {
+                return await RunProcessCoreAsync(fileName, arguments, workingDirectory, ct, streamStderrAsStdout, mirrorFailureOutputAsStderr);
+            }
+            finally
+            {
+                repoLock.Release();
+            }
+        }
+
+        return await RunProcessCoreAsync(fileName, arguments, workingDirectory, ct, streamStderrAsStdout, mirrorFailureOutputAsStderr);
+    }
+
+    private async Task<(int ExitCode, string? Stdout, string? Stderr)> RunProcessCoreAsync(
+        string fileName,
+        string arguments,
+        string? workingDirectory,
+        CancellationToken ct,
+        bool? streamStderrAsStdout = null,
+        bool? mirrorFailureOutputAsStderr = null)
+    {
         var gitLike = IsGitLikeProgressStreaming(fileName, arguments);
         var stderrAsOut = streamStderrAsStdout ?? gitLike;
         var mirror = mirrorFailureOutputAsStderr ?? gitLike;
@@ -1219,6 +1260,31 @@ public sealed class GitService(IOptions<AgentOptions> options, ILogger<GitServic
     }
 
     private async Task<(int ExitCode, string? Stdout, string? Stderr)> RunProcessWithStdinAsync(
+        string fileName,
+        string arguments,
+        string? workingDirectory,
+        string stdinContent,
+        CancellationToken ct)
+    {
+        if (string.Equals(fileName, "git", StringComparison.OrdinalIgnoreCase) &&
+            !string.IsNullOrWhiteSpace(workingDirectory))
+        {
+            var repoLock = GetRepoLock(workingDirectory);
+            await repoLock.WaitAsync(ct);
+            try
+            {
+                return await RunProcessWithStdinCoreAsync(fileName, arguments, workingDirectory, stdinContent, ct);
+            }
+            finally
+            {
+                repoLock.Release();
+            }
+        }
+
+        return await RunProcessWithStdinCoreAsync(fileName, arguments, workingDirectory, stdinContent, ct);
+    }
+
+    private async Task<(int ExitCode, string? Stdout, string? Stderr)> RunProcessWithStdinCoreAsync(
         string fileName,
         string arguments,
         string? workingDirectory,
@@ -1266,5 +1332,37 @@ public sealed class GitService(IOptions<AgentOptions> options, ILogger<GitServic
             || output.Contains("is not recognized as an internal or external command", StringComparison.OrdinalIgnoreCase)
             || output.Contains("run 'dotnet tool restore'", StringComparison.OrdinalIgnoreCase)
             || output.Contains("run \"dotnet tool restore\"", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static SemaphoreSlim GetRepoLock(string repoPath)
+    {
+        var key = Path.GetFullPath(repoPath).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        return RepoLocks.GetOrAdd(key, _ => new SemaphoreSlim(1, 1));
+    }
+
+    private static string EmptyHooksPath =>
+        _emptyHooksPath ??= CreateEmptyHooksPath();
+
+    private static string CreateEmptyHooksPath()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "GrayMoon-empty-hooks");
+        Directory.CreateDirectory(path);
+        return path.Replace('\\', '/');
+    }
+
+    private static string GetHooksConfigPrefix(bool skipHooks)
+    {
+        if (!skipHooks)
+            return string.Empty;
+
+        var escaped = EmptyHooksPath.Replace("\\", "\\\\").Replace("\"", "\\\"");
+        return $"-c core.hooksPath=\"{escaped}\" ";
+    }
+
+    private static bool IsRemoteBranchAlreadyDeleted(string output)
+    {
+        return output.Contains("remote ref does not exist", StringComparison.OrdinalIgnoreCase)
+            || (output.Contains("unable to delete", StringComparison.OrdinalIgnoreCase)
+                && output.Contains("does not exist", StringComparison.OrdinalIgnoreCase));
     }
 }


### PR DESCRIPTION
**Description:**

## Problem

The sync-to-default-branch flow was prone to two failure modes:

1. **Concurrent git operations** on the same repository could race against each other (e.g. a background fetch overlapping a checkout), causing transient errors.
2. **Post-checkout hooks** were firing during the orchestrated sync flow (checkout → fetch → pull), sometimes triggering recursive or conflicting side-effects before the repo was in a clean state.

## Changes

### `GitService.cs`
- Added a `RepoLocks` `ConcurrentDictionary<string, SemaphoreSlim>` that gives each repository path its own lock. All git process execution routes through `RunProcessCoreAsync` / `RunProcessWithStdinCoreAsync`, which acquire the per-repo semaphore before invoking the process — preventing concurrent git operations on the same repo.
- `CheckoutBranchAsync` now accepts a `skipHooks` parameter. When `true`, git's `core.hooksPath` is temporarily overridden to an empty directory (via `-c core.hooksPath=<empty>`) for the duration of that checkout, suppressing all hook execution.
- Added helpers: `GetRepoLock`, `GetHooksConfigPrefix`, `IsRemoteBranchAlreadyDeleted`.

### `IGitService.cs`
- Added `bool skipHooks = false` optional parameter to `CheckoutBranchAsync`.

### `SyncToDefaultBranchCommand.cs`
- Calls `CheckoutBranchAsync(..., skipHooks: true)` — the orchestrated fetch/pull that follows the checkout makes hook suppression during checkout safe.
