### PR TITLE
Implement synchronized-push live GitHub Actions overlay streaming with shared feed service

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,16 @@ Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManage
 
 ## What's new
 
+### Live GitHub Actions feed in synchronized push overlay
+
+When GrayMoon performs a dependency-synchronized push and is waiting for required package versions to appear in registries, the loading overlay terminal now streams live GitHub Actions updates for the repositories that were already pushed.
+
+- **Same live feed logic as Workspace Actions:** the overlay uses the same run/job/step polling path as the workspace GitHub Actions terminal, so status formatting and step transitions stay consistent.
+- **No duplicate retrieval logic:** the implementation reuses a shared service for workflow polling and step transition formatting.
+- **Only tracks real running workflows:** it subscribes when a run is actually in progress and appends updates into the overlay terminal stream.
+- **Stops retrying only when no workflows exist for a repo:** if GitHub reports no workflow definitions for that repository, GrayMoon marks that repo as "no workflows" and skips further discovery for it.
+- **Does not stop just because nothing is running yet:** repositories with workflow files but no current run continue to be checked on the normal discovery interval.
+
 ### Branch updates: PR workflows, commits visibility, and UI polish
 
 This branch adds several workflow-focused improvements in the workspace repositories view.

--- a/src/GrayMoon.App/Components/Shared/GhaWorkflowLiveTerminal.razor
+++ b/src/GrayMoon.App/Components/Shared/GhaWorkflowLiveTerminal.razor
@@ -1,10 +1,6 @@
-@using GrayMoon.App.Models
-@using GrayMoon.App.Repositories
 @using GrayMoon.App.Services
-@inject GitHubService GitHubService
-@inject ConnectorRepository ConnectorRepository
+@inject GhaWorkflowLiveFeedService GhaWorkflowLiveFeedService
 @inject LoadingOverlayUiSettingsService OverlayUiSettings
-@inject ILogger<GhaWorkflowLiveTerminal> Logger
 @implements IAsyncDisposable
 
 @if (RunId > 0 && !string.IsNullOrWhiteSpace(ConnectorName) && !string.IsNullOrWhiteSpace(Owner) && !string.IsNullOrWhiteSpace(RepositoryName))
@@ -50,11 +46,8 @@
     [Parameter] public string? WorkflowDisplayName { get; set; }
 
     private readonly List<string> _buffer = [];
-    private readonly Dictionary<string, string> _stepSignatures = new(StringComparer.Ordinal);
     private readonly string[] _visibleLineSlots = new string[BodyLineCount];
-    private Connector? _cachedConnector;
-    private string? _cachedConnectorName;
-    private bool _snapshottedSteps;
+    private GhaWorkflowLiveFeedState? _feedState;
     private string _caption = "Workflow · Connecting to GitHub Actions…";
     private string? _stepProgress;
     private CancellationTokenSource? _cts;
@@ -62,13 +55,6 @@
     private bool _needsRender;
 
     private const int BodyLineCount = 8;
-    /// <summary>Delay while jobs/steps are active - balances responsiveness vs API rate limits when many rows poll.</summary>
-    private const int PollIntervalActiveMs = 1_200;
-    /// <summary>Delay when waiting for GitHub to attach jobs to the run.</summary>
-    private const int PollIntervalWaitingJobsMs = 2_000;
-    /// <summary>Delay when all jobs report completed (terminal tail).</summary>
-    private const int PollIntervalIdleMs = 4_000;
-
     private string _captionTooltip =>
         string.IsNullOrWhiteSpace(_stepProgress) ? _caption : $"{_caption} · {_stepProgress}";
 
