### PR TITLE
Update dependencies: custom commit message, optional package list, and scoped default-branch warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,15 @@ Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManage
 
 ## What's new
 
+### Update dependencies: custom commit message and smarter default-branch warning
+
+The workspace **Update dependencies** confirmation dialog now lets you control how git commits are created during a coordinated dependency rollout.
+
+- **Optional commit subject:** enter a custom commit message (for example `chore(deps): bump AuroraVerityReview packages`). Leave it blank to keep the default `chore(deps): update package versions` for `.csproj` commits and `chore(deps): update versions (N)` for version-file commits.
+- **Include updated dependencies in commit message:** when checked (default), each repository commit still appends the package list in the body (`- PackageId to x.y.z`). Uncheck to commit only the subject line with no dependency list.
+- **Per-workspace memory:** your last commit message and checkbox choice are remembered for the current workspace for the rest of the app session (no database persistence). Reopening the dialog restores what you last used on Proceed; Cancel does not clear it.
+- **Default-branch warning only for repos that will change:** the protected-branch warning before update now lists only repositories that are on their default branch **and** have pending dependency updates in the current plan. Repos on default with nothing to update are omitted, so you are not asked to confirm a long list of repos GrayMoon will not touch.
+
 ### Live GitHub Actions feed in synchronized push overlay
 
 When GrayMoon performs a dependency-synchronized push and is waiting for required package versions to appear in registries, the loading overlay terminal now streams live GitHub Actions updates for the repositories that were already pushed.

--- a/src/GrayMoon.App/Components/Modals/UpdateDependenciesModal.razor
+++ b/src/GrayMoon.App/Components/Modals/UpdateDependenciesModal.razor
@@ -10,12 +10,30 @@
                     <button type="button" class="btn-close" aria-label="Close" @onclick="OnCancel"></button>
                 </div>
                 <div class="modal-body">
-                    <p class="mb-0">
+                    <p class="mb-3">
                         Proceed to update dependency versions in <code>.csproj</code> files to match the current versions of the referenced packages, update any configured version files that use those versions, and create git commits in each affected repository for the modified files.
                     </p>
+                    <div class="mb-3">
+                        <label for="updateDepsCommitMsg" class="form-label">Commit message <span class="text-muted">(optional)</span></label>
+                        <input id="updateDepsCommitMsg"
+                               type="text"
+                               class="form-control"
+                               placeholder="chore(deps): update package versions"
+                               @bind="_commitMessage"
+                               disabled="@IsBusy" />
+                    </div>
+                    <div class="form-check">
+                        <input id="updateDepsIncludeDeps"
+                               type="checkbox"
+                               class="form-check-input"
+                               style="@(!_includeDepsInMessage ? "opacity: 0.4;" : "")"
+                               @bind="_includeDepsInMessage"
+                               disabled="@IsBusy" />
+                        <label for="updateDepsIncludeDeps" class="form-check-label">Include updated dependencies in commit message</label>
+                    </div>
                 </div>
                 <div class="modal-footer">
