### PR TITLE
Fix branch sync pruning, push rejection handling, and GitHub PR lookup

### DIFF
--- a/src/GrayMoon.Abstractions/Notifications/RepositorySyncNotification.cs
+++ b/src/GrayMoon.Abstractions/Notifications/RepositorySyncNotification.cs
@@ -19,6 +19,8 @@ public sealed class RepositorySyncNotification
     public int? DefaultBranchAhead { get; init; }
     public List<RepositorySyncProjectNotification>? Projects { get; init; }
     public string? ErrorMessage { get; init; }
+    /// <summary>Remote branch names (with "origin/" prefix) currently present in local refs after fetch --prune. When set, the app prunes stale remote branches from the DB.</summary>
+    public List<string>? RemoteBranches { get; init; }
 }
 
 public sealed class RepositorySyncProjectNotification

--- a/src/GrayMoon.Agent/Commands/CheckoutHookSyncCommand.cs
+++ b/src/GrayMoon.Agent/Commands/CheckoutHookSyncCommand.cs
@@ -67,9 +67,10 @@ public sealed class CheckoutHookSyncCommand(IGitService git, ICsProjFileService 
         }
 
         bool? hasUpstream = null;
+        IReadOnlyList<string>? remoteBranches = null;
         if (branch != "-")
         {
-            var remoteBranches = await git.GetRemoteBranchesFromRefsAsync(payload.RepositoryPath, cancellationToken);
+            remoteBranches = await git.GetRemoteBranchesFromRefsAsync(payload.RepositoryPath, cancellationToken);
             hasUpstream = remoteBranches.Any(r => string.Equals(r, branch, StringComparison.OrdinalIgnoreCase));
         }
 
@@ -110,7 +111,9 @@ public sealed class CheckoutHookSyncCommand(IGitService git, ICsProjFileService 
                 DefaultBranchBehind = defaultBehind,
                 DefaultBranchAhead = defaultAhead,
                 Projects = syncProjects,
-                ErrorMessage = fetchError
+                ErrorMessage = fetchError,
+                // Include remote branches when fetch succeeded so the app can prune deleted remote branches from the DB
+                RemoteBranches = fetchError == null && remoteBranches != null ? remoteBranches.ToList() : null
             };
             await connection.InvokeAsync(AgentHubMethods.SyncCommand, notification, cancellationToken);
             logger.LogInformation("CheckoutHookSync sent: workspace={WorkspaceId}, repo={RepoId}, version={Version}, branch={Branch}, ↑{Outgoing} ↓{Incoming}, hasUpstream={HasUpstream}",

--- a/src/GrayMoon.Agent/Commands/SyncToDefaultBranchCommand.cs
+++ b/src/GrayMoon.Agent/Commands/SyncToDefaultBranchCommand.cs
@@ -24,6 +24,21 @@ public sealed class SyncToDefaultBranchCommand(IGitService git) : ICommandHandle
             };
         }
 
+        // Resolve default branch name first (needed for safety check before remote delete)
+        var defaultBranch = await git.GetDefaultBranchNameAsync(repoPath, cancellationToken);
+        if (string.IsNullOrWhiteSpace(defaultBranch))
+        {
+            return new SyncToDefaultBranchResponse
+            {
+                Success = false,
+                ErrorMessage = "Could not determine default branch"
+            };
+        }
+
+        // If the user confirmed remote branch deletion, delete it before fetch so --prune removes the tracking ref
+        if (request.DeleteRemoteBranch && !string.Equals(currentBranchName, defaultBranch, StringComparison.OrdinalIgnoreCase))
+            await git.DeleteBranchAsync(repoPath, currentBranchName, isRemote: true, force: false, cancellationToken);
+
         // Fetch to update remote-tracking refs and prune deleted remote branches
         var (fetchSuccess, fetchError) = await git.FetchAsync(repoPath, includeTags: true, request.BearerToken, cancellationToken);
         if (!fetchSuccess)
@@ -32,17 +47,6 @@ public sealed class SyncToDefaultBranchCommand(IGitService git) : ICommandHandle
             {
                 Success = false,
                 ErrorMessage = fetchError ?? "Failed to fetch from origin"
-            };
-        }
-
-        // Get default branch
-        var defaultBranch = await git.GetDefaultBranchNameAsync(repoPath, cancellationToken);
-        if (string.IsNullOrWhiteSpace(defaultBranch))
-        {
-            return new SyncToDefaultBranchResponse
-            {
-                Success = false,
-                ErrorMessage = "Could not determine default branch"
             };
         }
 

--- a/src/GrayMoon.Agent/Commands/SyncToDefaultBranchCommand.cs
+++ b/src/GrayMoon.Agent/Commands/SyncToDefaultBranchCommand.cs
@@ -24,6 +24,17 @@ public sealed class SyncToDefaultBranchCommand(IGitService git) : ICommandHandle
             };
         }
 
+        // Fetch to update remote-tracking refs and prune deleted remote branches
+        var (fetchSuccess, fetchError) = await git.FetchAsync(repoPath, includeTags: true, request.BearerToken, cancellationToken);
+        if (!fetchSuccess)
+        {
+            return new SyncToDefaultBranchResponse
+            {
+                Success = false,
+                ErrorMessage = fetchError ?? "Failed to fetch from origin"
+            };
+        }
+
         // Get default branch
         var defaultBranch = await git.GetDefaultBranchNameAsync(repoPath, cancellationToken);
         if (string.IsNullOrWhiteSpace(defaultBranch))
@@ -66,11 +77,20 @@ public sealed class SyncToDefaultBranchCommand(IGitService git) : ICommandHandle
             };
         }
 