@@ -86,6 +72,14 @@
     {
         if (RunId > 0 && _pollTask == null)
         {
+            _feedState = new GhaWorkflowLiveFeedState
+            {
+                ConnectorName = ConnectorName,
+                Owner = Owner,
+                RepositoryName = RepositoryName,
+                RunId = RunId,
+                WorkflowDisplayName = WorkflowDisplayName
+            };
             _cts = new CancellationTokenSource();
             _pollTask = PollLoopAsync(_cts.Token);
         }
@@ -118,114 +112,22 @@
     /// <returns>Milliseconds to wait before the next poll.</returns>
     private async Task<int> PollOnceAsync(CancellationToken cancellationToken)
     {
-        try
+        if (_feedState == null)
+            return GhaWorkflowLiveFeedService.PollIntervalWaitingJobsMs;
+
+        var update = await GhaWorkflowLiveFeedService.PollOnceAsync(_feedState, cancellationToken);
+        if (!string.Equals(_caption, update.Caption, StringComparison.Ordinal)
+            || !string.Equals(_stepProgress, update.StepProgress, StringComparison.Ordinal))
         {
-            var connector = await ResolveConnectorAsync(cancellationToken);
-            if (connector == null)
-            {
-                AppendUnique("Connector not found - cannot load job status.");
-                return PollIntervalWaitingJobsMs;
-            }
-
-            var response = await GitHubService.GetWorkflowRunJobsAsync(connector, Owner, RepositoryName, RunId, cancellationToken);
-            var jobs = response?.Jobs ?? [];
-
-            var caption = BuildCaption(jobs, WorkflowDisplayName);
-            var stepProgress = BuildStepProgressForCaptionJob(jobs);
-            if (!string.Equals(_caption, caption, StringComparison.Ordinal) || !string.Equals(_stepProgress, stepProgress, StringComparison.Ordinal))
-            {
-                _caption = caption;
-                _stepProgress = stepProgress;
-                _needsRender = true;
-            }
-
-            if (jobs.Count == 0)
-            {
-                _stepProgress = null;
-                AppendUnique("Waiting for GitHub to assign jobs to this run…");
-                return PollIntervalWaitingJobsMs;
-            }
-
-            if (!_snapshottedSteps)
-            {
-                _snapshottedSteps = true;
-                foreach (var job in jobs.OrderBy(j => j.Id))
-                {
-                    foreach (var step in (job.Steps ?? []).OrderBy(s => s.Number))
-                        _stepSignatures[$"{job.Id}:{step.Number}"] = $"{step.Status}|{step.Conclusion}";
-                }
-
-                var stepCount = jobs.Sum(j => j.Steps?.Count ?? 0);
-                AppendUnique($"Live · {jobs.Count} job(s), {stepCount} step(s) - streaming updates…");
-                return DeterminePollDelayMs(jobs);
-            }
-
-            foreach (var job in jobs.OrderBy(j => j.Id))
-            {
-                var steps = job.Steps ?? [];
-                foreach (var step in steps.OrderBy(s => s.Number))
-                {
-                    var key = $"{job.Id}:{step.Number}";
-                    var sig = $"{step.Status}|{step.Conclusion}";
-                    if (_stepSignatures.TryGetValue(key, out var prev) && prev == sig)
-                        continue;
-                    _stepSignatures[key] = sig;
-                    AppendUnique(FormatStepTransition(job.Name, step));
-                }
-            }
-
-            return DeterminePollDelayMs(jobs);
-        }
-        catch (Exception ex) when (!cancellationToken.IsCancellationRequested)
-        {
-            Logger.LogDebug(ex, "GHA live feed poll failed for run {RunId}", RunId);
-            var failureText = ex is HttpRequestException httpEx
-                ? GitHubApiErrorHelper.FormatFriendlyGitHubHttpError(httpEx)
-                : ex.Message;
-            AppendUnique($"Update failed: {failureText}");
-            return PollIntervalWaitingJobsMs;
-        }
-    }
-
-    private async Task<Connector?> ResolveConnectorAsync(CancellationToken cancellationToken)
-    {
-        if (_cachedConnector != null
-            && string.Equals(_cachedConnectorName, ConnectorName, StringComparison.Ordinal))
-            return _cachedConnector;
-
-        cancellationToken.ThrowIfCancellationRequested();
-        var connector = await ConnectorRepository.GetByNameAsync(ConnectorName);
-        if (connector != null)
-        {
-            _cachedConnector = connector;
-            _cachedConnectorName = ConnectorName;
+            _caption = update.Caption;
+            _stepProgress = update.StepProgress;
+            _needsRender = true;
         }
 
-        return connector;
-    }
+        foreach (var line in update.NewLines)
+            AppendUnique(line);
 
-    private static int DeterminePollDelayMs(IReadOnlyList<GitHubWorkflowJobDto> jobs)
-    {
-        foreach (var job in jobs)
-        {
-            var js = job.Status ?? "";
-            if (js.Equals("in_progress", StringComparison.OrdinalIgnoreCase)
-                || js.Equals("queued", StringComparison.OrdinalIgnoreCase)
-                || js.Equals("waiting", StringComparison.OrdinalIgnoreCase))
-            {
-                return PollIntervalActiveMs;
-            }
-
-            var steps = job.Steps;
-            if (steps == null) continue;
-            foreach (var step in steps)
-            {
-                if (string.Equals(step.Status, "in_progress", StringComparison.OrdinalIgnoreCase))
-                    return PollIntervalActiveMs;
-            }
-        }
-
-        return PollIntervalIdleMs;
+        return update.DelayMs;
     }
 
     private void RefreshVisibleLineSlots()
@@ -246,85 +148,6 @@
             _buffer.RemoveAt(0);
         RefreshVisibleLineSlots();
         _needsRender = true;
-    }
-
-    private static string BuildCaption(IReadOnlyList<GitHubWorkflowJobDto> jobs, string? workflowName)
-    {
-        var wf = string.IsNullOrWhiteSpace(workflowName) ? "Workflow" : workflowName!;
-        if (jobs.Count == 0)
-            return $"{wf} · Waiting for jobs…";
-
-        var job = GetCaptionJob(jobs)!;
-        var steps = job.Steps ?? [];
-        var step = steps.FirstOrDefault(s => string.Equals(s.Status, "in_progress", StringComparison.OrdinalIgnoreCase))
-                   ?? steps.LastOrDefault(s => string.Equals(s.Status, "completed", StringComparison.OrdinalIgnoreCase));
-
-        var stepLabel = step?.Name;
-        if (string.IsNullOrWhiteSpace(stepLabel))
-        {
-            if (string.Equals(job.Status, "queued", StringComparison.OrdinalIgnoreCase))
-                stepLabel = "Queued for runner…";
-            else if (string.Equals(job.Status, "in_progress", StringComparison.OrdinalIgnoreCase))
-                stepLabel = "Running…";
-            else
-                stepLabel = job.Status;
-        }
-
-        return $"{wf} · {job.Name} › {stepLabel}";
-    }
-
-    /// <summary>Same "current" job as <see cref="BuildCaption"/>; step counts come from the jobs API for that run.</summary>
-    private static GitHubWorkflowJobDto? GetCaptionJob(IReadOnlyList<GitHubWorkflowJobDto> jobs)
-    {
-        if (jobs.Count == 0) return null;
-        return jobs.FirstOrDefault(j => string.Equals(j.Status, "in_progress", StringComparison.OrdinalIgnoreCase))
-               ?? jobs.FirstOrDefault(j => string.Equals(j.Status, "queued", StringComparison.OrdinalIgnoreCase))
-               ?? jobs.FirstOrDefault(j => string.Equals(j.Status, "waiting", StringComparison.OrdinalIgnoreCase))
-               ?? jobs[0];
-    }
-
-    /// <summary>1-based index of the active step and total steps for the caption job (YAML steps GitHub reports for that job).</summary>
-    private static string? BuildStepProgressForCaptionJob(IReadOnlyList<GitHubWorkflowJobDto> jobs)
-    {
-        var job = GetCaptionJob(jobs);
-        if (job == null) return null;
-
-        var ordered = (job.Steps ?? []).OrderBy(s => s.Number).ToList();
-        var y = ordered.Count;
-        if (y == 0)
-            return null;
-
-        var inProgressIdx = ordered.FindIndex(s => string.Equals(s.Status, "in_progress", StringComparison.OrdinalIgnoreCase));
-        if (inProgressIdx >= 0)
-            return $"Step {inProgressIdx + 1} of {y}";
-
-        for (var i = 0; i < ordered.Count; i++)
-        {
-            if (!string.Equals(ordered[i].Status, "completed", StringComparison.OrdinalIgnoreCase))
-                return $"Step {i + 1} of {y}";
-        }
-
-        return $"Step {y} of {y}";
-    }
-
-    private static string FormatStepTransition(string jobName, GitHubWorkflowJobStepDto step)
-    {
-        if (string.Equals(step.Status, "completed", StringComparison.OrdinalIgnoreCase))
-        {
-            var c = step.Conclusion ?? "";
-            if (string.Equals(c, "success", StringComparison.OrdinalIgnoreCase))
-                return $"✓ {jobName} › {step.Name}";
-            if (string.Equals(c, "skipped", StringComparison.OrdinalIgnoreCase))
-                return $"⊘ {jobName} › {step.Name} (skipped)";
-            if (string.Equals(c, "failure", StringComparison.OrdinalIgnoreCase) || string.Equals(c, "cancelled", StringComparison.OrdinalIgnoreCase))
-                return $"✗ {jobName} › {step.Name} ({c})";
-            return $"• {jobName} › {step.Name} - {c}";
-        }
-
-        if (string.Equals(step.Status, "in_progress", StringComparison.OrdinalIgnoreCase))
-            return $"⧗ {jobName} › {step.Name}…";
-
-        return $"… {jobName} › {step.Name} - {step.Status}";
     }
 
     public async ValueTask DisposeAsync()

