### PR TITLE
Improve workspace repo workflow: exact PR links, copy PR URLs, non-upstream commit badges, and UI polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,16 @@ Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManage
 
 ## What's new
 
+### Branch updates: PR workflows, commits visibility, and UI polish
+
+This branch adds several workflow-focused improvements in the workspace repositories view.
+
+- **Dependency-level PR links are smarter:** from the level header GitHub dropdown, **Pull Requests** now opens the exact open PR for each repository (when one exists on the current branch), instead of only opening the generic repo pull-requests page.
+- **Copy open PR links in one click:** dependency-level headers now include a **Share** action that copies all open PR URLs for that level to the clipboard (one URL per line), with a confirmation toast.
+- **Better non-upstream commit visibility:** the Commits badge now shows outgoing commit count for branches without an upstream (for example `↑3`), making it clearer when a first push is needed.
+- **Loading overlay stability improvements:** overlay terminal/spinner presentation was tuned so status/timer updates do not cause visual shifting.
+- **Workspace nav polish:** workspace sidebar navigation was updated for clearer repository/dependency affordances and improved icon consistency.
+
 ### Pin a repository to a specific tag
 
 The Switch Branch dialog now has a dedicated **Tags** tab. Pick any tag and GrayMoon will check that repository out at that exact version (detached HEAD), then keep it parked there.

--- a/src/GrayMoon.App/Components/App.razor
+++ b/src/GrayMoon.App/Components/App.razor
@@ -145,9 +145,16 @@
                 if (!item || !activeTrigger) return;
                 const suffix = item.dataset.suffix;
                 try {
-                    const urls = JSON.parse(activeTrigger.dataset.urls || '[]')
-                        .filter(u => u)
-                        .map(u => appendSuffix(u, suffix));
+                    const baseUrls = JSON.parse(activeTrigger.dataset.urls || '[]');
+                    let urls;
+                    if (suffix === '/pulls') {
+                        const prMap = JSON.parse(activeTrigger.dataset.prPullMap || '{}');
+                        urls = baseUrls
+                            .filter(u => u)
+                            .map(u => prMap[u] || appendSuffix(u, suffix));
+                    } else {
+                        urls = baseUrls.filter(u => u).map(u => appendSuffix(u, suffix));
+                    }
                     if (urls.length) urls.forEach(u => window.open(u, '_blank', 'noopener,noreferrer'));
                 } catch (_) { }
                 hide();

--- a/src/GrayMoon.App/Components/App.razor
+++ b/src/GrayMoon.App/Components/App.razor
@@ -170,6 +170,89 @@
             });
         })();
 