+        var localBranches = await git.GetLocalBranchesAsync(repoPath, cancellationToken);
+        var remoteBranches = await git.GetRemoteBranchesFromRefsAsync(repoPath, cancellationToken);
+        var tags = await git.GetTagsAsync(repoPath, cancellationToken);
+        var currentTag = await git.GetCheckedOutTagAsync(repoPath, cancellationToken);
+
         return new SyncToDefaultBranchResponse
         {
             Success = true,
             CurrentBranch = defaultBranch,
-            DefaultBranch = defaultBranch
+            DefaultBranch = defaultBranch,
+            LocalBranches = localBranches,
+            RemoteBranches = remoteBranches,
+            Tags = tags,
+            CurrentTag = currentTag
         };
     }
 }

--- a/src/GrayMoon.Agent/Jobs/Requests/SyncToDefaultBranchRequest.cs
+++ b/src/GrayMoon.Agent/Jobs/Requests/SyncToDefaultBranchRequest.cs
@@ -19,4 +19,8 @@ public sealed class SyncToDefaultBranchRequest : WorkspaceCommandRequest
     /// <summary>When true, delete the previous local branch with -D (force). Set from PR merged status by the App.</summary>
     [JsonPropertyName("forceDeleteLocalBranch")]
     public bool ForceDeleteLocalBranch { get; set; }
+
+    /// <summary>When true, delete the remote branch before fetching. Set from user confirmation in the UI.</summary>
+    [JsonPropertyName("deleteRemoteBranch")]
+    public bool DeleteRemoteBranch { get; set; }
 }

--- a/src/GrayMoon.Agent/Jobs/Response/SyncToDefaultBranchResponse.cs
+++ b/src/GrayMoon.Agent/Jobs/Response/SyncToDefaultBranchResponse.cs
@@ -15,4 +15,16 @@ public sealed class SyncToDefaultBranchResponse
 
     [JsonPropertyName("errorMessage")]
     public string? ErrorMessage { get; set; }
+
+    [JsonPropertyName("localBranches")]
+    public IReadOnlyList<string>? LocalBranches { get; set; }
+
+    [JsonPropertyName("remoteBranches")]
+    public IReadOnlyList<string>? RemoteBranches { get; set; }
+
+    [JsonPropertyName("tags")]
+    public IReadOnlyList<string>? Tags { get; set; }
+
+    [JsonPropertyName("currentTag")]
+    public string? CurrentTag { get; set; }
 }

--- a/src/GrayMoon.Agent/Services/GitService.cs
+++ b/src/GrayMoon.Agent/Services/GitService.cs
@@ -336,7 +336,7 @@ public sealed class GitService(IOptions<AgentOptions> options, ILogger<GitServic
         var logArgs = "";
         if (string.IsNullOrWhiteSpace(bearerToken))
         {
-            args = $"fetch origin {refArgs}";
+            args = $"fetch origin --prune {refArgs}";
             logArgs = args;
         }
         else
@@ -345,7 +345,7 @@ public sealed class GitService(IOptions<AgentOptions> options, ILogger<GitServic
             var base64 = Convert.ToBase64String(Encoding.UTF8.GetBytes(credentials));
             var headerValue = "Authorization: Basic " + base64;
             var escaped = headerValue.Replace("\\", "\\\\").Replace("\"", "\\\"");
-            args = $"-c core.askpass=true -c credential.helper= -c \"http.extraHeader={escaped}\" fetch origin {refArgs}";
+            args = $"-c core.askpass=true -c credential.helper= -c \"http.extraHeader={escaped}\" fetch origin --prune {refArgs}";
             logArgs = "***";
         }
 

--- a/src/GrayMoon.App/Api/Endpoints/BranchEndpoints.cs
+++ b/src/GrayMoon.App/Api/Endpoints/BranchEndpoints.cs
@@ -162,7 +162,9 @@ public static class BranchEndpoints
 
         var workspaceId = body.WorkspaceId;
         var repositoryId = body.RepositoryId;
-        var branchName = body.BranchName;
+        var branchName = body.BranchName?.StartsWith("origin/", StringComparison.OrdinalIgnoreCase) == true
+            ? body.BranchName.Substring("origin/".Length)
+            : body.BranchName;
         var isTag = body.IsTag;
 
         if (workspaceId <= 0 || repositoryId <= 0 || string.IsNullOrWhiteSpace(branchName))
@@ -273,6 +275,7 @@ public static class BranchEndpoints
         GitHubRepositoryRepository repoRepository,
         WorkspacePullRequestRepository workspacePullRequestRepository,
         AppDbContext dbContext,
+        WorkspaceGitService workspaceGitService,
         IHubContext<WorkspaceSyncHub> hubContext,
         ConnectorHealthService connectorHealthService,
         ILoggerFactory loggerFactory)
@@ -331,14 +334,32 @@ public static class BranchEndpoints
             if (!commandSuccess)
                 return Results.Problem(errorMessage, statusCode: 500);
 
-            // Sync prunes the previous local branch; remove it from persistence
-            var toRemove = await dbContext.RepositoryBranches
-                .Where(rb => rb.WorkspaceRepositoryId == wr.WorkspaceRepositoryId && !rb.IsRemote && rb.BranchName == currentBranchName)
-                .ToListAsync(CancellationToken.None);
-            if (toRemove.Count > 0)
+            // Persist the full branch state returned by the agent (fetch --prune was run, so stale remote branches are gone)
+            if (syncResponse?.LocalBranches != null)
             {
-                dbContext.RepositoryBranches.RemoveRange(toRemove);
-                await dbContext.SaveChangesAsync(CancellationToken.None);
+                var localBranches = syncResponse.LocalBranches.Where(b => !string.IsNullOrWhiteSpace(b)).ToList();
+                var remoteBranches = syncResponse.RemoteBranches?.Where(b => !string.IsNullOrWhiteSpace(b)).ToList() ?? new List<string>();
+                var tags = syncResponse.Tags?.Where(t => !string.IsNullOrWhiteSpace(t)).ToList() ?? new List<string>();
+                await workspaceGitService.PersistBranchesAsync(
+                    wr.WorkspaceRepositoryId,
+                    localBranches,
+                    remoteBranches,
+                    syncResponse.DefaultBranch,
+                    tags,
+                    syncResponse.CurrentTag,
+                    CancellationToken.None);
+            }
+            else
+            {
+                // Fallback for older agents: prune only the previous local branch
+                var toRemove = await dbContext.RepositoryBranches
+                    .Where(rb => rb.WorkspaceRepositoryId == wr.WorkspaceRepositoryId && !rb.IsRemote && rb.BranchName == currentBranchName)
+                    .ToListAsync(CancellationToken.None);
+                if (toRemove.Count > 0)
+                {
+                    dbContext.RepositoryBranches.RemoveRange(toRemove);
+                    await dbContext.SaveChangesAsync(CancellationToken.None);
+                }
             }
 
             // Broadcast update to refresh UI

