### PR TITLE
Stream GitHub API calls to the loading overlay terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,12 +118,12 @@ Every GitHub REST call made by the app is now mirrored into the loading overlay 
 
 GrayMoon can now create GitHub pull requests without leaving the app. Use one dialog for a single repository, every repository in a dependency level, or all eligible workspace repositories.
 
-- **Three entry points:** the yellow **create** badge on a row (one repo), the dependency-level GitHub icon (repos in that level with commits ahead of default), and **Branch** split menu **New Pull Requests** (all eligible repos in the workspace).
+- **Three entry points:** the yellow **create** badge on a row (one repo), the dependency-level GitHub icon (repos in that level with commits ahead of default), and **Branch** split menu **Create PRs...** (all eligible repos in the workspace).
 - **One dialog, shared fields:** title (default generated from the branch name), optional description, draft checkbox, and optional reviewers. Title rules turn branch names like `feature/ABC-123-update-dependencies.v2` into readable subjects (ticket-style tokens such as `ABC-123` stay grouped).
 - **Reviewers:** users and teams are loaded from GitHub (merged across targets when multiple repos are selected). Search supports multiple words (space/comma separated). Teams appear first in the list.
 - **Open in GitHub:** opens compare/create pages in the browser (with a confirm when more than five repositories are involved).
 - **Create flow:** a confirmation step, then a loading overlay (`Creating N pull requests...`, then `Created x of N pull requests` after the first success). Per-repository results are summarized in toasts; a single successful PR can open in the browser automatically.
-- **Branch menu:** **Branch** is a split button with **New Branch**, **Switch Branch**, and **New Pull Requests**. The main **Update** button is unchanged.
+- **Branch menu:** **Branch** is a split button with **New Branch**, **Switch Branch**, and **Create PRs...**. The main **Update** button is unchanged.
 
 Only repositories that are eligible are included: not on a tag, on a feature branch (not default), with commits ahead of default, no open PR already, and a configured GitHub connector.
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,16 @@ Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManage
 
 ## What's new
 
+### GitHub API log in the loading overlay terminal
+
+Every GitHub REST call made by the app is now mirrored into the loading overlay command terminal, alongside existing agent command output and GitHub Actions lines during synchronized push.
+
+- **Toggle:** use the terminal icon in the overlay top bar (same control as agent/git logs). The feed is always collected; it is visible when the overlay is open and the terminal is enabled.
+- **Two lines per request:** an outbound line (`-> GET /repos/...`) in green, then a response line (`<- 200 (124ms)`) in gray for success or red for errors. A short body preview (up to 80 characters) may appear on a third indented line for JSON/text responses.
+- **Covers all GitHub operations:** pull request create, repository fetch, workflow polling, and any other call through `GitHubService` - not only push-time GHA updates.
+- **Safe by design:** no request bodies, no auth headers, and no tokens in the log. Query strings drop sensitive keys; response previews redact common secret field patterns. Logging never affects HTTP behavior if the terminal fails to append.
+- **Retries are visible:** Polly retries on rate limits or transient errors show as separate request/response pairs, which helps when diagnosing 429 storms.
+
 ### Create pull requests from the workspace repositories view
 
 GrayMoon can now create GitHub pull requests without leaving the app. Use one dialog for a single repository, every repository in a dependency level, or all eligible workspace repositories.

--- a/src/GrayMoon.App/Components/Modals/NewPullRequestModal.razor
+++ b/src/GrayMoon.App/Components/Modals/NewPullRequestModal.razor
@@ -37,9 +37,8 @@
                     <div class="mb-3">
                         <label class="form-label" for="new-pr-body">Description</label>
                         <textarea id="new-pr-body"
-                                  class="form-control"
+                                  class="form-control new-pr-body"
                                   rows="6"
-                                  style="resize: none;"
                                   @bind="_body"
                                   @bind:event="oninput"
                                   disabled="@IsBusy"></textarea>