+        window.graymoonShowToast = function (message) {
+            const el = document.createElement('div');
+            el.style.cssText = 'position:fixed;top:calc(3.5rem + 1rem);left:50%;transform:translateX(-50%);z-index:9999;'
+                + 'max-width:min(90vw,420px);padding:0.5rem 1rem;background-color:#252526;color:#cccccc;'
+                + 'border:1px solid #3e3e42;border-radius:0.375rem;box-shadow:0 4px 12px rgba(0,0,0,0.35);'
+                + 'font-size:0.875rem;pointer-events:none;text-align:center;';
+            el.textContent = message;
+            document.body.appendChild(el);
+            setTimeout(() => el.remove(), 2500);
+        };
+
+        // PR copy dropdown: body-appended fixed-position overlay for .pr-copy-dropdown-wrap elements.
+        (function () {
+            let prPanel = null, prHideTimer = null, activePrTrigger = null;
+
+            function buildPrPanel() {
+                prPanel = document.createElement('div');
+                prPanel.className = 'gm-gh-dropdown';
+                const title = document.createElement('div');
+                title.className = 'gm-gh-dropdown-title';
+                title.textContent = 'Pull Requests\u2026';
+                prPanel.appendChild(title);
+                const row = document.createElement('div');
+                row.className = 'gm-gh-dropdown-item';
+                row.innerHTML = '<i class="bi bi-clipboard" aria-hidden="true"></i><span>Copy Links to Clipboard</span>';
+                row.addEventListener('click', async () => {
+                    if (!activePrTrigger) return;
+                    try {
+                        const urls = JSON.parse(activePrTrigger.dataset.prUrls || '[]');
+                        if (urls.length === 0) {
+                            window.graymoonShowToast('No open pull requests in this level.');
+                        } else {
+                            await navigator.clipboard.writeText(urls.join('\n'));
+                            const n = urls.length;
+                            window.graymoonShowToast(n === 1 ? '1 PR link copied to clipboard.' : `${n} PR links copied to clipboard.`);
+                        }
+                    } catch (_) {
+                        window.graymoonShowToast('Could not copy to clipboard.');
+                    }
+                    hidePr();
+                });
+                prPanel.appendChild(row);
+                prPanel.addEventListener('mouseenter', cancelPrHide);
+                prPanel.addEventListener('mouseleave', schedulePrHide);
+                document.body.appendChild(prPanel);
+            }
+
+            function showPr(trigger) {
+                if (!prPanel) buildPrPanel();
+                cancelPrHide();
+                activePrTrigger = trigger;
+                const r = trigger.getBoundingClientRect();
+                prPanel.style.top = (r.bottom + 4) + 'px';
+                prPanel.style.right = (window.innerWidth - r.right) + 'px';
+                prPanel.style.left = 'auto';
+                prPanel.classList.add('gm-gh-dropdown--visible');
+            }
+
+            function hidePr() {
+                prPanel?.classList.remove('gm-gh-dropdown--visible');
+                activePrTrigger = null;
+            }
+
+            function schedulePrHide() { prHideTimer = setTimeout(hidePr, 150); }
+            function cancelPrHide() { clearTimeout(prHideTimer); }
+
+            document.addEventListener('mouseover', e => {
+                const wrap = e.target.closest('.pr-copy-dropdown-wrap');
+                if (wrap) { showPr(wrap); return; }
+                if (prPanel && prPanel.contains(e.target)) cancelPrHide();
+            });
+
+            document.addEventListener('mouseout', e => {
+                const inWrap = !!e.target.closest('.pr-copy-dropdown-wrap');
+                const inPanel = !!(prPanel && prPanel.contains(e.target));
+                if (!inWrap && !inPanel) return;
+                const to = e.relatedTarget;
+                if (!to) { schedulePrHide(); return; }
+                if (to.closest('.pr-copy-dropdown-wrap') || (prPanel && prPanel.contains(to))) return;
+                schedulePrHide();
+            });
+        })();
+
         window.graymoonStorageGet = (key) => localStorage.getItem(key);
         window.graymoonStorageSet = (key, value) => { localStorage.setItem(key, value); };
         document.body.addEventListener('click', (e) => {

--- a/src/GrayMoon.App/Components/Layout/NavMenu.razor
+++ b/src/GrayMoon.App/Components/Layout/NavMenu.razor
@@ -28,7 +28,7 @@
             <div class="nav-item px-3">
                 <NavLink class="nav-link" href="@($"workspaces/{workspaceId}")" Match="NavLinkMatch.All" title="Repositories">
                     <i class="bi bi-grid" aria-hidden="true"></i>
-                    <span class="nav-link-text">Repos</span>
+                    <span class="nav-link-text">Repositories</span>
                 </NavLink>
             </div>
 

--- a/src/GrayMoon.App/Components/Layout/NavMenu.razor
+++ b/src/GrayMoon.App/Components/Layout/NavMenu.razor
@@ -55,7 +55,7 @@
 
             <div class="nav-item px-3">
                 <NavLink class="nav-link" href="@($"workspaces/{workspaceId}/dependencies")" Match="NavLinkMatch.All" title="Dependencies">
-                    <i class="bi bi-share" aria-hidden="true"></i>
+                    <i class="bi bi-diagram-3" aria-hidden="true"></i>
                     <span class="nav-link-text">Deps</span>
                 </NavLink>
             </div>

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor
@@ -132,6 +132,7 @@
                                                                        OnOpenPr="() => ShowConfirmOpenPr(group)"
                                                                        OnSyncLevel="() => ShowConfirmSyncLevel(group.Select(wr => wr.RepositoryId).ToList())"
                                                                        OpenPrUrls="@GetOpenPrUrlsForGroup(group)"
+                                                                       OpenPrPullMap="@GetOpenPrPullMapForGroup(group)"
                                                                        />
                                     @foreach (var wr in group)
                                     {

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor
@@ -131,6 +131,7 @@
                                                                        OnSyncCommits="() => ShowConfirmSyncCommitsLevel(group.Select(wr => wr.RepositoryId).ToList())"
                                                                        OnOpenPr="() => ShowConfirmOpenPr(group)"
                                                                        OnSyncLevel="() => ShowConfirmSyncLevel(group.Select(wr => wr.RepositoryId).ToList())"
+                                                                       OpenPrUrls="@GetOpenPrUrlsForGroup(group)"
                                                                        />
                                     @foreach (var wr in group)
                                     {

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
@@ -2460,6 +2460,19 @@ public sealed partial class WorkspaceRepositories : IDisposable
         return prByRepositoryId.TryGetValue(repositoryId, out var pr) ? pr : null;
     }
 
+    private IReadOnlyList<string> GetOpenPrUrlsForGroup(IEnumerable<WorkspaceRepositoryLink> group)
+    {
+        var urls = new List<string>();
+        foreach (var wr in group)
+        {
+            if (!prByRepositoryId.TryGetValue(wr.RepositoryId, out var pr) || pr == null) continue;
+            if (!string.Equals(pr.State, "open", StringComparison.OrdinalIgnoreCase)) continue;
+            if (!string.IsNullOrEmpty(pr.HtmlUrl))
+                urls.Add(pr.HtmlUrl);
+        }
+        return urls;
+    }
+
     private string? GetRepositoryError(int repositoryId)
     {
         return repositoryErrors.TryGetValue(repositoryId, out var err) ? err : null;

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
@@ -2473,6 +2473,22 @@ public sealed partial class WorkspaceRepositories : IDisposable
         return urls;
     }
 
+    private IReadOnlyDictionary<string, string> GetOpenPrPullMapForGroup(IEnumerable<WorkspaceRepositoryLink> group)
+    {
+        var map = new Dictionary<string, string>();
+        foreach (var wr in group)
+        {
+            if (wr.Repository == null) continue;
+            var baseUrl = RepositoryUrlHelper.GetRepositoryUrl(wr.Repository.CloneUrl);
+            if (string.IsNullOrEmpty(baseUrl)) continue;
+            if (!prByRepositoryId.TryGetValue(wr.RepositoryId, out var pr) || pr == null) continue;
+            if (!string.Equals(pr.State, "open", StringComparison.OrdinalIgnoreCase)) continue;
+            if (!string.IsNullOrEmpty(pr.HtmlUrl))
+                map[baseUrl] = pr.HtmlUrl;
+        }
+        return map;
+    }
+
     private string? GetRepositoryError(int repositoryId)
     {
         return repositoryErrors.TryGetValue(repositoryId, out var err) ? err : null;

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.css
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.css
@@ -274,6 +274,26 @@
     color: #707070 !important;
 }
 
+/* Copy PR links icon */
+::deep .repositories-table .dependency-level-header .dependency-level-copy-pr-link,
+::deep .repositories-table .dependency-level-header .dependency-level-copy-pr-link i {
+    color: #505050 !important;
+    cursor: pointer;
+    font-weight: 400;
+    display: inline-flex;
+    align-items: center;
+    user-select: none;
+}
+
+::deep .repositories-table .dependency-level-header .dependency-level-copy-pr-link i {
+    font-size: 1.0rem;
+}
+
+::deep .repositories-table .dependency-level-header .dependency-level-copy-pr-link:hover,
+::deep .repositories-table .dependency-level-header .dependency-level-copy-pr-link:hover i {
+    color: #707070 !important;
+}
+
 /* Graph icon link: same style as PR/sync icons */
 ::deep .repositories-table .dependency-level-header .dependency-level-graph-link,
 ::deep .repositories-table .dependency-level-header .dependency-level-graph-link i {

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.css
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.css
@@ -274,7 +274,7 @@
     color: #707070 !important;
 }
 
-/* Copy PR links icon */
+/* Copy PR links icon: same style as other level header icons */
 ::deep .repositories-table .dependency-level-header .dependency-level-copy-pr-link,
 ::deep .repositories-table .dependency-level-header .dependency-level-copy-pr-link i {
     color: #505050 !important;
@@ -282,11 +282,10 @@
     font-weight: 400;
     display: inline-flex;
     align-items: center;
-    user-select: none;
 }
 
 ::deep .repositories-table .dependency-level-header .dependency-level-copy-pr-link i {
-    font-size: 1.0rem;
+    font-size: 1.1rem;
 }
 
 ::deep .repositories-table .dependency-level-header .dependency-level-copy-pr-link:hover,

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositoriesLevelHeader.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositoriesLevelHeader.razor
@@ -15,6 +15,13 @@
         </div>
         <div class="dependency-level-header-end">
             <span class="dependency-level-icons @(ActionsDisabled ? "dependency-level-icons--disabled" : "")">
+                <span class="dependency-level-copy-pr-link pr-copy-dropdown-wrap"
+                      data-pr-urls="@OpenPrUrlsJson"
+                      tabindex="0"
+                      aria-haspopup="true"
+                      aria-label="Copy open PR links to clipboard">
+                    <i class="bi bi-share" aria-hidden="true"></i>
+                </span>
                 <span class="dependency-level-sync-to-default-link"
                       role="button"
                       tabindex="@(ActionsDisabled ? -1 : 0)"
@@ -61,15 +68,9 @@
                     <i class="bi bi-arrow-repeat" aria-hidden="true"></i>
                 </span>
             </span>
-            <span class="dependency-level-copy-pr-link pr-copy-dropdown-wrap"
-                  data-pr-urls="@OpenPrUrlsJson"
-                  tabindex="0"
-                  aria-haspopup="true"
-                  aria-label="Copy open PR links to clipboard">
-                <i class="bi bi-clipboard" aria-hidden="true"></i>
-            </span>
             <span class="dependency-level-count github-dropdown-wrap"
                   data-urls="@BaseUrlsJson"
+                  data-pr-pull-map="@OpenPrPullMapJson"
                   tabindex="0"
                   aria-haspopup="true">
                 <span class="dependency-level-count-num">@RepositoryCount</span> @(RepositoryCount == 1 ? "repository" : "repositories")
@@ -89,10 +90,13 @@
     [Parameter] public EventCallback OnOpenPr { get; set; }
     [Parameter] public EventCallback OnSyncLevel { get; set; }
     [Parameter] public IReadOnlyList<string>? OpenPrUrls { get; set; }
+    [Parameter] public IReadOnlyDictionary<string, string>? OpenPrPullMap { get; set; }
 
     private int RepositoryCount => Group?.Count() ?? 0;
 
     private string OpenPrUrlsJson => System.Text.Json.JsonSerializer.Serialize(OpenPrUrls ?? (IReadOnlyList<string>)[]);
+
+    private string OpenPrPullMapJson => System.Text.Json.JsonSerializer.Serialize(OpenPrPullMap ?? (IReadOnlyDictionary<string, string>)new Dictionary<string, string>());
 
     private string BaseUrlsJson => System.Text.Json.JsonSerializer.Serialize(
         Group?.Select(wr => wr.Repository)

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositoriesLevelHeader.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositoriesLevelHeader.razor
@@ -61,6 +61,13 @@
                     <i class="bi bi-arrow-repeat" aria-hidden="true"></i>
                 </span>
             </span>
+            <span class="dependency-level-copy-pr-link pr-copy-dropdown-wrap"
+                  data-pr-urls="@OpenPrUrlsJson"
+                  tabindex="0"
+                  aria-haspopup="true"
+                  aria-label="Copy open PR links to clipboard">
+                <i class="bi bi-clipboard" aria-hidden="true"></i>
+            </span>
             <span class="dependency-level-count github-dropdown-wrap"
                   data-urls="@BaseUrlsJson"
                   tabindex="0"
@@ -81,8 +88,11 @@
     [Parameter] public EventCallback OnSyncCommits { get; set; }
     [Parameter] public EventCallback OnOpenPr { get; set; }
     [Parameter] public EventCallback OnSyncLevel { get; set; }
+    [Parameter] public IReadOnlyList<string>? OpenPrUrls { get; set; }
 
     private int RepositoryCount => Group?.Count() ?? 0;
+
+    private string OpenPrUrlsJson => System.Text.Json.JsonSerializer.Serialize(OpenPrUrls ?? (IReadOnlyList<string>)[]);
 
     private string BaseUrlsJson => System.Text.Json.JsonSerializer.Serialize(
         Group?.Select(wr => wr.Repository)

--- a/src/GrayMoon.App/Components/Shared/CommitsBadge.razor
+++ b/src/GrayMoon.App/Components/Shared/CommitsBadge.razor
@@ -14,7 +14,11 @@ else
       style="@($"background-color: {BgColor}; color: {TextColor};{(Clickable ? " cursor: pointer;" : "")}")"
       @onclick="HandleClick"
       title="@Title">
-    @if (NotUpstreamed)
+    @if (NotUpstreamed && X > 0)
+    {
+        @($"↑{X}")
+    }
+    else if (NotUpstreamed)
     {
         <span class="commits-badge-icon-up commits-badge-icon-up--black">
             <i class="bi bi-cloud-arrow-up" aria-hidden="true"></i>

--- a/src/GrayMoon.App/wwwroot/css/loading-overlay.css
+++ b/src/GrayMoon.App/wwwroot/css/loading-overlay.css
@@ -238,8 +238,8 @@
 .loading-overlay-content {
   position: absolute;
   left: 50%;
-  top: 50%;
-  transform: translate(-50%, -50%);
+  top: calc(50% - 1.5rem); /* anchor spinner centre at 50%; 1.5rem = half spinner height */
+  transform: translateX(-50%);
   z-index: 3;
   padding: 1rem;
   background: transparent;


### PR DESCRIPTION
## Summary
This PR improves the workspace repositories experience by making PR actions more actionable, improving commit visibility for non-upstream branches, and polishing related UI/navigation behavior.

## What changed
- Added dependency-level action to copy open PR links to clipboard (one link per line) with toast feedback.
- Updated dependency-level GitHub dropdown behavior so “Pull Requests” opens exact PR URLs when a repo has an open PR on the current branch (fallback remains repo pulls page).
- Improved commits badge behavior for branches without upstream:
  - Shows outgoing count (for example `↑3`) when commits exist.
  - Keeps “push-to-set-upstream” intent clearer.
- Polished dependency-level header actions:
  - Added a share-style icon for PR link copy action.
  - Reordered icon placement and aligned hover/cursor/color styling with existing header actions.
  - Removed redundant hover hint text for the copy action.
- Updated workspace navigation labels/icons:
  - Kept “Repositories” label.
  - Set dependencies label to “Deps”.
  - Switched dependencies nav icon to diagram-style icon for consistency.
- Applied loading overlay visual stability refinements so timer/progress updates do not shift UI unexpectedly.
- Updated README “What’s new” with branch feature notes.

## User impact
- Faster PR workflows across dependency levels.
- Less context-switching when preparing reviews/releases.
- Clearer branch state in commit badges, especially before first upstream push.
- Cleaner, more consistent navigation and header interactions.

## Notes
- Behavior is additive and backward-compatible.
- Where exact PR links are unavailable, existing GitHub destination behavior remains as fallback.