--- a/src/GrayMoon.App/Api/Endpoints/BranchEndpoints.cs
+++ b/src/GrayMoon.App/Api/Endpoints/BranchEndpoints.cs
@@ -287,6 +287,7 @@ public static class BranchEndpoints
         var workspaceId = body.WorkspaceId;
         var repositoryId = body.RepositoryId;
         var currentBranchName = body.CurrentBranchName;
+        var deleteRemoteBranch = body.DeleteRemoteBranch;
 
         if (workspaceId <= 0 || repositoryId <= 0 || string.IsNullOrWhiteSpace(currentBranchName))
             return Results.BadRequest("workspaceId, repositoryId, and currentBranchName are required.");
@@ -322,7 +323,8 @@ public static class BranchEndpoints
                 currentBranchName,
                 bearerToken = ConnectorHelpers.UnprotectToken(repo.Connector?.UserToken),
                 workspaceRoot,
-                forceDeleteLocalBranch
+                forceDeleteLocalBranch,
+                deleteRemoteBranch
             };
             var response = await agentBridge.SendCommandAsync("SyncToDefaultBranch", args, CancellationToken.None);
 
@@ -884,6 +886,7 @@ public sealed class SyncToDefaultBranchApiRequest
     public int WorkspaceId { get; set; }
     public int RepositoryId { get; set; }
     public string? CurrentBranchName { get; set; }
+    public bool DeleteRemoteBranch { get; set; }
 }
 
 public sealed class CommonBranchesApiRequest

--- a/src/GrayMoon.App/Components/Modals/SyncToDefaultOptionsModal.razor
+++ b/src/GrayMoon.App/Components/Modals/SyncToDefaultOptionsModal.razor
@@ -1,0 +1,85 @@
+@using Microsoft.AspNetCore.Components.Web
+
+@if (IsVisible)
+{
+    <div class="modal show d-block" tabindex="-1" style="background-color: rgba(0,0,0,0.5);"
+         @onkeydown="HandleKeyDown"
+         @ref="_modalElement">
+        <div class="modal-dialog modal-dialog-scrollable default-branch-warning-modal">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Sync to Default</h5>
+                    <button type="button" class="btn-close" aria-label="Close" @onclick="OnCancel"></button>
+                </div>
+                <div class="modal-body">
+                    <p class="mb-2 small">@Message</p>
+                    @if (RepoItems.Count > 0)
+                    {
+                        <div class="default-branch-warning-scroll small mb-3">
+                            <ul class="list-unstyled mb-0 ps-0">
+                                @foreach (var item in RepoItems)
+                                {
+                                    <li class="mb-1">
+                                        <code>@item.RepoName</code>
+                                        <span class="text-muted">(@item.BranchName)</span>
+                                        @if (item.HasRemote)
+                                        {
+                                            <span class="badge bg-secondary ms-1" style="font-size:0.65em;">remote</span>
+                                        }
+                                    </li>
+                                }
+                            </ul>
+                        </div>
+                    }
+                    @if (RepoItems.Any(r => r.HasRemote))
+                    {
+                        <div class="form-check mt-1">
+                            <input class="form-check-input" type="checkbox" id="deleteRemoteCheck"
+                                   checked="@DeleteRemoteBranches"
+                                   @onchange="OnDeleteRemoteChanged" />
+                            <label class="form-check-label small" for="deleteRemoteCheck">
+                                Delete remote branch@(RepoItems.Count(r => r.HasRemote) > 1 ? "es" : "")
+                            </label>
+                        </div>
+                    }
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-primary" @onclick="OnProceed">Proceed</button>
+                    <button type="button" class="btn btn-outline-secondary" @onclick="OnCancel">Cancel</button>
+                </div>
+            </div>
+        </div>
+    </div>
+}
+
+@code {
+    [Parameter] public bool IsVisible { get; set; }
+    [Parameter] public string Message { get; set; } = "";
+    [Parameter] public IReadOnlyList<(string RepoName, string BranchName, bool HasRemote)> RepoItems { get; set; } = Array.Empty<(string, string, bool)>();
+    [Parameter] public bool DeleteRemoteBranches { get; set; } = true;
+    [Parameter] public EventCallback<bool> DeleteRemoteBranchesChanged { get; set; }
+    [Parameter] public EventCallback OnProceed { get; set; }
+    [Parameter] public EventCallback OnCancel { get; set; }
+
+    private ElementReference _modalElement;
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (IsVisible)
+            await _modalElement.FocusAsync();
+    }
+
+    private async Task OnDeleteRemoteChanged(ChangeEventArgs e)
+    {
+        var val = e.Value is bool b ? b : bool.TryParse(e.Value?.ToString(), out var p) && p;
+        await DeleteRemoteBranchesChanged.InvokeAsync(val);
+    }
+
+    private async Task HandleKeyDown(KeyboardEventArgs e)
+    {
+        if (e.Key == "Escape")
+            await OnCancel.InvokeAsync();
+        else if (e.Key == "Enter")
+            await OnProceed.InvokeAsync();
+    }
+}

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor
@@ -248,6 +248,14 @@
                            OnProceed="@OnDefaultBranchWarningProceedAsync"
                            OnCancel="@CloseDefaultBranchWarningModal" />
 