-                    <button type="button" class="btn btn-warning" @onclick="OnProceed" disabled="@IsBusy">
+                    <button type="button" class="btn btn-warning" @onclick="OnProceedClick" disabled="@IsBusy">
                         @if (IsBusy)
                         {
                             <span class="spinner-border spinner-border-sm me-2" aria-hidden="true"></span>
@@ -34,10 +52,31 @@
 @code {
     [Parameter] public bool IsVisible { get; set; }
     [Parameter] public bool IsBusy { get; set; }
-    [Parameter] public EventCallback OnProceed { get; set; }
+    [Parameter] public string? InitialCommitMessage { get; set; }
+    [Parameter] public bool InitialIncludeDeps { get; set; } = true;
+    [Parameter] public EventCallback<(string? CommitMessage, bool IncludeDeps)> OnProceed { get; set; }
     [Parameter] public EventCallback OnCancel { get; set; }
 
     private ElementReference modalElement;
+    private string _commitMessage = "";
+    private bool _includeDepsInMessage = true;
+    private bool _prevIsVisible;
+
+    protected override void OnParametersSet()
+    {
+        if (IsVisible && !_prevIsVisible)
+        {
+            _commitMessage = InitialCommitMessage ?? "";
+            _includeDepsInMessage = InitialIncludeDeps;
+        }
+        _prevIsVisible = IsVisible;
+    }
+
+    private async Task OnProceedClick()
+    {
+        var msg = _commitMessage.Trim();
+        await OnProceed.InvokeAsync((string.IsNullOrEmpty(msg) ? null : msg, _includeDepsInMessage));
+    }
 
     private async Task HandleKeyDown(KeyboardEventArgs e)
     {

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor
@@ -214,6 +214,8 @@
 
 <UpdateDependenciesModal IsVisible="@_updateModal.IsVisible"
                          IsBusy="@isUpdating"
+                         InitialCommitMessage="@_updateModal.LastCommitMessage"
+                         InitialIncludeDeps="@_updateModal.LastIncludeDeps"
                          OnProceed="@OnUpdateProceedAsync"
                          OnCancel="@CloseUpdateModal" />
 

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
@@ -1171,10 +1171,16 @@ public sealed partial class WorkspaceRepositories : IDisposable
             return;
         }
 
+        await using var scope = ServiceScopeFactory.CreateAsyncScope();
+        var workspaceGitService = scope.ServiceProvider.GetRequiredService<WorkspaceGitService>();
+        var (updatePlan, _) = await workspaceGitService.GetUpdatePlanAsync(WorkspaceId);
+        var repoIdsWithUpdates = updatePlan.Select(p => p.RepoId).ToHashSet();
+
         var reposOnDefault = workspaceRepositories
             .Where(wr => !wr.IsOnTag
                 && !string.IsNullOrWhiteSpace(wr.DefaultBranchName)
-                && string.Equals(wr.BranchName, wr.DefaultBranchName, StringComparison.Ordinal))
+                && string.Equals(wr.BranchName, wr.DefaultBranchName, StringComparison.Ordinal)
+                && repoIdsWithUpdates.Contains(wr.RepositoryId))
             .ToList();
 
         if (reposOnDefault.Count > 0)
@@ -1209,14 +1215,19 @@ public sealed partial class WorkspaceRepositories : IDisposable
         }
     }
 
-    private async Task OnUpdateProceedAsync()
+    private async Task OnUpdateProceedAsync((string? CommitMessage, bool IncludeDeps) args)
     {
-        CloseUpdateModal();
-        await RunUpdateCoreAsync();
+        _updateModal = _updateModal with
+        {
+            IsVisible = false,
+            LastCommitMessage = args.CommitMessage,
+            LastIncludeDeps = args.IncludeDeps
+        };
+        await RunUpdateCoreAsync(args.CommitMessage, args.IncludeDeps);
     }
 
     /// <summary>Runs update (refresh, sync deps, commit per level, refresh version). Overlay shows progress.</summary>
-    private async Task RunUpdateCoreAsync()
+    private async Task RunUpdateCoreAsync(string? commitMessage = null, bool includeDepsInCommitMessage = true)
     {
         if (workspace == null || workspaceRepositories.Count == 0 || isUpdating || isSyncing)
             return;
@@ -1243,7 +1254,9 @@ public sealed partial class WorkspaceRepositories : IDisposable
                     _ = InvokeAsync(StateHasChanged);
                 },
                 onAppSideComplete: () => _updateAwaitingAgentTasks = true,
-                repoIdsToUpdate: null);
+                repoIdsToUpdate: null,
+                commitMessage: commitMessage,
+                includeDepsInCommitMessage: includeDepsInCommitMessage);
 
             isUpdating = false;
             await InvokeAsync(StateHasChanged);
@@ -2584,6 +2597,8 @@ public sealed partial class WorkspaceRepositories : IDisposable
     private sealed record UpdateModalState
     {
         public bool IsVisible { get; init; }
+        public string? LastCommitMessage { get; init; }
+        public bool LastIncludeDeps { get; init; } = true;
     }
 
     private sealed record UpdateSingleRepoDependenciesModalState

