### PR TITLE
Harden Windows agent install script and simplify install command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,67 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Line endings
+
+Always use **Windows (CRLF)** in generated or edited code. Do not use LF-only.
+
+## Task completion
+
+When you complete a task, write a single sentence summarizing what was done.
+
+## Commands
+
+```powershell
+# Build the solution
+dotnet build GrayMoon.sln
+
+# Run tests
+dotnet test src/GrayMoon.Common.Tests/GrayMoon.Common.Tests.csproj
+
+# Run a single test class
+dotnet test src/GrayMoon.Common.Tests/GrayMoon.Common.Tests.csproj --filter "FullyQualifiedName~FilterSearchExpressionTests"
+
+# Run the App locally (port 8384)
+dotnet run --project src/GrayMoon.App/GrayMoon.App.csproj
+
+# Run the Agent locally
+dotnet run --project src/GrayMoon.Agent/GrayMoon.Agent.csproj
+
+# Restore .NET tools (includes GitVersion)
+dotnet tool restore
+
+# Docker build (version injected via arg, GitVersion disabled inside container)
+docker build --build-arg VERSION=1.0.0 -t graymoon .
+```
+
+CI pushes to Docker Hub on commits to `main`, on tag pushes, or on any branch commit whose message contains `prerelease`.
+
+## Architecture
+
+GrayMoon is a **two-process** system — never combine them:
+
+- **GrayMoon.App** (`src/GrayMoon.App`) — ASP.NET Core 8 + Blazor Server, runs in Docker. Exposes the web UI and two SignalR hubs (`/hub/agent`, `/hubs/workspace-sync`). Never touches the local filesystem or runs git directly. SQLite database via EF Core at `/app/db` (volume-mounted). Uses `EnsureCreated()` — no incremental migrations yet.
+- **GrayMoon.Agent** (`src/GrayMoon.Agent`) — .NET console app / tool that runs on the developer's host machine. Connects to the App via SignalR, executes all git and filesystem operations, and exposes a local HTTP listener on `127.0.0.1:9191` for git hook callbacks.
+- **GrayMoon.Abstractions** (`src/GrayMoon.Abstractions`) — Shared interfaces and DTOs used by both App and Agent.
+- **GrayMoon.Common** (`src/GrayMoon.Common`) — Shared utilities (e.g. the boolean filter-search expression parser tested in `GrayMoon.Common.Tests`).
+
+### App → Agent command flow
+
+The App sends commands to the Agent over SignalR using a `requestId` (GUID). `AgentBridge` calls `AgentResponseDelivery.WaitAsync(requestId)` (a `TaskCompletionSource`) then fires `RequestCommand` to the Agent. The Agent enqueues a `JobEnvelope` into a bounded `Channel<JobEnvelope>`, runs it in one of up to 8 concurrent workers, and calls back `ResponseCommand` with the same `requestId`. `AgentResponseDelivery.Complete` resolves the TCS, unblocking the App's awaiter.
+
+### Agent → App sync (hook-driven)
+
+Git hooks (`post-commit`, `post-checkout`, `post-merge`, `pre-push`) POST JSON to the Agent's local HTTP listener (`/hook/notify` or `/hook/push`). The Agent processes these as `NotifyJobs` and pushes partial state updates back to the App via `SyncCommand` on the SignalR connection. `SyncCommandHandler` persists only non-null fields (partial update semantics) then broadcasts `WorkspaceSynced` to all browser clients.
+
+### Dependency levels
+
+Workspace repositories are topologically sorted into dependency levels (Kahn's algorithm). Level 1 = no dependencies; higher levels depend on lower ones. This drives: grid grouping, push ordering (synchronized push waits for NuGet availability level-by-level), and the dependency update flow.
+
+### Token encryption
+
+Connector tokens are AES-256-GCM encrypted at rest via `AesGcmTokenProtector` (backed by ASP.NET Core Data Protection). Keys live in `/app/db/DataProtection-Keys/`. All git remote operations pass the token at runtime via `-c http.extraHeader="Authorization: Basic ..."` — tokens are never written to disk by the Agent.
+
+### Database schema
+
+Schema is owned by EF Core but applied via `EnsureCreated()`. Core tables: `Connectors`, `Repositories`, `Workspaces`, `WorkspaceRepositories` (join with live state), `WorkspaceRepositoryPullRequest` (1:1 with link), `WorkspaceProject`, `ProjectDependency`, `WorkspaceFile`, `WorkspaceFileVersionConfig`, `RepositoryBranch`, `Settings`.

--- a/README.md
+++ b/README.md
@@ -195,4 +195,3 @@ The dependency count badge in the grid now opens a detailed popup when you hover
 - **Mismatch case (orange badge):** lists every package that needs updating with `CurrentVersion -> NewVersion`. Clicking the badge still triggers the per-repository update flow.
 - **Copy to clipboard:** the popup has a small clipboard icon in the top-right corner that copies the list (prefixed with the repository name) so you can paste it into a PR description, chat, or ticket. The copy action does not trigger the badge's main click.
 - **Pinned repositories** show the tooltip and the Copy button but the badge itself is non-clickable - exactly what you want when the repo is intentionally frozen.
-

--- a/src/GrayMoon.App/Components/Pages/Agent.razor
+++ b/src/GrayMoon.App/Components/Pages/Agent.razor
@@ -50,10 +50,10 @@
                             <small class="text-muted mt-2 d-block">
                                 The script will download, install, and start the agent service automatically.
                             </small>
-                            <p class="mb-0 small text-muted mt-2 d-block">
-                                The Windows service requires the .NET 8 (x64) runtime on the host.
-                                <a href="@AgentDotnet8RuntimeUrl" target="_blank" rel="noopener noreferrer">Download the .NET 8 runtime</a>
-                            </p>
+                            <div class="alert alert-warning mt-3" role="alert">
+                                <strong>Required:</strong> The Windows service requires the <span class="fw-bold text-danger">.NET 8 (x64) runtime</span> on the host.<br />
+                                <a href="@AgentDotnet8RuntimeUrl" target="_blank" rel="noopener noreferrer" class="fw-bold">Download the .NET 8 runtime</a>
+                            </div>
                         </div>
                         <div class="tab-pane @(ActiveTab == "uninstall" ? "show active" : "")" role="tabpanel">
                             <p class="mb-3">Run this PowerShell command as Administrator to uninstall the GrayMoon Agent Windows service:</p>
@@ -120,9 +120,9 @@
     {
         var baseUrl = NavigationManager.BaseUri.TrimEnd('/');
         var installUrl = $"{baseUrl}/api/agent/install";
-        installCommand = $"Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('{installUrl}'))";
+        installCommand = $"irm '{installUrl}' | iex";
         var uninstallUrl = $"{baseUrl}/api/agent/uninstall";
-        uninstallCommand = $"Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('{uninstallUrl}'))";
+        uninstallCommand = $"irm '{uninstallUrl}' | iex";
         SetDefaultTab();
     }
 

--- a/src/GrayMoon.App/Components/Pages/Agent.razor
+++ b/src/GrayMoon.App/Components/Pages/Agent.razor
@@ -50,10 +50,10 @@
                             <small class="text-muted mt-2 d-block">
                                 The script will download, install, and start the agent service automatically.
                             </small>
-                            <div class="alert alert-warning mt-3" role="alert">
-                                <strong>Required:</strong> The Windows service requires the <span class="fw-bold text-danger">.NET 8 (x64) runtime</span> on the host.<br />
-                                <a href="@AgentDotnet8RuntimeUrl" target="_blank" rel="noopener noreferrer" class="fw-bold">Download the .NET 8 runtime</a>
-                            </div>
+                            <p class="mb-0 small agent-runtime-note mt-2 d-block">
+                                The Windows service requires the .NET 8 (x64) runtime on the host.
+                                <a href="@AgentDotnet8RuntimeUrl" target="_blank" rel="noopener noreferrer">Download the .NET 8 runtime</a>
+                            </p>
                         </div>
                         <div class="tab-pane @(ActiveTab == "uninstall" ? "show active" : "")" role="tabpanel">
                             <p class="mb-3">Run this PowerShell command as Administrator to uninstall the GrayMoon Agent Windows service:</p>
@@ -120,9 +120,9 @@
     {
         var baseUrl = NavigationManager.BaseUri.TrimEnd('/');
         var installUrl = $"{baseUrl}/api/agent/install";
-        installCommand = $"irm '{installUrl}' | iex";
+        installCommand = $"irm {installUrl} | iex";
         var uninstallUrl = $"{baseUrl}/api/agent/uninstall";
-        uninstallCommand = $"irm '{uninstallUrl}' | iex";
+        uninstallCommand = $"irm {uninstallUrl} | iex";
         SetDefaultTab();
     }
 

--- a/src/GrayMoon.App/Components/Pages/Agent.razor.css
+++ b/src/GrayMoon.App/Components/Pages/Agent.razor.css
@@ -76,6 +76,18 @@
     text-overflow: ellipsis;
 }
 