+<SyncToDefaultOptionsModal IsVisible="@_syncToDefaultOptionsModal.IsVisible"
+                           Message="@_syncToDefaultOptionsModal.Message"
+                           RepoItems="@_syncToDefaultOptionsModal.RepoItems"
+                           DeleteRemoteBranches="@_syncToDefaultOptionsModal.DeleteRemoteBranches"
+                           DeleteRemoteBranchesChanged="@(v => _syncToDefaultOptionsModal = _syncToDefaultOptionsModal with { DeleteRemoteBranches = v })"
+                           OnProceed="@OnSyncToDefaultOptionsProceedAsync"
+                           OnCancel="@CloseSyncToDefaultOptionsModal" />
+
 <NewPullRequestModal IsVisible="@_newPrModal.IsVisible"
                      IsBusy="@isCreatingPullRequests"
                      Targets="@_newPrModal.Targets"

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
@@ -1112,7 +1112,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
         try
         {
             var repoIdsThatNeedPush = workspaceRepositories
-                .Where(wr => !wr.IsOnTag && ((wr.OutgoingCommits ?? 0) > 0 || wr.BranchHasUpstream == false))
+                .Where(wr => !wr.IsOnTag && (wr.OutgoingCommits ?? 0) > 0)
                 .Select(wr => wr.RepositoryId)
                 .ToHashSet();
             var depInfo = await WorkspaceDependencyService.GetPushDependencyInfoForRepoAsync(
@@ -1295,7 +1295,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
             pushPlanRepoIds = repoIdsWithUnpushed;
 
             var repoIdsThatNeedPush = workspaceRepositories
-                .Where(wr => !wr.IsOnTag && ((wr.OutgoingCommits ?? 0) > 0 || wr.BranchHasUpstream == false))
+                .Where(wr => !wr.IsOnTag && (wr.OutgoingCommits ?? 0) > 0)
                 .Select(wr => wr.RepositoryId)
                 .ToHashSet();
             var depInfo = await WorkspaceDependencyService.GetPushDependencyInfoForRepoSetAsync(

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
@@ -2366,7 +2366,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
                 ToastService.Show("Skipped sync to default: commits ahead of default branch and PR is not merged.");
                 return;
             }
-            await SyncToDefaultSingleRepoAfterCheckAsync(repositoryId, repositoryName, currentBranchName, hasUpstream, defaultBranch);
+            await SyncToDefaultSingleRepoAfterCheckAsync(repositoryId, repositoryName, currentBranchName, defaultBranch);
         }
         catch (Exception ex)
         {
@@ -2375,7 +2375,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
         }
     }
 
-    private async Task SyncToDefaultSingleRepoAfterCheckAsync(int repositoryId, string repositoryName, string currentBranchName, bool deleteRemoteFirst, string? defaultBranchName = null)
+    private async Task SyncToDefaultSingleRepoAfterCheckAsync(int repositoryId, string repositoryName, string currentBranchName, string? defaultBranchName = null)
     {
         if (workspace == null || isSyncingToDefault || isSyncing || isUpdating)
             return;
@@ -2391,7 +2391,6 @@ public sealed partial class WorkspaceRepositories : IDisposable
                 WorkspaceId,
                 repositoryId,
                 currentBranchName,
-                deleteRemoteFirst,
                 ApiBaseUrl,
                 CancellationToken.None);
 
@@ -2467,13 +2466,10 @@ public sealed partial class WorkspaceRepositories : IDisposable
                 await semaphore.WaitAsync();
                 try
                 {
-                    var hasUpstream = resultByRepo.TryGetValue(repositoryId, out var r) && r.HasUpstream == true;
-
                     var (success, errMsg) = await WorkspaceBranchHandler.SyncToDefaultSingleAsync(
                         WorkspaceId,
                         repositoryId,
                         currentBranchName,
-                        hasUpstream,
                         ApiBaseUrl,
                         CancellationToken.None);
 

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
@@ -101,6 +101,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
     private PushWithDependenciesModalState _pushWithDependenciesModal = new();
     private ConfirmModalState _confirmModal = new();
     private DefaultBranchWarningModalState _defaultBranchWarningModal = new();
+    private SyncToDefaultOptionsModalState _syncToDefaultOptionsModal = new();
     private string searchTerm = string.Empty;
 
     private bool _syncAwaitingAgentTasks;
@@ -594,6 +595,34 @@ public sealed partial class WorkspaceRepositories : IDisposable
             await action();
     }
 
+    private void ShowSyncToDefaultOptions(string message, IReadOnlyList<(string RepoName, string BranchName, bool HasRemote)> repoItems, Func<bool, Task> onProceed, bool defaultDeleteRemote = true)
+    {
+        _syncToDefaultOptionsModal = _syncToDefaultOptionsModal with
+        {
+            IsVisible = true,
+            Message = message,
+            RepoItems = repoItems,
+            DeleteRemoteBranches = defaultDeleteRemote,
+            PendingAction = onProceed
+        };
+        StateHasChanged();
+    }
+
+    private void CloseSyncToDefaultOptionsModal()
+    {
+        _syncToDefaultOptionsModal = _syncToDefaultOptionsModal with { IsVisible = false, PendingAction = null };
+        StateHasChanged();
+    }
+
+    private async Task OnSyncToDefaultOptionsProceedAsync()
+    {
+        var action = _syncToDefaultOptionsModal.PendingAction;
+        var deleteRemote = _syncToDefaultOptionsModal.DeleteRemoteBranches;
+        CloseSyncToDefaultOptionsModal();
+        if (action != null)
+            await action(deleteRemote);
+    }
+
 
     // --- New Pull Request dialog -----------------------------------------------------------
 