--- a/src/GrayMoon.App/Components/Modals/NewPullRequestModal.razor.css
+++ b/src/GrayMoon.App/Components/Modals/NewPullRequestModal.razor.css
@@ -48,12 +48,12 @@
 }
 
 .new-pr-reviewer-list {
-    max-height: calc(3 * 2.2rem);
+    max-height: calc(3 * 2.1rem);
     overflow-y: auto;
-    background-color: var(--bg-input);
+    background-color: color-mix(in srgb, var(--bg-input) 85%, #000 15%);
     color: var(--text-primary);
-    scrollbar-color: var(--text-muted) transparent;
-    scrollbar-width: thin;
+    scrollbar-color: rgba(148, 152, 158, 0.55) transparent;
+    scrollbar-width: auto;
 }
 
 .new-pr-reviewer-list::-webkit-scrollbar {
@@ -65,7 +65,7 @@
 }
 
 .new-pr-reviewer-list::-webkit-scrollbar-thumb {
-    background-color: var(--text-muted);
+    background-color: rgba(148, 152, 158, 0.55);
     border-radius: 5px;
 }
 
@@ -87,4 +87,27 @@
 
 .new-pr-reviewer-item:hover {
     background-color: rgba(255, 255, 255, 0.04);
+}
+
+.new-pr-body {
+    resize: none;
+    scrollbar-color: rgba(148, 152, 158, 0.55) transparent;
+    scrollbar-width: auto;
+}
+
+.new-pr-body::-webkit-scrollbar {
+    width: auto;
+}
+
+.new-pr-body::-webkit-scrollbar-track {
+    background: transparent;
+}
+
+.new-pr-body::-webkit-scrollbar-thumb {
+    background-color: rgba(148, 152, 158, 0.55);
+    border-radius: 3px;
+}
+
+.new-pr-body::-webkit-scrollbar-thumb:hover {
+    background-color: rgba(148, 152, 158, 0.8);
 }

--- a/src/GrayMoon.App/Components/Shared/WorkspaceRepositoriesHeader.razor
+++ b/src/GrayMoon.App/Components/Shared/WorkspaceRepositoriesHeader.razor
@@ -99,7 +99,7 @@
                                 role="menuitem"
                                 @onclick="HandleNewPullRequestClick"
                                 disabled="@BranchActionsDisabled">
-                            New Pull Requests
+                            Create PRs...
                         </button>
                     </li>
                 </ul>

--- a/src/GrayMoon.App/Program.cs
+++ b/src/GrayMoon.App/Program.cs
@@ -100,7 +100,9 @@ try
     builder.Services.AddHostedService<TokenHealthBackgroundService>();
 
     // Connector services
-    builder.Services.AddHttpClient<GitHubService>();
+    builder.Services.AddTransient<GitHubOverlayLoggingHandler>();
+    builder.Services.AddHttpClient<GitHubService>()
+        .AddHttpMessageHandler<GitHubOverlayLoggingHandler>();
     builder.Services.AddHttpClient<NuGetService>();
     builder.Services.AddScoped<ConnectorServiceFactory>();
     builder.Services.AddScoped<IPullRequestService, PullRequestService>();

--- a/src/GrayMoon.App/Services/GitHubOverlayLoggingHandler.cs
+++ b/src/GrayMoon.App/Services/GitHubOverlayLoggingHandler.cs
@@ -1,0 +1,110 @@
+using System.Diagnostics;
+using System.Text;
+using GrayMoon.Abstractions.Agent;
+
+namespace GrayMoon.App.Services;
+
+/// <summary>
+/// Emits one summary line per GitHub HTTP request into the overlay terminal.
+/// Never reads request/response bodies or headers; only method, path (with scrubbed query),
+/// status code, and elapsed time. Append failures are swallowed so the HTTP pipeline is never
+/// affected by terminal issues.
+/// </summary>
+internal sealed class GitHubOverlayLoggingHandler(OverlayCommandTerminalService overlayTerminal)
+    : DelegatingHandler
+{
+    private const string Label = "github";
+
+    private static readonly string[] SensitiveQueryKeys =
+    [
+        "token", "secret", "key", "auth", "password", "code"
+    ];
+
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        var sw = Stopwatch.StartNew();
+        var method = request.Method.Method;
+        var path = SafePath(request.RequestUri);
+
+        try
+        {
+            var response = await base.SendAsync(request, cancellationToken);
+            sw.Stop();
+
+            var kind = response.IsSuccessStatusCode
+                ? AgentCommandStreamKind.Stdout
+                : AgentCommandStreamKind.Stderr;
+
+            TryAppend(kind, $"{method} {path} {(int)response.StatusCode} ({sw.ElapsedMilliseconds}ms)");
+            return response;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            sw.Stop();
+            TryAppend(
+                AgentCommandStreamKind.Stderr,
+                $"{method} {path} FAILED {ex.GetType().Name} ({sw.ElapsedMilliseconds}ms)");
+            throw;
+        }
+    }
+
+    private void TryAppend(AgentCommandStreamKind kind, string text)
+    {
+        try
+        {
+            overlayTerminal.Append(Label, kind, text);
+        }
+        catch
+        {
+            // Never let terminal failures break the HTTP pipeline.
+        }
+    }
+
+    private static string SafePath(Uri? uri)
+    {
+        if (uri is null)
+            return "(no-uri)";
+
+        var absolute = uri.IsAbsoluteUri ? uri : new Uri(new Uri("https://api.github.com/"), uri);
+        var path = absolute.AbsolutePath;
+        var query = absolute.Query;
+
+        if (string.IsNullOrEmpty(query) || query == "?")
+            return path;
+
+        var trimmed = query.StartsWith('?') ? query[1..] : query;
+        var pairs = trimmed.Split('&', StringSplitOptions.RemoveEmptyEntries);
+        var builder = new StringBuilder();
+
+        foreach (var pair in pairs)
+        {
+            var eq = pair.IndexOf('=');
+            var key = eq >= 0 ? pair[..eq] : pair;
+
+            if (IsSensitiveKey(key))
+                continue;
+
+            if (builder.Length > 0)
+                builder.Append('&');
+            builder.Append(pair);
+        }
+
+        return builder.Length == 0 ? path : path + "?" + builder;
+    }
+
+    private static bool IsSensitiveKey(string key)
+    {
+        foreach (var sensitive in SensitiveQueryKeys)
+        {
+            if (key.Contains(sensitive, StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+        return false;
+    }
+}

--- a/src/GrayMoon.App/Services/GitHubOverlayLoggingHandler.cs
+++ b/src/GrayMoon.App/Services/GitHubOverlayLoggingHandler.cs
@@ -1,24 +1,33 @@
 using System.Diagnostics;
 using System.Text;
+using System.Text.RegularExpressions;
 using GrayMoon.Abstractions.Agent;
 
 namespace GrayMoon.App.Services;
 
 /// <summary>
 /// Emits one summary line per GitHub HTTP request into the overlay terminal.
-/// Never reads request/response bodies or headers; only method, path (with scrubbed query),
-/// status code, and elapsed time. Append failures are swallowed so the HTTP pipeline is never
-/// affected by terminal issues.
+/// Reads only headers, status, elapsed time, and a short (max 80 char) preview of textual
+/// response bodies. Never reads request bodies or any auth header. Append failures are
+/// swallowed so the HTTP pipeline is never affected by terminal issues.
 /// </summary>
-internal sealed class GitHubOverlayLoggingHandler(OverlayCommandTerminalService overlayTerminal)
+internal sealed partial class GitHubOverlayLoggingHandler(OverlayCommandTerminalService overlayTerminal)
     : DelegatingHandler
 {
     private const string Label = "github";
+    private const int MaxBodyChars = 80;
+    private const long MaxBufferBytes = 16 * 1024;
 
     private static readonly string[] SensitiveQueryKeys =
     [
         "token", "secret", "key", "auth", "password", "code"
     ];
+
+    [GeneratedRegex(@"\s+", RegexOptions.CultureInvariant)]
+    private static partial Regex WhitespaceRegex();
+
+    [GeneratedRegex(@"(?i)(token|secret|password|authorization|access_token|refresh_token)""?\s*[:=]\s*""?[^"",}\s]+", RegexOptions.CultureInvariant)]
+    private static partial Regex SensitiveValueRegex();
 
     protected override async Task<HttpResponseMessage> SendAsync(
         HttpRequestMessage request,
@@ -28,16 +37,27 @@ internal sealed class GitHubOverlayLoggingHandler(OverlayCommandTerminalService 
         var method = request.Method.Method;
         var path = SafePath(request.RequestUri);
 
+        TryAppend(AgentCommandStreamKind.Stdout, $"-> {method} {path}");
+
         try
         {
             var response = await base.SendAsync(request, cancellationToken);
             sw.Stop();
 
-            var kind = response.IsSuccessStatusCode
-                ? AgentCommandStreamKind.Stdout
+            var responseKind = response.IsSuccessStatusCode
+                ? AgentCommandStreamKind.CommandLine
                 : AgentCommandStreamKind.Stderr;
 
-            TryAppend(kind, $"{method} {path} {(int)response.StatusCode} ({sw.ElapsedMilliseconds}ms)");
+            // Append the status line immediately - this fires Changed so Blazor gets a render slot
+            // before the caller's continuation (which often closes the overlay) runs.
+            TryAppend(responseKind, $"<- {(int)response.StatusCode} ({sw.ElapsedMilliseconds}ms)");
+
+            // Body preview is a separate, lower-priority line. Awaiting here yields the circuit so
+            // the status line above has a chance to render before the overlay is dismissed.
+            var bodyPreview = await TryReadBodyPreviewAsync(response, cancellationToken);
+            if (!string.IsNullOrEmpty(bodyPreview))
+                TryAppend(AgentCommandStreamKind.CommandLine, $"   {bodyPreview}");
+
             return response;
         }
         catch (OperationCanceledException)
@@ -49,9 +69,63 @@ internal sealed class GitHubOverlayLoggingHandler(OverlayCommandTerminalService 
             sw.Stop();
             TryAppend(
                 AgentCommandStreamKind.Stderr,
-                $"{method} {path} FAILED {ex.GetType().Name} ({sw.ElapsedMilliseconds}ms)");
+                $"<- FAILED {ex.GetType().Name} ({sw.ElapsedMilliseconds}ms)");
             throw;
         }
+    }
+
+    private static async Task<string?> TryReadBodyPreviewAsync(HttpResponseMessage response, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var content = response.Content;
+            if (content is null)
+                return null;
+
+            if (!IsTextualContent(content.Headers.ContentType?.MediaType))
+                return null;
+
+            // Buffer the response so the original caller can still consume it normally.
+            // Throws if body exceeds MaxBufferBytes; we swallow and skip the preview.
+            await content.LoadIntoBufferAsync(MaxBufferBytes);
+
+            var raw = await content.ReadAsStringAsync(cancellationToken);
+            if (string.IsNullOrWhiteSpace(raw))
+                return null;
+
+            var collapsed = WhitespaceRegex().Replace(raw, " ").Trim();
+            var scrubbed = SensitiveValueRegex().Replace(collapsed, "$1=<redacted>");
+
+            if (scrubbed.Length > MaxBodyChars)
+                scrubbed = scrubbed[..MaxBodyChars] + "...";
+
+            return scrubbed;
+        }
+        catch
+        {
+            // Body too large, decoding failed, or content already disposed - just skip the preview.
+            return null;
+        }
+    }
+
+    private static bool IsTextualContent(string? mediaType)
+    {
+        if (string.IsNullOrWhiteSpace(mediaType))
+            return false;
+
+        if (mediaType.StartsWith("text/", StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        if (mediaType.StartsWith("application/", StringComparison.OrdinalIgnoreCase))
+        {
+            return mediaType.Contains("json", StringComparison.OrdinalIgnoreCase)
+                || mediaType.Contains("xml", StringComparison.OrdinalIgnoreCase)
+                || mediaType.Contains("yaml", StringComparison.OrdinalIgnoreCase)
+                || mediaType.Contains("javascript", StringComparison.OrdinalIgnoreCase)
+                || mediaType.Equals("application/x-www-form-urlencoded", StringComparison.OrdinalIgnoreCase);
+        }
+
+        return false;
     }
 
     private void TryAppend(AgentCommandStreamKind kind, string text)

--- a/src/GrayMoon.App/Services/WorkspacePushService.cs
+++ b/src/GrayMoon.App/Services/WorkspacePushService.cs
@@ -492,7 +492,6 @@ public sealed class WorkspacePushService(
             return false;
 
         var linksByRepoId = links.ToDictionary(l => l.RepositoryId);
-        var hasAnyWorkflowCandidates = false;
         foreach (var repo in reposAtLevel)
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -537,8 +536,6 @@ public sealed class WorkspacePushService(
                 _logger.LogDebug("Push wait: repo {RepoName} has no active GitHub Actions workflows; skipping live feed.", entry.RepositoryName);
                 continue;
             }
-
-            hasAnyWorkflowCandidates = true;
 
             foreach (var status in statuses)
             {


### PR DESCRIPTION
## Summary

- Add `GitHubOverlayLoggingHandler` on the `GitHubService` typed `HttpClient` so every GitHub REST call is logged to the overlay command terminal with label `[github]`.
- Log each call as a request line (`-> METHOD path`, green) and a response line (`<- status (ms)`, gray on success, red on error), with an optional indented body preview (up to 80 characters) for textual responses.
- Keep logging safe: no request bodies or auth headers, scrubbed query strings, redacted secret-like JSON fields, and swallowed append failures so HTTP behavior is unchanged.
- Polish the New Pull Request dialog: darker reviewers list background vs search input, and matching gray auto-width scrollbars on the description field and reviewers list.
- Remove unused `hasAnyWorkflowCandidates` in `WorkspacePushService`.

## Test plan

- [ ] Restart the app, open the loading overlay with the terminal enabled (terminal icon in overlay top bar).
- [ ] Trigger GitHub API work (e.g. create PR, refresh repos, or open New Pull Request dialog to load reviewers) and confirm `[github]` lines appear.
- [ ] Confirm request lines are green, success responses gray, and error responses red.
- [ ] Confirm response body previews appear for JSON responses and never include tokens.
- [ ] Confirm existing agent command lines and GHA overlay lines during synchronized push still work.
- [ ] Open New Pull Request modal: verify reviewers list is slightly darker than search, and scrollbars match on description and reviewers list.