--- a/src/GrayMoon.App/Program.cs
+++ b/src/GrayMoon.App/Program.cs
@@ -67,6 +67,7 @@ try
     builder.Services.AddScoped<ConnectorHealthService>();
     builder.Services.AddScoped<GitHubRepositoryService>();
     builder.Services.AddScoped<GitHubActionsService>();
+    builder.Services.AddScoped<GhaWorkflowLiveFeedService>();
     builder.Services.AddScoped<GitHubPullRequestService>();
     builder.Services.AddScoped<WorkspacePullRequestRepository>();
     builder.Services.AddScoped<WorkspacePullRequestService>();

--- a/src/GrayMoon.App/Services/GhaWorkflowLiveFeedService.cs
+++ b/src/GrayMoon.App/Services/GhaWorkflowLiveFeedService.cs
@@ -1,0 +1,243 @@
+using GrayMoon.App.Models;
+using GrayMoon.App.Repositories;
+
+namespace GrayMoon.App.Services;
+
+/// <summary>
+/// Shared polling logic for GitHub Actions run jobs/steps so multiple UI surfaces can stream the same live feed.
+/// </summary>
+public sealed class GhaWorkflowLiveFeedService(
+    GitHubService gitHubService,
+    ConnectorRepository connectorRepository,
+    ILogger<GhaWorkflowLiveFeedService> logger)
+{
+    public const int PollIntervalActiveMs = 1_200;
+    public const int PollIntervalWaitingJobsMs = 2_000;
+    public const int PollIntervalIdleMs = 4_000;
+
+    public async Task<GhaWorkflowLiveFeedUpdate> PollOnceAsync(
+        GhaWorkflowLiveFeedState state,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var connector = await ResolveConnectorAsync(state, cancellationToken);
+            if (connector == null)
+            {
+                return new GhaWorkflowLiveFeedUpdate(
+                    Caption: state.LastCaption,
+                    StepProgress: state.LastStepProgress,
+                    NewLines: ["Connector not found - cannot load job status."],
+                    DelayMs: PollIntervalWaitingJobsMs);
+            }
+
+            var response = await gitHubService.GetWorkflowRunJobsAsync(connector, state.Owner, state.RepositoryName, state.RunId, cancellationToken);
+            var jobs = response?.Jobs ?? [];
+
+            var caption = BuildCaption(jobs, state.WorkflowDisplayName);
+            var stepProgress = BuildStepProgressForCaptionJob(jobs);
+            state.LastCaption = caption;
+            state.LastStepProgress = stepProgress;
+
+            if (jobs.Count == 0)
+            {
+                return new GhaWorkflowLiveFeedUpdate(
+                    Caption: caption,
+                    StepProgress: null,
+                    NewLines: ["Waiting for GitHub to assign jobs to this run..."],
+                    DelayMs: PollIntervalWaitingJobsMs);
+            }
+
+            var newLines = new List<string>();
+            if (!state.SnapshottedSteps)
+            {
+                state.SnapshottedSteps = true;
+                foreach (var job in jobs.OrderBy(j => j.Id))
+                {
+                    foreach (var step in (job.Steps ?? []).OrderBy(s => s.Number))
+                        state.StepSignatures[$"{job.Id}:{step.Number}"] = $"{step.Status}|{step.Conclusion}";
+                }
+
+                var stepCount = jobs.Sum(j => j.Steps?.Count ?? 0);
+                newLines.Add($"Live - {jobs.Count} job(s), {stepCount} step(s) - streaming updates...");
+            }
+            else
+            {
+                foreach (var job in jobs.OrderBy(j => j.Id))
+                {
+                    var steps = job.Steps ?? [];
+                    foreach (var step in steps.OrderBy(s => s.Number))
+                    {
+                        var key = $"{job.Id}:{step.Number}";
+                        var sig = $"{step.Status}|{step.Conclusion}";
+                        if (state.StepSignatures.TryGetValue(key, out var prev) && prev == sig)
+                            continue;
+
+                        state.StepSignatures[key] = sig;
+                        newLines.Add(FormatStepTransition(job.Name, step));
+                    }
+                }
+            }
+
+            return new GhaWorkflowLiveFeedUpdate(
+                Caption: caption,
+                StepProgress: stepProgress,
+                NewLines: newLines,
+                DelayMs: DeterminePollDelayMs(jobs));
+        }
+        catch (Exception ex) when (!cancellationToken.IsCancellationRequested)
+        {
+            logger.LogDebug(ex, "GHA live feed poll failed for run {RunId}", state.RunId);
+            var failureText = ex is HttpRequestException httpEx
+                ? GitHubApiErrorHelper.FormatFriendlyGitHubHttpError(httpEx)
+                : ex.Message;
+            return new GhaWorkflowLiveFeedUpdate(
+                Caption: state.LastCaption,
+                StepProgress: state.LastStepProgress,
+                NewLines: [$"Update failed: {failureText}"],
+                DelayMs: PollIntervalWaitingJobsMs);
+        }
+    }
+
+    private async Task<Connector?> ResolveConnectorAsync(GhaWorkflowLiveFeedState state, CancellationToken cancellationToken)
+    {
+        if (state.CachedConnector != null
+            && string.Equals(state.CachedConnectorName, state.ConnectorName, StringComparison.Ordinal))
+        {
+            return state.CachedConnector;
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        var connector = await connectorRepository.GetByNameAsync(state.ConnectorName);
+        if (connector != null)
+        {
+            state.CachedConnector = connector;
+            state.CachedConnectorName = state.ConnectorName;
+        }
+
+        return connector;
+    }
+
+    private static int DeterminePollDelayMs(IReadOnlyList<GitHubWorkflowJobDto> jobs)
+    {
+        foreach (var job in jobs)
+        {
+            var js = job.Status ?? "";
+            if (js.Equals("in_progress", StringComparison.OrdinalIgnoreCase)
+                || js.Equals("queued", StringComparison.OrdinalIgnoreCase)
+                || js.Equals("waiting", StringComparison.OrdinalIgnoreCase))
+            {
+                return PollIntervalActiveMs;
+            }
+
+            var steps = job.Steps;
+            if (steps == null) continue;
+            foreach (var step in steps)
+            {
+                if (string.Equals(step.Status, "in_progress", StringComparison.OrdinalIgnoreCase))
+                    return PollIntervalActiveMs;
+            }
+        }
+
+        return PollIntervalIdleMs;
+    }
+
+    private static string BuildCaption(IReadOnlyList<GitHubWorkflowJobDto> jobs, string? workflowName)
+    {
+        var wf = string.IsNullOrWhiteSpace(workflowName) ? "Workflow" : workflowName!;
+        if (jobs.Count == 0)
+            return $"{wf} - Waiting for jobs...";
+
+        var job = GetCaptionJob(jobs)!;
+        var steps = job.Steps ?? [];
+        var step = steps.FirstOrDefault(s => string.Equals(s.Status, "in_progress", StringComparison.OrdinalIgnoreCase))
+                   ?? steps.LastOrDefault(s => string.Equals(s.Status, "completed", StringComparison.OrdinalIgnoreCase));
+
+        var stepLabel = step?.Name;
+        if (string.IsNullOrWhiteSpace(stepLabel))
+        {
+            if (string.Equals(job.Status, "queued", StringComparison.OrdinalIgnoreCase))
+                stepLabel = "Queued for runner...";
+            else if (string.Equals(job.Status, "in_progress", StringComparison.OrdinalIgnoreCase))
+                stepLabel = "Running...";
+            else
+                stepLabel = job.Status;
+        }
+
+        return $"{wf} - {job.Name} > {stepLabel}";
+    }
+
+    private static GitHubWorkflowJobDto? GetCaptionJob(IReadOnlyList<GitHubWorkflowJobDto> jobs)
+    {
+        if (jobs.Count == 0) return null;
+        return jobs.FirstOrDefault(j => string.Equals(j.Status, "in_progress", StringComparison.OrdinalIgnoreCase))
+               ?? jobs.FirstOrDefault(j => string.Equals(j.Status, "queued", StringComparison.OrdinalIgnoreCase))
+               ?? jobs.FirstOrDefault(j => string.Equals(j.Status, "waiting", StringComparison.OrdinalIgnoreCase))
+               ?? jobs[0];
+    }
+
+    private static string? BuildStepProgressForCaptionJob(IReadOnlyList<GitHubWorkflowJobDto> jobs)
+    {
+        var job = GetCaptionJob(jobs);
+        if (job == null) return null;
+
+        var ordered = (job.Steps ?? []).OrderBy(s => s.Number).ToList();
+        var y = ordered.Count;
+        if (y == 0)
+            return null;
+
+        var inProgressIdx = ordered.FindIndex(s => string.Equals(s.Status, "in_progress", StringComparison.OrdinalIgnoreCase));
+        if (inProgressIdx >= 0)
+            return $"Step {inProgressIdx + 1} of {y}";
+
+        for (var i = 0; i < ordered.Count; i++)
+        {
+            if (!string.Equals(ordered[i].Status, "completed", StringComparison.OrdinalIgnoreCase))
+                return $"Step {i + 1} of {y}";
+        }
+
+        return $"Step {y} of {y}";
+    }
+
+    private static string FormatStepTransition(string jobName, GitHubWorkflowJobStepDto step)
+    {
+        if (string.Equals(step.Status, "completed", StringComparison.OrdinalIgnoreCase))
+        {
+            var c = step.Conclusion ?? "";
+            if (string.Equals(c, "success", StringComparison.OrdinalIgnoreCase))
+                return $"OK {jobName} > {step.Name}";
+            if (string.Equals(c, "skipped", StringComparison.OrdinalIgnoreCase))
+                return $"SKIP {jobName} > {step.Name} (skipped)";
+            if (string.Equals(c, "failure", StringComparison.OrdinalIgnoreCase) || string.Equals(c, "cancelled", StringComparison.OrdinalIgnoreCase))
+                return $"FAIL {jobName} > {step.Name} ({c})";
+            return $"INFO {jobName} > {step.Name} - {c}";
+        }
+
+        if (string.Equals(step.Status, "in_progress", StringComparison.OrdinalIgnoreCase))
+            return $"RUN {jobName} > {step.Name}...";
+
+        return $"WAIT {jobName} > {step.Name} - {step.Status}";
+    }
+}
+
+public sealed class GhaWorkflowLiveFeedState
+{
+    public required string ConnectorName { get; init; }
+    public required string Owner { get; init; }
+    public required string RepositoryName { get; init; }
+    public required long RunId { get; init; }
+    public string? WorkflowDisplayName { get; init; }
+
+    internal Connector? CachedConnector { get; set; }
+    internal string? CachedConnectorName { get; set; }
+    internal bool SnapshottedSteps { get; set; }
+    internal Dictionary<string, string> StepSignatures { get; } = new(StringComparer.Ordinal);
+    internal string LastCaption { get; set; } = "Workflow - Connecting to GitHub Actions...";
+    internal string? LastStepProgress { get; set; }
+}
+
+public sealed record GhaWorkflowLiveFeedUpdate(
+    string Caption,
+    string? StepProgress,
+    IReadOnlyList<string> NewLines,
+    int DelayMs);