--- a/src/GrayMoon.App/Services/DependencyUpdateOrchestrator.cs
+++ b/src/GrayMoon.App/Services/DependencyUpdateOrchestrator.cs
@@ -23,13 +23,17 @@ public sealed class DependencyUpdateOrchestrator(
     /// Stops on first error and reports it via <paramref name="onRepoError"/>.
     /// </summary>
     /// <param name="repoIdsToUpdate">Optional. When set, only these repositories are considered for the update plan and all steps.</param>
+    /// <param name="commitMessage">Optional user-supplied commit subject line. When provided, replaces the default subject in all commits created during this update.</param>
+    /// <param name="includeDepsInCommitMessage">When true, the list of updated packages is appended to the commit message body.</param>
     public async Task RunAsync(
         int workspaceId,
         CancellationToken cancellationToken,
         Action<string> setProgress,
         Action<int, string> onRepoError,
         Action? onAppSideComplete = null,
-        IReadOnlySet<int>? repoIdsToUpdate = null)
+        IReadOnlySet<int>? repoIdsToUpdate = null,
+        string? commitMessage = null,
+        bool includeDepsInCommitMessage = true)
     {
         var hadError = false;
         void OnRepoError(int repoId, string msg)
@@ -73,7 +77,8 @@ public sealed class DependencyUpdateOrchestrator(
                     cancellationToken,
                     levelProgress,
                     onAppSideComplete,
-                    OnRepoError))
+                    OnRepoError,
+                    commitMessage))
             {
                 hadError = true;
                 break;
@@ -106,7 +111,9 @@ public sealed class DependencyUpdateOrchestrator(
                     if (c == t)
                         onAppSideComplete?.Invoke();
                 },
-                cancellationToken);
+                cancellationToken,
+                commitMessageOverride: commitMessage,
+                includeDepsInCommitMessage: includeDepsInCommitMessage);
             foreach (var (repoId, errMsg) in commitResults)
             {
                 if (!string.IsNullOrEmpty(errMsg))
@@ -234,7 +241,8 @@ public sealed class DependencyUpdateOrchestrator(
         CancellationToken cancellationToken,
         Action<string> setProgress,
         Action? onAppSideComplete,
-        Action<int, string> onRepoError)
+        Action<int, string> onRepoError,
+        string? commitMessageOverride = null)
     {
         setProgress("Updating version files...");
         var (_, _, fileError, updatedFiles) = await fileVersionService.UpdateAllVersionsAsync(
@@ -274,7 +282,8 @@ public sealed class DependencyUpdateOrchestrator(
             workspaceId,
             byRepo,
             onProgress: (c, t, _) => setProgress($"Committed version files {c} of {t}"),
-            cancellationToken: cancellationToken);
+            cancellationToken: cancellationToken,
+            commitMessageOverride: commitMessageOverride);
 
         var committedVersionRepoIds = new List<int>();
         foreach (var (repoId, errMsg) in vfCommitResults)

--- a/src/GrayMoon.App/Services/WorkspaceGitService.cs
+++ b/src/GrayMoon.App/Services/WorkspaceGitService.cs
@@ -428,7 +428,9 @@ public class WorkspaceGitService(
         int workspaceId,
         IReadOnlyList<SyncDependenciesRepoPayload> reposToCommit,
         Action<int, int, int>? onProgress = null,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default,
+        string? commitMessageOverride = null,
+        bool includeDepsInCommitMessage = true)
     {
         if (!_agentBridge.IsAgentConnected || reposToCommit.Count == 0)
             return Array.Empty<(int, string?)>();
@@ -462,17 +464,28 @@ public class WorkspaceGitService(
                     .Where(p => p.Length > 0)
                     .Distinct()
                     .ToList();
-                var lines = new List<string> { "chore(deps): update package versions", "" };
-                var seen = new HashSet<(string Id, string Version)>();
-                foreach (var pu in repo.ProjectUpdates)
+                var subject = string.IsNullOrWhiteSpace(commitMessageOverride)
+                    ? "chore(deps): update package versions"
+                    : commitMessageOverride.Trim();
+                string commitMessage;
+                if (includeDepsInCommitMessage)
                 {
-                    foreach (var (packageId, _, newVersion) in pu.PackageUpdates)
+                    var lines = new List<string> { subject, "" };
+                    var seen = new HashSet<(string Id, string Version)>();
+                    foreach (var pu in repo.ProjectUpdates)
                     {
-                        if (seen.Add((packageId, newVersion)))
-                            lines.Add($"- {packageId} to {newVersion}");
+                        foreach (var (packageId, _, newVersion) in pu.PackageUpdates)
+                        {
+                            if (seen.Add((packageId, newVersion)))
+                                lines.Add($"- {packageId} to {newVersion}");
+                        }
                     }
+                    commitMessage = string.Join("\r\n", lines);
                 }
-                var commitMessage = string.Join("\r\n", lines);
+                else
+                {
+                    commitMessage = subject;
+                }
 
                 var args = new
                 {
@@ -505,7 +518,8 @@ public class WorkspaceGitService(
         int workspaceId,
         IReadOnlyList<(int RepoId, string RepoName, IReadOnlyList<string> FilePaths)> reposAndPaths,
         Action<int, int, int>? onProgress = null,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default,
+        string? commitMessageOverride = null)
     {
         if (!_agentBridge.IsAgentConnected || reposAndPaths.Count == 0)
             return Array.Empty<(int, string?)>();
@@ -540,7 +554,9 @@ public class WorkspaceGitService(
                     .ToList();
                 if (pathsToStage.Count == 0)
                     return (RepoId: repo.RepoId, ErrorMessage: (string?)"No paths to stage.");
-                var commitMessage = $"chore(deps): update versions ({pathsToStage.Count})";
+                var commitMessage = string.IsNullOrWhiteSpace(commitMessageOverride)
+                    ? $"chore(deps): update versions ({pathsToStage.Count})"
+                    : commitMessageOverride.Trim();
                 var args = new
                 {
                     workspaceName = workspace.Name,

--- a/src/GrayMoon.App/Services/WorkspaceUpdateHandler.cs
+++ b/src/GrayMoon.App/Services/WorkspaceUpdateHandler.cs
@@ -17,7 +17,9 @@ public sealed class WorkspaceUpdateHandler(
         Action<string> setProgress,
         Action<int, string> setRepositoryError,
         Action? onAppSideComplete = null,
-        IReadOnlySet<int>? repoIdsToUpdate = null)
+        IReadOnlySet<int>? repoIdsToUpdate = null,
+        string? commitMessage = null,
+        bool includeDepsInCommitMessage = true)
     {
         try
         {
@@ -27,7 +29,9 @@ public sealed class WorkspaceUpdateHandler(
                 setProgress,
                 setRepositoryError,
                 onAppSideComplete,
-                repoIdsToUpdate);
+                repoIdsToUpdate,
+                commitMessage,
+                includeDepsInCommitMessage);
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {


### PR DESCRIPTION
## Summary

- Add optional commit message and "Include updated dependencies in commit message" checkbox to the **Update dependencies** modal.
- Thread commit options through the update pipeline (handler, orchestrator, git service) so `.csproj` and version-file commits use the chosen subject; dependency commits can omit the package list body when unchecked.
- Remember the last commit message and checkbox state per workspace for the current app session (restored when the modal reopens after Proceed; Cancel keeps values).
- Narrow the default-branch warning before update to repositories that are on default **and** have pending updates in the current plan (via `GetUpdatePlanAsync`), so unchanged repos on `main` are not listed.

## Details

### Update dependencies modal

- Optional commit subject with placeholder `chore(deps): update package versions`.
- Checkbox (default on) to append per-repo package lines (`- {packageId} to {version}`) to dependency update commits.
- Checkbox input dims when unchecked (`opacity: 0.4` on `.form-check-input`).
- `OnProceed` passes `(CommitMessage?, IncludeDeps)`; empty subject falls back to existing defaults.

### Commit behavior

- Custom subject replaces default for dependency and version-file commits when provided.
- When "include dependencies" is off, dependency commits use subject only (no bullet list).
- Version-file commits use custom subject when set; otherwise `chore(deps): update versions (N)`.

### Default-branch warning

- Before showing the warning, load repos with actual pending updates from the update plan.
- Only repos on default branch **and** in that set appear in the warning and count toward whether to show it.

## Test plan

- [ ] Open **Update dependencies** on a workspace with mismatched deps; confirm placeholder and checkbox default (checked).
- [ ] Enter a custom commit message, uncheck include dependencies, proceed; verify commits use subject only (no package bullets).
- [ ] Repeat with checkbox checked; verify commits include package list under custom subject.
- [ ] Leave message blank; verify default subjects unchanged.
- [ ] Proceed once, cancel next time; reopen modal and confirm message + checkbox restored.
- [ ] Workspace with many repos on default but few needing updates: warning lists only repos with pending updates.
- [ ] Workspace with no pending updates on default: no default-branch warning (or empty list / skip to update modal as designed).