+.agent-runtime-note {
+    color: var(--text-primary);
+}
+
+.agent-runtime-note a {
+    color: var(--text-primary);
+}
+
+.agent-runtime-note a:hover {
+    color: #fff;
+}
+
 .host-info-grid {
     display: grid;
     grid-template-columns: auto 1fr;

--- a/src/GrayMoon.App/Resources/install-agent.ps1
+++ b/src/GrayMoon.App/Resources/install-agent.ps1
@@ -258,8 +258,8 @@ function New-Win32ServiceWithLogon {
         StartName = $StartName
         StartPassword = $StartPassword
         LoadOrderGroup = ''
-        LoadOrderGroupDependencies = ''
-        ServiceDependencies = ''
+        LoadOrderGroupDependencies = $null
+        ServiceDependencies = $null
     }
     if ($out.ReturnValue -ne 0) {
         throw "Win32_Service.Create failed with return code $($out.ReturnValue)."

--- a/src/GrayMoon.App/Resources/install-agent.ps1
+++ b/src/GrayMoon.App/Resources/install-agent.ps1
@@ -1,32 +1,45 @@
 # GrayMoon Agent Installation Script
-# Downloads a zip of the framework-dependent agent (graymoon-agent.exe + DLLs), extracts to Program Files, and registers the Windows service.
-# The host must have the .NET 8 runtime (or ASP.NET Core 8 runtime) installed for the same RID as the published agent.
+# Downloads a zip of the framework-dependent agent (graymoon-agent.exe + DLLs),
+# extracts to Program Files, grants "Log on as a service" to the current user,
+# and registers the Windows service using native Windows APIs.
+#
+# Run from a fresh Administrator PowerShell window.
+# The host must have the .NET 8 runtime installed for the same RID as the published agent.
 
 $ErrorActionPreference = 'Stop'
 
 Write-Host 'GrayMoon Agent Installation' -ForegroundColor Cyan
 
 # Check if running as Administrator
-$isAdmin = ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+$isAdmin = ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole(
+    [Security.Principal.WindowsBuiltInRole]::Administrator
+)
+
 if (-not $isAdmin) {
     Write-Host 'ERROR: This script must be run as Administrator' -ForegroundColor Red
     return 1
 }
 
-# Service name
+# Service configuration
 $serviceName = 'GrayMoonAgent'
 $serviceDisplayName = 'GrayMoon Agent'
 $serviceDescription = 'Host-side agent for GrayMoon: executes git and repository I/O operations'
+
 $agentPath = Join-Path $env:ProgramFiles 'GrayMoon'
 $agentExe = Join-Path $agentPath 'graymoon-agent.exe'
-$downloadUrl = '{DOWNLOAD_URL}'
+
+$downloadUrl = 'http://localhost:8384/api/agent/download?platform=windows'
+$hubUrl = 'http://localhost:8384/hub/agent'
+
 $zipPath = Join-Path $env:TEMP 'graymoon-agent-windows-install.zip'
 
+# Native credential validation
+if (-not ('GrayMoonNativeLogonValidator' -as [type])) {
 Add-Type @"
 using System;
 using System.Runtime.InteropServices;
 
-public static class NativeLogonValidator
+public static class GrayMoonNativeLogonValidator
 {
     [DllImport("advapi32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
     public static extern bool LogonUser(
@@ -41,6 +54,234 @@ public static class NativeLogonValidator
     public static extern bool CloseHandle(IntPtr hObject);
 }
 "@
+}
+
+# Native LSA rights helper.
+# IMPORTANT:
+# Add-Type cannot replace an already loaded type in the same PowerShell process.
+# If you edit this C# code and re-run it, open a fresh Administrator PowerShell window.
+if (-not ('GrayMoonServiceLogonRights' -as [type])) {
+Add-Type @"
+using System;
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+
+public static class GrayMoonServiceLogonRights
+{
+    [StructLayout(LayoutKind.Sequential)]
+    private struct LSA_UNICODE_STRING
+    {
+        public ushort Length;
+        public ushort MaximumLength;
+        public IntPtr Buffer;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct LSA_OBJECT_ATTRIBUTES
+    {
+        public uint Length;
+        public IntPtr RootDirectory;
+        public IntPtr ObjectName;
+        public uint Attributes;
+        public IntPtr SecurityDescriptor;
+        public IntPtr SecurityQualityOfService;
+    }
+
+    [DllImport("advapi32.dll", SetLastError = false)]
+    private static extern uint LsaOpenPolicy(
+        IntPtr SystemName,
+        ref LSA_OBJECT_ATTRIBUTES ObjectAttributes,
+        uint DesiredAccess,
+        out IntPtr PolicyHandle);
+
+    [DllImport("advapi32.dll", SetLastError = false)]
+    private static extern uint LsaAddAccountRights(
+        IntPtr PolicyHandle,
+        IntPtr AccountSid,
+        LSA_UNICODE_STRING[] UserRights,
+        uint CountOfRights);
+
+    [DllImport("advapi32.dll")]
+    private static extern uint LsaClose(IntPtr ObjectHandle);
+
+    [DllImport("advapi32.dll")]
+    private static extern int LsaNtStatusToWinError(uint Status);
+
+    private const uint POLICY_CREATE_ACCOUNT = 0x00000010;
+    private const uint POLICY_LOOKUP_NAMES   = 0x00000800;
+
+    public static void AddAccountRight(byte[] sidBytes, string rightName)
+    {
+        if (sidBytes == null || sidBytes.Length == 0)
+            throw new ArgumentException("SID is empty.", nameof(sidBytes));
+
+        if (string.IsNullOrWhiteSpace(rightName))
+            throw new ArgumentException("Right name is empty.", nameof(rightName));
+
+        LSA_OBJECT_ATTRIBUTES attributes = new LSA_OBJECT_ATTRIBUTES();
+        attributes.Length = (uint)Marshal.SizeOf(typeof(LSA_OBJECT_ATTRIBUTES));
+
+        IntPtr policyHandle = IntPtr.Zero;
+        IntPtr sidPtr = IntPtr.Zero;
+        IntPtr rightPtr = IntPtr.Zero;
+
+        uint status = LsaOpenPolicy(
+            IntPtr.Zero,
+            ref attributes,
+            POLICY_CREATE_ACCOUNT | POLICY_LOOKUP_NAMES,
+            out policyHandle);
+
+        if (status != 0)
+        {
+            int error = LsaNtStatusToWinError(status);
+            throw new Win32Exception(error, "LsaOpenPolicy failed.");
+        }
+
+        try
+        {
+            sidPtr = Marshal.AllocHGlobal(sidBytes.Length);
+            Marshal.Copy(sidBytes, 0, sidPtr, sidBytes.Length);
+
+            rightPtr = Marshal.StringToHGlobalUni(rightName);
+
+            LSA_UNICODE_STRING right = new LSA_UNICODE_STRING();
+            right.Length = (ushort)(rightName.Length * 2);
+            right.MaximumLength = (ushort)((rightName.Length + 1) * 2);
+            right.Buffer = rightPtr;
+
+            LSA_UNICODE_STRING[] rights = new LSA_UNICODE_STRING[] { right };
+
+            status = LsaAddAccountRights(policyHandle, sidPtr, rights, 1);
+
+            if (status != 0)
+            {
+                int error = LsaNtStatusToWinError(status);
+                throw new Win32Exception(error, "LsaAddAccountRights failed.");
+            }
+        }
+        finally
+        {
+            if (rightPtr != IntPtr.Zero)
+                Marshal.FreeHGlobal(rightPtr);
+
+            if (sidPtr != IntPtr.Zero)
+                Marshal.FreeHGlobal(sidPtr);
+
+            if (policyHandle != IntPtr.Zero)
+                LsaClose(policyHandle);
+        }
+    }
+}
+"@
+}
+
+# Native Windows service creation helper.
+# This avoids Win32_Service.Create and therefore avoids the CIM ServiceType mismatch.
+if (-not ('GrayMoonNativeServiceInstaller' -as [type])) {
+Add-Type @"
+using System;
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+
+public static class GrayMoonNativeServiceInstaller
+{
+    private const uint SC_MANAGER_CREATE_SERVICE = 0x00000002;
+
+    private const uint SERVICE_ALL_ACCESS = 0x000F01FF;
+    private const uint SERVICE_WIN32_OWN_PROCESS = 0x00000010;
+    private const uint SERVICE_AUTO_START = 0x00000002;
+    private const uint SERVICE_ERROR_NORMAL = 0x00000001;
+
+    [DllImport("advapi32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+    private static extern IntPtr OpenSCManagerW(
+        string lpMachineName,
+        string lpDatabaseName,
+        uint dwDesiredAccess);
+
+    [DllImport("advapi32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+    private static extern IntPtr CreateServiceW(
+        IntPtr hSCManager,
+        string lpServiceName,
+        string lpDisplayName,
+        uint dwDesiredAccess,
+        uint dwServiceType,
+        uint dwStartType,
+        uint dwErrorControl,
+        string lpBinaryPathName,
+        string lpLoadOrderGroup,
+        IntPtr lpdwTagId,
+        string lpDependencies,
+        string lpServiceStartName,
+        string lpPassword);
+
+    [DllImport("advapi32.dll", SetLastError = true)]
+    private static extern bool CloseServiceHandle(IntPtr hSCObject);
+
+    public static void CreateOwnProcessAutoService(
+        string name,
+        string displayName,
+        string pathName,
+        string startName,
+        string password)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            throw new ArgumentException("Service name is empty.", nameof(name));
+
+        if (string.IsNullOrWhiteSpace(displayName))
+            throw new ArgumentException("Service display name is empty.", nameof(displayName));
+
+        if (string.IsNullOrWhiteSpace(pathName))
+            throw new ArgumentException("Service path is empty.", nameof(pathName));
+
+        if (string.IsNullOrWhiteSpace(startName))
+            throw new ArgumentException("Service account is empty.", nameof(startName));
+
+        IntPtr scm = IntPtr.Zero;
+        IntPtr service = IntPtr.Zero;
+
+        scm = OpenSCManagerW(null, null, SC_MANAGER_CREATE_SERVICE);
+
+        if (scm == IntPtr.Zero)
+        {
+            int error = Marshal.GetLastWin32Error();
+            throw new Win32Exception(error, "OpenSCManagerW failed.");
+        }
+
+        try
+        {
+            service = CreateServiceW(
+                scm,
+                name,
+                displayName,
+                SERVICE_ALL_ACCESS,
+                SERVICE_WIN32_OWN_PROCESS,
+                SERVICE_AUTO_START,
+                SERVICE_ERROR_NORMAL,
+                pathName,
+                null,
+                IntPtr.Zero,
+                null,
+                startName,
+                password);
+
+            if (service == IntPtr.Zero)
+            {
+                int error = Marshal.GetLastWin32Error();
+                throw new Win32Exception(error, "CreateServiceW failed.");
+            }
+        }
+        finally
+        {
+            if (service != IntPtr.Zero)
+                CloseServiceHandle(service);
+
+            if (scm != IntPtr.Zero)
+                CloseServiceHandle(scm);
+        }
+    }
+}
+"@
+}
 
 function Split-AccountName {
     param(
@@ -50,6 +291,7 @@ function Split-AccountName {
 
     if ($AccountName.Contains('\')) {
         $parts = $AccountName.Split('\', 2)
+
         return @{
             Domain = $parts[0]
             UserName = $parts[1]
@@ -58,6 +300,7 @@ function Split-AccountName {
 
     if ($AccountName.Contains('@')) {
         $parts = $AccountName.Split('@', 2)
+
         return @{
             Domain = $parts[1]
             UserName = $parts[0]
@@ -74,26 +317,27 @@ function Test-UserCredentials {
     param(
         [Parameter(Mandatory = $true)]
         [string]$AccountName,
+
         [Parameter(Mandatory = $true)]
         [string]$Password
     )
 
     $identity = Split-AccountName -AccountName $AccountName
     $tokenHandle = [IntPtr]::Zero
-    $logonTypeInteractive = 2
-    $providerDefault = 0
 
-    $ok = [NativeLogonValidator]::LogonUser(
+    # LOGON32_LOGON_INTERACTIVE = 2
+    # LOGON32_PROVIDER_DEFAULT = 0
+    $ok = [GrayMoonNativeLogonValidator]::LogonUser(
         $identity.UserName,
         $identity.Domain,
         $Password,
-        $logonTypeInteractive,
-        $providerDefault,
+        2,
+        0,
         [ref]$tokenHandle
     )
 
     if ($ok -and $tokenHandle -ne [IntPtr]::Zero) {
-        [void][NativeLogonValidator]::CloseHandle($tokenHandle)
+        [void][GrayMoonNativeLogonValidator]::CloseHandle($tokenHandle)
     }
 
     return $ok
@@ -105,116 +349,49 @@ function Grant-ServiceLogonRight {
         [string]$AccountName
     )
 
-    $sid = ([System.Security.Principal.NTAccount]$AccountName).Translate([System.Security.Principal.SecurityIdentifier]).Value
-    $sidEntry = "*$sid"
-    $tempDir = Join-Path $env:TEMP "GrayMoon-ServiceRights"
-    New-Item -ItemType Directory -Path $tempDir -Force | Out-Null
-
-    $cfgPath = Join-Path $tempDir "secpol.cfg"
-    $infPath = Join-Path $tempDir "secpol.inf"
-    $dbPath = Join-Path $tempDir "secpol.sdb"
-
     try {
-        $null = & secedit /export /cfg "$cfgPath" /areas USER_RIGHTS
-        if ($LASTEXITCODE -ne 0) {
-            throw "Failed to export local security policy."
-        }
+        $ntAccount = New-Object System.Security.Principal.NTAccount($AccountName)
+        $sidObj = $ntAccount.Translate([System.Security.Principal.SecurityIdentifier])
 
-        $content = if (Test-Path $cfgPath) { Get-Content -Path $cfgPath -ErrorAction Stop } else { @() }
-        $lineIndex = -1
-        for ($i = 0; $i -lt $content.Count; $i++) {
-            if ($content[$i] -match '^SeServiceLogonRight\s*=') {
-                $lineIndex = $i
-                break
-            }
-        }
+        $sidBytes = New-Object byte[] $sidObj.BinaryLength
+        $sidObj.GetBinaryForm($sidBytes, 0)
 
-        $newLine = "SeServiceLogonRight = $sidEntry"
-        if ($lineIndex -ge 0) {
-            $existingPart = ($content[$lineIndex] -split '=', 2)[1]
-            $entries = @()
-            if (-not [string]::IsNullOrWhiteSpace($existingPart)) {
-                $entries = $existingPart.Split(',') | ForEach-Object { $_.Trim() } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
-            }
-
-            if ($entries -contains $sidEntry) {
-                return
-            }
-
-            $entries += $sidEntry
-            $newLine = "SeServiceLogonRight = $($entries -join ',')"
-            $content[$lineIndex] = $newLine
-        } else {
-            $privilegeSectionIndex = -1
-            for ($i = 0; $i -lt $content.Count; $i++) {
-                if ($content[$i] -match '^\[Privilege Rights\]') {
-                    $privilegeSectionIndex = $i
-                    break
-                }
-            }
-
-            if ($privilegeSectionIndex -lt 0) {
-                $content += "[Privilege Rights]"
-                $content += $newLine
-            } else {
-                $insertIndex = $privilegeSectionIndex + 1
-                while ($insertIndex -lt $content.Count -and -not $content[$insertIndex].StartsWith('[')) {
-                    $insertIndex++
-                }
-
-                $before = @()
-                $after = @()
-                if ($insertIndex -gt 0) {
-                    $before = $content[0..($insertIndex - 1)]
-                }
-                if ($insertIndex -lt $content.Count) {
-                    $after = $content[$insertIndex..($content.Count - 1)]
-                }
-                $content = @($before + $newLine + $after)
-            }
-        }
-
-        @"
-[Unicode]
-Unicode=yes
-[Version]
-signature="`$CHICAGO`$"
-Revision=1
-[Privilege Rights]
-$newLine
-"@ | Set-Content -Path $infPath -Encoding Unicode -Force
-
-        $null = & secedit /configure /db "$dbPath" /cfg "$infPath" /areas USER_RIGHTS
-        if ($LASTEXITCODE -ne 0) {
-            throw "Failed to apply local security policy update."
-        }
+        [GrayMoonServiceLogonRights]::AddAccountRight($sidBytes, 'SeServiceLogonRight')
     }
-    finally {
-        Remove-Item -Path $cfgPath -Force -ErrorAction SilentlyContinue
-        Remove-Item -Path $infPath -Force -ErrorAction SilentlyContinue
-        Remove-Item -Path $dbPath -Force -ErrorAction SilentlyContinue
+    catch {
+        throw "Failed to grant 'Log on as a service' to '$AccountName'. $($_.Exception.Message)"
     }
 }
 
 function Build-AgentServiceCommandLine {
     param(
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory = $true)]
         [string]$AgentExePath,
-        [Parameter(Mandatory)]
+
+        [Parameter(Mandatory = $true)]
         [string]$HubUrl
     )
-    '"' + $AgentExePath + '" run -u "' + $HubUrl + '"'
+
+    return '"' + $AgentExePath + '" run -u "' + $HubUrl + '"'
 }
 
 function Set-Win32ServicePathName {
     param(
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory = $true)]
         [string]$Name,
-        [Parameter(Mandatory)]
+
+        [Parameter(Mandatory = $true)]
         [string]$PathName
     )
+
     $svc = Get-CimInstance -ClassName Win32_Service -Filter "Name='$Name'" -ErrorAction Stop
-    $out = Invoke-CimMethod -InputObject $svc -MethodName Change -Arguments @{ PathName = $PathName }
+
+    $out = Invoke-CimMethod `
+        -InputObject $svc `
+        -MethodName Change `
+        -Arguments @{ PathName = $PathName } `
+        -ErrorAction Stop
+
     if ($out.ReturnValue -ne 0) {
         throw "Win32_Service.Change failed with return code $($out.ReturnValue). PathName: $PathName"
     }
@@ -222,144 +399,206 @@ function Set-Win32ServicePathName {
 
 function Set-ServiceDescriptionRegistry {
     param(
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory = $true)]
         [string]$Name,
-        [Parameter(Mandatory)]
+
+        [Parameter(Mandatory = $true)]
         [string]$Description
     )
+
     $keyPath = "HKLM:\SYSTEM\CurrentControlSet\Services\$Name"
+
     if (-not (Test-Path -LiteralPath $keyPath)) {
         return
     }
-    Set-ItemProperty -LiteralPath $keyPath -Name Description -Value $Description -Type String -Force -ErrorAction SilentlyContinue | Out-Null
+
+    Set-ItemProperty `
+        -LiteralPath $keyPath `
+        -Name Description `
+        -Value $Description `
+        -Type String `
+        -Force `
+        -ErrorAction SilentlyContinue | Out-Null
 }
 
-function New-Win32ServiceWithLogon {
+function New-WindowsServiceWithLogon {
     param(
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory = $true)]
         [string]$Name,
-        [Parameter(Mandatory)]
+
+        [Parameter(Mandatory = $true)]
         [string]$DisplayName,
-        [Parameter(Mandatory)]
+
+        [Parameter(Mandatory = $true)]
         [string]$PathName,
-        [Parameter(Mandatory)]
+
+        [Parameter(Mandatory = $true)]
         [string]$StartName,
-        [Parameter(Mandatory)]
+
+        [Parameter(Mandatory = $true)]
         [string]$StartPassword
     )
-    $out = Invoke-CimMethod -ClassName Win32_Service -MethodName Create -Arguments @{
-        Name = $Name
-        DisplayName = $DisplayName
-        PathName = $PathName
-        ServiceType = [uint32]16
-        ErrorControl = [uint32]1
-        StartMode = 'Automatic'
-        DesktopInteract = $false
-        StartName = $StartName
-        StartPassword = $StartPassword
-        LoadOrderGroup = ''
-        LoadOrderGroupDependencies = $null
-        ServiceDependencies = $null
-    }
-    if ($out.ReturnValue -ne 0) {
-        throw "Win32_Service.Create failed with return code $($out.ReturnValue)."
-    }
+
+    [GrayMoonNativeServiceInstaller]::CreateOwnProcessAutoService(
+        $Name,
+        $DisplayName,
+        $PathName,
+        $StartName,
+        $StartPassword
+    )
 }
 
 Write-Host 'Checking for existing service...' -ForegroundColor Yellow
+
 $existingService = Get-Service -Name $serviceName -ErrorAction SilentlyContinue
 $serviceExists = $null -ne $existingService
 $wasRunning = $false
 
-# Stop service if it's running (needed to unlock the executable file)
+# Stop service if it is running. This is needed to unlock the executable file.
 if ($serviceExists -and $existingService.Status -eq 'Running') {
     Write-Host 'Found running service. Stopping to allow file update...' -ForegroundColor Yellow
+
     try {
         Stop-Service -Name $serviceName -Force -ErrorAction Stop | Out-Null
         Start-Sleep -Seconds 2
         $wasRunning = $true
         Write-Host 'Service stopped.' -ForegroundColor Green
-    } catch {
+    }
+    catch {
         Write-Host "WARNING: Failed to stop service: $_" -ForegroundColor Yellow
-        Write-Host "Attempting to download anyway..." -ForegroundColor Yellow
+        Write-Host 'Attempting to download anyway...' -ForegroundColor Yellow
     }
 }
 
-# Prepare installation directory (clear existing files so the zip extract does not leave stale DLLs)
+# Prepare installation directory.
+# Clear existing files so the zip extract does not leave stale DLLs.
 Write-Host 'Preparing installation directory...' -ForegroundColor Yellow
-if (-not (Test-Path $agentPath)) {
-    New-Item -ItemType Directory -Path $agentPath -Force | Out-Null
-} else {
-    Get-ChildItem -Path $agentPath -Force | Remove-Item -Recurse -Force -ErrorAction Stop
+
+try {
+    if (-not (Test-Path -LiteralPath $agentPath)) {
+        New-Item -ItemType Directory -Path $agentPath -Force | Out-Null
+    }
+    else {
+        Get-ChildItem -LiteralPath $agentPath -Force | Remove-Item -Recurse -Force -ErrorAction Stop
+    }
+}
+catch {
+    Write-Host "ERROR: Failed to prepare installation directory '$agentPath': $_" -ForegroundColor Red
+
+    if ($wasRunning) {
+        try {
+            Start-Service -Name $serviceName -ErrorAction SilentlyContinue
+        }
+        catch {
+        }
+    }
+
+    return 1
 }
 
-# Download agent archive, then extract (framework-dependent publish: exe + DLLs)
-Write-Host "Downloading agent from {BASE_URL}..." -ForegroundColor Yellow
+# Download agent archive.
+Write-Host 'Downloading agent from http://localhost:8384...' -ForegroundColor Yellow
+
+$webClient = $null
+
 try {
     $webClient = New-Object System.Net.WebClient
     $webClient.DownloadFile($downloadUrl, $zipPath)
+
     Write-Host 'Download completed.' -ForegroundColor Green
-} catch {
+}
+catch {
     Write-Host "ERROR: Failed to download agent: $_" -ForegroundColor Red
+
     if ($wasRunning) {
-        Write-Host "Attempting to restart the service..." -ForegroundColor Yellow
+        Write-Host 'Attempting to restart the service...' -ForegroundColor Yellow
+
         try {
             Start-Service -Name $serviceName -ErrorAction SilentlyContinue
-        } catch {
-            Write-Host "Could not restart service. Please restart manually." -ForegroundColor Yellow
+        }
+        catch {
         }
     }
+
     return 1
 }
+finally {
+    if ($null -ne $webClient) {
+        $webClient.Dispose()
+    }
+}
 
+# Extract agent.
 Write-Host 'Extracting agent...' -ForegroundColor Yellow
+
 try {
     Expand-Archive -LiteralPath $zipPath -DestinationPath $agentPath -Force
-} catch {
+}
+catch {
     Write-Host "ERROR: Failed to extract agent: $_" -ForegroundColor Red
+
     if ($wasRunning) {
-        try { Start-Service -Name $serviceName -ErrorAction SilentlyContinue } catch { }
+        try {
+            Start-Service -Name $serviceName -ErrorAction SilentlyContinue
+        }
+        catch {
+        }
     }
+
     return 1
-} finally {
-    Remove-Item -Path $zipPath -Force -ErrorAction SilentlyContinue
+}
+finally {
+    Remove-Item -LiteralPath $zipPath -Force -ErrorAction SilentlyContinue
 }
 
-if (-not (Test-Path -Path $agentExe)) {
+if (-not (Test-Path -LiteralPath $agentExe)) {
     Write-Host "ERROR: graymoon-agent.exe not found under $agentPath after extract. Install .NET 8 Runtime if the app fails to start." -ForegroundColor Red
+
     if ($wasRunning) {
-        try { Start-Service -Name $serviceName -ErrorAction SilentlyContinue } catch { }
+        try {
+            Start-Service -Name $serviceName -ErrorAction SilentlyContinue
+        }
+        catch {
+        }
     }
+
     return 1
 }
+
+$binPath = Build-AgentServiceCommandLine -AgentExePath $agentExe -HubUrl $hubUrl
 
 if ($serviceExists) {
     Write-Host 'Agent files updated.' -ForegroundColor Green
     Write-Host 'Updating service to use the new binary path and hub URL...' -ForegroundColor Yellow
+
     try {
-        $hubUrl = '{HUB_URL}'
-        $binPath = Build-AgentServiceCommandLine -AgentExePath $agentExe -HubUrl $hubUrl
         Set-Win32ServicePathName -Name $serviceName -PathName $binPath
         Set-ServiceDescriptionRegistry -Name $serviceName -Description $serviceDescription
+
         Write-Host 'Service configuration updated successfully.' -ForegroundColor Green
-    } catch {
+    }
+    catch {
         Write-Host "ERROR: Failed to update service binary path: $_" -ForegroundColor Red
         Write-Host "Agent files are under $agentPath but the service was not updated. Fix the service command line or re-run this script after resolving the error." -ForegroundColor Yellow
+
         return 1
     }
-} else {
-    # Service doesn't exist: create it
+}
+else {
     Write-Host 'Installing as Windows service...' -ForegroundColor Yellow
-    try {
-        $hubUrl = '{HUB_URL}'
-        $binPath = Build-AgentServiceCommandLine -AgentExePath $agentExe -HubUrl $hubUrl
 
-        # Install service to run as current user (required for git credentials, dotnet tools, and user environment)
+    try {
+        # Run service as current user.
+        # This is useful for git credentials, dotnet tools, and user environment.
         $currentUser = [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
+
         Write-Host "Service will run as: $currentUser" -ForegroundColor Cyan
-        Write-Host "Enter password for $currentUser (required for service to access git credentials and dotnet tools):" -ForegroundColor Yellow
-        $password = Read-Host -Prompt "Password" -AsSecureString
+        Write-Host "Enter password for $currentUser. This is required for the service to access git credentials and dotnet tools." -ForegroundColor Yellow
+
+        $password = Read-Host -Prompt 'Password' -AsSecureString
         $passwordBstr = [IntPtr]::Zero
+        $passwordPlain = $null
+
         try {
             $passwordBstr = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($password)
             $passwordPlain = [Runtime.InteropServices.Marshal]::PtrToStringBSTR($passwordBstr)
@@ -371,31 +610,49 @@ if ($serviceExists) {
             Write-Host 'Granting "Log on as a service" right...' -ForegroundColor Yellow
             Grant-ServiceLogonRight -AccountName $currentUser
 
-            New-Win32ServiceWithLogon -Name $serviceName -DisplayName $serviceDisplayName -PathName $binPath -StartName $currentUser -StartPassword $passwordPlain
+            Write-Host 'Creating Windows service...' -ForegroundColor Yellow
+
+            New-WindowsServiceWithLogon `
+                -Name $serviceName `
+                -DisplayName $serviceDisplayName `
+                -PathName $binPath `
+                -StartName $currentUser `
+                -StartPassword $passwordPlain
+
             Set-ServiceDescriptionRegistry -Name $serviceName -Description $serviceDescription
         }
         finally {
             if ($passwordBstr -ne [IntPtr]::Zero) {
                 [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($passwordBstr)
             }
+
             $passwordPlain = $null
-            $password.Dispose()
+
+            if ($null -ne $password) {
+                $password.Dispose()
+            }
+
             [System.GC]::Collect()
         }
 
         Write-Host 'Service installed successfully.' -ForegroundColor Green
-    } catch {
+    }
+    catch {
         Write-Host "ERROR: Failed to install service: $_" -ForegroundColor Red
+
         return 1
     }
 }
 
-# Start service
+# Start service.
 Write-Host 'Starting service...' -ForegroundColor Yellow
+
 try {
     Start-Service -Name $serviceName -ErrorAction Stop | Out-Null
+
     Write-Host 'Service started successfully.' -ForegroundColor Green
-} catch {
+}
+catch {
     Write-Host "WARNING: Failed to start service: $_" -ForegroundColor Yellow
     Write-Host 'You may need to start it manually using: Start-Service -Name GrayMoonAgent' -ForegroundColor Yellow
 }

--- a/src/GrayMoon.App/Resources/install-agent.ps1
+++ b/src/GrayMoon.App/Resources/install-agent.ps1
@@ -251,7 +251,7 @@ function New-Win32ServiceWithLogon {
         Name = $Name
         DisplayName = $DisplayName
         PathName = $PathName
-        ServiceType = [uint8]16
+        ServiceType = [uint32]16
         ErrorControl = [uint32]1
         StartMode = 'Automatic'
         DesktopInteract = $false

--- a/src/GrayMoon.App/Resources/install-agent.ps1
+++ b/src/GrayMoon.App/Resources/install-agent.ps1
@@ -107,8 +107,7 @@ public static class GrayMoonServiceLogonRights
     [DllImport("advapi32.dll")]
     private static extern int LsaNtStatusToWinError(uint Status);
 
-    private const uint POLICY_CREATE_ACCOUNT = 0x00000010;
-    private const uint POLICY_LOOKUP_NAMES   = 0x00000800;
+    private const uint POLICY_ALL_ACCESS = 0x000F0FFF;
 
     public static void AddAccountRight(byte[] sidBytes, string rightName)
     {
@@ -121,37 +120,36 @@ public static class GrayMoonServiceLogonRights
         LSA_OBJECT_ATTRIBUTES attributes = new LSA_OBJECT_ATTRIBUTES();
         attributes.Length = (uint)Marshal.SizeOf(typeof(LSA_OBJECT_ATTRIBUTES));
 
+        GCHandle sidHandle = GCHandle.Alloc(sidBytes, GCHandleType.Pinned);
         IntPtr policyHandle = IntPtr.Zero;
-        IntPtr sidPtr = IntPtr.Zero;
         IntPtr rightPtr = IntPtr.Zero;
-
-        uint status = LsaOpenPolicy(
-            IntPtr.Zero,
-            ref attributes,
-            POLICY_CREATE_ACCOUNT | POLICY_LOOKUP_NAMES,
-            out policyHandle);
-
-        if (status != 0)
-        {
-            int error = LsaNtStatusToWinError(status);
-            throw new Win32Exception(error, "LsaOpenPolicy failed.");
-        }
 
         try
         {
-            sidPtr = Marshal.AllocHGlobal(sidBytes.Length);
-            Marshal.Copy(sidBytes, 0, sidPtr, sidBytes.Length);
+            uint status = LsaOpenPolicy(
+                IntPtr.Zero,
+                ref attributes,
+                POLICY_ALL_ACCESS,
+                out policyHandle);
+
+            if (status != 0)
+            {
+                int error = LsaNtStatusToWinError(status);
+                throw new Win32Exception(error, "LsaOpenPolicy failed.");
+            }
 
             rightPtr = Marshal.StringToHGlobalUni(rightName);
 
-            LSA_UNICODE_STRING right = new LSA_UNICODE_STRING();
-            right.Length = (ushort)(rightName.Length * 2);
-            right.MaximumLength = (ushort)((rightName.Length + 1) * 2);
-            right.Buffer = rightPtr;
+            LSA_UNICODE_STRING[] rights = new LSA_UNICODE_STRING[1];
+            rights[0].Buffer = rightPtr;
+            rights[0].Length = (ushort)(rightName.Length * 2);
+            rights[0].MaximumLength = (ushort)((rightName.Length + 1) * 2);
 
-            LSA_UNICODE_STRING[] rights = new LSA_UNICODE_STRING[] { right };
-
-            status = LsaAddAccountRights(policyHandle, sidPtr, rights, 1);
+            status = LsaAddAccountRights(
+                policyHandle,
+                sidHandle.AddrOfPinnedObject(),
+                rights,
+                1);
 
             if (status != 0)
             {
@@ -164,11 +162,11 @@ public static class GrayMoonServiceLogonRights
             if (rightPtr != IntPtr.Zero)
                 Marshal.FreeHGlobal(rightPtr);
 
-            if (sidPtr != IntPtr.Zero)
-                Marshal.FreeHGlobal(sidPtr);
-
             if (policyHandle != IntPtr.Zero)
                 LsaClose(policyHandle);
+
+            if (sidHandle.IsAllocated)
+                sidHandle.Free();
         }
     }
 }
@@ -343,23 +341,132 @@ function Test-UserCredentials {
     return $ok
 }
 
+function Grant-ServiceLogonRight-Secedit {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$AccountSidString
+    )
+
+    $secedit = Join-Path $env:WINDIR 'System32\secedit.exe'
+    if (-not (Test-Path -LiteralPath $secedit)) {
+        throw 'secedit.exe was not found.'
+    }
+
+    $guid = [guid]::NewGuid().ToString('N')
+    $infFile = Join-Path $env:TEMP "graymoon-secpol-$guid.inf"
+    $dbFile = Join-Path $env:TEMP "graymoon-secedit-$guid.sdb"
+    $logFile = Join-Path $env:TEMP "graymoon-secedit-$guid.log"
+    $sidToken = "*$AccountSidString"
+
+    try {
+        & $secedit /export /cfg $infFile /areas USER_RIGHTS | Out-Null
+        if ($LASTEXITCODE -ne 0) {
+            throw "secedit export exited with code $LASTEXITCODE."
+        }
+
+        if (-not (Test-Path -LiteralPath $infFile)) {
+            throw "secedit export did not create '$infFile'."
+        }
+
+        $lines = @(Get-Content -LiteralPath $infFile -Encoding Unicode)
+        $updated = $false
+        $privilegeLineIndex = -1
+
+        for ($i = 0; $i -lt $lines.Count; $i++) {
+            if ($lines[$i] -match '(?i)^\s*SeServiceLogonRight\s*=') {
+                $privilegeLineIndex = $i
+                break
+            }
+        }
+
+        if ($privilegeLineIndex -ge 0) {
+            $line = $lines[$privilegeLineIndex]
+            if ($line -match [regex]::Escape($AccountSidString)) {
+                return
+            }
+
+            $value = ($line -split '=', 2)[1].Trim()
+            if ([string]::IsNullOrWhiteSpace($value)) {
+                $lines[$privilegeLineIndex] = "SeServiceLogonRight = $sidToken"
+            }
+            else {
+                $lines[$privilegeLineIndex] = "SeServiceLogonRight = $value,$sidToken"
+            }
+
+            $updated = $true
+        }
+        else {
+            $sectionIndex = -1
+            for ($i = 0; $i -lt $lines.Count; $i++) {
+                if ($lines[$i] -match '^\[Privilege Rights\]\s*$') {
+                    $sectionIndex = $i
+                    break
+                }
+            }
+
+            if ($sectionIndex -ge 0) {
+                $before = $lines[0..$sectionIndex]
+                $after = @()
+                if ($sectionIndex -lt ($lines.Count - 1)) {
+                    $after = $lines[($sectionIndex + 1)..($lines.Count - 1)]
+                }
+
+                $lines = $before + @("SeServiceLogonRight = $sidToken") + $after
+            }
+            else {
+                $lines = $lines + @('[Privilege Rights]', "SeServiceLogonRight = $sidToken")
+            }
+
+            $updated = $true
+        }
+
+        if (-not $updated) {
+            return
+        }
+
+        $lines | Set-Content -LiteralPath $infFile -Encoding Unicode
+
+        & $secedit /configure /db $dbFile /cfg $infFile /areas USER_RIGHTS /log $logFile | Out-Null
+        if ($LASTEXITCODE -ne 0) {
+            $logText = ''
+            if (Test-Path -LiteralPath $logFile) {
+                $logText = Get-Content -LiteralPath $logFile -Raw -ErrorAction SilentlyContinue
+            }
+
+            throw "secedit configure exited with code $LASTEXITCODE. $logText"
+        }
+    }
+    finally {
+        Remove-Item -LiteralPath $infFile, $dbFile, $logFile -Force -ErrorAction SilentlyContinue
+    }
+}
+
 function Grant-ServiceLogonRight {
     param(
         [Parameter(Mandatory = $true)]
-        [string]$AccountName
+        [System.Security.Principal.SecurityIdentifier]$AccountSid
     )
 
+    $sidBytes = New-Object byte[] $AccountSid.BinaryLength
+    $AccountSid.GetBinaryForm($sidBytes, 0)
+    $sidString = $AccountSid.Value
+    $lsaError = $null
+
     try {
-        $ntAccount = New-Object System.Security.Principal.NTAccount($AccountName)
-        $sidObj = $ntAccount.Translate([System.Security.Principal.SecurityIdentifier])
-
-        $sidBytes = New-Object byte[] $sidObj.BinaryLength
-        $sidObj.GetBinaryForm($sidBytes, 0)
-
         [GrayMoonServiceLogonRights]::AddAccountRight($sidBytes, 'SeServiceLogonRight')
+        return
     }
     catch {
-        throw "Failed to grant 'Log on as a service' to '$AccountName'. $($_.Exception.Message)"
+        $lsaError = $_.Exception.Message
+    }
+
+    Write-Host "LSA grant failed ($lsaError). Trying secedit..." -ForegroundColor Yellow
+
+    try {
+        Grant-ServiceLogonRight-Secedit -AccountSidString $sidString
+    }
+    catch {
+        throw "Failed to grant 'Log on as a service' (SID: $sidString). LSA: $lsaError. Secedit: $($_.Exception.Message)"
     }
 }
 
@@ -608,7 +715,7 @@ else {
             }
 
             Write-Host 'Granting "Log on as a service" right...' -ForegroundColor Yellow
-            Grant-ServiceLogonRight -AccountName $currentUser
+            Grant-ServiceLogonRight -AccountSid ([System.Security.Principal.WindowsIdentity]::GetCurrent().User)
 
             Write-Host 'Creating Windows service...' -ForegroundColor Yellow
 

--- a/src/GrayMoon.App/Resources/install-agent.ps1
+++ b/src/GrayMoon.App/Resources/install-agent.ps1
@@ -113,10 +113,10 @@ public static class GrayMoonServiceLogonRights
     public static void AddAccountRight(byte[] sidBytes, string rightName)
     {
         if (sidBytes == null || sidBytes.Length == 0)
-            throw new ArgumentException("SID is empty.", nameof(sidBytes));
+            throw new ArgumentException("SID is empty.", "sidBytes");
 
         if (string.IsNullOrWhiteSpace(rightName))
-            throw new ArgumentException("Right name is empty.", nameof(rightName));
+            throw new ArgumentException("Right name is empty.", "rightName");
 
         LSA_OBJECT_ATTRIBUTES attributes = new LSA_OBJECT_ATTRIBUTES();
         attributes.Length = (uint)Marshal.SizeOf(typeof(LSA_OBJECT_ATTRIBUTES));
@@ -225,16 +225,16 @@ public static class GrayMoonNativeServiceInstaller
         string password)
     {
         if (string.IsNullOrWhiteSpace(name))
-            throw new ArgumentException("Service name is empty.", nameof(name));
+            throw new ArgumentException("Service name is empty.", "name");
 
         if (string.IsNullOrWhiteSpace(displayName))
-            throw new ArgumentException("Service display name is empty.", nameof(displayName));
+            throw new ArgumentException("Service display name is empty.", "displayName");
 
         if (string.IsNullOrWhiteSpace(pathName))
-            throw new ArgumentException("Service path is empty.", nameof(pathName));
+            throw new ArgumentException("Service path is empty.", "pathName");
 
         if (string.IsNullOrWhiteSpace(startName))
-            throw new ArgumentException("Service account is empty.", nameof(startName));
+            throw new ArgumentException("Service account is empty.", "startName");
 
         IntPtr scm = IntPtr.Zero;
         IntPtr service = IntPtr.Zero;

--- a/src/GrayMoon.App/Resources/install-agent.ps1
+++ b/src/GrayMoon.App/Resources/install-agent.ps1
@@ -34,12 +34,12 @@ $hubUrl = 'http://localhost:8384/hub/agent'
 $zipPath = Join-Path $env:TEMP 'graymoon-agent-windows-install.zip'
 
 # Native credential validation
-if (-not ('GrayMoonNativeLogonValidator' -as [type])) {
+if (-not ('GrayMoonNativeLogonValidatorV2' -as [type])) {
 Add-Type @"
 using System;
 using System.Runtime.InteropServices;
 
-public static class GrayMoonNativeLogonValidator
+public static class GrayMoonNativeLogonValidatorV2
 {
     [DllImport("advapi32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
     public static extern bool LogonUser(
@@ -59,14 +59,15 @@ public static class GrayMoonNativeLogonValidator
 # Native LSA rights helper.
 # IMPORTANT:
 # Add-Type cannot replace an already loaded type in the same PowerShell process.
-# If you edit this C# code and re-run it, open a fresh Administrator PowerShell window.
-if (-not ('GrayMoonServiceLogonRights' -as [type])) {
+# If you edit this C# code and re-run it, open a fresh Administrator PowerShell window
+# or change the class name again.
+if (-not ('GrayMoonServiceLogonRightsV2' -as [type])) {
 Add-Type @"
 using System;
 using System.ComponentModel;
 using System.Runtime.InteropServices;
 
-public static class GrayMoonServiceLogonRights
+public static class GrayMoonServiceLogonRightsV2
 {
     [StructLayout(LayoutKind.Sequential)]
     private struct LSA_UNICODE_STRING
@@ -177,13 +178,13 @@ public static class GrayMoonServiceLogonRights
 
 # Native Windows service creation helper.
 # This avoids Win32_Service.Create and therefore avoids the CIM ServiceType mismatch.
-if (-not ('GrayMoonNativeServiceInstaller' -as [type])) {
+if (-not ('GrayMoonNativeServiceInstallerV2' -as [type])) {
 Add-Type @"
 using System;
 using System.ComponentModel;
 using System.Runtime.InteropServices;
 
-public static class GrayMoonNativeServiceInstaller
+public static class GrayMoonNativeServiceInstallerV2
 {
     private const uint SC_MANAGER_CREATE_SERVICE = 0x00000002;
 
@@ -327,7 +328,7 @@ function Test-UserCredentials {
 
     # LOGON32_LOGON_INTERACTIVE = 2
     # LOGON32_PROVIDER_DEFAULT = 0
-    $ok = [GrayMoonNativeLogonValidator]::LogonUser(
+    $ok = [GrayMoonNativeLogonValidatorV2]::LogonUser(
         $identity.UserName,
         $identity.Domain,
         $Password,
@@ -337,7 +338,7 @@ function Test-UserCredentials {
     )
 
     if ($ok -and $tokenHandle -ne [IntPtr]::Zero) {
-        [void][GrayMoonNativeLogonValidator]::CloseHandle($tokenHandle)
+        [void][GrayMoonNativeLogonValidatorV2]::CloseHandle($tokenHandle)
     }
 
     return $ok
@@ -356,7 +357,7 @@ function Grant-ServiceLogonRight {
         $sidBytes = New-Object byte[] $sidObj.BinaryLength
         $sidObj.GetBinaryForm($sidBytes, 0)
 
-        [GrayMoonServiceLogonRights]::AddAccountRight($sidBytes, 'SeServiceLogonRight')
+        [GrayMoonServiceLogonRightsV2]::AddAccountRight($sidBytes, 'SeServiceLogonRight')
     }
     catch {
         throw "Failed to grant 'Log on as a service' to '$AccountName'. $($_.Exception.Message)"
@@ -439,7 +440,7 @@ function New-WindowsServiceWithLogon {
         [string]$StartPassword
     )
 
-    [GrayMoonNativeServiceInstaller]::CreateOwnProcessAutoService(
+    [GrayMoonNativeServiceInstallerV2]::CreateOwnProcessAutoService(
         $Name,
         $DisplayName,
         $PathName,

--- a/src/GrayMoon.App/Resources/install-agent.ps1
+++ b/src/GrayMoon.App/Resources/install-agent.ps1
@@ -34,12 +34,12 @@ $hubUrl = 'http://localhost:8384/hub/agent'
 $zipPath = Join-Path $env:TEMP 'graymoon-agent-windows-install.zip'
 
 # Native credential validation
-if (-not ('GrayMoonNativeLogonValidatorV2' -as [type])) {
+if (-not ('GrayMoonNativeLogonValidator' -as [type])) {
 Add-Type @"
 using System;
 using System.Runtime.InteropServices;
 
-public static class GrayMoonNativeLogonValidatorV2
+public static class GrayMoonNativeLogonValidator
 {
     [DllImport("advapi32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
     public static extern bool LogonUser(
@@ -59,15 +59,14 @@ public static class GrayMoonNativeLogonValidatorV2
 # Native LSA rights helper.
 # IMPORTANT:
 # Add-Type cannot replace an already loaded type in the same PowerShell process.
-# If you edit this C# code and re-run it, open a fresh Administrator PowerShell window
-# or change the class name again.
-if (-not ('GrayMoonServiceLogonRightsV2' -as [type])) {
+# If you edit this C# code and re-run it, open a fresh Administrator PowerShell window.
+if (-not ('GrayMoonServiceLogonRights' -as [type])) {
 Add-Type @"
 using System;
 using System.ComponentModel;
 using System.Runtime.InteropServices;
 
-public static class GrayMoonServiceLogonRightsV2
+public static class GrayMoonServiceLogonRights
 {
     [StructLayout(LayoutKind.Sequential)]
     private struct LSA_UNICODE_STRING
@@ -178,13 +177,13 @@ public static class GrayMoonServiceLogonRightsV2
 
 # Native Windows service creation helper.
 # This avoids Win32_Service.Create and therefore avoids the CIM ServiceType mismatch.
-if (-not ('GrayMoonNativeServiceInstallerV2' -as [type])) {
+if (-not ('GrayMoonNativeServiceInstaller' -as [type])) {
 Add-Type @"
 using System;
 using System.ComponentModel;
 using System.Runtime.InteropServices;
 
-public static class GrayMoonNativeServiceInstallerV2
+public static class GrayMoonNativeServiceInstaller
 {
     private const uint SC_MANAGER_CREATE_SERVICE = 0x00000002;
 
@@ -328,7 +327,7 @@ function Test-UserCredentials {
 
     # LOGON32_LOGON_INTERACTIVE = 2
     # LOGON32_PROVIDER_DEFAULT = 0
-    $ok = [GrayMoonNativeLogonValidatorV2]::LogonUser(
+    $ok = [GrayMoonNativeLogonValidator]::LogonUser(
         $identity.UserName,
         $identity.Domain,
         $Password,
@@ -338,7 +337,7 @@ function Test-UserCredentials {
     )
 
     if ($ok -and $tokenHandle -ne [IntPtr]::Zero) {
-        [void][GrayMoonNativeLogonValidatorV2]::CloseHandle($tokenHandle)
+        [void][GrayMoonNativeLogonValidator]::CloseHandle($tokenHandle)
     }
 
     return $ok
@@ -357,7 +356,7 @@ function Grant-ServiceLogonRight {
         $sidBytes = New-Object byte[] $sidObj.BinaryLength
         $sidObj.GetBinaryForm($sidBytes, 0)
 
-        [GrayMoonServiceLogonRightsV2]::AddAccountRight($sidBytes, 'SeServiceLogonRight')
+        [GrayMoonServiceLogonRights]::AddAccountRight($sidBytes, 'SeServiceLogonRight')
     }
     catch {
         throw "Failed to grant 'Log on as a service' to '$AccountName'. $($_.Exception.Message)"
@@ -440,7 +439,7 @@ function New-WindowsServiceWithLogon {
         [string]$StartPassword
     )
 
-    [GrayMoonNativeServiceInstallerV2]::CreateOwnProcessAutoService(
+    [GrayMoonNativeServiceInstaller]::CreateOwnProcessAutoService(
         $Name,
         $DisplayName,
         $PathName,


### PR DESCRIPTION
## Summary

Improves the Windows GrayMoon Agent install experience after reports that the one-click install script failed on some hosts (notably certain Windows 11 machines). The install script no longer creates the service via WMI `Win32_Service.Create` (which can fail with a CIM `ServiceType` mismatch on some systems). It now uses native `CreateServiceW` / SCM APIs, grants **Log on as a service** via LSA with a `secedit` fallback, and hardens error handling and cleanup around download, extract, and service lifecycle.

The Agent page install/uninstall snippets are simplified to `irm <url> | iex`, and the .NET 8 runtime note is styled for readability on dark UI.

**Known limitation:** These changes improve reliability on several failing machines but **do not fully resolve the install issue on all Windows 11 systems** tested. Failures on those hosts still need investigation (environment-specific policy, security software, account/SID handling, or other local factors).

## Changes

- **`install-agent.ps1`**
  - Create new services with `GrayMoonNativeServiceInstaller` (`OpenSCManagerW` / `CreateServiceW`) instead of `Invoke-CimMethod Win32_Service.Create`.
  - Grant `SeServiceLogonRight` via LSA (`LsaAddAccountRights`), falling back to an improved `secedit` export/configure path.
  - Prefix embedded `Add-Type` types (`GrayMoonNativeLogonValidator`, etc.) and guard loading so re-running in the same PowerShell session is safer; document using a fresh elevated window.
  - Clearer failure paths when stopping the service, preparing `%ProgramFiles%\GrayMoon`, downloading, or extracting; attempt to restart the service when an upgrade was interrupted.
- **`Agent.razor` / `Agent.razor.css`**
  - Shorter install/uninstall commands (`irm ... | iex`).
  - `.agent-runtime-note` styling for the .NET 8 runtime message.
- **`CLAUDE.md`**
  - Contributor-oriented repo commands and architecture notes.

## Test plan

- [ ] On a clean Windows 10/11 VM (elevated PowerShell): copy install command from Agent page, run `irm ... | iex`, confirm download/extract under `%ProgramFiles%\GrayMoon`, service created as current user, and service starts.
- [ ] Re-run install over an existing `GrayMoonAgent` service (upgrade path): files replaced, binary path/hub URL updated, service restarts.
- [ ] Verify uninstall still works from the Agent page command.
- [ ] Confirm install still targets the **App host URL** for download and hub (not a hardcoded localhost) when served from Docker/remote host.
- [ ] On a Windows 11 machine where install **previously failed**, re-test and capture full console output if it still fails (for follow-up).