--- a/src/GrayMoon.App/Services/OverlayCommandTerminalService.cs
+++ b/src/GrayMoon.App/Services/OverlayCommandTerminalService.cs
@@ -29,6 +29,11 @@ public sealed class OverlayCommandTerminalService
         Changed?.Invoke(this, EventArgs.Empty);
     }
 
+    public void Append(string? streamLabel, AgentCommandStreamKind kind, string text)
+    {
+        Append(new AgentCommandStreamLine(streamLabel, kind, text));
+    }
+
     public void Clear()
     {
         lock (_lock)

--- a/src/GrayMoon.App/Services/WorkspacePushService.cs
+++ b/src/GrayMoon.App/Services/WorkspacePushService.cs
@@ -584,7 +584,7 @@ public sealed class WorkspacePushService(
             if (update.NewLines.Count == 0)
                 continue;
 
-            var label = $"gha:{feed.RepositoryName}";
+            var label = $"{feed.RepositoryName} [gha]";
             foreach (var line in update.NewLines)
                 _overlayCommandTerminalService.Append(label, AgentCommandStreamKind.Stdout, line);
         }

--- a/src/GrayMoon.App/Services/WorkspacePushService.cs
+++ b/src/GrayMoon.App/Services/WorkspacePushService.cs
@@ -150,6 +150,7 @@ public sealed class WorkspacePushService(
 
         var levelsAsc = payload.Select(p => p.DependencyLevel ?? 0).Distinct().OrderBy(x => x).ToList();
         var lastLevel = levelsAsc[^1];
+        var pushedRepos = new List<PushRepoPayload>();
         foreach (var level in levelsAsc)
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -219,14 +220,14 @@ public sealed class WorkspacePushService(
                         {
                             lastGhaDiscoveryUtc = DateTime.UtcNow;
                             _ = await DiscoverRunningWorkflowsForLevelAsync(
-                                reposAtLevel,
+                                pushedRepos,
                                 links,
                                 ghaFeedByRunKey,
                                 noWorkflowRepoIds,
                                 linkedToken);
 
-                            // Permanently disable only when every repo at this level is confirmed to have no workflows at all.
-                            if (reposAtLevel.All(r => noWorkflowRepoIds.Contains(r.RepoId)))
+                            // Permanently disable only when every previously-pushed repo is confirmed to have no workflows at all.
+                            if (pushedRepos.Count > 0 && pushedRepos.All(r => noWorkflowRepoIds.Contains(r.RepoId)))
                                 ghaDiscoveryEnabled = false;
                         }
 
@@ -297,6 +298,7 @@ public sealed class WorkspacePushService(
                 onAppSideComplete: level == lastLevel ? null : onAppSideComplete,
                 cancellationToken);
             await UpdateCommitCountsAndUpstreamAfterPushAsync(workspaceId, reposAtLevel, cancellationToken);
+            pushedRepos.AddRange(reposAtLevel);
         }
 
         await UpdateCommitCountsAndUpstreamAfterPushAsync(workspaceId, payload, cancellationToken);

--- a/src/GrayMoon.App/Services/WorkspacePushService.cs
+++ b/src/GrayMoon.App/Services/WorkspacePushService.cs
@@ -181,6 +181,8 @@ public sealed class WorkspacePushService(
                 var foundByIndex = new bool[totalDeps];
                 var foundLock = new object();
                 var ghaFeedByRunKey = new Dictionary<string, GhaWorkflowLiveFeedState>(StringComparer.Ordinal);
+                var noWorkflowRepoIds = new HashSet<int>();
+                var ghaDiscoveryEnabled = true;
                 var lastGhaDiscoveryUtc = DateTime.MinValue;
                 var lastGhaPollUtc = DateTime.MinValue;
                 int getFoundCount()
@@ -210,16 +212,22 @@ public sealed class WorkspacePushService(
 
                     if (_gitHubActionsService != null
                         && _ghaWorkflowLiveFeedService != null
-                        && _overlayCommandTerminalService != null)
+                        && _overlayCommandTerminalService != null
+                        && ghaDiscoveryEnabled)
                     {
                         if ((DateTime.UtcNow - lastGhaDiscoveryUtc).TotalSeconds >= 6)
                         {
                             lastGhaDiscoveryUtc = DateTime.UtcNow;
-                            await DiscoverRunningWorkflowsForLevelAsync(
+                            _ = await DiscoverRunningWorkflowsForLevelAsync(
                                 reposAtLevel,
                                 links,
                                 ghaFeedByRunKey,
+                                noWorkflowRepoIds,
                                 linkedToken);
+
+                            // Permanently disable only when every repo at this level is confirmed to have no workflows at all.
+                            if (reposAtLevel.All(r => noWorkflowRepoIds.Contains(r.RepoId)))
+                                ghaDiscoveryEnabled = false;
                         }
 
                         if (ghaFeedByRunKey.Count > 0 && (DateTime.UtcNow - lastGhaPollUtc).TotalMilliseconds >= GhaWorkflowLiveFeedService.PollIntervalActiveMs)
@@ -471,19 +479,24 @@ public sealed class WorkspacePushService(
         await UpdateCommitCountsAndUpstreamAfterPushAsync(workspaceId, payload, cancellationToken);
     }
 
-    private async Task DiscoverRunningWorkflowsForLevelAsync(
+    private async Task<bool> DiscoverRunningWorkflowsForLevelAsync(
         IReadOnlyList<PushRepoPayload> reposAtLevel,
         IReadOnlyList<WorkspaceRepositoryLink> links,
         Dictionary<string, GhaWorkflowLiveFeedState> ghaFeedByRunKey,
+        ISet<int> noWorkflowRepoIds,
         CancellationToken cancellationToken)
     {
         if (_gitHubActionsService == null)
-            return;
+            return false;
 
         var linksByRepoId = links.ToDictionary(l => l.RepositoryId);
+        var hasAnyWorkflowCandidates = false;
         foreach (var repo in reposAtLevel)
         {
             cancellationToken.ThrowIfCancellationRequested();
+
+            if (noWorkflowRepoIds.Contains(repo.RepoId))
+                continue;
 
             if (!linksByRepoId.TryGetValue(repo.RepoId, out var link)
                 || link.Repository?.Connector == null
@@ -517,7 +530,13 @@ public sealed class WorkspacePushService(
             }
 
             if (statuses == null || statuses.Count == 0)
+            {
+                noWorkflowRepoIds.Add(repo.RepoId);
+                _logger.LogDebug("Push wait: repo {RepoName} has no active GitHub Actions workflows; skipping live feed.", entry.RepositoryName);
                 continue;
+            }
+
+            hasAnyWorkflowCandidates = true;
 
             foreach (var status in statuses)
             {
@@ -544,6 +563,8 @@ public sealed class WorkspacePushService(
                 _overlayCommandTerminalService?.Append($"gha:{entry.RepositoryName}", AgentCommandStreamKind.Stdout, $"Run #{status.RunId.Value} - subscribing to job updates...");
             }
         }
+
+        return true;
     }
 
     private async Task PumpGhaLiveFeedIntoOverlayAsync(

--- a/src/GrayMoon.App/Services/WorkspacePushService.cs
+++ b/src/GrayMoon.App/Services/WorkspacePushService.cs
@@ -27,7 +27,10 @@ public sealed class WorkspacePushService(
     PackageRegistrySyncService? packageRegistrySyncService = null,
     NuGetService? nuGetService = null,
     ConnectorRepository? connectorRepository = null,
-    ConnectorHealthService? connectorHealthService = null)
+    ConnectorHealthService? connectorHealthService = null,
+    GitHubActionsService? gitHubActionsService = null,
+    GhaWorkflowLiveFeedService? ghaWorkflowLiveFeedService = null,
+    OverlayCommandTerminalService? overlayCommandTerminalService = null)
 {
     private readonly IAgentBridge _agentBridge = agentBridge ?? throw new ArgumentNullException(nameof(agentBridge));
     private readonly WorkspaceService _workspaceService = workspaceService ?? throw new ArgumentNullException(nameof(workspaceService));
@@ -42,6 +45,9 @@ public sealed class WorkspacePushService(
     private readonly NuGetService? _nuGetService = nuGetService;
     private readonly ConnectorRepository? _connectorRepository = connectorRepository;
     private readonly ConnectorHealthService? _connectorHealthService = connectorHealthService;
+    private readonly GitHubActionsService? _gitHubActionsService = gitHubActionsService;
+    private readonly GhaWorkflowLiveFeedService? _ghaWorkflowLiveFeedService = ghaWorkflowLiveFeedService;
+    private readonly OverlayCommandTerminalService? _overlayCommandTerminalService = overlayCommandTerminalService;
 
     /// <summary>Gets the push plan: all workspace repos by dependency level. Used to show multi-level push dialog and push with dependency synchronization.</summary>
     public async Task<(IReadOnlyList<PushRepoPayload> Payload, bool IsMultiLevel)> GetPushPlanAsync(int workspaceId, CancellationToken cancellationToken = default)
@@ -174,6 +180,9 @@ public sealed class WorkspacePushService(
                 var deadline = DateTime.UtcNow + totalTimeout;
                 var foundByIndex = new bool[totalDeps];
                 var foundLock = new object();
+                var ghaFeedByRunKey = new Dictionary<string, GhaWorkflowLiveFeedState>(StringComparer.Ordinal);
+                var lastGhaDiscoveryUtc = DateTime.MinValue;
+                var lastGhaPollUtc = DateTime.MinValue;
                 int getFoundCount()
                 {
                     lock (foundLock) { return foundByIndex.Count(x => x); }
@@ -198,6 +207,27 @@ public sealed class WorkspacePushService(
                     var mm = totalSec / 60;
                     var ss = totalSec % 60;
                     levelProgress?.Invoke($"{line1}\n{mm:D2}:{ss:D2}");
+
+                    if (_gitHubActionsService != null
+                        && _ghaWorkflowLiveFeedService != null
+                        && _overlayCommandTerminalService != null)
+                    {
+                        if ((DateTime.UtcNow - lastGhaDiscoveryUtc).TotalSeconds >= 6)
+                        {
+                            lastGhaDiscoveryUtc = DateTime.UtcNow;
+                            await DiscoverRunningWorkflowsForLevelAsync(
+                                reposAtLevel,
+                                links,
+                                ghaFeedByRunKey,
+                                linkedToken);
+                        }
+
+                        if (ghaFeedByRunKey.Count > 0 && (DateTime.UtcNow - lastGhaPollUtc).TotalMilliseconds >= GhaWorkflowLiveFeedService.PollIntervalActiveMs)
+                        {
+                            lastGhaPollUtc = DateTime.UtcNow;
+                            await PumpGhaLiveFeedIntoOverlayAsync(ghaFeedByRunKey.Values, linkedToken);
+                        }
+                    }
 
                     if ((DateTime.UtcNow - lastPollUtc).TotalSeconds >= 2)
                     {
@@ -439,6 +469,102 @@ public sealed class WorkspacePushService(
         onProgressMessage?.Invoke($"Pushing {payload.Count} {(payload.Count == 1 ? "repository" : "repositories")}...");
         await PushReposAsync(workspace, payload, bearerByRepoId, onProgressMessage, onRepoError, onAppSideComplete, cancellationToken);
         await UpdateCommitCountsAndUpstreamAfterPushAsync(workspaceId, payload, cancellationToken);
+    }
+
+    private async Task DiscoverRunningWorkflowsForLevelAsync(
+        IReadOnlyList<PushRepoPayload> reposAtLevel,
+        IReadOnlyList<WorkspaceRepositoryLink> links,
+        Dictionary<string, GhaWorkflowLiveFeedState> ghaFeedByRunKey,
+        CancellationToken cancellationToken)
+    {
+        if (_gitHubActionsService == null)
+            return;
+
+        var linksByRepoId = links.ToDictionary(l => l.RepositoryId);
+        foreach (var repo in reposAtLevel)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (!linksByRepoId.TryGetValue(repo.RepoId, out var link)
+                || link.Repository?.Connector == null
+                || string.IsNullOrWhiteSpace(link.BranchName)
+                || string.IsNullOrWhiteSpace(link.Repository.OrgName)
+                || string.IsNullOrWhiteSpace(link.Repository.RepositoryName))
+            {
+                continue;
+            }
+
+            var entry = new GitHubRepositoryEntry
+            {
+                RepositoryId = link.Repository.RepositoryId,
+                ConnectorName = link.Repository.Connector.ConnectorName,
+                OrgName = link.Repository.OrgName,
+                RepositoryName = link.Repository.RepositoryName,
+                CloneUrl = link.Repository.CloneUrl,
+                Visibility = link.Repository.Visibility,
+                Archived = link.Repository.Archived
+            };
+
+            IReadOnlyList<ActionStatusInfo>? statuses;
+            try
+            {
+                statuses = await _gitHubActionsService.GetWorkflowStatusesForBranchAsync(entry, link.BranchName!, cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Push wait: failed to discover running workflows for repo {RepoId}", repo.RepoId);
+                continue;
+            }
+
+            if (statuses == null || statuses.Count == 0)
+                continue;
+
+            foreach (var status in statuses)
+            {
+                if (!string.Equals(status.Status, "running", StringComparison.OrdinalIgnoreCase)
+                    || !status.RunId.HasValue
+                    || status.RunId.Value <= 0)
+                {
+                    continue;
+                }
+
+                var runKey = $"{entry.ConnectorName}|{entry.OrgName}|{entry.RepositoryName}|{status.RunId.Value}";
+                if (ghaFeedByRunKey.ContainsKey(runKey))
+                    continue;
+
+                ghaFeedByRunKey[runKey] = new GhaWorkflowLiveFeedState
+                {
+                    ConnectorName = entry.ConnectorName,
+                    Owner = entry.OrgName ?? string.Empty,
+                    RepositoryName = entry.RepositoryName,
+                    RunId = status.RunId.Value,
+                    WorkflowDisplayName = status.WorkflowName
+                };
+
+                _overlayCommandTerminalService?.Append($"gha:{entry.RepositoryName}", AgentCommandStreamKind.Stdout, $"Run #{status.RunId.Value} - subscribing to job updates...");
+            }
+        }
+    }
+
+    private async Task PumpGhaLiveFeedIntoOverlayAsync(
+        IEnumerable<GhaWorkflowLiveFeedState> feeds,
+        CancellationToken cancellationToken)
+    {
+        if (_ghaWorkflowLiveFeedService == null || _overlayCommandTerminalService == null)
+            return;
+
+        foreach (var feed in feeds)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var update = await _ghaWorkflowLiveFeedService.PollOnceAsync(feed, cancellationToken);
+            if (update.NewLines.Count == 0)
+                continue;
+
+            var label = $"gha:{feed.RepositoryName}";
+            foreach (var line in update.NewLines)
+                _overlayCommandTerminalService.Append(label, AgentCommandStreamKind.Stdout, line);
+        }
     }
 
     private async Task PushReposAsync(


### PR DESCRIPTION
## Summary
This PR introduces end-to-end live GitHub Actions streaming into the loading overlay during dependency-synchronized pushes, using a shared polling pipeline with the Workspace Actions terminal and documented behavior in README.

## What’s implemented
1. Added shared GitHub Actions live feed service for run/job/step polling and step-transition formatting.
2. Integrated live feed into synchronized push wait flow so overlay terminal streams workflow updates while waiting for required package versions.
3. Wired feed discovery to track workflows from previously pushed repositories (the repos where CI starts during dependency rollout).
4. Added repository-level workflow-presence gating:
1. Repositories with no workflow definitions are marked and skipped for further discovery.
2. Repositories with workflows but no current run continue to be re-checked.
5. Added global discovery stop condition only after all relevant already-pushed repositories are confirmed to have no workflows.
6. Added overlay terminal append overload to support direct stream writes from the push pipeline.
7. Registered the shared live feed service in DI.
8. Refactored Workspace Actions live terminal component to use the shared service (single retrieval/formatting path; no duplicated polling logic).
9. Updated README with a new “What’s new” section describing the synchronized-push live overlay behavior and guard semantics.

## Technical details
1. New service: `GhaWorkflowLiveFeedService`
1. Centralizes polling cadence, caption/step progress construction, step snapshot/transition tracking, and transition line formatting.
2. Push integration: `WorkspacePushService`
1. Discovers running workflow runs during package-wait intervals.
2. Streams new live lines to `OverlayCommandTerminalService` using `gha:{repoName}` labels.
3. Maintains per-run feed state and per-repo “no workflows” cache.
3. UI integration: `GhaWorkflowLiveTerminal`
1. Delegates polling/state-update logic to shared feed service.
4. Overlay stream support: `OverlayCommandTerminalService`
1. Added convenience append overload for labeled stream lines.
5. DI: Program.cs
1. Registers `GhaWorkflowLiveFeedService` as scoped.

## User impact
During synchronized pushes, the loading overlay terminal now provides live GitHub Actions execution visibility (job/step transitions) while dependency packages propagate, aligned with the same feed behavior used in Workspace Actions.