@@ -930,9 +959,16 @@ public sealed partial class WorkspaceRepositories : IDisposable
             _syncToDefaultCheckResults = checkResults.Where(r => safeRepoIds.Contains(r.RepoId)).ToList();
             var safeCount = safeRepoIds.Count;
             var message = safeCount == 1
-                ? "This will checkout the default branch, remove the current branch locally, and pull the latest. If the branch had an upstream, the remote branch may be deleted. Uncommitted local changes can block checkout."
-                : $"This will sync {safeCount} repositories to their default branch: checkout default, remove the current branch locally, and pull. If a branch had an upstream, the remote branch may be deleted. Uncommitted local changes can block checkout for that repo.";
-            ShowConfirm(message, () => SyncToDefaultLevelAsync(safeRepoIds), "Proceed");
+                ? "This will checkout the default branch, remove the current branch locally, and pull the latest. Uncommitted local changes can block checkout."
+                : $"This will sync {safeCount} repositories to their default branch: checkout default, remove the current branch locally, and pull. Uncommitted local changes can block checkout for that repo.";
+            var repoItems = _syncToDefaultCheckResults
+                .Select(r =>
+                {
+                    var wr2 = workspaceRepositories.FirstOrDefault(w => w.RepositoryId == r.RepoId);
+                    return (RepoName: wr2?.Repository?.RepositoryName ?? r.RepoId.ToString(), BranchName: wr2?.BranchName ?? "", HasRemote: r.HasUpstream == true);
+                })
+                .ToList();
+            ShowSyncToDefaultOptions(message, repoItems, deleteRemote => SyncToDefaultLevelAsync(safeRepoIds, deleteRemote));
         }
         catch (Exception ex)
         {
@@ -2366,7 +2402,19 @@ public sealed partial class WorkspaceRepositories : IDisposable
                 ToastService.Show("Skipped sync to default: commits ahead of default branch and PR is not merged.");
                 return;
             }
-            await SyncToDefaultSingleRepoAfterCheckAsync(repositoryId, repositoryName, currentBranchName, defaultBranch);
+
+            if (hasUpstream)
+            {
+                var branchName = wr?.BranchName ?? currentBranchName;
+                ShowSyncToDefaultOptions(
+                    "This will checkout the default branch, remove the current branch locally, and pull the latest.",
+                    [(repositoryName!, branchName, true)],
+                    deleteRemote => SyncToDefaultSingleRepoAfterCheckAsync(repositoryId, repositoryName, currentBranchName, deleteRemote, defaultBranch));
+            }
+            else
+            {
+                await SyncToDefaultSingleRepoAfterCheckAsync(repositoryId, repositoryName, currentBranchName, deleteRemoteBranch: false, defaultBranch);
+            }
         }
         catch (Exception ex)
         {
@@ -2375,7 +2423,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
         }
     }
 
-    private async Task SyncToDefaultSingleRepoAfterCheckAsync(int repositoryId, string repositoryName, string currentBranchName, string? defaultBranchName = null)
+    private async Task SyncToDefaultSingleRepoAfterCheckAsync(int repositoryId, string repositoryName, string currentBranchName, bool deleteRemoteBranch = false, string? defaultBranchName = null)
     {
         if (workspace == null || isSyncingToDefault || isSyncing || isUpdating)
             return;
@@ -2391,6 +2439,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
                 WorkspaceId,
                 repositoryId,
                 currentBranchName,
+                deleteRemoteBranch,
                 ApiBaseUrl,
                 CancellationToken.None);
 
@@ -2417,7 +2466,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
         }
     }
 
-    private async Task SyncToDefaultLevelAsync(List<int> repositoryIds)
+    private async Task SyncToDefaultLevelAsync(List<int> repositoryIds, bool deleteRemoteBranch = false)
     {
         if (workspace == null || repositoryIds == null || repositoryIds.Count == 0 || isSyncingToDefault || isSyncing || isUpdating)
             return;
@@ -2470,6 +2519,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
                         WorkspaceId,
                         repositoryId,
                         currentBranchName,
+                        deleteRemoteBranch,
                         ApiBaseUrl,
                         CancellationToken.None);
 
@@ -2745,6 +2795,15 @@ public sealed partial class WorkspaceRepositories : IDisposable
         public string Message { get; init; } = "";
         public IReadOnlyList<(string RepoName, string DefaultBranchName)> RepoItems { get; init; } = Array.Empty<(string, string)>();
         public Func<Task>? PendingAction { get; init; }
+    }
+
+    private sealed record SyncToDefaultOptionsModalState
+    {
+        public bool IsVisible { get; init; }
+        public string Message { get; init; } = "";
+        public IReadOnlyList<(string RepoName, string BranchName, bool HasRemote)> RepoItems { get; init; } = Array.Empty<(string, string, bool)>();
+        public bool DeleteRemoteBranches { get; init; } = true;
+        public Func<bool, Task>? PendingAction { get; init; }
     }
 
     private sealed class RepositoriesModalState

--- a/src/GrayMoon.App/Models/Api/BranchesApiModels.cs
+++ b/src/GrayMoon.App/Models/Api/BranchesApiModels.cs
@@ -106,6 +106,18 @@ public sealed class SyncToDefaultBranchResponse
 
     [JsonPropertyName("errorMessage")]
     public string? ErrorMessage { get; set; }
+
+    [JsonPropertyName("localBranches")]
+    public List<string>? LocalBranches { get; set; }
+
+    [JsonPropertyName("remoteBranches")]
+    public List<string>? RemoteBranches { get; set; }
+
+    [JsonPropertyName("tags")]
+    public List<string>? Tags { get; set; }
+
+    [JsonPropertyName("currentTag")]
+    public string? CurrentTag { get; set; }
 }
 
 /// <summary>API response for POST /api/branches/delete (camelCase).</summary>

