### PR TITLE
Create GitHub pull requests from workspace repositories view

### DIFF
--- a/.cursor/plans/github_pr_creation_dialog_59ccc36d.plan.md
+++ b/.cursor/plans/github_pr_creation_dialog_59ccc36d.plan.md
@@ -1,0 +1,331 @@
+---
+name: github pr creation dialog
+overview: Add a `NewPullRequestModal` and `PullRequestService` to GrayMoon, then wire three entry points in `WorkspaceRepositories` (split-button "New Pull Request", yellow `create` badge, dependency-level git icon) so they all open the same modal and create PRs via the existing `GitHubService`/`HttpClient` stack.
+todos:
+  - id: github-service
+    content: Extend GitHubService with CreatePullRequestAsync, RequestReviewersAsync, GetCollaboratorsAsync and corresponding DTOs in GitHubDtos.cs
+    status: completed
+  - id: pr-service
+    content: Add IPullRequestService/PullRequestService + request/result/progress models; register in Program.cs
+    status: completed
+  - id: title-helper
+    content: Add PullRequestTitleHelper static class with branch->title conversion (preserve dash after uppercase, ticket-id prefixing)
+    status: completed
+  - id: modal
+    content: "Create NewPullRequestModal.razor with title, description (+helper text), draft checkbox, reviewer picker (single repo: collaborators list, multi: free-text), Open-in-GitHub left + Cancel/Create right"
+    status: completed
+  - id: branch-modal-tab
+    content: Add InitialTab parameter to BranchModal and respect it in OnParametersSet
+    status: completed
+  - id: split-button
+    content: "Replace Update button in WorkspaceRepositoriesHeader.razor with Blazor split-button dropdown: New Branch, Switch Branch, separator, New Pull Request; remove standalone Branch button"
+    status: completed
+  - id: pr-badge
+    content: Convert PRBadge yellow create anchor to a clickable EventCallback; surface OnCreatePr via WorkspaceRepositoriesRow
+    status: completed
+  - id: wire-page
+    content: Wire WorkspaceRepositories.razor.cs with OpenPullRequestDialogFor{All,Repository,Repositories}Async, overlay messages, summary toast, and Open-in-GitHub multi-tab handling (>5 confirm)
+    status: completed
+  - id: level-icon
+    content: Repoint dependency-level git icon (currently ShowConfirmOpenPr) to OpenPullRequestDialogForRepositoriesAsync(group)
+    status: completed
+  - id: lint-check
+    content: Run ReadLints on touched files; fix introduced warnings
+    status: completed
+isProject: false
+---
+
+# GitHub PR Creation Dialog in GrayMoon
+
+## Scope and constraints
+
+- .NET 8 Blazor Server, Bootstrap 5.1, custom modal pattern (`*Modal.razor` with `IsVisible` + `EventCallback`s, not a modal service).
+- GitHub client is the custom [src/GrayMoon.App/Services/GitHubService.cs](src/GrayMoon.App/Services/GitHubService.cs) on `HttpClient`. Reuse it; do not introduce Octokit.
+- Auth is per-repo via `Repository.Connector.UserToken` (encrypted). Use the same `EnsureConnectorConfigured` pattern as existing PR fetch methods.
+- Row model is [WorkspaceRepositoryLink](src/GrayMoon.App/Models/WorkspaceRepositoryLink.cs) (no `WorkspaceRepositoryViewModel`); plan uses this directly.
+- Windows CRLF, ASCII hyphens only, primary constructors where the body is trivial.
+
+## 1. GitHub API layer - extend `GitHubService`
+
+In [src/GrayMoon.App/Services/GitHubService.cs](src/GrayMoon.App/Services/GitHubService.cs), add three POST methods alongside `GetPullRequestForBranchAsync`. Use a small private `PostAsJsonAsync<TReq,TRes>` helper that mirrors the existing `CreateGetRequest` (Bearer token, `application/vnd.github+json`, UA, `X-GitHub-Api-Version`) and runs through the same Polly pipeline.
+
+- `CreatePullRequestAsync(Connector, owner, repo, CreatePullRequestApiBody, ct)` -> `POST /repos/{owner}/{repo}/pulls` -> `GitHubPullRequestDto`.
+- `RequestReviewersAsync(Connector, owner, repo, pull_number, reviewers[], teamReviewers[], ct)` -> `POST /repos/{owner}/{repo}/pulls/{n}/requested_reviewers` (best-effort).
+- `GetCollaboratorsAsync(Connector, owner, repo, ct)` -> `GET /repos/{owner}/{repo}/collaborators?affiliation=all&per_page=100` -> `List<GitHubCollaboratorDto>` (best-effort; returns empty on 403/404).
+
+In [src/GrayMoon.App/Models/GitHubDtos.cs](src/GrayMoon.App/Models/GitHubDtos.cs), add:
+
+- `GitHubCreatePullRequestRequestDto { title, head, base, body?, draft }` (lowercase `JsonPropertyName`s; null `body`/`draft` omitted via `JsonIgnoreCondition.WhenWritingNull`).
+- `GitHubRequestReviewersRequestDto { reviewers, team_reviewers }`.
+- `GitHubCollaboratorDto { login, type }`.
+- Extend `GitHubPullRequestDto` with `[JsonPropertyName("body")] public string? Body` (used elsewhere later; harmless).
+
+Friendly error mapping: reuse existing `GitHubApiErrorHelper.FormatFriendlyGitHubHttpError` for 422 (validation - e.g. "A pull request already exists"), 401/403, 404, 422 with `errors[].message`.
+
+## 2. New `PullRequestService`
+
+New file: `src/GrayMoon.App/Services/PullRequestService.cs`.
+
+```csharp
+public interface IPullRequestService
+{
+    Task<CreatePullRequestResult> CreatePullRequestAsync(CreatePullRequestRequest request, CancellationToken ct);
+    Task<IReadOnlyList<CreatePullRequestResult>> CreatePullRequestsAsync(
+        IReadOnlyList<CreatePullRequestRequest> requests,
+        IProgress<CreatePullRequestProgress>? progress,
+        CancellationToken ct);
+    Task<IReadOnlyList<string>> GetCollaboratorLoginsAsync(int repositoryId, CancellationToken ct);
+}
+```
+
+- Sequential execution in `CreatePullRequestsAsync` (PR creation order can matter for cross-repo workflows; matches existing `DependencyUpdateOrchestrator` style). Continue on per-repo failures; abort only on global auth failures.
+- Resolves `Connector` per repo via `IServiceScopeFactory` + existing `WorkspaceRepository` / `RepositoryRepository` (mirror how `WorkspacePullRequestService` does it).
+- After successful PR create, if `request.Reviewers` is non-empty, call `RequestReviewersAsync`; treat reviewer failure as non-fatal (sets `ReviewerWarning` but leaves `Success=true`).
+- Validation up front: non-empty title, head, base, owner, repo; otherwise return failed `CreatePullRequestResult` without calling the API.
+
+Models in the same file (or `Models/PullRequestModels.cs`):
+
+```csharp
+public sealed class CreatePullRequestRequest
+{
+    public required int RepositoryId { get; init; }
+    public required string Owner { get; init; }
+    public required string RepositoryName { get; init; }
+    public required string HeadBranch { get; init; }
+    public required string BaseBranch { get; init; }
+    public required string Title { get; init; }
+    public string? Body { get; init; }
+    public bool IsDraft { get; init; }
+    public IReadOnlyList<string> Reviewers { get; init; } = [];
+}
+
+public sealed class CreatePullRequestResult
+{
+    public required int RepositoryId { get; init; }
+    public required string RepositoryName { get; init; }
+    public bool Success { get; init; }
+    public int? PullRequestNumber { get; init; }
+    public string? PullRequestUrl { get; init; }
+    public string? ErrorMessage { get; init; }
+    public string? ReviewerWarning { get; init; }
+}
+
+public sealed class CreatePullRequestProgress
+{
+    public int Created { get; init; }
+    public int Failed { get; init; }
+    public int Total { get; init; }
+    public string? CurrentRepositoryName { get; init; }
+}
+```
+
+Register in [src/GrayMoon.App/Program.cs](src/GrayMoon.App/Program.cs) next to other GitHub services:
+
+```csharp
+builder.Services.AddScoped<IPullRequestService, PullRequestService>();
+```
+
+## 3. Title generator helper
+
+New file: `src/GrayMoon.App/Services/PullRequestTitleHelper.cs`.
+
+- `BuildDefaultTitle(string branchName)`:
+  - Replace `-`, `_`, `.`, `/` with space, **except** retain `-` when it follows an uppercase letter (Regex `(?<![A-Z])-` -> space).
+  - Collapse multiple spaces and trim.
+  - Preserve original casing.
+- Example test: `feature/ABC-123-update-dependencies.v2` -> `feature ABC-123 update dependencies v2`. Spec example shows `ABC-123 feature ...`; we will match the spec by **moving the first all-uppercase token (ticket id) to the front** only when it contains a digit (matches `[A-Z]+-\d+`).
+- Keep helper static, no DI. No external library.
+
+## 4. New `NewPullRequestModal.razor`
+
+New file: `src/GrayMoon.App/Components/Modals/NewPullRequestModal.razor`.
+
+Follows the existing modal pattern (`IsVisible` + `EventCallback`s, Bootstrap 5.1, Escape closes, no separate `.razor.cs`). Body fields:
+
+- Title `input.form-control` (required, prefilled from helper).
+- Description `textarea.form-control` rows="6" with `<div class="form-text text-muted">If left empty, the repository pull request template will be used if available.</div>`.
+- `<div class="form-check">` for `Draft pull request`.
+- Reviewers section:
+  - When a single repository: show a chip/checkbox list of collaborator logins fetched via `IPullRequestService.GetCollaboratorLoginsAsync` on open (loading spinner while fetching, hidden on error).
+  - When multiple repositories: show a comma-separated free-text input only.
+  - Field is optional in both cases.
+
+Footer (Bootstrap modal-footer with `justify-content-between` so the gray button is left-aligned):
+
+```html
+<button class="btn btn-secondary" @onclick="OnOpenInGitHubClick">Open in GitHub</button>
+<div class="d-flex gap-2">
+  <button class="btn btn-outline-secondary" @onclick="OnCancel">Cancel</button>
+  <button class="btn btn-primary" @onclick="OnCreateClick" disabled="@(IsBusy || !IsValid)">Create</button>
+</div>
+```
+
+Parameters:
+
+```csharp
+[Parameter] public bool IsVisible { get; set; }
+[Parameter] public bool IsBusy { get; set; }
+[Parameter] public IReadOnlyList<NewPrTargetRepo> Targets { get; set; } = [];
+[Parameter] public EventCallback<NewPrFormResult> OnCreate { get; set; }
+[Parameter] public EventCallback OnCancel { get; set; }
+[Parameter] public EventCallback OnOpenInGitHub { get; set; }
+```
+
+Where `NewPrTargetRepo` is a lightweight record `(int RepositoryId, string Owner, string RepositoryName, string HeadBranch, string BaseBranch, string? CloneUrl)` built by the page from `WorkspaceRepositoryLink`. The modal does not depend on EF types.
+
+Default title generation runs in `OnParametersSet` when the modal opens (`IsVisible` transitions to true) using the unified head branch when all `Targets` share one; otherwise leave empty and show "Multiple branches" helper text. Validation requires non-empty title.
+
+## 5. Wire `WorkspaceRepositories.razor` + code-behind
+
+In [src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs](src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs), add:
+
+```csharp
+private NewPullRequestModalState _newPrModal = new();
+private bool isCreatingPullRequests;
+private string createPrProgressMessage = "Creating Pull Requests...";
+
+private sealed record NewPullRequestModalState
+{
+    public bool IsVisible { get; init; }
+    public IReadOnlyList<NewPrTargetRepo> Targets { get; init; } = [];
+}
+
+private Task OpenPullRequestDialogForAllRepositoriesAsync()
+    => OpenPullRequestDialogCoreAsync(workspaceRepositories);
+
+private Task OpenPullRequestDialogForRepositoryAsync(WorkspaceRepositoryLink link)
+    => OpenPullRequestDialogCoreAsync(new[] { link });
+
+private Task OpenPullRequestDialogForRepositoriesAsync(IReadOnlyList<WorkspaceRepositoryLink> links)
+    => OpenPullRequestDialogCoreAsync(links);
+```
+
+`OpenPullRequestDialogCoreAsync` filters to GitHub repos with a non-default head branch and ahead commits (mirrors `ShowConfirmOpenPr` filter), maps to `NewPrTargetRepo`, shows a toast if empty, otherwise sets `_newPrModal = new { IsVisible = true, Targets = ... }`.
+
+Create handler runs the standard load overlay:
+
+```csharp
+isCreatingPullRequests = true;
+createPrProgressMessage = "Creating Pull Requests...";
+var progress = new Progress<CreatePullRequestProgress>(p =>
+{
+    createPrProgressMessage = $"Created {p.Created} of {p.Total} pull requests";
+    _ = InvokeAsync(StateHasChanged);
+});
+var results = await PullRequestService.CreatePullRequestsAsync(requests, progress, ct);
+isCreatingPullRequests = false;
+// toast summary; refresh PR cache via WorkspacePullRequestService
+```
+
+Open-in-GitHub handler: build compare URLs from each target (`{repoUrl}/compare/{base}...{head}`); if `Targets.Count > 5`, call existing `ShowConfirm("Open X repositories in separate tabs?", ...)` then `JSRuntime.InvokeVoidAsync("graymoonOpenUrls", urls)`; else open directly (reuses existing `graymoonOpenUrls` JS in `App.razor`).
+
+Add overlay markup next to existing one in [WorkspaceRepositories.razor](src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor):
+
+```razor
+<LoadingOverlay IsVisible="@isCreatingPullRequests" Message="@createPrProgressMessage" />
+<NewPullRequestModal IsVisible="@_newPrModal.IsVisible"
+                     Targets="@_newPrModal.Targets"
+                     IsBusy="@isCreatingPullRequests"
+                     OnCreate="HandleCreatePullRequestsAsync"
+                     OnCancel="CloseNewPullRequestModal"
+                     OnOpenInGitHub="HandleNewPrOpenInGitHubAsync" />
+```
+
+Inject `IPullRequestService` into the page.
+
+## 6. Replace `Update` button with Bootstrap split-button dropdown
+
+Modify [src/GrayMoon.App/Components/Shared/WorkspaceRepositoriesHeader.razor](src/GrayMoon.App/Components/Shared/WorkspaceRepositoriesHeader.razor). Since the project already has Bootstrap 5.1 but no `dropdown-toggle-split` examples, we use the Blazor-controlled toggle pattern (matches `ConnectorModal.razor` / `WorkspaceDependencies.razor`):
+
+```razor
+<div class="btn-group">
+    <button class="btn @(HasUnmatchedDependencies ? "btn-danger" : "btn-outline-secondary")"
+            @onclick="@(() => OnUpdate.InvokeAsync())"
+            disabled="@(...)">Update</button>
+    <button type="button"
+            class="btn @(HasUnmatchedDependencies ? "btn-danger" : "btn-outline-secondary") dropdown-toggle dropdown-toggle-split"
+            @onclick="ToggleUpdateMenu"
+            disabled="@(...)">
+        <span class="visually-hidden">Toggle Dropdown</span>
+    </button>
+    @if (_updateMenuOpen)
+    {
+        <ul class="dropdown-menu show" style="...">
+            <li><button class="dropdown-item" @onclick="OnNewBranchClick">New Branch</button></li>
+            <li><button class="dropdown-item" @onclick="OnSwitchBranchClick">Switch Branch</button></li>
+            <li><hr class="dropdown-divider" /></li>
+            <li><button class="dropdown-item" @onclick="OnNewPullRequestClick">New Pull Request</button></li>
+        </ul>
+    }
+</div>
+```
+
+Add three new `EventCallback`s and a private `_updateMenuOpen` bool. Click-outside dismissal can reuse existing JS pattern from `ConnectorModal` (window click listener) or simply close on item click + on `OnUpdate` click, which is sufficient for v1.
+
+Remove the standalone existing `Branch` button (lines 59-63) since `New Branch` / `Switch Branch` move into the dropdown. Wire the page's existing `OnShowBranch` to `OnNewBranchClick`, plus a new `OnShowSwitchBranch` callback for the switch tab.
+
+## 7. Add initial-tab parameter to `BranchModal`
+
+In [src/GrayMoon.App/Components/Modals/BranchModal.razor](src/GrayMoon.App/Components/Modals/BranchModal.razor):
+
+- Add `[Parameter] public string? InitialTab { get; set; }`.
+- In `OnParametersSet`, change `activeTab = "newbranch";` to `activeTab = (InitialTab == "switchbranch") ? "switchbranch" : "newbranch";`.
+
+In `WorkspaceRepositories.razor.cs` `BranchModalState` record, add `public string InitialTab { get; init; } = "newbranch";` and pass through to `<BranchModal InitialTab="@_branchModal.InitialTab" .../>`. `ShowBranchModalAsync(string tab = "newbranch")` sets it.
+
+## 8. Yellow `create` badge -> single repo PR dialog
+
+In [src/GrayMoon.App/Components/Shared/PRBadge.razor](src/GrayMoon.App/Components/Shared/PRBadge.razor), replace the `<a target="_blank">` with a Blazor `@onclick` button-styled span and add a new `[Parameter] public EventCallback OnCreateClick { get; set; }`. Drop the `CreatePrUrl` parameter usage for navigation, keep visual styling (`badge pr-badge pr-badge-create`).
+
+In [WorkspaceRepositoriesRow.razor](src/GrayMoon.App/Components/Pages/WorkspaceRepositoriesRow.razor), pass `OnCreateClick="() => OnCreatePr.InvokeAsync(Link)"`; add `[Parameter] public EventCallback<WorkspaceRepositoryLink> OnCreatePr { get; set; }`. In `WorkspaceRepositories.razor`, wire `OnCreatePr="OpenPullRequestDialogForRepositoryAsync"`.
+
+## 9. Dependency-level git icon -> multi-repo PR dialog
+
+In [src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs](src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs), change the `OnOpenPr` wiring (currently `() => ShowConfirmOpenPr(group)`) to `() => OpenPullRequestDialogForRepositoriesAsync(group.ToList())`. Keep `ShowConfirmOpenPr` only if still used elsewhere (it isn't).
+
+## 10. Validation, errors, telemetry
+
+- `PullRequestService` returns a per-repo `CreatePullRequestResult`; the page renders a summary toast: `"Created N of M pull requests"`. On any failure, show a second `ToastService.ShowError` with the first failure reason. Optionally render a small results list in the existing overlay area (out of scope for v1; keep toast only).
+- Map common errors via `GitHubApiErrorHelper`:
+  - 401 -> "GitHub token missing or invalid."
+  - 403 -> "Insufficient permissions on {owner}/{repo}."
+  - 404 -> "Repository or base branch not found."
+  - 422 `A pull request already exists` -> "A pull request for {head} already exists."
+  - 422 `No commits between` -> "No commits between {base} and {head}."
+  - Rate limit (403 + `x-ratelimit-remaining: 0`) -> "GitHub rate limit hit."
+- Log via `ILogger<PullRequestService>` at `LogInformation` on success, `LogWarning` on per-repo failure.
+
+## 11. Open-in-GitHub button behavior (per user choice)
+
+- Single target: open one compare URL via `graymoonOpenUrls`.
+- 2-5 targets: open all directly.
+- >5 targets: reuse `ShowConfirm($"Do you want to open {N} repositories in separate tabs?", openAll)` from the existing confirm modal pattern.
+
+## 12. Files touched (summary)
+
+- New: `src/GrayMoon.App/Services/PullRequestService.cs`, `src/GrayMoon.App/Services/PullRequestTitleHelper.cs`, `src/GrayMoon.App/Components/Modals/NewPullRequestModal.razor`.
+- Modified: `GitHubService.cs`, `GitHubDtos.cs`, `Program.cs`, `WorkspaceRepositoriesHeader.razor`, `BranchModal.razor`, `PRBadge.razor`, `WorkspaceRepositoriesRow.razor`, `WorkspaceRepositories.razor`, `WorkspaceRepositories.razor.cs`.
+
+## 13. Non-goals
+
+- No labels, milestones, `maintainer_can_modify`.
+- No template auto-expansion; helper text only.
+- No persisted PR state in SQLite (existing refresh path picks it up).
+- No new toast/notification component; reuse `IToastService`.
+- No new bootstrap CSS; reuse 5.1 classes.
+
+## Architecture sketch
+
+```mermaid
+flowchart LR
+  Header[Header split button: New Pull Request] --> Page[WorkspaceRepositories]
+  Badge[Yellow create badge] --> Page
+  LevelIcon[Level git icon] --> Page
+  Page --> Modal[NewPullRequestModal]
+  Modal --> Page
+  Page --> Svc[PullRequestService]
+  Svc --> GH[GitHubService]
+  GH --> API[GitHub REST API]
+  Svc --> Page
+  Page --> Overlay[LoadingOverlay: Created x of y]
+```

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ GrayMoon is useful for:
 
 - You get one view of branch/version/PR/action status across repositories.
 - You can see GitHub Actions results for the current branch across all repositories in a workspace.
-- You can open multiple repositories (and multiple new PR pages by dependency level) in GitHub with one action.
+- You can create pull requests across one, several, or all workspace repositories from one dialog, with optional reviewers and draft support.
 - You can run coordinated dependency updates instead of editing each repo manually.
 - You can create one feature branch (for example `feature/dependency-update`) across repos, auto-update package refs, auto-commit, and push together.
 - When rolling out changes, GrayMoon can push multiple repositories in parallel so the full workflow finishes faster than pushing repo-by-repo manually.
@@ -103,6 +103,19 @@ Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManage
 6. Continue working in your IDE while GrayMoon tracks changes in the background; GrayMoon UI does not need to stay open as long as the Docker app and agent services are running.
 
 ## What's new
+
+### Create pull requests from the workspace repositories view
+
+GrayMoon can now create GitHub pull requests without leaving the app. Use one dialog for a single repository, every repository in a dependency level, or all eligible workspace repositories.
+
+- **Three entry points:** the yellow **create** badge on a row (one repo), the dependency-level GitHub icon (repos in that level with commits ahead of default), and **Branch** split menu **New Pull Requests** (all eligible repos in the workspace).
+- **One dialog, shared fields:** title (default generated from the branch name), optional description, draft checkbox, and optional reviewers. Title rules turn branch names like `feature/ABC-123-update-dependencies.v2` into readable subjects (ticket-style tokens such as `ABC-123` stay grouped).
+- **Reviewers:** users and teams are loaded from GitHub (merged across targets when multiple repos are selected). Search supports multiple words (space/comma separated). Teams appear first in the list.
+- **Open in GitHub:** opens compare/create pages in the browser (with a confirm when more than five repositories are involved).
+- **Create flow:** a confirmation step, then a loading overlay (`Creating N pull requests...`, then `Created x of N pull requests` after the first success). Per-repository results are summarized in toasts; a single successful PR can open in the browser automatically.
+- **Branch menu:** **Branch** is a split button with **New Branch**, **Switch Branch**, and **New Pull Requests**. The main **Update** button is unchanged.
+
+Only repositories that are eligible are included: not on a tag, on a feature branch (not default), with commits ahead of default, no open PR already, and a configured GitHub connector.
 
 ### Update dependencies: custom commit message and smarter default-branch warning
 

--- a/src/GrayMoon.App/Components/Modals/BranchModal.razor
+++ b/src/GrayMoon.App/Components/Modals/BranchModal.razor
@@ -228,6 +228,7 @@
     /// <summary>Local branch name when every repo in the workspace reports the same current branch; used for Current badge and disabling redundant checkout.</summary>
     [Parameter] public string? WorkspaceUnifiedCurrentBranch { get; set; }
     [Parameter] public bool HasTaggedRepos { get; set; }
+    [Parameter] public string? InitialTab { get; set; }
     [Parameter] public EventCallback OnCancel { get; set; }
     [Parameter] public EventCallback<(string NewBranchName, string BaseBranch, bool SkipReposOnTags)> OnCreateBranch { get; set; }
     [Parameter] public EventCallback OnFetchBranches { get; set; }
@@ -404,7 +405,9 @@
             selectedBaseBranch = "__default__";
             errorMessage = null;
             showBranchExistsConfirmation = false;
-            activeTab = "newbranch";
+            activeTab = string.Equals(InitialTab, "switchbranch", StringComparison.OrdinalIgnoreCase)
+                ? "switchbranch"
+                : "newbranch";
             switchBranchFilter = "";
             selectedSwitchBranchKey = null;
             _focusSwitchFilterOnNextRender = false;

--- a/src/GrayMoon.App/Components/Modals/ConfirmModal.razor
+++ b/src/GrayMoon.App/Components/Modals/ConfirmModal.razor
@@ -5,7 +5,7 @@
     <div class="modal show d-block" tabindex="-1" style="background-color: rgba(0,0,0,0.5); z-index: 1075;"
          @onkeydown="HandleKeyDown"
          @ref="_modalElement">
-        <div class="modal-dialog">
+        <div class="modal-dialog modal-dialog-centered">
             <div class="modal-content">
                 <div class="modal-header">
                     <h5 class="modal-title">Confirm</h5>

--- a/src/GrayMoon.App/Components/Modals/ConfirmModal.razor
+++ b/src/GrayMoon.App/Components/Modals/ConfirmModal.razor
@@ -2,7 +2,7 @@
 
 @if (IsVisible)
 {
-    <div class="modal show d-block" tabindex="-1" style="background-color: rgba(0,0,0,0.5);"
+    <div class="modal show d-block" tabindex="-1" style="background-color: rgba(0,0,0,0.5); z-index: 1075;"
          @onkeydown="HandleKeyDown"
          @ref="_modalElement">
         <div class="modal-dialog">

--- a/src/GrayMoon.App/Components/Modals/NewPullRequestModal.razor
+++ b/src/GrayMoon.App/Components/Modals/NewPullRequestModal.razor
@@ -62,63 +62,57 @@
                             <label class="form-label mb-0" for="new-pr-reviewers-filter">Reviewers <span class="text-muted">(optional)</span></label>
                             <span class="new-pr-reviewers-count">@GetReviewerCountText()</span>
                         </div>
-                        <input id="new-pr-reviewers-filter"
-                               type="text"
-                               class="form-control"
-                               placeholder="search user or team..."
-                               @bind="_reviewerFilter"
-                               @bind:event="oninput"
-                               disabled="@(IsBusy || _isLoadingReviewers)" />
-                        <div class="new-pr-reviewer-list border rounded mt-2">
-                            @if (_isLoadingReviewers)
-                            {
-                                <div class="d-flex align-items-center gap-2 p-3 text-muted">
-                                    <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
-                                    Loading reviewers...
-                                </div>
-                            }
-                            else
-                            {
-                                var filtered = GetFilteredReviewers();
-                                @if (filtered.Count == 0)
+                        <div class="new-pr-reviewer-box">
+                            <input id="new-pr-reviewers-filter"
+                                   type="text"
+                                   class="new-pr-reviewer-search"
+                                   placeholder="search user or team..."
+                                   @bind="_reviewerFilter"
+                                   @bind:event="oninput"
+                                   disabled="@(IsBusy || _isLoadingReviewers)" />
+                            <div class="new-pr-reviewer-list">
+                                @if (_isLoadingReviewers)
                                 {
-                                    <div class="text-muted p-3">
-                                        @(_allReviewers.Count == 0
-                                            ? "No reviewers were returned by GitHub."
-                                            : "No users or teams match the filter.")
+                                    <div class="d-flex align-items-center gap-2 px-2 py-2 text-muted">
+                                        <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
+                                        Loading reviewers...
                                     </div>
                                 }
                                 else
                                 {
-                                    @foreach (var item in filtered)
+                                    var filtered = GetFilteredReviewers();
+                                    @if (filtered.Count == 0)
                                     {
-                                        var isChecked = IsReviewerSelected(item);
-                                        var key = ReviewerKey(item);
-                                        <label class="new-pr-reviewer-item d-flex align-items-center gap-2 px-2 py-1"
-                                               for="@($"new-pr-reviewer-{key}")">
-                                            <input id="@($"new-pr-reviewer-{key}")"
-                                                   type="checkbox"
-                                                   class="form-check-input m-0"
-                                                   checked="@isChecked"
-                                                   @onchange="@((ChangeEventArgs e) => ToggleReviewer(item, e.Value is bool b && b))"
-                                                   disabled="@IsBusy" />
-                                            @if (item.IsTeam)
-                                            {
-                                                <i class="bi bi-people" aria-hidden="true"></i>
-                                            }
-                                            else
-                                            {
-                                                <i class="bi bi-person" aria-hidden="true"></i>
-                                            }
-                                            <span class="flex-grow-1">@item.Name</span>
-                                            @if (item.IsTeam)
-                                            {
-                                                <span class="badge bg-secondary">team</span>
-                                            }
-                                        </label>
+                                        <div class="text-muted px-2 py-2">
+                                            @(_allReviewers.Count == 0
+                                                ? "No reviewers were returned by GitHub."
+                                                : "No users or teams match the filter.")
+                                        </div>
+                                    }
+                                    else
+                                    {
+                                        @foreach (var item in filtered)
+                                        {
+                                            var isChecked = IsReviewerSelected(item);
+                                            var key = ReviewerKey(item);
+                                            <label class="new-pr-reviewer-item d-flex align-items-center gap-2 px-2 py-1"
+                                                   for="@($"new-pr-reviewer-{key}")">
+                                                <input id="@($"new-pr-reviewer-{key}")"
+                                                       type="checkbox"
+                                                       class="form-check-input m-0"
+                                                       checked="@isChecked"
+                                                       @onchange="@((ChangeEventArgs e) => ToggleReviewer(item, e.Value is bool b && b))"
+                                                       disabled="@IsBusy" />
+                                                <span class="flex-grow-1">@item.Name</span>
+                                                @if (item.IsTeam)
+                                                {
+                                                    <span class="badge bg-secondary">team</span>
+                                                }
+                                            </label>
+                                        }
                                     }
                                 }
-                            }
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -252,10 +246,10 @@
 
             if (ct.IsCancellationRequested) return;
 
-            _allReviewers = users
-                .Select(u => new ReviewerItem(u, IsTeam: false))
-                .Concat(teams.Select(t => new ReviewerItem(t, IsTeam: true)))
-                .OrderBy(r => r.IsTeam)
+            _allReviewers = teams
+                .Select(t => new ReviewerItem(t, IsTeam: true))
+                .Concat(users.Select(u => new ReviewerItem(u, IsTeam: false)))
+                .OrderByDescending(r => r.IsTeam)
                 .ThenBy(r => r.Name, StringComparer.OrdinalIgnoreCase)
                 .ToList();
         }

--- a/src/GrayMoon.App/Components/Modals/NewPullRequestModal.razor
+++ b/src/GrayMoon.App/Components/Modals/NewPullRequestModal.razor
@@ -1,0 +1,387 @@
+@using GrayMoon.App.Services
+@inject IPullRequestService PullRequestService
+@inject ILogger<NewPullRequestModal> Logger
+
+@if (IsVisible)
+{
+    <div class="modal show d-block" tabindex="-1" style="background-color: rgba(0,0,0,0.5);"
+         @onkeydown="HandleKeyDown"
+         @ref="modalElement">
+        <div class="modal-dialog modal-lg">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">
+                        @if (Targets.Count == 1)
+                        {
+                            <text>New Pull Request - @Targets[0].RepositoryName</text>
+                        }
+                        else
+                        {
+                            <text>New Pull Request - @Targets.Count repositories</text>
+                        }
+                    </h5>
+                    <button type="button" class="btn-close" aria-label="Close" @onclick="HandleCancelClick" disabled="@IsBusy"></button>
+                </div>
+                <div class="modal-body">
+                    <div class="mb-3">
+                        <label class="form-label" for="new-pr-title">Title</label>
+                        <input id="new-pr-title"
+                               type="text"
+                               class="form-control"
+                               @bind="_title"
+                               @bind:event="oninput"
+                               @ref="titleInput"
+                               disabled="@IsBusy" />
+                    </div>
+
+                    <div class="mb-3">
+                        <label class="form-label" for="new-pr-body">Description</label>
+                        <textarea id="new-pr-body"
+                                  class="form-control"
+                                  rows="6"
+                                  style="resize: none;"
+                                  @bind="_body"
+                                  @bind:event="oninput"
+                                  disabled="@IsBusy"></textarea>
+                        <div class="form-text text-muted">
+                            If left empty, the repository pull request template will be used if available.
+                        </div>
+                    </div>
+
+                    <div class="form-check mb-3">
+                        <input id="new-pr-draft"
+                               type="checkbox"
+                               class="form-check-input"
+                               @bind="_isDraft"
+                               disabled="@IsBusy" />
+                        <label for="new-pr-draft" class="form-check-label">Draft pull request</label>
+                    </div>
+
+                    <div class="mb-2">
+                        <div class="d-flex align-items-center justify-content-between new-pr-reviewers-label-row">
+                            <label class="form-label mb-0" for="new-pr-reviewers-filter">Reviewers <span class="text-muted">(optional)</span></label>
+                            <span class="new-pr-reviewers-count">@GetReviewerCountText()</span>
+                        </div>
+                        <input id="new-pr-reviewers-filter"
+                               type="text"
+                               class="form-control"
+                               placeholder="search user or team..."
+                               @bind="_reviewerFilter"
+                               @bind:event="oninput"
+                               disabled="@(IsBusy || _isLoadingReviewers)" />
+                        <div class="new-pr-reviewer-list border rounded mt-2">
+                            @if (_isLoadingReviewers)
+                            {
+                                <div class="d-flex align-items-center gap-2 p-3 text-muted">
+                                    <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
+                                    Loading reviewers...
+                                </div>
+                            }
+                            else
+                            {
+                                var filtered = GetFilteredReviewers();
+                                @if (filtered.Count == 0)
+                                {
+                                    <div class="text-muted p-3">
+                                        @(_allReviewers.Count == 0
+                                            ? "No reviewers were returned by GitHub."
+                                            : "No users or teams match the filter.")
+                                    </div>
+                                }
+                                else
+                                {
+                                    @foreach (var item in filtered)
+                                    {
+                                        var isChecked = IsReviewerSelected(item);
+                                        var key = ReviewerKey(item);
+                                        <label class="new-pr-reviewer-item d-flex align-items-center gap-2 px-2 py-1"
+                                               for="@($"new-pr-reviewer-{key}")">
+                                            <input id="@($"new-pr-reviewer-{key}")"
+                                                   type="checkbox"
+                                                   class="form-check-input m-0"
+                                                   checked="@isChecked"
+                                                   @onchange="@((ChangeEventArgs e) => ToggleReviewer(item, e.Value is bool b && b))"
+                                                   disabled="@IsBusy" />
+                                            @if (item.IsTeam)
+                                            {
+                                                <i class="bi bi-people" aria-hidden="true"></i>
+                                            }
+                                            else
+                                            {
+                                                <i class="bi bi-person" aria-hidden="true"></i>
+                                            }
+                                            <span class="flex-grow-1">@item.Name</span>
+                                            @if (item.IsTeam)
+                                            {
+                                                <span class="badge bg-secondary">team</span>
+                                            }
+                                        </label>
+                                    }
+                                }
+                            }
+                        </div>
+                    </div>
+                </div>
+                <div class="modal-footer d-flex justify-content-between">
+                    <button type="button"
+                            class="btn btn-secondary"
+                            @onclick="HandleOpenInGitHubClick"
+                            disabled="@IsBusy">
+                        Open in GitHub
+                    </button>
+                    <div class="d-flex gap-2">
+                        <button type="button" class="btn btn-outline-secondary" @onclick="HandleCancelClick" disabled="@IsBusy">
+                            Cancel
+                        </button>
+                        <button type="button"
+                                class="btn btn-primary"
+                                @onclick="HandleCreateClick"
+                                disabled="@(IsBusy || !IsValid)">
+                            @if (IsBusy)
+                            {
+                                <span class="spinner-border spinner-border-sm me-2" aria-hidden="true"></span>
+                            }
+                            Create
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+}
+
+@code {
+    [Parameter] public bool IsVisible { get; set; }
+    [Parameter] public bool IsBusy { get; set; }
+    [Parameter] public IReadOnlyList<NewPrTargetRepo> Targets { get; set; } = Array.Empty<NewPrTargetRepo>();
+    [Parameter] public EventCallback<NewPrFormResult> OnCreate { get; set; }
+    [Parameter] public EventCallback OnCancel { get; set; }
+    [Parameter] public EventCallback OnOpenInGitHub { get; set; }
+
+    private ElementReference modalElement;
+    private ElementReference titleInput;
+
+    private string _title = string.Empty;
+    private string _body = string.Empty;
+    private bool _isDraft;
+    private string _reviewerFilter = string.Empty;
+    private List<ReviewerItem> _allReviewers = new();
+    private readonly HashSet<string> _selectedReviewerKeys = new(StringComparer.OrdinalIgnoreCase);
+    private bool _isLoadingReviewers;
+    private bool _wasVisible;
+    private bool _focusTitleOnNextRender;
+    private CancellationTokenSource? _reviewersCts;
+
+    private bool HasUnifiedHeadBranch => Targets.Count > 0
+        && Targets.Select(t => t.HeadBranch).Distinct(StringComparer.Ordinal).Count() == 1;
+
+    private bool IsValid => !string.IsNullOrWhiteSpace(_title) && Targets.Count > 0;
+
+    protected override void OnParametersSet()
+    {
+        if (IsVisible && !_wasVisible)
+        {
+            _title = ComputeDefaultTitle();
+            _body = string.Empty;
+            _isDraft = false;
+            _reviewerFilter = string.Empty;
+            _selectedReviewerKeys.Clear();
+            _allReviewers = new();
+            _focusTitleOnNextRender = true;
+
+            _ = LoadReviewersAsync();
+        }
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (IsVisible && _focusTitleOnNextRender)
+        {
+            _focusTitleOnNextRender = false;
+            try
+            {
+                await titleInput.FocusAsync();
+            }
+            catch { }
+        }
+
+        if (!IsVisible && _wasVisible)
+        {
+            _wasVisible = false;
+            _reviewersCts?.Cancel();
+            _reviewersCts?.Dispose();
+            _reviewersCts = null;
+        }
+        else if (IsVisible && !_wasVisible)
+        {
+            _wasVisible = true;
+        }
+    }
+
+    private string ComputeDefaultTitle()
+    {
+        if (Targets.Count == 0)
+            return string.Empty;
+        return PullRequestTitleHelper.BuildDefaultTitle(Targets[0].HeadBranch);
+    }
+
+    private async Task LoadReviewersAsync()
+    {
+        if (Targets.Count == 0) return;
+
+        _reviewersCts?.Cancel();
+        _reviewersCts?.Dispose();
+        _reviewersCts = new CancellationTokenSource();
+        var ct = _reviewersCts.Token;
+
+        _isLoadingReviewers = true;
+        StateHasChanged();
+
+        try
+        {
+            var users = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var teams = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            var tasks = Targets.SelectMany(t => new Task[]
+            {
+                FetchUsersAsync(t.RepositoryId, users, ct),
+                FetchTeamsAsync(t.RepositoryId, teams, ct)
+            }).ToList();
+
+            await Task.WhenAll(tasks);
+
+            if (ct.IsCancellationRequested) return;
+
+            _allReviewers = users
+                .Select(u => new ReviewerItem(u, IsTeam: false))
+                .Concat(teams.Select(t => new ReviewerItem(t, IsTeam: true)))
+                .OrderBy(r => r.IsTeam)
+                .ThenBy(r => r.Name, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+        }
+        catch (OperationCanceledException)
+        {
+            // ignored
+        }
+        catch (Exception ex)
+        {
+            Logger.LogDebug(ex, "Failed to load reviewers for {Count} target(s)", Targets.Count);
+            _allReviewers = new();
+        }
+        finally
+        {
+            _isLoadingReviewers = false;
+            StateHasChanged();
+        }
+    }
+
+    private async Task FetchUsersAsync(int repositoryId, HashSet<string> sink, CancellationToken ct)
+    {
+        try
+        {
+            var users = await PullRequestService.GetCollaboratorLoginsAsync(repositoryId, ct);
+            lock (sink)
+            {
+                foreach (var u in users)
+                    if (!string.IsNullOrWhiteSpace(u))
+                        sink.Add(u);
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogDebug(ex, "GetCollaboratorLogins failed for RepositoryId={RepositoryId}", repositoryId);
+        }
+    }
+
+    private async Task FetchTeamsAsync(int repositoryId, HashSet<string> sink, CancellationToken ct)
+    {
+        try
+        {
+            var teams = await PullRequestService.GetTeamSlugsAsync(repositoryId, ct);
+            lock (sink)
+            {
+                foreach (var t in teams)
+                    if (!string.IsNullOrWhiteSpace(t))
+                        sink.Add(t);
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogDebug(ex, "GetTeamSlugs failed for RepositoryId={RepositoryId}", repositoryId);
+        }
+    }
+
+    private List<ReviewerItem> GetFilteredReviewers()
+    {
+        var q = _reviewerFilter?.Trim();
+        if (string.IsNullOrWhiteSpace(q))
+            return _allReviewers;
+        return _allReviewers
+            .Where(r => r.Name.Contains(q, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+    }
+
+    private bool IsReviewerSelected(ReviewerItem item)
+        => _selectedReviewerKeys.Contains(ReviewerKey(item));
+
+    private void ToggleReviewer(ReviewerItem item, bool isChecked)
+    {
+        var key = ReviewerKey(item);
+        if (isChecked) _selectedReviewerKeys.Add(key);
+        else _selectedReviewerKeys.Remove(key);
+    }
+
+    private static string ReviewerKey(ReviewerItem item) => (item.IsTeam ? "team:" : "user:") + item.Name;
+
+    private string GetReviewerCountText()
+    {
+        if (_isLoadingReviewers) return "loading...";
+        if (_allReviewers.Count == 0) return string.Empty;
+        var selected = _selectedReviewerKeys.Count;
+        var total = _allReviewers.Count;
+        return selected == 0
+            ? $"{total} available"
+            : $"{selected} selected of {total}";
+    }
+
+    private async Task HandleKeyDown(KeyboardEventArgs e)
+    {
+        if (e.Key == "Escape" && !IsBusy)
+            await HandleCancelClick();
+    }
+
+    private async Task HandleCancelClick()
+    {
+        await OnCancel.InvokeAsync();
+    }
+
+    private async Task HandleOpenInGitHubClick()
+    {
+        await OnOpenInGitHub.InvokeAsync();
+    }
+
+    private async Task HandleCreateClick()
+    {
+        if (!IsValid) return;
+
+        var users = new List<string>();
+        var teams = new List<string>();
+        foreach (var item in _allReviewers)
+        {
+            if (!_selectedReviewerKeys.Contains(ReviewerKey(item))) continue;
+            if (item.IsTeam) teams.Add(item.Name);
+            else users.Add(item.Name);
+        }
+
+        var result = new NewPrFormResult(
+            Title: _title.Trim(),
+            Body: string.IsNullOrWhiteSpace(_body) ? null : _body,
+            IsDraft: _isDraft,
+            Reviewers: users,
+            TeamReviewers: teams);
+
+        await OnCreate.InvokeAsync(result);
+    }
+
+    private sealed record ReviewerItem(string Name, bool IsTeam);
+}

--- a/src/GrayMoon.App/Components/Modals/NewPullRequestModal.razor
+++ b/src/GrayMoon.App/Components/Modals/NewPullRequestModal.razor
@@ -310,8 +310,11 @@
         var q = _reviewerFilter?.Trim();
         if (string.IsNullOrWhiteSpace(q))
             return _allReviewers;
+        var words = q.Split(new[] { ' ', ',', ';' }, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        if (words.Length == 0)
+            return _allReviewers;
         return _allReviewers
-            .Where(r => r.Name.Contains(q, StringComparison.OrdinalIgnoreCase))
+            .Where(r => words.Any(w => r.Name.Contains(w, StringComparison.OrdinalIgnoreCase)))
             .ToList();
     }
 

--- a/src/GrayMoon.App/Components/Modals/NewPullRequestModal.razor.css
+++ b/src/GrayMoon.App/Components/Modals/NewPullRequestModal.razor.css
@@ -3,21 +3,85 @@
     border-color: #6c757d;
 }
 
+.new-pr-reviewers-label-row {
+    margin-bottom: 0.5rem;
+}
+
 .new-pr-reviewers-count {
     font-size: 0.8125rem;
-    color: var(--text-muted, #6c757d);
+    color: var(--text-muted);
+}
+
+.new-pr-reviewer-box {
+    border: 1px solid var(--border-input, var(--border-color));
+    border-radius: 0.375rem;
+    overflow: hidden;
+    background-color: var(--bg-input);
+    color: var(--text-primary);
+}
+
+.new-pr-reviewer-search {
+    width: 100%;
+    border: none;
+    outline: none;
+    background-color: var(--bg-input);
+    color: var(--text-primary);
+    padding: 0.375rem 0.75rem;
+    font-size: 1rem;
+    line-height: 1.5;
+    border-bottom: 1px solid var(--border-input, var(--border-color));
+}
+
+.new-pr-reviewer-search::placeholder {
+    color: var(--text-muted);
+}
+
+.new-pr-reviewer-search:focus {
+    outline: none;
+    box-shadow: none;
+}
+
+.new-pr-reviewer-search:disabled {
+    background-color: var(--bg-input);
+    opacity: 0.7;
+    cursor: not-allowed;
 }
 
 .new-pr-reviewer-list {
-    max-height: calc(3 * 2.25rem);
+    max-height: calc(3 * 2.2rem);
     overflow-y: auto;
+    background-color: var(--bg-input);
+    color: var(--text-primary);
+    scrollbar-color: var(--text-muted) transparent;
+    scrollbar-width: thin;
+}
+
+.new-pr-reviewer-list::-webkit-scrollbar {
+    width: 10px;
+}
+
+.new-pr-reviewer-list::-webkit-scrollbar-track {
+    background: transparent;
+}
+
+.new-pr-reviewer-list::-webkit-scrollbar-thumb {
+    background-color: var(--text-muted);
+    border-radius: 5px;
+    border: 2px solid transparent;
+    background-clip: padding-box;
+}
+
+.new-pr-reviewer-list::-webkit-scrollbar-thumb:hover {
+    background-color: #8a8a8a;
+    background-clip: padding-box;
 }
 
 .new-pr-reviewer-item {
     cursor: pointer;
     user-select: none;
-    border-bottom: 1px solid var(--border-color, rgba(0, 0, 0, 0.075));
+    border-bottom: 1px solid var(--border-color);
     margin: 0;
+    color: var(--text-primary);
 }
 
 .new-pr-reviewer-item:last-child {
@@ -25,5 +89,5 @@
 }
 
 .new-pr-reviewer-item:hover {
-    background-color: rgba(13, 110, 253, 0.06);
+    background-color: rgba(255, 255, 255, 0.04);
 }

--- a/src/GrayMoon.App/Components/Modals/NewPullRequestModal.razor.css
+++ b/src/GrayMoon.App/Components/Modals/NewPullRequestModal.razor.css
@@ -57,7 +57,7 @@
 }
 
 .new-pr-reviewer-list::-webkit-scrollbar {
-    width: 10px;
+    width: auto;
 }
 
 .new-pr-reviewer-list::-webkit-scrollbar-track {
@@ -67,13 +67,10 @@
 .new-pr-reviewer-list::-webkit-scrollbar-thumb {
     background-color: var(--text-muted);
     border-radius: 5px;
-    border: 2px solid transparent;
-    background-clip: padding-box;
 }
 
 .new-pr-reviewer-list::-webkit-scrollbar-thumb:hover {
     background-color: #8a8a8a;
-    background-clip: padding-box;
 }
 
 .new-pr-reviewer-item {

--- a/src/GrayMoon.App/Components/Modals/NewPullRequestModal.razor.css
+++ b/src/GrayMoon.App/Components/Modals/NewPullRequestModal.razor.css
@@ -1,0 +1,29 @@
+.form-check-input:not(:checked) {
+    background-color: #6c757d;
+    border-color: #6c757d;
+}
+
+.new-pr-reviewers-count {
+    font-size: 0.8125rem;
+    color: var(--text-muted, #6c757d);
+}
+
+.new-pr-reviewer-list {
+    max-height: calc(3 * 2.25rem);
+    overflow-y: auto;
+}
+
+.new-pr-reviewer-item {
+    cursor: pointer;
+    user-select: none;
+    border-bottom: 1px solid var(--border-color, rgba(0, 0, 0, 0.075));
+    margin: 0;
+}
+
+.new-pr-reviewer-item:last-child {
+    border-bottom: none;
+}
+
+.new-pr-reviewer-item:hover {
+    background-color: rgba(13, 110, 253, 0.06);
+}

--- a/src/GrayMoon.App/Components/Modals/NewPullRequestModels.cs
+++ b/src/GrayMoon.App/Components/Modals/NewPullRequestModels.cs
@@ -1,0 +1,18 @@
+namespace GrayMoon.App.Components.Modals;
+
+/// <summary>Per-repository input for the New Pull Request modal.</summary>
+public sealed record NewPrTargetRepo(
+    int RepositoryId,
+    string Owner,
+    string RepositoryName,
+    string HeadBranch,
+    string BaseBranch,
+    string? CloneUrl);
+
+/// <summary>Result emitted by the New Pull Request modal when the user clicks Create.</summary>
+public sealed record NewPrFormResult(
+    string Title,
+    string? Body,
+    bool IsDraft,
+    IReadOnlyList<string> Reviewers,
+    IReadOnlyList<string> TeamReviewers);

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor
@@ -23,6 +23,7 @@
 @inject WorkspaceDependencyService WorkspaceDependencyService
 @inject WorkspaceBranchHandler WorkspaceBranchHandler
 @inject AgentQueueStateService AgentQueueStateService
+@inject IPullRequestService PullRequestService
 @using WorkspaceModel = GrayMoon.App.Models.Workspace
 
 <PageTitle>Repositories - GrayMoon</PageTitle>
@@ -45,7 +46,9 @@
                                     AgentTasksPendingCount="@AgentTasksPendingCount"
                                     IsOverlayVisible="@(isLoading || isSyncing || isPushing || isUpdating || isCommitSyncing || isCheckingOut || isCreatingBranches || isCreatingBranch || isSyncingToDefault || isWorkspaceBranchesFetching || isWorkspaceBranchesCheckingOut || ShowRepositoriesFetchOverlay)"
                                     OnShowRepositories="ShowRepositoriesModalAsync"
-                                    OnShowBranch="ShowBranchModalAsync"
+                                    OnShowBranch="() => ShowBranchModalAsync()"
+                                    OnShowSwitchBranch='() => ShowBranchModalAsync("switchbranch")'
+                                    OnNewPullRequest="OpenPullRequestDialogForAllRepositoriesAsync"
                                     OnUpdate="OnUpdateClickAsync"
                                     OnPull="OnPullClickAsync"
                                     OnPush="OnPushClickAsync"
@@ -129,7 +132,7 @@
                                                                        ActionsDisabled="@group.All(wr => wr.IsOnTag)"
                                                                        OnSyncToDefault="() => ShowConfirmSyncToDefaultLevel(group.Select(wr => wr.RepositoryId).ToList())"
                                                                        OnSyncCommits="() => ShowConfirmSyncCommitsLevel(group.Select(wr => wr.RepositoryId).ToList())"
-                                                                       OnOpenPr="() => ShowConfirmOpenPr(group)"
+                                                                       OnOpenPr="() => OpenPullRequestDialogForRepositoriesAsync(group.ToList())"
                                                                        OnSyncLevel="() => ShowConfirmSyncLevel(group.Select(wr => wr.RepositoryId).ToList())"
                                                                        OpenPrUrls="@GetOpenPrUrlsForGroup(group)"
                                                                        OpenPrPullMap="@GetOpenPrPullMapForGroup(group)"
@@ -160,6 +163,7 @@
                                                                   OnPrBadgeMouseEnter="() => RefreshPrOnBadgeEnterAsync(wr.RepositoryId)"
                                                                   OnSyncClick="() => SyncSingleRepoAsync(wr.RepositoryId)"
                                                                   OnCopyDependencies="CopyDependenciesToClipboard"
+                                                                  OnCreatePr="OpenPullRequestDialogForRepositoryAsync"
                                                                   OnDismissError="() => DismissRepositoryError(wr.RepositoryId)" />
                                     }
                                 }
@@ -190,6 +194,7 @@
                    WorkspaceName="@(workspace?.Name)"
                    WorkspaceId="@WorkspaceId"
                    HasTaggedRepos="@hasTaggedRepos"
+                   InitialTab="@_branchModal.InitialTab"
                    CommonBranchNames="@_branchModal.CommonBranchNames"
                    CommonLocalBranchNames="@_branchModal.CommonLocalBranchNames"
                    CommonRemoteBranchNames="@_branchModal.CommonRemoteBranchNames"
@@ -243,7 +248,15 @@
                            OnProceed="@OnDefaultBranchWarningProceedAsync"
                            OnCancel="@CloseDefaultBranchWarningModal" />
 
+<NewPullRequestModal IsVisible="@_newPrModal.IsVisible"
+                     IsBusy="@isCreatingPullRequests"
+                     Targets="@_newPrModal.Targets"
+                     OnCreate="HandleCreatePullRequestsAsync"
+                     OnCancel="CloseNewPullRequestModal"
+                     OnOpenInGitHub="HandleNewPrOpenInGitHubAsync" />
+
 <LoadingOverlay IsVisible="@isLoading" Message="Loading workspace..." />
+<LoadingOverlay IsVisible="@isCreatingPullRequests" Message="@createPrProgressMessage" />
 <LoadingOverlay IsVisible="@isSyncing"
                 Message="@GetOverlayMessage(syncProgressMessage, isSyncing, _syncAwaitingAgentTasks)"
                 PendingAgentTasksCount="@AgentTasksPendingCount"

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
@@ -735,6 +735,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
         var ct = _createPrCts.Token;
 
         var total = requests.Count;
+        _newPrModal = _newPrModal with { IsVisible = false };
         isCreatingPullRequests = true;
         createPrProgressMessage = "Creating Pull Requests...";
         StateHasChanged();
@@ -766,7 +767,6 @@ public sealed partial class WorkspaceRepositories : IDisposable
         }
 
         isCreatingPullRequests = false;
-        _newPrModal = _newPrModal with { IsVisible = false };
 
         var successCount = results.Count(r => r.Success);
         var failedCount = results.Count - successCount;

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
@@ -737,12 +737,18 @@ public sealed partial class WorkspaceRepositories : IDisposable
         var total = requests.Count;
         _newPrModal = _newPrModal with { IsVisible = false };
         isCreatingPullRequests = true;
-        createPrProgressMessage = "Creating Pull Requests...";
+        createPrProgressMessage = total == 1
+            ? "Creating 1 pull request..."
+            : $"Creating {total} pull requests...";
         StateHasChanged();
 
         var progress = new Progress<CreatePullRequestProgress>(p =>
         {
-            createPrProgressMessage = $"Created {p.Created} of {p.Total} pull requests";
+            createPrProgressMessage = p.Created == 0
+                ? (p.Total == 1
+                    ? "Creating 1 pull request..."
+                    : $"Creating {p.Total} pull requests...")
+                : $"Created {p.Created} of {p.Total} pull requests";
             _ = InvokeAsync(StateHasChanged);
         });
 

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using GrayMoon.Abstractions.Exceptions;
+using GrayMoon.App.Components.Modals;
 using GrayMoon.App.Models;
 using GrayMoon.App.Repositories;
 using GrayMoon.App.Services;
@@ -594,42 +595,235 @@ public sealed partial class WorkspaceRepositories : IDisposable
     }
 
 
-    private void ShowConfirmOpenPr(IEnumerable<WorkspaceRepositoryLink> group)
+    // --- New Pull Request dialog -----------------------------------------------------------
+
+    private NewPullRequestModalState _newPrModal = new();
+    private bool isCreatingPullRequests;
+    private string createPrProgressMessage = "Creating Pull Requests...";
+    private CancellationTokenSource? _createPrCts;
+
+    private Task OpenPullRequestDialogForAllRepositoriesAsync()
+        => OpenPullRequestDialogCoreAsync(workspaceRepositories);
+
+    private Task OpenPullRequestDialogForRepositoryAsync(WorkspaceRepositoryLink link)
+        => OpenPullRequestDialogCoreAsync(new[] { link });
+
+    private Task OpenPullRequestDialogForRepositoriesAsync(IReadOnlyList<WorkspaceRepositoryLink> links)
+        => OpenPullRequestDialogCoreAsync(links);
+
+    private Task OpenPullRequestDialogCoreAsync(IEnumerable<WorkspaceRepositoryLink> links)
     {
-        const int confirmThreshold = 10;
-        var toOpen = new List<string>();
-        foreach (var wr in group)
+        var targets = new List<NewPrTargetRepo>();
+        foreach (var wr in links)
         {
-            if (wr.Repository == null || string.IsNullOrWhiteSpace(wr.BranchName)) continue;
-            var repoUrl = RepositoryUrlHelper.GetRepositoryUrl(wr.Repository.CloneUrl);
-            if (string.IsNullOrEmpty(repoUrl)) continue;
+            var repo = wr.Repository;
+            if (repo == null) continue;
+            if (wr.IsOnTag) continue;
+            if (string.IsNullOrWhiteSpace(wr.BranchName)) continue;
+            if (string.IsNullOrWhiteSpace(wr.DefaultBranchName)) continue;
+            if (string.Equals(wr.BranchName, wr.DefaultBranchName, StringComparison.Ordinal)) continue;
+            if ((wr.DefaultBranchAheadCommits ?? 0) <= 0) continue;
+            if (!RepositoryUrlHelper.TryParseGitHubOwnerRepo(repo.CloneUrl, out var owner, out var repoName) || owner == null || repoName == null)
+                continue;
 
             var hasOpenPr = wr.PullRequest != null && string.Equals(wr.PullRequest.State, "open", StringComparison.OrdinalIgnoreCase);
-            if (hasOpenPr && !string.IsNullOrEmpty(wr.PullRequest!.HtmlUrl))
-            {
-                toOpen.Add(wr.PullRequest.HtmlUrl);
-            }
-            else if ((wr.DefaultBranchAheadCommits ?? 0) > 0)
-            {
-                if (!string.IsNullOrWhiteSpace(wr.DefaultBranchName))
-                {
-                    toOpen.Add($"{repoUrl}/compare/{wr.DefaultBranchName}...{Uri.EscapeDataString(wr.BranchName)}");
-                }
-            }
+            if (hasOpenPr) continue;
+
+            targets.Add(new NewPrTargetRepo(
+                RepositoryId: wr.RepositoryId,
+                Owner: owner,
+                RepositoryName: repoName,
+                HeadBranch: wr.BranchName!,
+                BaseBranch: wr.DefaultBranchName!,
+                CloneUrl: repo.CloneUrl));
         }
-        if (toOpen.Count == 0)
+
+        if (targets.Count == 0)
         {
-            ToastService.Show("No repositories found that have an open pull request or ahead commits to open in GitHub.");
+            ToastService.Show("No eligible repositories to create a pull request from.");
+            return Task.CompletedTask;
+        }
+
+        _newPrModal = new NewPullRequestModalState
+        {
+            IsVisible = true,
+            Targets = targets
+        };
+        StateHasChanged();
+        return Task.CompletedTask;
+    }
+
+    private void CloseNewPullRequestModal()
+    {
+        _newPrModal = _newPrModal with { IsVisible = false };
+        _createPrCts?.Cancel();
+        StateHasChanged();
+    }
+
+    private async Task HandleNewPrOpenInGitHubAsync()
+    {
+        var targets = _newPrModal.Targets;
+        if (targets.Count == 0) return;
+
+        var urls = new List<string>();
+        foreach (var t in targets)
+        {
+            var repoUrl = RepositoryUrlHelper.GetRepositoryUrl(t.CloneUrl);
+            if (string.IsNullOrEmpty(repoUrl)) continue;
+            urls.Add($"{repoUrl}/compare/{t.BaseBranch}...{Uri.EscapeDataString(t.HeadBranch)}");
+        }
+        if (urls.Count == 0)
+        {
+            ToastService.Show("No GitHub URLs are available for the selected repositories.");
             return;
         }
-        async Task OpenPrAsync()
+
+        async Task OpenAsync()
         {
-            await JSRuntime.InvokeVoidAsync("graymoonOpenUrls", toOpen);
+            await JSRuntime.InvokeVoidAsync("graymoonOpenUrls", urls);
         }
-        if (toOpen.Count < confirmThreshold)
-            _ = OpenPrAsync();
+
+        if (urls.Count > 5)
+        {
+            ShowConfirm($"Do you want to open {urls.Count} repositories in separate tabs?", OpenAsync);
+        }
         else
-            ShowConfirm($"Do you want to open pull request for {toOpen.Count} repositories?", OpenPrAsync);
+        {
+            await OpenAsync();
+        }
+    }
+
+    private Task HandleCreatePullRequestsAsync(NewPrFormResult form)
+    {
+        var targets = _newPrModal.Targets;
+        if (targets.Count == 0) return Task.CompletedTask;
+        if (string.IsNullOrWhiteSpace(form.Title))
+        {
+            ToastService.ShowError("Title is required.");
+            return Task.CompletedTask;
+        }
+
+        var requests = targets.Select(t => new CreatePullRequestRequest
+        {
+            RepositoryId = t.RepositoryId,
+            Owner = t.Owner,
+            RepositoryName = t.RepositoryName,
+            HeadBranch = t.HeadBranch,
+            BaseBranch = t.BaseBranch,
+            Title = form.Title,
+            Body = form.Body,
+            IsDraft = form.IsDraft,
+            Reviewers = form.Reviewers,
+            TeamReviewers = form.TeamReviewers
+        }).ToList();
+
+        var draftSuffix = form.IsDraft ? " as draft" : string.Empty;
+        var message = requests.Count == 1
+            ? $"Create pull request for {requests[0].RepositoryName}{draftSuffix}?"
+            : $"Create {requests.Count} pull requests{draftSuffix}?";
+
+        ShowConfirm(message, () => ExecuteCreatePullRequestsAsync(requests), "Create");
+        return Task.CompletedTask;
+    }
+
+    private async Task ExecuteCreatePullRequestsAsync(IReadOnlyList<CreatePullRequestRequest> requests)
+    {
+        if (requests.Count == 0) return;
+
+        _createPrCts?.Cancel();
+        _createPrCts = new CancellationTokenSource();
+        var ct = _createPrCts.Token;
+
+        var total = requests.Count;
+        isCreatingPullRequests = true;
+        createPrProgressMessage = "Creating Pull Requests...";
+        StateHasChanged();
+
+        var progress = new Progress<CreatePullRequestProgress>(p =>
+        {
+            createPrProgressMessage = $"Created {p.Created} of {p.Total} pull requests";
+            _ = InvokeAsync(StateHasChanged);
+        });
+
+        IReadOnlyList<CreatePullRequestResult> results;
+        try
+        {
+            results = await PullRequestService.CreatePullRequestsAsync(requests, progress, ct);
+        }
+        catch (OperationCanceledException)
+        {
+            isCreatingPullRequests = false;
+            StateHasChanged();
+            return;
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Create pull requests failed");
+            ToastService.ShowError($"Failed to create pull requests: {ex.Message}");
+            isCreatingPullRequests = false;
+            StateHasChanged();
+            return;
+        }
+
+        isCreatingPullRequests = false;
+        _newPrModal = _newPrModal with { IsVisible = false };
+
+        var successCount = results.Count(r => r.Success);
+        var failedCount = results.Count - successCount;
+
+        if (successCount > 0 && failedCount == 0)
+        {
+            ToastService.Show($"Created {successCount} of {total} pull requests.");
+        }
+        else if (successCount > 0)
+        {
+            ToastService.Show($"Created {successCount} of {total} pull requests.");
+            var firstFailure = results.First(r => !r.Success);
+            ToastService.ShowError($"{firstFailure.RepositoryName}: {firstFailure.ErrorMessage}");
+        }
+        else
+        {
+            var firstFailure = results.FirstOrDefault(r => !r.Success);
+            var msg = firstFailure?.ErrorMessage ?? "Pull request creation failed.";
+            ToastService.ShowError($"No pull requests were created. {msg}");
+        }
+
+        var firstSuccess = results.FirstOrDefault(r => r.Success);
+        if (successCount == 1 && firstSuccess?.PullRequestUrl is { Length: > 0 } url)
+        {
+            try
+            {
+                await JSRuntime.InvokeVoidAsync("graymoonOpenUrls", new[] { url });
+            }
+            catch (Exception ex)
+            {
+                Logger.LogDebug(ex, "Failed to open created PR URL");
+            }
+        }
+
+        var refreshedIds = results.Where(r => r.Success).Select(r => r.RepositoryId).ToList();
+        if (refreshedIds.Count > 0)
+        {
+            try
+            {
+                await using var scope = ServiceScopeFactory.CreateAsyncScope();
+                var workspacePrService = scope.ServiceProvider.GetRequiredService<WorkspacePullRequestService>();
+                await workspacePrService.RefreshPullRequestsAsync(WorkspaceId, refreshedIds, CancellationToken.None);
+                prByRepositoryId = await workspacePrService.GetPersistedPullRequestsForWorkspaceAsync(WorkspaceId, CancellationToken.None);
+            }
+            catch (Exception ex)
+            {
+                Logger.LogDebug(ex, "Failed to refresh pull requests after creation");
+            }
+        }
+
+        StateHasChanged();
+    }
+
+    private sealed record NewPullRequestModalState
+    {
+        public bool IsVisible { get; init; }
+        public IReadOnlyList<NewPrTargetRepo> Targets { get; init; } = Array.Empty<NewPrTargetRepo>();
     }
 
     private void ShowConfirmSyncCommitsLevel(List<int> repositoryIds)
@@ -1850,7 +2044,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
         return first;
     }
 
-    private async Task ShowBranchModalAsync()
+    private async Task ShowBranchModalAsync(string initialTab = "newbranch")
     {
         if (workspace == null || workspaceRepositories.Count == 0)
             return;
@@ -1865,7 +2059,8 @@ public sealed partial class WorkspaceRepositories : IDisposable
         _branchModal = _branchModal with
         {
             IsVisible = true,
-            WorkspaceUnifiedCurrentBranch = GetUnifiedWorkspaceCurrentBranch(workspaceRepositories)
+            WorkspaceUnifiedCurrentBranch = GetUnifiedWorkspaceCurrentBranch(workspaceRepositories),
+            InitialTab = string.Equals(initialTab, "switchbranch", StringComparison.OrdinalIgnoreCase) ? "switchbranch" : "newbranch"
         };
         StateHasChanged();
     }
@@ -2583,6 +2778,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
         public string DefaultDisplayText { get; init; } = "multiple";
         /// <summary>Local branch name when every linked repo reports the same current branch; otherwise null.</summary>
         public string? WorkspaceUnifiedCurrentBranch { get; init; }
+        public string InitialTab { get; init; } = "newbranch";
     }
 
     private sealed record SwitchBranchModalState

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositoriesRow.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositoriesRow.razor
@@ -83,7 +83,7 @@
                             DefaultBranchAheadCommits="@Link.DefaultBranchAheadCommits"
                             IsPrVerified="@IsPrVerified"
                             IsOnTag="@Link.IsOnTag"
-                            CreatePrUrl="@(string.IsNullOrEmpty(repoUrl) || string.IsNullOrEmpty(Link.DefaultBranchName) ? null : $"{repoUrl}/compare/{Link.DefaultBranchName}...{Uri.EscapeDataString(Link.BranchName ?? "")}")" />
+                            OnCreateClick="@(() => OnCreatePr.InvokeAsync(Link))" />
                 </span>
                 <span class="metrics-block metrics-deps">
                     @if (depCount == 0)
@@ -234,6 +234,7 @@
     [Parameter] public EventCallback OnSyncClick { get; set; }
     [Parameter] public EventCallback OnDismissError { get; set; }
     [Parameter] public EventCallback OnPrBadgeMouseEnter { get; set; }
+    [Parameter] public EventCallback<WorkspaceRepositoryLink> OnCreatePr { get; set; }
     /// <summary>Fired when the user clicks the Copy button on the dependency-mismatch tooltip. Payload is the formatted text to copy to the clipboard.</summary>
     [Parameter] public EventCallback<string> OnCopyDependencies { get; set; }
 

--- a/src/GrayMoon.App/Components/Shared/PRBadge.razor
+++ b/src/GrayMoon.App/Components/Shared/PRBadge.razor
@@ -64,14 +64,14 @@ else if (PullRequest != null && string.Equals(PullRequest.State, "open", StringC
 }
 else if (IsPrVerified && (PullRequest == null || !string.Equals(PullRequest.State, "open", StringComparison.OrdinalIgnoreCase)) && (DefaultBranchAheadCommits ?? 0) > 0)
 {
-    @if (CreatePrUrl != null)
-    {
-        <a href="@CreatePrUrl" target="_blank" rel="noopener noreferrer" class="badge pr-badge pr-badge-create" title="Create pull request">create</a>
-    }
-    else
-    {
-        <span class="badge pr-badge pr-badge-create" title="Create pull request">create</span>
-    }
+    <span class="badge pr-badge pr-badge-create"
+          role="button"
+          tabindex="0"
+          title="Create pull request"
+          style="cursor: pointer;"
+          @onclick="HandleCreateClick"
+          @onclick:preventDefault
+          @onclick:stopPropagation>create</span>
 }
 else
 {
@@ -81,11 +81,20 @@ else
 @code {
     [Parameter] public PullRequestInfo? PullRequest { get; set; }
     [Parameter] public int? DefaultBranchAheadCommits { get; set; }
+    /// <summary>Deprecated. The create badge now invokes <see cref="OnCreateClick"/> instead of navigating to a URL.</summary>
     [Parameter] public string? CreatePrUrl { get; set; }
+    /// <summary>Raised when the user clicks the yellow "create" badge.</summary>
+    [Parameter] public EventCallback OnCreateClick { get; set; }
     /// <summary>When false, never show "create"; show "none" until PR state has been verified via API.</summary>
     [Parameter] public bool IsPrVerified { get; set; }
     /// <summary>True when the repository is checked out at a tag (detached HEAD); PRs require a branch, so render blank.</summary>
     [Parameter] public bool IsOnTag { get; set; }
+
+    private async Task HandleCreateClick()
+    {
+        if (OnCreateClick.HasDelegate)
+            await OnCreateClick.InvokeAsync();
+    }
 
     private static string GetOpenPrMergeabilityClass(PullRequestInfo pr)
     {

--- a/src/GrayMoon.App/Components/Shared/WorkspaceRepositoriesHeader.razor
+++ b/src/GrayMoon.App/Components/Shared/WorkspaceRepositoriesHeader.razor
@@ -56,14 +56,58 @@
                 }
             </div>
         </div>
-        <button class="btn btn-outline-secondary"
-                @onclick="@(() => OnShowBranch.InvokeAsync())"
-                disabled="@(IsSyncing || IsUpdating || IsPushing || RepositoriesCount == 0 || AgentTasksPendingCount > 0)">
-            Branch
-        </button>
+        <div class="btn-group position-relative">
+            <button class="btn btn-outline-secondary"
+                    @onclick="HandleBranchPrimaryClick"
+                    @onclick:stopPropagation
+                    disabled="@BranchActionsDisabled">
+                Branch
+            </button>
+            <button type="button"
+                    class="btn btn-outline-secondary dropdown-toggle dropdown-toggle-split"
+                    aria-label="Toggle Branch menu"
+                    aria-expanded="@(_branchMenuOpen ? "true" : "false")"
+                    @onclick="ToggleBranchMenu"
+                    @onclick:stopPropagation
+                    disabled="@BranchMenuToggleDisabled">
+                <span class="visually-hidden">Toggle Dropdown</span>
+            </button>
+            @if (_branchMenuOpen)
+            {
+                <div class="branch-menu-backdrop" @onclick="CloseBranchMenu"></div>
+                <ul class="dropdown-menu show shadow branch-menu-list"
+                    role="menu">
+                    <li>
+                        <button class="dropdown-item" type="button"
+                                role="menuitem"
+                                @onclick="HandleNewBranchClick"
+                                disabled="@BranchActionsDisabled">
+                            New Branch
+                        </button>
+                    </li>
+                    <li>
+                        <button class="dropdown-item" type="button"
+                                role="menuitem"
+                                @onclick="HandleSwitchBranchClick"
+                                disabled="@BranchActionsDisabled">
+                            Switch Branch
+                        </button>
+                    </li>
+                    <li><hr class="dropdown-divider branch-menu-divider" /></li>
+                    <li>
+                        <button class="dropdown-item" type="button"
+                                role="menuitem"
+                                @onclick="HandleNewPullRequestClick"
+                                disabled="@BranchActionsDisabled">
+                            New Pull Requests
+                        </button>
+                    </li>
+                </ul>
+            }
+        </div>
         <button class="btn @(HasUnmatchedDependencies ? "btn-danger" : "btn-outline-secondary")"
                 @onclick="@(() => OnUpdate.InvokeAsync())"
-                disabled="@(WorkspaceName == null || RepositoriesCount == 0 || IsSyncing || IsUpdating || IsPushing || AgentTasksPendingCount > 0)">
+                disabled="@UpdateDisabled">
             Update
         </button>
         @if (HasIncomingCommits)
@@ -109,6 +153,8 @@
 
     [Parameter] public EventCallback OnShowRepositories { get; set; }
     [Parameter] public EventCallback OnShowBranch { get; set; }
+    [Parameter] public EventCallback OnShowSwitchBranch { get; set; }
+    [Parameter] public EventCallback OnNewPullRequest { get; set; }
     [Parameter] public EventCallback OnUpdate { get; set; }
     [Parameter] public EventCallback OnPull { get; set; }
     [Parameter] public EventCallback OnPush { get; set; }
@@ -116,4 +162,49 @@
     [Parameter] public EventCallback<ChangeEventArgs> OnSearchChanged { get; set; }
     [Parameter] public EventCallback OnClearSearch { get; set; }
     [Parameter] public EventCallback<KeyboardEventArgs> OnSearchKeyDown { get; set; }
+
+    private bool _branchMenuOpen;
+
+    private bool UpdateDisabled =>
+        WorkspaceName == null || RepositoriesCount == 0 || IsSyncing || IsUpdating || IsPushing || AgentTasksPendingCount > 0;
+
+    private bool BranchActionsDisabled =>
+        IsSyncing || IsUpdating || IsPushing || RepositoriesCount == 0 || AgentTasksPendingCount > 0;
+
+    private bool BranchMenuToggleDisabled =>
+        IsSyncing || IsUpdating || IsPushing || AgentTasksPendingCount > 0;
+
+    private void ToggleBranchMenu()
+    {
+        _branchMenuOpen = !_branchMenuOpen;
+    }
+
+    private void CloseBranchMenu()
+    {
+        _branchMenuOpen = false;
+    }
+
+    private async Task HandleBranchPrimaryClick()
+    {
+        CloseBranchMenu();
+        await OnShowBranch.InvokeAsync();
+    }
+
+    private async Task HandleNewBranchClick()
+    {
+        CloseBranchMenu();
+        await OnShowBranch.InvokeAsync();
+    }
+
+    private async Task HandleSwitchBranchClick()
+    {
+        CloseBranchMenu();
+        await OnShowSwitchBranch.InvokeAsync();
+    }
+
+    private async Task HandleNewPullRequestClick()
+    {
+        CloseBranchMenu();
+        await OnNewPullRequest.InvokeAsync();
+    }
 }

--- a/src/GrayMoon.App/Components/Shared/WorkspaceRepositoriesHeader.razor.css
+++ b/src/GrayMoon.App/Components/Shared/WorkspaceRepositoriesHeader.razor.css
@@ -1,0 +1,33 @@
+.branch-menu-list {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: auto;
+    margin-top: 0.125rem;
+    z-index: 1051;
+    min-width: 100%;
+}
+
+.branch-menu-backdrop {
+    position: fixed;
+    inset: 0;
+    background: transparent;
+    z-index: 1050;
+}
+
+.branch-menu-divider {
+    border-top-color: var(--border-color, #6c757d);
+    opacity: 0.9;
+    margin: 0.25rem 0;
+}
+
+.dropdown-toggle-split {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.dropdown-toggle-split::after {
+    vertical-align: middle;
+    margin-left: 0;
+}

--- a/src/GrayMoon.App/Models/GitHubDtos.cs
+++ b/src/GrayMoon.App/Models/GitHubDtos.cs
@@ -181,6 +181,9 @@ public class GitHubPullRequestDto
     [JsonPropertyName("title")]
     public string? Title { get; set; }
 
+    [JsonPropertyName("body")]
+    public string? Body { get; set; }
+
     [JsonPropertyName("head")]
     public GitHubPullRequestHeadDto? Head { get; set; }
 
@@ -198,4 +201,54 @@ public class GitHubPullRequestHeadDto
 {
     [JsonPropertyName("ref")]
     public string Ref { get; set; } = string.Empty;
+}
+
+/// <summary>Body for POST /repos/{owner}/{repo}/pulls.</summary>
+public sealed class GitHubCreatePullRequestRequestDto
+{
+    [JsonPropertyName("title")]
+    public string Title { get; set; } = string.Empty;
+
+    [JsonPropertyName("head")]
+    public string Head { get; set; } = string.Empty;
+
+    [JsonPropertyName("base")]
+    public string Base { get; set; } = string.Empty;
+
+    [JsonPropertyName("body")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Body { get; set; }
+
+    [JsonPropertyName("draft")]
+    public bool Draft { get; set; }
+}
+
+/// <summary>Body for POST /repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers.</summary>
+public sealed class GitHubRequestReviewersRequestDto
+{
+    [JsonPropertyName("reviewers")]
+    public List<string> Reviewers { get; set; } = new();
+
+    [JsonPropertyName("team_reviewers")]
+    public List<string> TeamReviewers { get; set; } = new();
+}
+
+/// <summary>Item from GET /repos/{owner}/{repo}/collaborators.</summary>
+public sealed class GitHubCollaboratorDto
+{
+    [JsonPropertyName("login")]
+    public string Login { get; set; } = string.Empty;
+
+    [JsonPropertyName("type")]
+    public string Type { get; set; } = string.Empty;
+}
+
+/// <summary>Item from GET /repos/{owner}/{repo}/teams.</summary>
+public sealed class GitHubTeamDto
+{
+    [JsonPropertyName("slug")]
+    public string Slug { get; set; } = string.Empty;
+
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = string.Empty;
 }

--- a/src/GrayMoon.App/Program.cs
+++ b/src/GrayMoon.App/Program.cs
@@ -103,6 +103,7 @@ try
     builder.Services.AddHttpClient<GitHubService>();
     builder.Services.AddHttpClient<NuGetService>();
     builder.Services.AddScoped<ConnectorServiceFactory>();
+    builder.Services.AddScoped<IPullRequestService, PullRequestService>();
 
     // Persist Data Protection keys to db volume so antiforgery and other protected data survive container restarts
     var keyRingDir = Path.Combine(Path.GetDirectoryName(GetDatabasePath(connectionString) ?? "db") ?? "db", "DataProtection-Keys");

--- a/src/GrayMoon.App/Services/GitHubService.cs
+++ b/src/GrayMoon.App/Services/GitHubService.cs
@@ -457,6 +457,144 @@ public class GitHubService : IConnectorService
         }
     }
 
+    /// <summary>Creates a pull request via POST /repos/{owner}/{repo}/pulls. Throws on non-success.</summary>
+    public async Task<GitHubPullRequestDto> CreatePullRequestAsync(
+        Connector connector,
+        string owner,
+        string repo,
+        GitHubCreatePullRequestRequestDto body,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(owner))
+            throw new ArgumentException("Owner is required.", nameof(owner));
+        if (string.IsNullOrWhiteSpace(repo))
+            throw new ArgumentException("Repository is required.", nameof(repo));
+        ArgumentNullException.ThrowIfNull(body);
+
+        EnsureConnectorConfigured(connector);
+
+        var requestUri = $"repos/{owner}/{repo}/pulls";
+        var payload = JsonSerializer.Serialize(body);
+
+        var dto = await PostAsync<GitHubPullRequestDto>(connector, requestUri, payload, cancellationToken);
+        if (dto == null)
+            throw new InvalidOperationException("GitHub returned an empty response when creating a pull request.");
+        return dto;
+    }
+
+    /// <summary>Requests reviewers via POST /repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers. Throws on non-success.</summary>
+    public async Task RequestReviewersAsync(
+        Connector connector,
+        string owner,
+        string repo,
+        int pullNumber,
+        IReadOnlyList<string> reviewers,
+        IReadOnlyList<string> teamReviewers,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(owner))
+            throw new ArgumentException("Owner is required.", nameof(owner));
+        if (string.IsNullOrWhiteSpace(repo))
+            throw new ArgumentException("Repository is required.", nameof(repo));
+        if (pullNumber <= 0)
+            throw new ArgumentOutOfRangeException(nameof(pullNumber));
+
+        EnsureConnectorConfigured(connector);
+
+        var body = new GitHubRequestReviewersRequestDto
+        {
+            Reviewers = reviewers?.Where(static r => !string.IsNullOrWhiteSpace(r)).ToList() ?? new List<string>(),
+            TeamReviewers = teamReviewers?.Where(static r => !string.IsNullOrWhiteSpace(r)).ToList() ?? new List<string>()
+        };
+        if (body.Reviewers.Count == 0 && body.TeamReviewers.Count == 0)
+            return;
+
+        var requestUri = $"repos/{owner}/{repo}/pulls/{pullNumber}/requested_reviewers";
+        var payload = JsonSerializer.Serialize(body);
+        await PostAsync(connector, requestUri, payload, cancellationToken);
+    }
+
+    /// <summary>Lists teams via GET /repos/{owner}/{repo}/teams. Returns empty list on 403/404.</summary>
+    public async Task<List<GitHubTeamDto>> GetTeamsAsync(
+        Connector connector,
+        string owner,
+        string repo,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(owner))
+            throw new ArgumentException("Owner is required.", nameof(owner));
+        if (string.IsNullOrWhiteSpace(repo))
+            throw new ArgumentException("Repository is required.", nameof(repo));
+
+        EnsureConnectorConfigured(connector);
+
+        var requestUri = $"repos/{owner}/{repo}/teams?per_page=100";
+
+        try
+        {
+            return await GetAsync<List<GitHubTeamDto>>(connector, requestUri, cancellationToken)
+                ?? new List<GitHubTeamDto>();
+        }
+        catch (GitHubHttpRequestException ex) when (ex.StatusCode is HttpStatusCode.Forbidden or HttpStatusCode.NotFound)
+        {
+            _logger.LogDebug(ex, "GitHub API list teams failed (treated as empty). Owner={Owner}, Repo={Repo}", owner, repo);
+            return new List<GitHubTeamDto>();
+        }
+    }
+
+    /// <summary>Lists collaborators via GET /repos/{owner}/{repo}/collaborators. Returns empty list on 403/404.</summary>
+    public async Task<List<GitHubCollaboratorDto>> GetCollaboratorsAsync(
+        Connector connector,
+        string owner,
+        string repo,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(owner))
+            throw new ArgumentException("Owner is required.", nameof(owner));
+        if (string.IsNullOrWhiteSpace(repo))
+            throw new ArgumentException("Repository is required.", nameof(repo));
+
+        EnsureConnectorConfigured(connector);
+
+        var requestUri = $"repos/{owner}/{repo}/collaborators?affiliation=all&per_page=100";
+
+        try
+        {
+            return await GetAsync<List<GitHubCollaboratorDto>>(connector, requestUri, cancellationToken)
+                ?? new List<GitHubCollaboratorDto>();
+        }
+        catch (GitHubHttpRequestException ex) when (ex.StatusCode is HttpStatusCode.Forbidden or HttpStatusCode.NotFound)
+        {
+            _logger.LogDebug(ex, "GitHub API list collaborators failed (treated as empty). Owner={Owner}, Repo={Repo}", owner, repo);
+            return new List<GitHubCollaboratorDto>();
+        }
+    }
+
+    private async Task<T?> PostAsync<T>(Connector connector, string requestUri, string? payload, CancellationToken cancellationToken = default)
+    {
+        var baseUrl = string.IsNullOrWhiteSpace(connector.ApiBaseUrl)
+            ? "https://api.github.com/"
+            : connector.ApiBaseUrl.TrimEnd('/') + "/";
+
+        using var response = await GitHubMutationRetryPipeline.ExecuteAsync(async ct =>
+        {
+            using var request = CreatePostRequest(connector, requestUri, payload);
+            return await _httpClient.SendAsync(request, ct);
+        }, cancellationToken);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            var errorContent = await response.Content.ReadAsStringAsync(cancellationToken);
+            _logger.LogError("GitHub API POST failed. Status: {StatusCode}, URL: {Url}, Response: {Response}",
+                response.StatusCode,
+                new Uri(new Uri(baseUrl), requestUri),
+                errorContent);
+            throw GitHubApiErrorHelper.CreateHttpRequestException(response.StatusCode, errorContent, response);
+        }
+
+        return await response.Content.ReadFromJsonAsync<T>(_jsonOptions, cancellationToken);
+    }
+
     private void EnsureConfigured()
     {
         if (string.IsNullOrWhiteSpace(_options.PersonalAccessToken))

--- a/src/GrayMoon.App/Services/PullRequestService.cs
+++ b/src/GrayMoon.App/Services/PullRequestService.cs
@@ -1,0 +1,267 @@
+using GrayMoon.App.Data;
+using GrayMoon.App.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace GrayMoon.App.Services;
+
+/// <summary>Creates GitHub pull requests for one or many workspace repositories.</summary>
+public interface IPullRequestService
+{
+    Task<CreatePullRequestResult> CreatePullRequestAsync(
+        CreatePullRequestRequest request,
+        CancellationToken cancellationToken);
+
+    Task<IReadOnlyList<CreatePullRequestResult>> CreatePullRequestsAsync(
+        IReadOnlyList<CreatePullRequestRequest> requests,
+        IProgress<CreatePullRequestProgress>? progress,
+        CancellationToken cancellationToken);
+
+    Task<IReadOnlyList<string>> GetCollaboratorLoginsAsync(int repositoryId, CancellationToken cancellationToken);
+
+    Task<IReadOnlyList<string>> GetTeamSlugsAsync(int repositoryId, CancellationToken cancellationToken);
+}
+
+public sealed class PullRequestService(
+    AppDbContext dbContext,
+    GitHubService gitHubService,
+    ILogger<PullRequestService> logger) : IPullRequestService
+{
+    public async Task<CreatePullRequestResult> CreatePullRequestAsync(
+        CreatePullRequestRequest request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        if (string.IsNullOrWhiteSpace(request.Title))
+            return Fail(request, "Title is required.");
+        if (string.IsNullOrWhiteSpace(request.Owner))
+            return Fail(request, "Repository owner is required.");
+        if (string.IsNullOrWhiteSpace(request.RepositoryName))
+            return Fail(request, "Repository name is required.");
+        if (string.IsNullOrWhiteSpace(request.HeadBranch))
+            return Fail(request, "Head branch is required.");
+        if (string.IsNullOrWhiteSpace(request.BaseBranch))
+            return Fail(request, "Base branch is required.");
+
+        var repo = await dbContext.Repositories
+            .AsNoTracking()
+            .Include(r => r.Connector)
+            .FirstOrDefaultAsync(r => r.RepositoryId == request.RepositoryId, cancellationToken);
+
+        if (repo?.Connector is not { } connector)
+            return Fail(request, "GitHub connector not configured for this repository.");
+
+        if (connector.ConnectorType != ConnectorType.GitHub)
+            return Fail(request, "Repository connector is not a GitHub connector.");
+
+        var body = new GitHubCreatePullRequestRequestDto
+        {
+            Title = request.Title.Trim(),
+            Head = request.HeadBranch,
+            Base = request.BaseBranch,
+            Body = string.IsNullOrWhiteSpace(request.Body) ? null : request.Body,
+            Draft = request.IsDraft
+        };
+
+        GitHubPullRequestDto created;
+        try
+        {
+            created = await gitHubService.CreatePullRequestAsync(connector, request.Owner, request.RepositoryName, body, cancellationToken);
+        }
+        catch (HttpRequestException ex)
+        {
+            var friendly = GitHubApiErrorHelper.FormatFriendlyGitHubHttpError(ex);
+            logger.LogWarning(ex, "Create PR failed for {Owner}/{Repo} {Head}->{Base}", request.Owner, request.RepositoryName, request.HeadBranch, request.BaseBranch);
+            return Fail(request, friendly);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Create PR errored for {Owner}/{Repo} {Head}->{Base}", request.Owner, request.RepositoryName, request.HeadBranch, request.BaseBranch);
+            return Fail(request, ex.Message);
+        }
+
+        string? reviewerWarning = null;
+        if ((request.Reviewers.Count > 0 || request.TeamReviewers.Count > 0) && created.Number > 0)
+        {
+            try
+            {
+                await gitHubService.RequestReviewersAsync(
+                    connector,
+                    request.Owner,
+                    request.RepositoryName,
+                    created.Number,
+                    request.Reviewers,
+                    request.TeamReviewers,
+                    cancellationToken);
+            }
+            catch (HttpRequestException ex)
+            {
+                reviewerWarning = GitHubApiErrorHelper.FormatFriendlyGitHubHttpError(ex);
+                logger.LogWarning(ex, "Request reviewers failed for {Owner}/{Repo} PR #{Number}", request.Owner, request.RepositoryName, created.Number);
+            }
+            catch (Exception ex)
+            {
+                reviewerWarning = ex.Message;
+                logger.LogWarning(ex, "Request reviewers errored for {Owner}/{Repo} PR #{Number}", request.Owner, request.RepositoryName, created.Number);
+            }
+        }
+
+        logger.LogInformation("Created PR #{Number} for {Owner}/{Repo} {Head}->{Base}",
+            created.Number, request.Owner, request.RepositoryName, request.HeadBranch, request.BaseBranch);
+
+        return new CreatePullRequestResult
+        {
+            RepositoryId = request.RepositoryId,
+            RepositoryName = request.RepositoryName,
+            Success = true,
+            PullRequestNumber = created.Number,
+            PullRequestUrl = created.HtmlUrl,
+            ReviewerWarning = reviewerWarning
+        };
+    }
+
+    public async Task<IReadOnlyList<CreatePullRequestResult>> CreatePullRequestsAsync(
+        IReadOnlyList<CreatePullRequestRequest> requests,
+        IProgress<CreatePullRequestProgress>? progress,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(requests);
+
+        var results = new List<CreatePullRequestResult>(requests.Count);
+        var created = 0;
+        var failed = 0;
+        var total = requests.Count;
+
+        progress?.Report(new CreatePullRequestProgress { Created = 0, Failed = 0, Total = total });
+
+        foreach (var request in requests)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            progress?.Report(new CreatePullRequestProgress
+            {
+                Created = created,
+                Failed = failed,
+                Total = total,
+                CurrentRepositoryName = request.RepositoryName
+            });
+
+            var result = await CreatePullRequestAsync(request, cancellationToken);
+            results.Add(result);
+
+            if (result.Success)
+                created++;
+            else
+                failed++;
+
+            progress?.Report(new CreatePullRequestProgress
+            {
+                Created = created,
+                Failed = failed,
+                Total = total,
+                CurrentRepositoryName = request.RepositoryName
+            });
+        }
+
+        return results;
+    }
+
+    public async Task<IReadOnlyList<string>> GetCollaboratorLoginsAsync(int repositoryId, CancellationToken cancellationToken)
+    {
+        var ctx = await ResolveRepoContextAsync(repositoryId, cancellationToken);
+        if (ctx == null) return Array.Empty<string>();
+
+        try
+        {
+            var collaborators = await gitHubService.GetCollaboratorsAsync(ctx.Value.Connector, ctx.Value.Owner, ctx.Value.Name, cancellationToken);
+            return collaborators
+                .Where(c => !string.IsNullOrWhiteSpace(c.Login))
+                .Select(c => c.Login)
+                .OrderBy(login => login, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+        }
+        catch (Exception ex)
+        {
+            logger.LogDebug(ex, "GetCollaboratorLogins failed. RepositoryId={RepositoryId}", repositoryId);
+            return Array.Empty<string>();
+        }
+    }
+
+    public async Task<IReadOnlyList<string>> GetTeamSlugsAsync(int repositoryId, CancellationToken cancellationToken)
+    {
+        var ctx = await ResolveRepoContextAsync(repositoryId, cancellationToken);
+        if (ctx == null) return Array.Empty<string>();
+
+        try
+        {
+            var teams = await gitHubService.GetTeamsAsync(ctx.Value.Connector, ctx.Value.Owner, ctx.Value.Name, cancellationToken);
+            return teams
+                .Where(t => !string.IsNullOrWhiteSpace(t.Slug))
+                .Select(t => t.Slug)
+                .OrderBy(slug => slug, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+        }
+        catch (Exception ex)
+        {
+            logger.LogDebug(ex, "GetTeamSlugs failed. RepositoryId={RepositoryId}", repositoryId);
+            return Array.Empty<string>();
+        }
+    }
+
+    private async Task<(Connector Connector, string Owner, string Name)?> ResolveRepoContextAsync(int repositoryId, CancellationToken cancellationToken)
+    {
+        var repo = await dbContext.Repositories
+            .AsNoTracking()
+            .Include(r => r.Connector)
+            .FirstOrDefaultAsync(r => r.RepositoryId == repositoryId, cancellationToken);
+
+        if (repo?.Connector is not { } connector || connector.ConnectorType != ConnectorType.GitHub)
+            return null;
+
+        if (!RepositoryUrlHelper.TryParseGitHubOwnerRepo(repo.CloneUrl, out var owner, out var name) || owner == null || name == null)
+            return null;
+
+        return (connector, owner, name);
+    }
+
+    private static CreatePullRequestResult Fail(CreatePullRequestRequest request, string message) => new()
+    {
+        RepositoryId = request.RepositoryId,
+        RepositoryName = request.RepositoryName,
+        Success = false,
+        ErrorMessage = message
+    };
+}
+
+public sealed class CreatePullRequestRequest
+{
+    public required int RepositoryId { get; init; }
+    public required string Owner { get; init; }
+    public required string RepositoryName { get; init; }
+    public required string HeadBranch { get; init; }
+    public required string BaseBranch { get; init; }
+    public required string Title { get; init; }
+    public string? Body { get; init; }
+    public bool IsDraft { get; init; }
+    public IReadOnlyList<string> Reviewers { get; init; } = Array.Empty<string>();
+    public IReadOnlyList<string> TeamReviewers { get; init; } = Array.Empty<string>();
+}
+
+public sealed class CreatePullRequestResult
+{
+    public required int RepositoryId { get; init; }
+    public required string RepositoryName { get; init; }
+    public bool Success { get; init; }
+    public int? PullRequestNumber { get; init; }
+    public string? PullRequestUrl { get; init; }
+    public string? ErrorMessage { get; init; }
+    public string? ReviewerWarning { get; init; }
+}
+
+public sealed class CreatePullRequestProgress
+{
+    public int Created { get; init; }
+    public int Failed { get; init; }
+    public int Total { get; init; }
+    public string? CurrentRepositoryName { get; init; }
+}

--- a/src/GrayMoon.App/Services/PullRequestTitleHelper.cs
+++ b/src/GrayMoon.App/Services/PullRequestTitleHelper.cs
@@ -1,0 +1,64 @@
+using System.Text.RegularExpressions;
+
+namespace GrayMoon.App.Services;
+
+/// <summary>Builds a default PR title from a branch name.</summary>
+/// <remarks>
+/// Replaces <c>-</c>, <c>_</c>, <c>.</c>, <c>/</c> with spaces, except a <c>-</c> immediately following an uppercase letter
+/// (so ticket identifiers like <c>ABC-123</c> are kept together). Capitalization is preserved. Duplicate whitespace
+/// is collapsed. If a ticket-id token (one or more uppercase letters followed by <c>-</c> and digits) is present,
+/// it is moved to the front.
+/// </remarks>
+public static class PullRequestTitleHelper
+{
+    private static readonly Regex DashNotAfterUpperRegex = new(
+        @"(?<![A-Z])-",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+    private static readonly Regex MultipleWhitespaceRegex = new(
+        @"\s+",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+    private static readonly Regex TicketIdRegex = new(
+        @"^[A-Z]+-\d+$",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+    public static string BuildDefaultTitle(string? branchName)
+    {
+        if (string.IsNullOrWhiteSpace(branchName))
+            return string.Empty;
+
+        var working = branchName.Trim();
+        working = working.Replace('_', ' ').Replace('.', ' ').Replace('/', ' ');
+        working = DashNotAfterUpperRegex.Replace(working, " ");
+        working = MultipleWhitespaceRegex.Replace(working, " ").Trim();
+
+        if (working.Length == 0)
+            return string.Empty;
+
+        var tokens = working.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        var ticketIndex = -1;
+        for (var i = 0; i < tokens.Length; i++)
+        {
+            if (TicketIdRegex.IsMatch(tokens[i]))
+            {
+                ticketIndex = i;
+                break;
+            }
+        }
+
+        if (ticketIndex > 0)
+        {
+            var ticket = tokens[ticketIndex];
+            var reordered = new List<string>(tokens.Length) { ticket };
+            for (var i = 0; i < tokens.Length; i++)
+            {
+                if (i == ticketIndex) continue;
+                reordered.Add(tokens[i]);
+            }
+            return string.Join(' ', reordered);
+        }
+
+        return string.Join(' ', tokens);
+    }
+}

--- a/src/GrayMoon.App/Services/WorkspacePushService.cs
+++ b/src/GrayMoon.App/Services/WorkspacePushService.cs
@@ -584,7 +584,7 @@ public sealed class WorkspacePushService(
             if (update.NewLines.Count == 0)
                 continue;
 
-            var label = $"{feed.RepositoryName} [gha]";
+            var label = $"gha:{feed.RepositoryName}";
             foreach (var line in update.NewLines)
                 _overlayCommandTerminalService.Append(label, AgentCommandStreamKind.Stdout, line);
         }


### PR DESCRIPTION
## Summary

Adds in-app GitHub pull request creation for workspace repositories. Users can open one shared dialog from three places, fill in title/description/draft/reviewers once, and create PRs across one or many repos without opening multiple GitHub tabs.

## What's included

- **New Pull Request modal** (`NewPullRequestModal`) with title, description, draft checkbox, and reviewer picker (users + teams from GitHub API)
- **`IPullRequestService` / `PullRequestService`** for creating PRs per repo, progress reporting, and post-create reviewer requests
- **GitHub API extensions** in `GitHubService`: create PR, request reviewers, list collaborators and teams
- **Branch split button** on workspace repositories header: New Branch, Switch Branch, New Pull Requests (Update button unchanged)
- **Entry points:**
  - Yellow **create** badge on a row (single repo)
  - Dependency-level GitHub icon (repos in that level)
  - **New Pull Requests** from Branch dropdown (all eligible workspace repos)
- **Eligibility filter:** feature branch, ahead of default, no open PR, GitHub connector, not on tag
- **UX:** confirm before create, loading overlay with progress text, summary toasts, optional auto-open for a single successful PR
- **Default PR title** from branch name via `PullRequestTitleHelper`
- **README** updated under What's new

## Test plan

- [ ] Open PR dialog from create badge for one repo with commits ahead of default
- [ ] Open from dependency-level icon for multiple repos in a level
- [ ] Open from Branch > New Pull Requests for all eligible repos
- [ ] Verify title default, draft flag, reviewer search (multi-word), teams listed before users
- [ ] Confirm dialog appears centered; both dialogs close on confirm; overlay shows Creating N then Created x of N
- [ ] Partial failure shows success + error toasts without stopping other repos
- [ ] Open in GitHub opens compare URLs; confirm when > 5 repos