--- a/src/GrayMoon.App/Models/GitHubDtos.cs
+++ b/src/GrayMoon.App/Models/GitHubDtos.cs
@@ -163,6 +163,16 @@ public sealed class GitHubContentResponse
     public string? Content { get; set; }
 }
 
+public sealed class GitHubUserDto
+{
+    [JsonPropertyName("login")]
+    public string? Login { get; set; }
+
+    /// <summary>"User" for human accounts, "Bot" for GitHub Apps and automation accounts.</summary>
+    [JsonPropertyName("type")]
+    public string? Type { get; set; }
+}
+
 /// <summary>Pull request list item from GET /repos/{owner}/{repo}/pulls.</summary>
 public class GitHubPullRequestDto
 {
@@ -195,6 +205,9 @@ public class GitHubPullRequestDto
 
     [JsonPropertyName("changed_files")]
     public int? ChangedFiles { get; set; }
+
+    [JsonPropertyName("user")]
+    public GitHubUserDto? User { get; set; }
 }
 
 public class GitHubPullRequestHeadDto

--- a/src/GrayMoon.App/Services/GitHubService.cs
+++ b/src/GrayMoon.App/Services/GitHubService.cs
@@ -400,7 +400,7 @@ public class GitHubService : IConnectorService
         return (organizations.Count, repositories.Count);
     }
 
-    /// <summary>Gets the pull request for the given branch in the repo, if any. Uses GET /repos/{owner}/{repo}/pulls?state=all&amp;head=owner:branch&amp;per_page=1. Returns null when no PR or API error.</summary>
+    /// <summary>Gets the pull request for the given branch in the repo, if any. Fetches up to 5 and returns the first one opened by a human (user.type != "Bot"), falling back to the first match when all are bots. Returns null when no PR or API error.</summary>
     public async Task<GitHubPullRequestDto?> GetPullRequestForBranchAsync(Connector connector, string owner, string repo, string branch, CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(owner))
@@ -413,17 +413,21 @@ public class GitHubService : IConnectorService
         EnsureConnectorConfigured(connector);
 
         var head = $"{owner}:{Uri.EscapeDataString(branch)}";
-        var requestUri = $"repos/{owner}/{repo}/pulls?state=all&head={head}&per_page=1";
+        var requestUri = $"repos/{owner}/{repo}/pulls?state=all&head={head}&per_page=5";
 
         try
         {
             var list = await GetAsync<List<GitHubPullRequestDto>>(connector, requestUri, cancellationToken);
-            var pr = list?.FirstOrDefault();
-            if (pr == null)
+            if (list == null || list.Count == 0)
                 return null;
-            if (pr.Head != null && !string.Equals(pr.Head.Ref, branch, StringComparison.OrdinalIgnoreCase))
+
+            var matching = list.Where(pr => pr.Head == null || string.Equals(pr.Head.Ref, branch, StringComparison.OrdinalIgnoreCase)).ToList();
+            if (matching.Count == 0)
                 return null;
-            return pr;
+
+            // Prefer a PR opened by a human; fall back to first match if all are bots
+            return matching.FirstOrDefault(pr => !string.Equals(pr.User?.Type, "Bot", StringComparison.OrdinalIgnoreCase))
+                ?? matching[0];
         }
         catch (Exception ex)
         {

--- a/src/GrayMoon.App/Services/SyncCommandHandler.cs
+++ b/src/GrayMoon.App/Services/SyncCommandHandler.cs
@@ -69,6 +69,25 @@ public sealed class SyncCommandHandler(
 
         await dbContext.SaveChangesAsync();
 
+        // Prune remote branches from DB that no longer exist in git (fetch --prune ran on the agent side)
+        if (n.RemoteBranches != null)
+        {
+            var freshRemotes = n.RemoteBranches
+                .Where(b => !string.IsNullOrWhiteSpace(b))
+                .Select(b => b.StartsWith("origin/", StringComparison.OrdinalIgnoreCase) ? b : "origin/" + b)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+            var dbRemotes = await dbContext.RepositoryBranches
+                .Where(rb => rb.WorkspaceRepositoryId == wr.WorkspaceRepositoryId && rb.IsRemote)
+                .ToListAsync();
+            var stale = dbRemotes.Where(rb => !freshRemotes.Contains(rb.BranchName ?? "")).ToList();
+            if (stale.Count > 0)
+            {
+                dbContext.RepositoryBranches.RemoveRange(stale);
+                await dbContext.SaveChangesAsync();
+                logger.LogInformation("SyncCommand pruned {Count} stale remote branch(es) for repo {RepositoryId}", stale.Count, n.RepositoryId);
+            }
+        }
+
         if (n.Projects is { Count: > 0 })
         {
             var syncProjects = n.Projects

--- a/src/GrayMoon.App/Services/WorkspaceBranchHandler.cs
+++ b/src/GrayMoon.App/Services/WorkspaceBranchHandler.cs
@@ -169,13 +169,14 @@ public sealed class WorkspaceBranchHandler(
         int workspaceId,
         int repositoryId,
         string? currentBranchName,
+        bool deleteRemoteBranch,
         string apiBaseUrl,
         CancellationToken cancellationToken)
     {
         var httpClient = httpClientFactory.CreateClient();
         var baseUrl = apiBaseUrl;
 
-        var apiRequest = new { workspaceId, repositoryId, currentBranchName };
+        var apiRequest = new { workspaceId, repositoryId, currentBranchName, deleteRemoteBranch };
         var json = JsonSerializer.Serialize(apiRequest);
         using var content = new StringContent(json, System.Text.Encoding.UTF8, "application/json");
         using var response = await httpClient.PostAsync($"{baseUrl}/api/branches/sync-to-default", content, cancellationToken);

--- a/src/GrayMoon.App/Services/WorkspaceBranchHandler.cs
+++ b/src/GrayMoon.App/Services/WorkspaceBranchHandler.cs
@@ -169,29 +169,11 @@ public sealed class WorkspaceBranchHandler(
         int workspaceId,
         int repositoryId,
         string? currentBranchName,
-        bool hasUpstream,
         string apiBaseUrl,
         CancellationToken cancellationToken)
     {
         var httpClient = httpClientFactory.CreateClient();
         var baseUrl = apiBaseUrl;
-
-        if (hasUpstream)
-        {
-            var deleteRequest = new { workspaceId, repositoryId, branchName = currentBranchName, isRemote = true };
-            var deleteJson = JsonSerializer.Serialize(deleteRequest);
-            using var deleteContent = new StringContent(deleteJson, System.Text.Encoding.UTF8, "application/json");
-            using var deleteResponse = await httpClient.PostAsync($"{baseUrl}/api/branches/delete", deleteContent, cancellationToken);
-            if (!deleteResponse.IsSuccessStatusCode)
-            {
-                var deleteError = await deleteResponse.Content.ReadAsStringAsync(cancellationToken);
-                if (deleteError.IndexOf("not exist", StringComparison.OrdinalIgnoreCase) < 0 &&
-                    deleteError.IndexOf("not found", StringComparison.OrdinalIgnoreCase) < 0)
-                {
-                    logger.LogWarning("Delete remote branch failed for repo {RepositoryId}: {StatusCode}", repositoryId, deleteResponse.StatusCode);
-                }
-            }
-        }
 
         var apiRequest = new { workspaceId, repositoryId, currentBranchName };
         var json = JsonSerializer.Serialize(apiRequest);

--- a/src/GrayMoon.App/Services/WorkspacePullRequestService.cs
+++ b/src/GrayMoon.App/Services/WorkspacePullRequestService.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using GrayMoon.App.Data;
 using GrayMoon.App.Models;
 using GrayMoon.App.Repositories;
@@ -14,6 +15,9 @@ public sealed class WorkspacePullRequestService(
     IOptions<WorkspaceOptions> workspaceOptions,
     ILogger<WorkspacePullRequestService> logger)
 {
+    private static readonly TimeSpan CacheTtl = TimeSpan.FromSeconds(60);
+    private readonly ConcurrentDictionary<(int RepoId, string Branch), (PullRequestInfo? Result, DateTime FetchedAt)> _cache = new();
+
     private int MaxConcurrency => Math.Max(1, workspaceOptions.Value.MaxParallelOperations);
 
     /// <summary>Returns persisted PR state for the workspace keyed by RepositoryId. Used when building grid from cache.</summary>
@@ -43,7 +47,16 @@ public sealed class WorkspacePullRequestService(
             await semaphore.WaitAsync(cancellationToken);
             try
             {
-                var pr = await gitHubPullRequestService.GetPullRequestForBranchAsync(wr.Repository!, wr.Repository!.Connector, wr.BranchName, cancellationToken);
+                var branch = wr.BranchName!;
+                var cacheKey = (wr.RepositoryId, branch);
+                if (_cache.TryGetValue(cacheKey, out var cached) && DateTime.UtcNow - cached.FetchedAt < CacheTtl)
+                {
+                    logger.LogTrace("PR cache hit for repo {RepositoryId}, branch {Branch}", wr.RepositoryId, branch);
+                    return;
+                }
+
+                var pr = await gitHubPullRequestService.GetPullRequestForBranchAsync(wr.Repository!, wr.Repository!.Connector, branch, cancellationToken);
+                _cache[cacheKey] = (pr, DateTime.UtcNow);
                 await pullRequestRepository.UpsertAsync(wr.WorkspaceRepositoryId, pr, cancellationToken);
             }
             catch (Exception ex)

--- a/src/GrayMoon.App/Services/WorkspacePushService.cs
+++ b/src/GrayMoon.App/Services/WorkspacePushService.cs
@@ -355,6 +355,8 @@ public sealed class WorkspacePushService(
         if (!success)
         {
             var rawErr = response.Error ?? AgentResponseJson.DeserializeAgentResponse<PushRepositoryResponse>(response.Data!)?.ErrorMessage;
+            if (IsNonFastForwardRejection(rawErr))
+                await FetchAfterRejectionAsync(workspaceId, repositoryId, repo.RepositoryName, workspace.Name, workspaceRoot, cancellationToken);
             return (false, FormatPushError(rawErr));
         }
 
@@ -622,6 +624,8 @@ public sealed class WorkspacePushService(
                 if (!success)
                 {
                     var rawErr = response.Error ?? AgentResponseJson.DeserializeAgentResponse<PushRepositoryResponse>(response.Data!)?.ErrorMessage;
+                    if (IsNonFastForwardRejection(rawErr))
+                        await FetchAfterRejectionAsync(workspace.WorkspaceId, repo.RepoId, repo.RepoName, workspace.Name, workspaceRoot, cancellationToken);
                     onRepoError?.Invoke(repo.RepoId, FormatPushError(rawErr));
                 }
                 var c = Interlocked.Increment(ref completed);
@@ -637,13 +641,38 @@ public sealed class WorkspacePushService(
         await Task.WhenAll(pushTasks);
     }
 
+    private static bool IsNonFastForwardRejection(string? err) =>
+        err != null &&
+        (err.Contains("non-fast-forward", StringComparison.OrdinalIgnoreCase) ||
+         (err.Contains("[rejected]", StringComparison.OrdinalIgnoreCase) && err.Contains("fetch first", StringComparison.OrdinalIgnoreCase)));
+
     private static string FormatPushError(string? rawError)
     {
         var err = rawError ?? "Push failed";
-        if (err.Contains("non-fast-forward", StringComparison.OrdinalIgnoreCase) ||
-            (err.Contains("[rejected]", StringComparison.OrdinalIgnoreCase) && err.Contains("fetch first", StringComparison.OrdinalIgnoreCase)))
-            return "Push rejected: remote has new commits not present locally. Fetch or pull before pushing.";
+        if (IsNonFastForwardRejection(err))
+            return "Push rejected: remote has new commits. Fetching latest state — pull and retry.";
         return err;
+    }
+
+    private async Task FetchAfterRejectionAsync(int workspaceId, int repositoryId, string repoName, string workspaceName, string? workspaceRoot, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _agentBridge.SendCommandAsync("RefreshBranches", new
+            {
+                workspaceName,
+                repositoryId,
+                repositoryName = repoName,
+                workspaceRoot
+            }, cancellationToken);
+            await UpdateCommitCountsAndUpstreamAfterPushAsync(workspaceId,
+                [new PushRepoPayload(repositoryId, repoName, null, [])],
+                cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Fetch after push rejection failed for repo {RepoId}", repositoryId);
+        }
     }
 
     private async Task UpdateCommitCountsAndUpstreamAfterPushAsync(int workspaceId, IReadOnlyList<PushRepoPayload> repos, CancellationToken cancellationToken)

--- a/src/GrayMoon.App/Services/WorkspacePushService.cs
+++ b/src/GrayMoon.App/Services/WorkspacePushService.cs
@@ -354,8 +354,8 @@ public sealed class WorkspacePushService(
         var success = response.Success && response.Data != null && AgentResponseJson.DeserializeAgentResponse<PushRepositoryResponse>(response.Data) is { Success: true };
         if (!success)
         {
-            var err = response.Error ?? AgentResponseJson.DeserializeAgentResponse<PushRepositoryResponse>(response.Data!)?.ErrorMessage ?? "Push failed";
-            return (false, err);
+            var rawErr = response.Error ?? AgentResponseJson.DeserializeAgentResponse<PushRepositoryResponse>(response.Data!)?.ErrorMessage;
+            return (false, FormatPushError(rawErr));
         }
 
         await UpdateCommitCountsAndUpstreamAfterPushAsync(workspaceId,
@@ -621,8 +621,8 @@ public sealed class WorkspacePushService(
                 var success = response.Success && response.Data != null && AgentResponseJson.DeserializeAgentResponse<PushRepositoryResponse>(response.Data) is { Success: true };
                 if (!success)
                 {
-                    var err = response.Error ?? AgentResponseJson.DeserializeAgentResponse<PushRepositoryResponse>(response.Data!)?.ErrorMessage ?? "Push failed";
-                    onRepoError?.Invoke(repo.RepoId, err);
+                    var rawErr = response.Error ?? AgentResponseJson.DeserializeAgentResponse<PushRepositoryResponse>(response.Data!)?.ErrorMessage;
+                    onRepoError?.Invoke(repo.RepoId, FormatPushError(rawErr));
                 }
                 var c = Interlocked.Increment(ref completed);
                 onProgressMessage?.Invoke($"Pushed {c} of {total}");
@@ -635,6 +635,15 @@ public sealed class WorkspacePushService(
             }
         });
         await Task.WhenAll(pushTasks);
+    }
+
+    private static string FormatPushError(string? rawError)
+    {
+        var err = rawError ?? "Push failed";
+        if (err.Contains("non-fast-forward", StringComparison.OrdinalIgnoreCase) ||
+            (err.Contains("[rejected]", StringComparison.OrdinalIgnoreCase) && err.Contains("fetch first", StringComparison.OrdinalIgnoreCase)))
+            return "Push rejected: remote has new commits not present locally. Fetch or pull before pushing.";
+        return err;
     }
 
     private async Task UpdateCommitCountsAndUpstreamAfterPushAsync(int workspaceId, IReadOnlyList<PushRepoPayload> repos, CancellationToken cancellationToken)


### PR DESCRIPTION
## Summary

- **Remote branch hygiene:** `git fetch` now uses `--prune` on the Agent. Sync notifications include the current remote branch list, and the App prunes stale `RepositoryBranches` rows when hooks or sync commands report updated refs. Sync-to-default fetches first and returns full local/remote/tag state so the App can persist an accurate branch list instead of only removing the previous local branch.
- **Sync-to-default no longer deletes remote branches:** Removed the pre-sync remote branch delete flow from `WorkspaceBranchHandler` and the workspace UI. GrayMoon no longer tries to delete `origin/<branch>` when switching back to default; branch state is refreshed from git instead.
- **Push rejection UX:** Non-fast-forward push failures are detected, surfaced with a clear message ("remote has new commits"), and trigger an automatic branch refresh so the grid reflects the latest remote state.
- **GitHub PR lookup:** Fetches up to 5 PRs per branch and prefers PRs opened by humans over bot-authored ones (e.g. Dependabot). Added a 60-second in-memory cache to reduce duplicate GitHub API calls during grid refresh.
- **Minor fixes:** Checkout accepts `origin/` prefixed branch names; push dependency planning only includes repos with outgoing commits (not merely missing upstream).

## Test plan

- [ ] Delete a remote branch on GitHub, fetch/sync a workspace repo, and confirm the branch disappears from the UI and DB without manual cleanup
- [ ] Sync a feature branch back to default and confirm the remote tracking branch is **not** deleted on origin
- [ ] After sync-to-default, confirm local branches, remote branches, and tags in the UI match `git branch -a` / `git tag`
- [ ] Push when the remote has new commits and confirm the error message is user-friendly and commit counts refresh after the automatic fetch
- [ ] On a branch with both a bot PR and a human PR, confirm the grid shows the human-authored PR
- [ ] Verify PR state still loads correctly and repeated grid refreshes within 60s do not spam GitHub (cache hit in logs)
- [ ] Checkout using a branch name with an `origin/` prefix and confirm it succeeds