### PR TITLE
Add workspace New Feature workflow with Update & Push, inline branch sync, and sync-to-default fixes

### DIFF
--- a/src/GrayMoon.Agent/Abstractions/IGitService.cs
+++ b/src/GrayMoon.Agent/Abstractions/IGitService.cs
@@ -23,9 +23,9 @@ public interface IGitService
     /// Fetches only the refs needed for commit counts: the current branch and the default origin branch (when available),
     /// instead of fetching all remote branches and tags. Returns (success, errorMessage).
     /// </summary>
-    Task<(bool Success, string? ErrorMessage)> FetchMinimalAsync(string repoPath, string branchName, string? defaultBranchOriginRef, string? bearerToken, CancellationToken ct);
+    Task<(bool Success, string? ErrorMessage)> FetchMinimalAsync(string repoPath, string branchName, string? defaultBranchOriginRef, string? bearerToken, CancellationToken ct, bool skipUpstreamCheck = false);
     /// <summary>Returns (outgoing count, incoming count, hasUpstream) for the current branch vs origin/branchName. When the branch has no upstream, returns (null, null) or (aheadOfDefault, null) and hasUpstream false. When <paramref name="defaultBranchOriginRef"/> is provided and branch has no upstream, uses it instead of resolving default again.</summary>
-    Task<(int? Outgoing, int? Incoming, bool HasUpstream)> GetCommitCountsAsync(string repoPath, string branchName, string? defaultBranchOriginRef, CancellationToken ct);
+    Task<(int? Outgoing, int? Incoming, bool HasUpstream)> GetCommitCountsAsync(string repoPath, string branchName, string? defaultBranchOriginRef, CancellationToken ct, bool skipUpstreamCheck = false);
     /// <summary>Returns (behind, ahead, defaultBranchName) for the current branch vs the default branch. DefaultBranchName is without "origin/" prefix. When <paramref name="defaultBranchOriginRef"/> is provided, uses it instead of resolving.</summary>
     Task<(int? DefaultBehind, int? DefaultAhead, string? DefaultBranchName)> GetCommitCountsVsDefaultAsync(string repoPath, string? defaultBranchOriginRef, CancellationToken ct);
     /// <summary>Pulls from origin. Returns (success, mergeConflict, errorMessage).</summary>

--- a/src/GrayMoon.Agent/Abstractions/IGitService.cs
+++ b/src/GrayMoon.Agent/Abstractions/IGitService.cs
@@ -43,7 +43,7 @@ public interface IGitService
     /// <summary>Checks out the specified branch. Returns (success, errorMessage). When <paramref name="skipHooks"/> is true, hooks are disabled for the checkout (orchestrated flows such as sync-to-default).</summary>
     Task<(bool Success, string? ErrorMessage)> CheckoutBranchAsync(string repoPath, string branchName, CancellationToken ct, bool skipHooks = false);
     /// <summary>Creates a new branch from the given base branch and checks it out. Returns (success, errorMessage).</summary>
-    Task<(bool Success, string? ErrorMessage)> CreateBranchAsync(string repoPath, string newBranchName, string baseBranchName, CancellationToken ct);
+    Task<(bool Success, string? ErrorMessage)> CreateBranchAsync(string repoPath, string newBranchName, string baseBranchName, CancellationToken ct, bool skipHooks = false);
     /// <summary>Deletes a local branch. Returns true if successful. Only deletes if branch is not current and is merged or force flag is set.</summary>
     Task<bool> DeleteLocalBranchAsync(string repoPath, string branchName, bool force, CancellationToken ct);
     /// <summary>Deletes a local or remote branch. Returns (success, errorMessage). For remote, runs git push origin --delete. For local, when <paramref name="force"/> is true, uses git branch -D.</summary>

--- a/src/GrayMoon.Agent/Commands/CreateBranchCommand.cs
+++ b/src/GrayMoon.Agent/Commands/CreateBranchCommand.cs
@@ -4,7 +4,7 @@ using GrayMoon.Agent.Jobs.Response;
 
 namespace GrayMoon.Agent.Commands;
 
-public sealed class CreateBranchCommand(IGitService git) : ICommandHandler<CreateBranchRequest, CreateBranchResponse>
+public sealed class CreateBranchCommand(IGitService git, IAgentTokenProvider tokenProvider) : ICommandHandler<CreateBranchRequest, CreateBranchResponse>
 {
     public async Task<CreateBranchResponse> ExecuteAsync(CreateBranchRequest request, CancellationToken cancellationToken = default)
     {
@@ -25,7 +25,7 @@ public sealed class CreateBranchCommand(IGitService git) : ICommandHandler<Creat
             };
         }
 
-        var (success, errorMessage) = await git.CreateBranchAsync(repoPath, newBranchName, baseBranchName, cancellationToken);
+        var (success, errorMessage) = await git.CreateBranchAsync(repoPath, newBranchName, baseBranchName, cancellationToken, skipHooks: request.SkipHooks);
         if (!success)
         {
             return new CreateBranchResponse
@@ -37,10 +37,67 @@ public sealed class CreateBranchCommand(IGitService git) : ICommandHandler<Creat
 
         var currentBranch = await git.GetCurrentBranchNameAsync(repoPath, cancellationToken);
 
+        if (!request.SkipHooks)
+        {
+            return new CreateBranchResponse
+            {
+                Success = true,
+                CurrentBranch = currentBranch
+            };
+        }
+
+        // Inline sync: collect the same state as CheckoutHookSyncCommand so the app
+        // can persist it immediately without waiting for the suppressed post-checkout hook.
+        var defaultRef = await git.GetDefaultBranchOriginRefAsync(repoPath, cancellationToken);
+
+        string? token = await tokenProvider.GetTokenForRepositoryAsync(request.RepositoryId, cancellationToken);
+        string? fetchError = null;
+        if (token != null)
+        {
+            var (fetchSuccess, err) = await git.FetchMinimalAsync(repoPath, "-", defaultRef, token, cancellationToken);
+            if (!fetchSuccess)
+                fetchError = err;
+        }
+
+        var (versionResult, _) = await git.GetVersionAsync(repoPath, nonNormalize: true, cancellationToken);
+        var version = versionResult?.InformationalVersion ?? "-";
+        var branch = versionResult?.BranchName ?? versionResult?.EscapedBranchName ?? "-";
+
+        var currentTag = await git.GetCheckedOutTagAsync(repoPath, cancellationToken);
+        if (currentTag != null)
+            branch = "-";
+
+        int? outgoing = null;
+        int? incoming = null;
+        int? defaultBehind = null;
+        int? defaultAhead = null;
+        bool? hasUpstream = null;
+        if (branch != "-")
+        {
+            var (o, i, _) = await git.GetCommitCountsAsync(repoPath, branch, defaultRef, cancellationToken);
+            outgoing = o;
+            incoming = i;
+            var (db, da, _) = await git.GetCommitCountsVsDefaultAsync(repoPath, defaultRef, cancellationToken);
+            defaultBehind = db;
+            defaultAhead = da;
+
+            var remoteBranches = await git.GetRemoteBranchesFromRefsAsync(repoPath, cancellationToken);
+            hasUpstream = remoteBranches.Any(r => string.Equals(r, branch, StringComparison.OrdinalIgnoreCase));
+        }
+
         return new CreateBranchResponse
         {
             Success = true,
-            CurrentBranch = currentBranch
+            CurrentBranch = currentBranch,
+            Version = version,
+            Branch = branch,
+            Tag = currentTag,
+            OutgoingCommits = outgoing,
+            IncomingCommits = incoming,
+            HasUpstream = hasUpstream,
+            DefaultBranchBehind = defaultBehind,
+            DefaultBranchAhead = defaultAhead,
+            FetchError = fetchError
         };
     }
 }

--- a/src/GrayMoon.Agent/Commands/CreateBranchCommand.cs
+++ b/src/GrayMoon.Agent/Commands/CreateBranchCommand.cs
@@ -54,7 +54,7 @@ public sealed class CreateBranchCommand(IGitService git, IAgentTokenProvider tok
         string? fetchError = null;
         if (token != null)
         {
-            var (fetchSuccess, err) = await git.FetchMinimalAsync(repoPath, "-", defaultRef, token, cancellationToken);
+            var (fetchSuccess, err) = await git.FetchMinimalAsync(repoPath, "-", defaultRef, token, cancellationToken, skipUpstreamCheck: true);
             if (!fetchSuccess)
                 fetchError = err;
         }
@@ -74,7 +74,7 @@ public sealed class CreateBranchCommand(IGitService git, IAgentTokenProvider tok
         bool? hasUpstream = null;
         if (branch != "-")
         {
-            var (o, i, _) = await git.GetCommitCountsAsync(repoPath, branch, defaultRef, cancellationToken);
+            var (o, i, _) = await git.GetCommitCountsAsync(repoPath, branch, defaultRef, cancellationToken, skipUpstreamCheck: true);
             outgoing = o;
             incoming = i;
             var (db, da, _) = await git.GetCommitCountsVsDefaultAsync(repoPath, defaultRef, cancellationToken);

--- a/src/GrayMoon.Agent/Jobs/Requests/CreateBranchRequest.cs
+++ b/src/GrayMoon.Agent/Jobs/Requests/CreateBranchRequest.cs
@@ -15,4 +15,10 @@ public sealed class CreateBranchRequest : WorkspaceCommandRequest
 
     [JsonPropertyName("baseBranchName")]
     public string? BaseBranchName { get; set; }
+
+    [JsonPropertyName("repositoryId")]
+    public int RepositoryId { get; set; }
+
+    [JsonPropertyName("skipHooks")]
+    public bool SkipHooks { get; set; }
 }

--- a/src/GrayMoon.Agent/Jobs/Response/CreateBranchResponse.cs
+++ b/src/GrayMoon.Agent/Jobs/Response/CreateBranchResponse.cs
@@ -12,4 +12,32 @@ public sealed class CreateBranchResponse
 
     [JsonPropertyName("errorMessage")]
     public string? ErrorMessage { get; set; }
+
+    // Populated only when SkipHooks=true (inline sync path)
+    [JsonPropertyName("version")]
+    public string? Version { get; set; }
+
+    [JsonPropertyName("branch")]
+    public string? Branch { get; set; }
+
+    [JsonPropertyName("tag")]
+    public string? Tag { get; set; }
+
+    [JsonPropertyName("outgoingCommits")]
+    public int? OutgoingCommits { get; set; }
+
+    [JsonPropertyName("incomingCommits")]
+    public int? IncomingCommits { get; set; }
+
+    [JsonPropertyName("hasUpstream")]
+    public bool? HasUpstream { get; set; }
+
+    [JsonPropertyName("defaultBranchBehind")]
+    public int? DefaultBranchBehind { get; set; }
+
+    [JsonPropertyName("defaultBranchAhead")]
+    public int? DefaultBranchAhead { get; set; }
+
+    [JsonPropertyName("fetchError")]
+    public string? FetchError { get; set; }
 }

--- a/src/GrayMoon.Agent/Services/GitService.cs
+++ b/src/GrayMoon.Agent/Services/GitService.cs
@@ -770,7 +770,7 @@ public sealed class GitService(IOptions<AgentOptions> options, ILogger<GitServic
         return (true, null);
     }
 
-    public async Task<(bool Success, string? ErrorMessage)> CreateBranchAsync(string repoPath, string newBranchName, string baseBranchName, CancellationToken ct)
+    public async Task<(bool Success, string? ErrorMessage)> CreateBranchAsync(string repoPath, string newBranchName, string baseBranchName, CancellationToken ct, bool skipHooks = false)
     {
         if (string.IsNullOrWhiteSpace(repoPath) || !Directory.Exists(repoPath) || string.IsNullOrWhiteSpace(newBranchName) || string.IsNullOrWhiteSpace(baseBranchName))
             return (false, "Invalid repository path or branch name");
@@ -796,9 +796,11 @@ public sealed class GitService(IOptions<AgentOptions> options, ILogger<GitServic
         if (exitRemote == 0)
             startPoint = remoteCandidate;
 
+        var hooksPrefix = GetHooksConfigPrefix(skipHooks);
+
         // Create and checkout new branch from the chosen start point in a single checkout, so we only
         // trigger one post-checkout hook instead of first checking out the base branch and then the new branch.
-        var (exitCode, stdout, stderr) = await RunProcessAsync("git", $"checkout -b {newBranchName} --no-track {startPoint}", repoPath, ct);
+        var (exitCode, stdout, stderr) = await RunProcessAsync("git", $"{hooksPrefix}checkout -b {newBranchName} --no-track {startPoint}", repoPath, ct);
         if (exitCode != 0)
         {
             // Branch may already exist (e.g. persistence out of date); try checkout existing
@@ -806,7 +808,7 @@ public sealed class GitService(IOptions<AgentOptions> options, ILogger<GitServic
             if (verifyExit == 0)
             {
                 logger.LogWarning("Branch {Branch} already exists in {RepoPath}; checking out existing branch.", newBranchName, repoPath);
-                var (coExit, coOut, coErr) = await RunProcessAsync("git", $"checkout {newBranchName}", repoPath, ct);
+                var (coExit, coOut, coErr) = await RunProcessAsync("git", $"{hooksPrefix}checkout {newBranchName}", repoPath, ct);
                 if (coExit != 0)
                 {
                     var combined = CombineOutput(coOut, coErr);

--- a/src/GrayMoon.Agent/Services/GitService.cs
+++ b/src/GrayMoon.Agent/Services/GitService.cs
@@ -284,7 +284,7 @@ public sealed class GitService(IOptions<AgentOptions> options, ILogger<GitServic
         return (true, null);
     }
 
-    public async Task<(bool Success, string? ErrorMessage)> FetchMinimalAsync(string repoPath, string branchName, string? defaultBranchOriginRef, string? bearerToken, CancellationToken ct)
+    public async Task<(bool Success, string? ErrorMessage)> FetchMinimalAsync(string repoPath, string branchName, string? defaultBranchOriginRef, string? bearerToken, CancellationToken ct, bool skipUpstreamCheck = false)
     {
         if (string.IsNullOrWhiteSpace(repoPath) || !Directory.Exists(repoPath))
             return (true, null);
@@ -300,7 +300,7 @@ public sealed class GitService(IOptions<AgentOptions> options, ILogger<GitServic
         // Resolve the upstream ref (e.g. origin/main) and use that as the fetch target for the
         // current branch rather than the branch name itself. This avoids fetching non-upstreamed
         // local branches and ensures we are always fetching the configured remote tracking ref.
-        var upstreamRef = await GetUpstreamRefAsync(repoPath, ct);
+        var upstreamRef = skipUpstreamCheck ? null : await GetUpstreamRefAsync(repoPath, ct);
         logger.LogDebug("Git minimal fetch upstream ref for {RepoPath}: {UpstreamRef}", repoPath, upstreamRef ?? "<none>");
 
         if (!string.IsNullOrWhiteSpace(upstreamRef))
@@ -374,7 +374,7 @@ public sealed class GitService(IOptions<AgentOptions> options, ILogger<GitServic
         return (true, null);
     }
 
-    public async Task<(int? Outgoing, int? Incoming, bool HasUpstream)> GetCommitCountsAsync(string repoPath, string branchName, string? defaultBranchOriginRef, CancellationToken ct)
+    public async Task<(int? Outgoing, int? Incoming, bool HasUpstream)> GetCommitCountsAsync(string repoPath, string branchName, string? defaultBranchOriginRef, CancellationToken ct, bool skipUpstreamCheck = false)
     {
         if (string.IsNullOrWhiteSpace(repoPath) || !Directory.Exists(repoPath) || string.IsNullOrWhiteSpace(branchName))
             return (null, null, false);
@@ -383,7 +383,7 @@ public sealed class GitService(IOptions<AgentOptions> options, ILogger<GitServic
 
         // Resolve upstream ref (e.g. origin/main) once for this branch. When there is no upstream
         // configured we fall back to comparing against the default branch only.
-        var upstreamRef = await GetUpstreamRefAsync(repoPath, ct);
+        var upstreamRef = skipUpstreamCheck ? null : await GetUpstreamRefAsync(repoPath, ct);
         if (string.IsNullOrWhiteSpace(upstreamRef))
         {
             var defaultBranch = defaultBranchOriginRef ?? await GetDefaultBranchAsync(repoPath, ct);

--- a/src/GrayMoon.Agent/Services/GitService.cs
+++ b/src/GrayMoon.Agent/Services/GitService.cs
@@ -798,7 +798,7 @@ public sealed class GitService(IOptions<AgentOptions> options, ILogger<GitServic
 
         // Create and checkout new branch from the chosen start point in a single checkout, so we only
         // trigger one post-checkout hook instead of first checking out the base branch and then the new branch.
-        var (exitCode, stdout, stderr) = await RunProcessAsync("git", $"checkout -b {newBranchName} {startPoint}", repoPath, ct);
+        var (exitCode, stdout, stderr) = await RunProcessAsync("git", $"checkout -b {newBranchName} --no-track {startPoint}", repoPath, ct);
         if (exitCode != 0)
         {
             // Branch may already exist (e.g. persistence out of date); try checkout existing

--- a/src/GrayMoon.App/Api/Endpoints/BranchEndpoints.cs
+++ b/src/GrayMoon.App/Api/Endpoints/BranchEndpoints.cs
@@ -274,6 +274,7 @@ public static class BranchEndpoints
         WorkspaceRepository workspaceRepository,
         GitHubRepositoryRepository repoRepository,
         WorkspacePullRequestRepository workspacePullRequestRepository,
+        WorkspacePullRequestService workspacePullRequestService,
         AppDbContext dbContext,
         WorkspaceGitService workspaceGitService,
         IHubContext<WorkspaceSyncHub> hubContext,
@@ -312,8 +313,11 @@ public static class BranchEndpoints
         {
             await connectorHealthService.EnsureConnectorHealthyForRepositoryAsync(repo.RepositoryId, CancellationToken.None);
 
+            await workspacePullRequestService.RefreshPullRequestsAsync(workspaceId, [repositoryId], force: true, CancellationToken.None);
             var prByRepo = await workspacePullRequestRepository.GetByWorkspaceIdAsync(workspaceId, CancellationToken.None);
-            var forceDeleteLocalBranch = prByRepo.TryGetValue(repositoryId, out var pr) && pr?.IsMerged == true;
+            var forceDeleteLocalBranch = body.AllowForceDeleteLocalBranch
+                && prByRepo.TryGetValue(repositoryId, out var pr)
+                && (pr?.IsMerged == true || pr?.IsClosed == true);
 
             var workspaceRoot = await workspaceService.GetRootPathForWorkspaceAsync(workspace, CancellationToken.None);
             var args = new
@@ -887,6 +891,7 @@ public sealed class SyncToDefaultBranchApiRequest
     public int RepositoryId { get; set; }
     public string? CurrentBranchName { get; set; }
     public bool DeleteRemoteBranch { get; set; }
+    public bool AllowForceDeleteLocalBranch { get; set; } = true;
 }
 
 public sealed class CommonBranchesApiRequest

--- a/src/GrayMoon.App/Components/Modals/NewFeatureModal.razor
+++ b/src/GrayMoon.App/Components/Modals/NewFeatureModal.razor
@@ -95,38 +95,35 @@
                             }
                         </div>
                     </div>
+
+                    @if (HasTaggedRepos)
+                    {
+                        <div class="form-check mb-3">
+                            <input class="form-check-input" type="checkbox" id="new-feature-skip-tags"
+                                   style="@(!skipReposOnTags ? "opacity: 0.4;" : "")"
+                                   @bind="skipReposOnTags" />
+                            <label class="form-check-label" for="new-feature-skip-tags">
+                                Skip repos on tags
+                            </label>
+                            <div class="form-text">Repositories checked out on a tag will not be affected</div>
+                        </div>
+                    }
+
+                    <div class="form-check mb-3">
+                        <input class="form-check-input" type="checkbox" id="new-feature-update-deps"
+                               @bind="updateDependencies" />
+                        <label class="form-check-label" for="new-feature-update-deps">Update dependencies</label>
+                        <div class="form-text">Bump package versions and commit changes per dependency level</div>
+                    </div>
+
+                    <div class="form-check mb-0">
+                        <input class="form-check-input" type="checkbox" id="new-feature-push"
+                               @bind="pushChanges" />
+                        <label class="form-check-label" for="new-feature-push">Push changes</label>
+                        <div class="form-text">Push all repositories using synchronized push (waits for NuGet availability per level)</div>
+                    </div>
                 </div>
                 <div class="modal-footer">
-                    <div class="d-flex flex-column gap-2 me-auto">
-                        @if (HasTaggedRepos)
-                        {
-                            <div class="form-check mb-0">
-                                <input class="form-check-input" type="checkbox" id="new-feature-skip-tags"
-                                       style="@(!skipReposOnTags ? "opacity: 0.4;" : "")"
-                                       @bind="skipReposOnTags" />
-                                <label class="form-check-label" for="new-feature-skip-tags"
-                                       title="Repositories checked out on a tag will not be affected">
-                                    Skip repos on tags
-                                </label>
-                            </div>
-                        }
-                        <div class="form-check mb-0">
-                            <input class="form-check-input" type="checkbox" id="new-feature-update-deps"
-                                   @bind="updateDependencies" />
-                            <label class="form-check-label" for="new-feature-update-deps">
-                                Update dependencies
-                                <small class="text-muted d-block">Bump package versions and commit changes per dependency level</small>
-                            </label>
-                        </div>
-                        <div class="form-check mb-0">
-                            <input class="form-check-input" type="checkbox" id="new-feature-push"
-                                   @bind="pushChanges" />
-                            <label class="form-check-label" for="new-feature-push">
-                                Push changes
-                                <small class="text-muted d-block">Push all repositories using synchronized push (waits for NuGet availability per level)</small>
-                            </label>
-                        </div>
-                    </div>
                     @if (!showBranchExistsConfirmation)
                     {
                         <button type="button" class="btn btn-primary" @onclick="CreateAsync"

--- a/src/GrayMoon.App/Components/Modals/NewFeatureModal.razor
+++ b/src/GrayMoon.App/Components/Modals/NewFeatureModal.razor
@@ -11,7 +11,7 @@
         <div class="modal-dialog new-feature-modal-dialog">
             <div class="modal-content">
                 <div class="modal-header">
-                    <h5 class="modal-title">@(string.IsNullOrEmpty(WorkspaceName) ? "New Feature" : $"{WorkspaceName} — New Feature")</h5>
+                    <h5 class="modal-title">@(string.IsNullOrEmpty(WorkspaceName) ? "New Feature" : $"New Feature — {WorkspaceName}")</h5>
                     <button type="button" class="btn-close" @onclick="OnCancel"></button>
                 </div>
                 <div class="modal-body">
@@ -100,7 +100,6 @@
                     {
                         <div class="form-check mb-3">
                             <input class="form-check-input" type="checkbox" id="new-feature-skip-tags"
-                                   style="@(!skipReposOnTags ? "opacity: 0.4;" : "")"
                                    @bind="skipReposOnTags" />
                             <label class="form-check-label" for="new-feature-skip-tags">
                                 Skip repos on tags

--- a/src/GrayMoon.App/Components/Modals/NewFeatureModal.razor
+++ b/src/GrayMoon.App/Components/Modals/NewFeatureModal.razor
@@ -1,0 +1,344 @@
+﻿@using System.Text.Json
+@inject IHttpClientFactory HttpClientFactory
+@inject NavigationManager NavigationManager
+@inject ILogger<NewFeatureModal> Logger
+
+@if (IsVisible)
+{
+    <div class="modal show d-block" tabindex="-1" style="background-color: rgba(0,0,0,0.5);"
+         @onkeydown="HandleKeyDown"
+         @ref="modalElement">
+        <div class="modal-dialog new-feature-modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">@(string.IsNullOrEmpty(WorkspaceName) ? "New Feature" : $"{WorkspaceName} — New Feature")</h5>
+                    <button type="button" class="btn-close" @onclick="OnCancel"></button>
+                </div>
+                <div class="modal-body">
+                    <p class="text-muted mb-3" style="font-size: 0.9em;">
+                        Creates a new branch across all workspace repositories. Optionally updates package dependencies with commits, then pushes all changes using a synchronized push.
+                    </p>
+
+                    @if (errorMessage != null)
+                    {
+                        <div class="alert alert-danger alert-dismissible d-flex align-items-start" role="alert">
+                            <div class="flex-grow-1" style="white-space: pre-wrap; word-wrap: break-word;">@errorMessage</div>
+                            <button type="button" class="btn-close ms-2" aria-label="Close" @onclick='() => { errorMessage = null; StateHasChanged(); }'></button>
+                        </div>
+                    }
+                    @if (showBranchExistsConfirmation)
+                    {
+                        <div class="alert alert-warning d-flex flex-column align-items-start mb-3" role="alert">
+                            <div class="d-flex align-items-start w-100">
+                                <i class="bi bi-exclamation-triangle-fill me-2 flex-shrink-0"></i>
+                                <div class="flex-grow-1">
+                                    <p class="mb-1">@branchExistsConfirmMessage</p>
+                                    <p class="mb-0">Those repositories will have the existing branch checked out.</p>
+                                </div>
+                            </div>
+                            <div class="d-flex gap-2 mt-2">
+                                <button type="button" class="btn btn-warning" @onclick="ProceedWithCreateAsync" disabled="@isCreating">
+                                    Proceed
+                                </button>
+                                <button type="button" class="btn btn-outline-secondary" @onclick="DismissBranchExistsConfirmation" disabled="@isCreating">Cancel</button>
+                            </div>
+                        </div>
+                    }
+
+                    <div class="mb-3">
+                        <label class="form-label" for="new-feature-branch-name">Branch name</label>
+                        <input id="new-feature-branch-name"
+                               type="text"
+                               class="form-control"
+                               placeholder="e.g. feature/my-feature"
+                               @bind="newBranchName"
+                               @bind:event="oninput"
+                               @onkeydown="HandleBranchNameKeyDown"
+                               @ref="branchNameInput" />
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label" for="new-feature-based-on">Based on</label>
+                        <div class="position-relative">
+                            <button type="button"
+                                    id="new-feature-based-on"
+                                    class="new-branch-based-on-trigger border rounded w-100 d-flex align-items-center gap-2 text-start"
+                                    style="cursor: pointer; padding: 0.375rem 0.75rem;"
+                                    @onclick="ToggleBasedOnDropdown">
+                                <span class="d-flex align-items-center gap-2 flex-grow-1 min-w-0">
+                                    <span class="text-truncate">@GetSelectedBaseDisplayText()</span>
+                                    @if (selectedBaseBranch == "__default__")
+                                    {
+                                        <span class="badge bg-success flex-shrink-0">Default</span>
+                                    }
+                                </span>
+                                <i class="bi bi-chevron-down flex-shrink-0 text-secondary"></i>
+                            </button>
+                            @if (showBasedOnDropdown)
+                            {
+                                <ul class="list-unstyled border rounded mt-1 mb-0 py-1 new-branch-based-on-list position-absolute start-0 end-0 shadow"
+                                    style="z-index: 1050; max-height: 280px; overflow-y: auto; font-size: 1rem;">
+                                    <li class="new-branch-based-on-item px-3 py-2 @(selectedBaseBranch == "__default__" ? "selected" : "")"
+                                        style="cursor: pointer;"
+                                        @onclick='() => SelectBaseBranch("__default__")'>
+                                        <span>@DefaultDisplayText</span>
+                                        <span class="badge bg-success ms-2">Default</span>
+                                    </li>
+                                    @foreach (var branch in CommonBranchNames)
+                                    {
+                                        <li class="new-branch-based-on-item px-3 py-2 @(selectedBaseBranch == branch ? "selected" : "")"
+                                            style="cursor: pointer;"
+                                            @onclick='() => SelectBaseBranch(branch)'>
+                                            @branch
+                                        </li>
+                                    }
+                                </ul>
+                            }
+                        </div>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <div class="d-flex flex-column gap-2 me-auto">
+                        @if (HasTaggedRepos)
+                        {
+                            <div class="form-check mb-0">
+                                <input class="form-check-input" type="checkbox" id="new-feature-skip-tags"
+                                       style="@(!skipReposOnTags ? "opacity: 0.4;" : "")"
+                                       @bind="skipReposOnTags" />
+                                <label class="form-check-label" for="new-feature-skip-tags"
+                                       title="Repositories checked out on a tag will not be affected">
+                                    Skip repos on tags
+                                </label>
+                            </div>
+                        }
+                        <div class="form-check mb-0">
+                            <input class="form-check-input" type="checkbox" id="new-feature-update-deps"
+                                   @bind="updateDependencies" />
+                            <label class="form-check-label" for="new-feature-update-deps">
+                                Update dependencies
+                                <small class="text-muted d-block">Bump package versions and commit changes per dependency level</small>
+                            </label>
+                        </div>
+                        <div class="form-check mb-0">
+                            <input class="form-check-input" type="checkbox" id="new-feature-push"
+                                   @bind="pushChanges" />
+                            <label class="form-check-label" for="new-feature-push">
+                                Push changes
+                                <small class="text-muted d-block">Push all repositories using synchronized push (waits for NuGet availability per level)</small>
+                            </label>
+                        </div>
+                    </div>
+                    @if (!showBranchExistsConfirmation)
+                    {
+                        <button type="button" class="btn btn-primary" @onclick="CreateAsync"
+                                disabled="@(string.IsNullOrWhiteSpace(newBranchName) || isCreating)">
+                            Create
+                        </button>
+                    }
+                    <button type="button" class="btn btn-secondary" @onclick="OnCancel" disabled="@isCreating">Cancel</button>
+                </div>
+            </div>
+        </div>
+    </div>
+}
+
+@code {
+    [Parameter] public bool IsVisible { get; set; }
+    [Parameter] public string? WorkspaceName { get; set; }
+    [Parameter] public int WorkspaceId { get; set; }
+    [Parameter] public IReadOnlyList<string> CommonBranchNames { get; set; } = Array.Empty<string>();
+    [Parameter] public string DefaultDisplayText { get; set; } = "multiple";
+    [Parameter] public bool HasTaggedRepos { get; set; }
+    [Parameter] public EventCallback<NewFeatureRequest> OnCreate { get; set; }
+    [Parameter] public EventCallback OnCancel { get; set; }
+
+    private string newBranchName = "";
+    private string selectedBaseBranch = "__default__";
+    private bool skipReposOnTags = true;
+    private bool updateDependencies = false;
+    private bool pushChanges = false;
+    private bool isCreating = false;
+    private string? errorMessage;
+    private bool showBranchExistsConfirmation = false;
+    private string branchExistsConfirmMessage = "";
+    private string? _pendingCreateName;
+    private string? _pendingCreateBaseBranch;
+    private bool showBasedOnDropdown = false;
+    private ElementReference modalElement;
+    private ElementReference branchNameInput;
+    private bool _wasVisible;
+
+    private string GetSelectedBaseDisplayText()
+    {
+        if (selectedBaseBranch == "__default__")
+            return DefaultDisplayText;
+        return selectedBaseBranch;
+    }
+
+    private void ToggleBasedOnDropdown()
+    {
+        showBasedOnDropdown = !showBasedOnDropdown;
+    }
+
+    private void SelectBaseBranch(string value)
+    {
+        selectedBaseBranch = value;
+        showBasedOnDropdown = false;
+    }
+
+    private void DismissBranchExistsConfirmation()
+    {
+        showBranchExistsConfirmation = false;
+        branchExistsConfirmMessage = "";
+        _pendingCreateName = null;
+        _pendingCreateBaseBranch = null;
+        StateHasChanged();
+    }
+
+    protected override void OnParametersSet()
+    {
+        if (IsVisible && !_wasVisible)
+        {
+            newBranchName = "";
+            selectedBaseBranch = "__default__";
+            errorMessage = null;
+            showBranchExistsConfirmation = false;
+            showBasedOnDropdown = false;
+            skipReposOnTags = true;
+            updateDependencies = false;
+            pushChanges = false;
+        }
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (IsVisible && !_wasVisible)
+        {
+            _wasVisible = true;
+            StateHasChanged();
+            try { await branchNameInput.FocusAsync(); } catch { }
+        }
+        else if (!IsVisible)
+        {
+            _wasVisible = false;
+            showBasedOnDropdown = false;
+        }
+    }
+
+    private async Task CreateAsync()
+    {
+        var name = newBranchName?.Trim();
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            errorMessage = "Enter a branch name.";
+            return;
+        }
+        var baseBranch = selectedBaseBranch ?? "__default__";
+
+        showBranchExistsConfirmation = false;
+        isCreating = true;
+        errorMessage = null;
+        StateHasChanged();
+
+        try
+        {
+            var count = await GetRepositoryCountWhereBranchExistsAsync(name);
+            if (count > 0)
+            {
+                branchExistsConfirmMessage = count == 1
+                    ? "The branch already exists in 1 repository."
+                    : $"The branch already exists in {count} repositories.";
+                _pendingCreateName = name;
+                _pendingCreateBaseBranch = baseBranch;
+                showBranchExistsConfirmation = true;
+                isCreating = false;
+                StateHasChanged();
+                return;
+            }
+
+            await OnCreate.InvokeAsync(new NewFeatureRequest(name, baseBranch, skipReposOnTags, updateDependencies, pushChanges));
+        }
+        finally
+        {
+            isCreating = false;
+            StateHasChanged();
+        }
+    }
+
+    private async Task ProceedWithCreateAsync()
+    {
+        if (string.IsNullOrWhiteSpace(_pendingCreateName) || string.IsNullOrWhiteSpace(_pendingCreateBaseBranch))
+            return;
+
+        isCreating = true;
+        StateHasChanged();
+
+        try
+        {
+            await OnCreate.InvokeAsync(new NewFeatureRequest(_pendingCreateName, _pendingCreateBaseBranch, skipReposOnTags, updateDependencies, pushChanges));
+            DismissBranchExistsConfirmation();
+        }
+        finally
+        {
+            isCreating = false;
+            StateHasChanged();
+        }
+    }
+
+    private async Task<int> GetRepositoryCountWhereBranchExistsAsync(string branchName)
+    {
+        try
+        {
+            var httpClient = HttpClientFactory.CreateClient();
+            var request = new { workspaceId = WorkspaceId, branchName };
+            var json = JsonSerializer.Serialize(request);
+            var content = new System.Net.Http.StringContent(json, System.Text.Encoding.UTF8, "application/json");
+            var baseUrl = NavigationManager.BaseUri.TrimEnd('/');
+            var response = await httpClient.PostAsync($"{baseUrl}/api/branches/exists-in-workspace", content);
+            if (!response.IsSuccessStatusCode)
+                return 0;
+            var responseContent = await response.Content.ReadAsStringAsync();
+            var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+            var data = JsonSerializer.Deserialize<BranchExistsInWorkspaceResponse>(responseContent, options);
+            return data?.Count ?? 0;
+        }
+        catch
+        {
+            return 0;
+        }
+    }
+
+    private async Task HandleKeyDown(KeyboardEventArgs e)
+    {
+        if (e.Key == "Escape" || e.Code == "Escape")
+        {
+            if (showBranchExistsConfirmation)
+                DismissBranchExistsConfirmation();
+            else
+                await OnCancel.InvokeAsync();
+            return;
+        }
+        if (e.Key == "Enter" && !isCreating)
+        {
+            if (showBranchExistsConfirmation)
+                await ProceedWithCreateAsync();
+            else if (!string.IsNullOrWhiteSpace(newBranchName?.Trim()))
+                await CreateAsync();
+        }
+    }
+
+    private async Task HandleBranchNameKeyDown(KeyboardEventArgs e)
+    {
+        if (e.Key == "Enter" && !isCreating)
+        {
+            if (showBranchExistsConfirmation)
+                await ProceedWithCreateAsync();
+            else if (!string.IsNullOrWhiteSpace(newBranchName?.Trim()))
+                await CreateAsync();
+        }
+    }
+
+    private sealed class BranchExistsInWorkspaceResponse
+    {
+        public int Count { get; set; }
+    }
+}

--- a/src/GrayMoon.App/Components/Modals/NewFeatureModal.razor
+++ b/src/GrayMoon.App/Components/Modals/NewFeatureModal.razor
@@ -11,12 +11,12 @@
         <div class="modal-dialog new-feature-modal-dialog">
             <div class="modal-content">
                 <div class="modal-header">
-                    <h5 class="modal-title">@(string.IsNullOrEmpty(WorkspaceName) ? "New Feature" : $"New Feature — {WorkspaceName}")</h5>
+                    <h5 class="modal-title">New Feature</h5>
                     <button type="button" class="btn-close" @onclick="OnCancel"></button>
                 </div>
                 <div class="modal-body">
                     <p class="text-muted mb-3" style="font-size: 0.9em;">
-                        Creates a new branch across all workspace repositories, updates package dependencies with commits, and pushes all changes using a synchronized push. Uncheck any step to skip it.
+                        Creates a new branch across all workspace repositories, updates package dependencies with commits, and pushes all changes using a synchronized push.
                     </p>
 
                     @if (errorMessage != null)
@@ -110,14 +110,16 @@
 
                     <div class="form-check mb-3">
                         <input class="form-check-input" type="checkbox" id="new-feature-update-deps"
-                               @bind="updateDependencies" />
+                               checked="@updateDependencies"
+                               @onchange="OnUpdateDependenciesChanged" />
                         <label class="form-check-label" for="new-feature-update-deps">Update dependencies</label>
                         <div class="form-text">Bump package versions and commit changes per dependency level</div>
                     </div>
 
                     <div class="form-check mb-0">
                         <input class="form-check-input" type="checkbox" id="new-feature-push"
-                               @bind="pushChanges" />
+                               @bind="pushChanges"
+                               disabled="@(!updateDependencies)" />
                         <label class="form-check-label" for="new-feature-push">Push changes</label>
                         <div class="form-text">Push all repositories using synchronized push (waits for NuGet availability per level)</div>
                     </div>
@@ -179,6 +181,13 @@
     {
         selectedBaseBranch = value;
         showBasedOnDropdown = false;
+    }
+
+    private void OnUpdateDependenciesChanged(ChangeEventArgs e)
+    {
+        updateDependencies = (bool)(e.Value ?? false);
+        if (!updateDependencies)
+            pushChanges = false;
     }
 
     private void DismissBranchExistsConfirmation()

--- a/src/GrayMoon.App/Components/Modals/NewFeatureModal.razor
+++ b/src/GrayMoon.App/Components/Modals/NewFeatureModal.razor
@@ -16,7 +16,7 @@
                 </div>
                 <div class="modal-body">
                     <p class="text-muted mb-3" style="font-size: 0.9em;">
-                        Creates a new branch across all workspace repositories. Optionally updates package dependencies with commits, then pushes all changes using a synchronized push.
+                        Creates a new branch across all repositories, updates package dependencies with commits, and pushes — so your team can start working immediately. Uncheck any step to skip it.
                     </p>
 
                     @if (errorMessage != null)
@@ -150,8 +150,8 @@
     private string newBranchName = "";
     private string selectedBaseBranch = "__default__";
     private bool skipReposOnTags = true;
-    private bool updateDependencies = false;
-    private bool pushChanges = false;
+    private bool updateDependencies = true;
+    private bool pushChanges = true;
     private bool isCreating = false;
     private string? errorMessage;
     private bool showBranchExistsConfirmation = false;
@@ -200,8 +200,8 @@
             showBranchExistsConfirmation = false;
             showBasedOnDropdown = false;
             skipReposOnTags = true;
-            updateDependencies = false;
-            pushChanges = false;
+            updateDependencies = true;
+            pushChanges = true;
         }
     }
 

--- a/src/GrayMoon.App/Components/Modals/NewFeatureModal.razor
+++ b/src/GrayMoon.App/Components/Modals/NewFeatureModal.razor
@@ -16,7 +16,7 @@
                 </div>
                 <div class="modal-body">
                     <p class="text-muted mb-3" style="font-size: 0.9em;">
-                        Creates a new branch across all repositories, updates package dependencies with commits, and pushes — so your team can start working immediately. Uncheck any step to skip it.
+                        Creates a new branch across all workspace repositories, updates package dependencies with commits, and pushes all changes using a synchronized push. Uncheck any step to skip it.
                     </p>
 
                     @if (errorMessage != null)

--- a/src/GrayMoon.App/Components/Modals/NewFeatureModal.razor.css
+++ b/src/GrayMoon.App/Components/Modals/NewFeatureModal.razor.css
@@ -2,6 +2,11 @@
     max-width: 600px;
 }
 
+.form-check-input:not(:checked) {
+    background-color: #6c757d;
+    border-color: #6c757d;
+}
+
 .new-branch-based-on-trigger {
     height: calc(1.5em + 0.75rem + 2px);
     background-color: var(--bg-input);

--- a/src/GrayMoon.App/Components/Modals/NewFeatureModal.razor.css
+++ b/src/GrayMoon.App/Components/Modals/NewFeatureModal.razor.css
@@ -1,0 +1,54 @@
+﻿.new-feature-modal-dialog {
+    max-width: 600px;
+}
+
+.new-branch-based-on-trigger {
+    height: calc(1.5em + 0.75rem + 2px);
+    background-color: var(--bg-input);
+    color: var(--text-primary);
+    border: 1px solid var(--border-input) !important;
+    box-shadow: none !important;
+}
+
+.new-branch-based-on-trigger .text-truncate {
+    color: var(--text-primary);
+}
+
+.new-branch-based-on-list {
+    background-color: var(--bg-input);
+    color: var(--text-primary);
+    border: 1px solid var(--border-input) !important;
+    box-shadow: none !important;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: auto;
+    scrollbar-color: #5a5a5a var(--bg-input, #252526);
+}
+
+.new-branch-based-on-list::-webkit-scrollbar {
+    width: 8px;
+}
+
+.new-branch-based-on-list::-webkit-scrollbar-track {
+    background: var(--bg-input, #252526);
+}
+
+.new-branch-based-on-list::-webkit-scrollbar-thumb {
+    background: #5a5a5a;
+    border-radius: 4px;
+}
+
+.new-branch-based-on-list::-webkit-scrollbar-thumb:hover {
+    background: #6a6a6a;
+}
+
+.new-branch-based-on-item {
+    color: var(--text-primary);
+}
+
+.new-branch-based-on-item.selected {
+    background-color: var(--bg-active);
+}
+
+.new-branch-based-on-item:hover {
+    background-color: var(--bg-hover);
+}

--- a/src/GrayMoon.App/Components/Modals/NewFeatureModels.cs
+++ b/src/GrayMoon.App/Components/Modals/NewFeatureModels.cs
@@ -1,0 +1,9 @@
+﻿namespace GrayMoon.App.Components.Modals;
+
+/// <summary>Input collected by the New Feature modal when the user clicks Create.</summary>
+public sealed record NewFeatureRequest(
+    string NewBranchName,
+    string BaseBranch,
+    bool SkipReposOnTags,
+    bool UpdateDependencies,
+    bool PushChanges);

--- a/src/GrayMoon.App/Components/Modals/OperationErrorModal.razor
+++ b/src/GrayMoon.App/Components/Modals/OperationErrorModal.razor
@@ -1,0 +1,37 @@
+﻿@if (IsVisible)
+{
+    <div class="modal show d-block" tabindex="-1" style="background-color: rgba(0,0,0,0.5);"
+         @onkeydown="HandleKeyDown"
+         @ref="modalElement">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header bg-danger text-white">
+                    <h5 class="modal-title">
+                        <i class="bi bi-exclamation-triangle-fill me-2"></i>@Title
+                    </h5>
+                </div>
+                <div class="modal-body" style="white-space: pre-wrap; word-wrap: break-word;">
+                    @Message
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" @onclick="OnClose">Close</button>
+                </div>
+            </div>
+        </div>
+    </div>
+}
+
+@code {
+    [Parameter] public bool IsVisible { get; set; }
+    [Parameter] public string Title { get; set; } = "Operation Failed";
+    [Parameter] public string Message { get; set; } = "";
+    [Parameter] public EventCallback OnClose { get; set; }
+
+    private ElementReference modalElement;
+
+    private async Task HandleKeyDown(KeyboardEventArgs e)
+    {
+        if (e.Key == "Escape" || e.Code == "Escape")
+            await OnClose.InvokeAsync();
+    }
+}

--- a/src/GrayMoon.App/Components/Modals/SyncToDefaultOptionsModal.razor
+++ b/src/GrayMoon.App/Components/Modals/SyncToDefaultOptionsModal.razor
@@ -42,6 +42,14 @@
                             </label>
                         </div>
                     }
+                    <div class="form-check mt-1">
+                        <input class="form-check-input" type="checkbox" id="forceDeleteLocalCheck"
+                               checked="@AllowForceDeleteLocalBranch"
+                               @onchange="OnAllowForceDeleteLocalChanged" />
+                        <label class="form-check-label small" for="forceDeleteLocalCheck">
+                            Delete local branch@(RepoItems.Count > 1 ? "es" : "") and use force delete (-D) for closed/merged PRs
+                        </label>
+                    </div>
                 </div>
                 <div class="modal-footer">
                     <button type="button" class="btn btn-primary" @onclick="OnProceed">Proceed</button>
@@ -58,6 +66,8 @@
     [Parameter] public IReadOnlyList<(string RepoName, string BranchName, bool HasRemote)> RepoItems { get; set; } = Array.Empty<(string, string, bool)>();
     [Parameter] public bool DeleteRemoteBranches { get; set; } = true;
     [Parameter] public EventCallback<bool> DeleteRemoteBranchesChanged { get; set; }
+    [Parameter] public bool AllowForceDeleteLocalBranch { get; set; } = true;
+    [Parameter] public EventCallback<bool> AllowForceDeleteLocalBranchChanged { get; set; }
     [Parameter] public EventCallback OnProceed { get; set; }
     [Parameter] public EventCallback OnCancel { get; set; }
 
@@ -73,6 +83,12 @@
     {
         var val = e.Value is bool b ? b : bool.TryParse(e.Value?.ToString(), out var p) && p;
         await DeleteRemoteBranchesChanged.InvokeAsync(val);
+    }
+
+    private async Task OnAllowForceDeleteLocalChanged(ChangeEventArgs e)
+    {
+        var val = e.Value is bool b ? b : bool.TryParse(e.Value?.ToString(), out var p) && p;
+        await AllowForceDeleteLocalBranchChanged.InvokeAsync(val);
     }
 
     private async Task HandleKeyDown(KeyboardEventArgs e)

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor
@@ -287,39 +287,6 @@
                      Message="@_operationErrorModal.Message"
                      OnClose="CloseOperationErrorModal" />
 
-<LoadingOverlay IsVisible="@isLoading" Message="Loading workspace..." />
-<LoadingOverlay IsVisible="@isCreatingPullRequests" Message="@createPrProgressMessage" />
-<LoadingOverlay IsVisible="@isSyncing"
-                Message="@GetOverlayMessage(syncProgressMessage, isSyncing, _syncAwaitingAgentTasks)"
-                PendingAgentTasksCount="@AgentTasksPendingCount"
-                OnAbort="AbortSyncAsync" />
-<LoadingOverlay IsVisible="@isPushing"
-                Message="@GetOverlayMessage(pushProgressMessage, isPushing, _pushAwaitingAgentTasks)"
-                PendingAgentTasksCount="@AgentTasksPendingCount"
-                OnAbort="AbortPushAsync" />
-<LoadingOverlay IsVisible="@isUpdating"
-                Message="@GetOverlayMessage(updateProgressMessage, isUpdating, _updateAwaitingAgentTasks)"
-                PendingAgentTasksCount="@AgentTasksPendingCount"
-                OnAbort="AbortUpdateAsync" />
-<LoadingOverlay IsVisible="@isCommitSyncing"
-                Message="@GetOverlayMessage(commitSyncProgressMessage, isCommitSyncing, _commitSyncAwaitingAgentTasks)"
-                PendingAgentTasksCount="@AgentTasksPendingCount"
-                OnAbort="AbortCommitSyncAsync" />
-<LoadingOverlay IsVisible="@isCheckingOut"
-                Message="@checkoutProgressMessage"
-                PendingAgentTasksCount="@AgentTasksPendingCount"
-                OnAbort="AbortCheckoutAsync" />
-<LoadingOverlay IsVisible="@ShowRepositoriesFetchOverlay" Message="@RepositoriesFetchOverlayMessage" OnAbort="AbortFetchRepositories" />
-<LoadingOverlay IsVisible="@isCreatingBranches"
-                Message="@GetOverlayMessage(createBranchesProgressMessage, isCreatingBranches, _creatingBranchesAwaitingAgentTasks)"
-                PendingAgentTasksCount="@AgentTasksPendingCount" />
-<LoadingOverlay IsVisible="@isCreatingBranch" Message="@createBranchMessage" />
-<LoadingOverlay IsVisible="@isSyncingToDefault"
-                Message="@GetOverlayMessage(syncToDefaultMessage, isSyncingToDefault, _syncToDefaultAwaitingAgentTasks)"
-                PendingAgentTasksCount="@AgentTasksPendingCount" />
-<LoadingOverlay IsVisible="@isWorkspaceBranchesFetching"
-                Message="@workspaceBranchesFetchProgressMessage"
-                OnAbort="AbortWorkspaceBranchesFetchAsync" />
-<LoadingOverlay IsVisible="@isWorkspaceBranchesCheckingOut"
-                Message="@workspaceBranchesCheckoutProgressMessage"
-                OnAbort="AbortWorkspaceBranchesCheckoutAsync" />
+<LoadingOverlay IsVisible="@IsAnyOverlayVisible"
+               Message="@ActiveOverlayMessage"
+               OnAbort="@ActiveOverlayAbort" />

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor
@@ -22,6 +22,7 @@
 @inject WorkspacePushHandler WorkspacePushHandler
 @inject WorkspaceDependencyService WorkspaceDependencyService
 @inject WorkspaceBranchHandler WorkspaceBranchHandler
+@inject NewFeatureOrchestrator NewFeatureOrchestrator
 @inject AgentQueueStateService AgentQueueStateService
 @inject IPullRequestService PullRequestService
 @using WorkspaceModel = GrayMoon.App.Models.Workspace

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor
@@ -46,6 +46,7 @@
                                     AgentTasksPendingCount="@AgentTasksPendingCount"
                                     IsOverlayVisible="@(isLoading || isSyncing || isPushing || isUpdating || isCommitSyncing || isCheckingOut || isCreatingBranches || isCreatingBranch || isSyncingToDefault || isWorkspaceBranchesFetching || isWorkspaceBranchesCheckingOut || ShowRepositoriesFetchOverlay)"
                                     OnShowRepositories="ShowRepositoriesModalAsync"
+                                    OnNewFeature="ShowNewFeatureModalAsync"
                                     OnShowBranch="() => ShowBranchModalAsync()"
                                     OnShowSwitchBranch='() => ShowBranchModalAsync("switchbranch")'
                                     OnNewPullRequest="OpenPullRequestDialogForAllRepositoriesAsync"
@@ -262,6 +263,20 @@
                      OnCreate="HandleCreatePullRequestsAsync"
                      OnCancel="CloseNewPullRequestModal"
                      OnOpenInGitHub="HandleNewPrOpenInGitHubAsync" />
+
+<NewFeatureModal IsVisible="@_newFeatureModal.IsVisible"
+                 WorkspaceName="@(workspace?.Name)"
+                 WorkspaceId="@WorkspaceId"
+                 CommonBranchNames="@_newFeatureModal.CommonBranchNames"
+                 DefaultDisplayText="@_newFeatureModal.DefaultDisplayText"
+                 HasTaggedRepos="@hasTaggedRepos"
+                 OnCreate="HandleNewFeatureCreateAsync"
+                 OnCancel="CloseNewFeatureModal" />
+
+<OperationErrorModal IsVisible="@_operationErrorModal.IsVisible"
+                     Title="@_operationErrorModal.Title"
+                     Message="@_operationErrorModal.Message"
+                     OnClose="CloseOperationErrorModal" />
 
 <LoadingOverlay IsVisible="@isLoading" Message="Loading workspace..." />
 <LoadingOverlay IsVisible="@isCreatingPullRequests" Message="@createPrProgressMessage" />

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor
@@ -52,6 +52,7 @@
                                     OnShowSwitchBranch='() => ShowBranchModalAsync("switchbranch")'
                                     OnNewPullRequest="OpenPullRequestDialogForAllRepositoriesAsync"
                                     OnUpdate="OnUpdateClickAsync"
+                                    OnUpdateAndPush="OnUpdateAndPushClickAsync"
                                     OnPull="OnPullClickAsync"
                                     OnPush="OnPushClickAsync"
                                     OnSync="SyncAsync"
@@ -225,6 +226,13 @@
                          InitialIncludeDeps="@_updateModal.LastIncludeDeps"
                          OnProceed="@OnUpdateProceedAsync"
                          OnCancel="@CloseUpdateModal" />
+
+<UpdateDependenciesModal IsVisible="@_updateAndPushModal.IsVisible"
+                         IsBusy="@isUpdating"
+                         InitialCommitMessage="@_updateAndPushModal.LastCommitMessage"
+                         InitialIncludeDeps="@_updateAndPushModal.LastIncludeDeps"
+                         OnProceed="@OnUpdateAndPushProceedAsync"
+                         OnCancel="@CloseUpdateAndPushModal" />
 
 <UpdateSingleRepositoryDependenciesModal IsVisible="@_updateSingleRepoModal.IsVisible"
                           Payload="@_updateSingleRepoModal.Payload"

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor
@@ -263,6 +263,8 @@
                            RepoItems="@_syncToDefaultOptionsModal.RepoItems"
                            DeleteRemoteBranches="@_syncToDefaultOptionsModal.DeleteRemoteBranches"
                            DeleteRemoteBranchesChanged="@(v => _syncToDefaultOptionsModal = _syncToDefaultOptionsModal with { DeleteRemoteBranches = v })"
+                           AllowForceDeleteLocalBranch="@_syncToDefaultOptionsModal.AllowForceDeleteLocalBranch"
+                           AllowForceDeleteLocalBranchChanged="@(v => _syncToDefaultOptionsModal = _syncToDefaultOptionsModal with { AllowForceDeleteLocalBranch = v })"
                            OnProceed="@OnSyncToDefaultOptionsProceedAsync"
                            OnCancel="@CloseSyncToDefaultOptionsModal" />
 

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor
@@ -265,7 +265,7 @@
                      OnOpenInGitHub="HandleNewPrOpenInGitHubAsync" />
 
 <NewFeatureModal IsVisible="@_newFeatureModal.IsVisible"
-                 WorkspaceName="@(workspace?.Name)"
+                 WorkspaceName="@_newFeatureModal.WorkspaceName"
                  WorkspaceId="@WorkspaceId"
                  CommonBranchNames="@_newFeatureModal.CommonBranchNames"
                  DefaultDisplayText="@_newFeatureModal.DefaultDisplayText"

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
@@ -2332,7 +2332,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
         _createBranchesCts?.Dispose();
         _createBranchesCts = new CancellationTokenSource();
         isCreatingBranches = true;
-        isUpdating = request.UpdateDependencies;
+        isUpdating = false;
         SetCreateBranchesProgress("Creating branches...");
         errorMessage = null;
         StateHasChanged();
@@ -2353,9 +2353,16 @@ public sealed partial class WorkspaceRepositories : IDisposable
                 setProgress: msg =>
                 {
                     if (msg.StartsWith("Creating", StringComparison.OrdinalIgnoreCase))
+                    {
                         SetCreateBranchesProgress(msg);
+                    }
                     else
+                    {
+                        // Transition overlay: branch creation phase done, update phase starting.
+                        isCreatingBranches = false;
+                        isUpdating = true;
                         SetUpdateProgress(msg);
+                    }
                     _ = InvokeAsync(StateHasChanged);
                 },
                 reportBranchProgress: (completed, total) =>

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
@@ -637,7 +637,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
             await action();
     }
 
-    private void ShowSyncToDefaultOptions(string message, IReadOnlyList<(string RepoName, string BranchName, bool HasRemote)> repoItems, Func<bool, Task> onProceed, bool defaultDeleteRemote = true)
+    private void ShowSyncToDefaultOptions(string message, IReadOnlyList<(string RepoName, string BranchName, bool HasRemote)> repoItems, Func<bool, bool, Task> onProceed, bool defaultDeleteRemote = true)
     {
         _syncToDefaultOptionsModal = _syncToDefaultOptionsModal with
         {
@@ -645,6 +645,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
             Message = message,
             RepoItems = repoItems,
             DeleteRemoteBranches = defaultDeleteRemote,
+            AllowForceDeleteLocalBranch = true,
             PendingAction = onProceed
         };
         StateHasChanged();
@@ -660,9 +661,10 @@ public sealed partial class WorkspaceRepositories : IDisposable
     {
         var action = _syncToDefaultOptionsModal.PendingAction;
         var deleteRemote = _syncToDefaultOptionsModal.DeleteRemoteBranches;
+        var allowForce = _syncToDefaultOptionsModal.AllowForceDeleteLocalBranch;
         CloseSyncToDefaultOptionsModal();
         if (action != null)
-            await action(deleteRemote);
+            await action(deleteRemote, allowForce);
     }
 
 
@@ -887,7 +889,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
             {
                 await using var scope = ServiceScopeFactory.CreateAsyncScope();
                 var workspacePrService = scope.ServiceProvider.GetRequiredService<WorkspacePullRequestService>();
-                await workspacePrService.RefreshPullRequestsAsync(WorkspaceId, refreshedIds, CancellationToken.None);
+                await workspacePrService.RefreshPullRequestsAsync(WorkspaceId, refreshedIds, cancellationToken: CancellationToken.None);
                 prByRepositoryId = await workspacePrService.GetPersistedPullRequestsForWorkspaceAsync(WorkspaceId, CancellationToken.None);
             }
             catch (Exception ex)
@@ -1012,7 +1014,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
                     return (RepoName: wr2?.Repository?.RepositoryName ?? r.RepoId.ToString(), BranchName: wr2?.BranchName ?? "", HasRemote: r.HasUpstream == true);
                 })
                 .ToList();
-            ShowSyncToDefaultOptions(message, repoItems, deleteRemote => SyncToDefaultLevelAsync(safeRepoIds, deleteRemote));
+            ShowSyncToDefaultOptions(message, repoItems, (deleteRemote, allowForce) => SyncToDefaultLevelAsync(safeRepoIds, deleteRemote, allowForce));
         }
         catch (Exception ex)
         {
@@ -2834,11 +2836,11 @@ public sealed partial class WorkspaceRepositories : IDisposable
                 ShowSyncToDefaultOptions(
                     "This will checkout the default branch, remove the current branch locally, and pull the latest.",
                     [(repositoryName!, branchName, true)],
-                    deleteRemote => SyncToDefaultSingleRepoAfterCheckAsync(repositoryId, repositoryName, currentBranchName, deleteRemote, defaultBranch));
+                    (deleteRemote, allowForce) => SyncToDefaultSingleRepoAfterCheckAsync(repositoryId, repositoryName, currentBranchName, deleteRemote, defaultBranch, allowForce));
             }
             else
             {
-                await SyncToDefaultSingleRepoAfterCheckAsync(repositoryId, repositoryName, currentBranchName, deleteRemoteBranch: false, defaultBranch);
+                await SyncToDefaultSingleRepoAfterCheckAsync(repositoryId, repositoryName, currentBranchName, deleteRemoteBranch: false, defaultBranch, allowForceDeleteLocalBranch: true);
             }
         }
         catch (Exception ex)
@@ -2848,7 +2850,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
         }
     }
 
-    private async Task SyncToDefaultSingleRepoAfterCheckAsync(int repositoryId, string repositoryName, string currentBranchName, bool deleteRemoteBranch = false, string? defaultBranchName = null)
+    private async Task SyncToDefaultSingleRepoAfterCheckAsync(int repositoryId, string repositoryName, string currentBranchName, bool deleteRemoteBranch = false, string? defaultBranchName = null, bool allowForceDeleteLocalBranch = true)
     {
         if (workspace == null || isSyncingToDefault || isSyncing || isUpdating)
             return;
@@ -2865,6 +2867,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
                 repositoryId,
                 currentBranchName,
                 deleteRemoteBranch,
+                allowForceDeleteLocalBranch,
                 ApiBaseUrl,
                 CancellationToken.None);
 
@@ -2891,7 +2894,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
         }
     }
 
-    private async Task SyncToDefaultLevelAsync(List<int> repositoryIds, bool deleteRemoteBranch = false)
+    private async Task SyncToDefaultLevelAsync(List<int> repositoryIds, bool deleteRemoteBranch = false, bool allowForceDeleteLocalBranch = true)
     {
         if (workspace == null || repositoryIds == null || repositoryIds.Count == 0 || isSyncingToDefault || isSyncing || isUpdating)
             return;
@@ -2945,6 +2948,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
                         repositoryId,
                         currentBranchName,
                         deleteRemoteBranch,
+                        allowForceDeleteLocalBranch,
                         ApiBaseUrl,
                         CancellationToken.None);
 
@@ -3228,7 +3232,8 @@ public sealed partial class WorkspaceRepositories : IDisposable
         public string Message { get; init; } = "";
         public IReadOnlyList<(string RepoName, string BranchName, bool HasRemote)> RepoItems { get; init; } = Array.Empty<(string, string, bool)>();
         public bool DeleteRemoteBranches { get; init; } = true;
-        public Func<bool, Task>? PendingAction { get; init; }
+        public bool AllowForceDeleteLocalBranch { get; init; } = true;
+        public Func<bool, bool, Task>? PendingAction { get; init; }
     }
 
     private sealed class RepositoriesModalState

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
@@ -114,6 +114,41 @@ public sealed partial class WorkspaceRepositories : IDisposable
 
     private int AgentTasksPendingCount => AgentQueueStateService.GetPendingCountForWorkspace(WorkspaceId);
 
+    private bool IsAnyOverlayVisible =>
+        isLoading || isCreatingPullRequests || isSyncing || isPushing || isUpdating ||
+        isCommitSyncing || isCheckingOut || ShowRepositoriesFetchOverlay ||
+        isCreatingBranches || isCreatingBranch || isSyncingToDefault ||
+        isWorkspaceBranchesFetching || isWorkspaceBranchesCheckingOut;
+
+    private string? ActiveOverlayMessage =>
+        isLoading ? "Loading workspace..." :
+        isCreatingPullRequests ? createPrProgressMessage :
+        isSyncing ? GetOverlayMessage(syncProgressMessage, isSyncing, _syncAwaitingAgentTasks) :
+        isPushing ? GetOverlayMessage(pushProgressMessage, isPushing, _pushAwaitingAgentTasks) :
+        isUpdating ? GetOverlayMessage(updateProgressMessage, isUpdating, _updateAwaitingAgentTasks) :
+        isCommitSyncing ? GetOverlayMessage(commitSyncProgressMessage, isCommitSyncing, _commitSyncAwaitingAgentTasks) :
+        isCheckingOut ? checkoutProgressMessage :
+        ShowRepositoriesFetchOverlay ? RepositoriesFetchOverlayMessage :
+        isCreatingBranches ? GetOverlayMessage(createBranchesProgressMessage, isCreatingBranches, _creatingBranchesAwaitingAgentTasks) :
+        isCreatingBranch ? createBranchMessage :
+        isSyncingToDefault ? GetOverlayMessage(syncToDefaultMessage, isSyncingToDefault, _syncToDefaultAwaitingAgentTasks) :
+        isWorkspaceBranchesFetching ? workspaceBranchesFetchProgressMessage :
+        isWorkspaceBranchesCheckingOut ? workspaceBranchesCheckoutProgressMessage :
+        null;
+
+    // Returns default(EventCallback) (HasDelegate == false) for operations with no abort:
+    // isLoading, isCreatingPullRequests, isCreatingBranches, isCreatingBranch, isSyncingToDefault.
+    private EventCallback ActiveOverlayAbort =>
+        isSyncing ? EventCallback.Factory.Create(this, (Action)AbortSyncAsync) :
+        isPushing ? EventCallback.Factory.Create(this, (Action)AbortPushAsync) :
+        isUpdating ? EventCallback.Factory.Create(this, (Action)AbortUpdateAsync) :
+        isCommitSyncing ? EventCallback.Factory.Create(this, (Action)AbortCommitSyncAsync) :
+        isCheckingOut ? EventCallback.Factory.Create(this, (Action)AbortCheckoutAsync) :
+        ShowRepositoriesFetchOverlay ? EventCallback.Factory.Create(this, (Action)AbortFetchRepositories) :
+        isWorkspaceBranchesFetching ? EventCallback.Factory.Create(this, (Action)AbortWorkspaceBranchesFetchAsync) :
+        isWorkspaceBranchesCheckingOut ? EventCallback.Factory.Create(this, (Action)AbortWorkspaceBranchesCheckoutAsync) :
+        default;
+
     private const int RefreshDebounceMs = 200;
     private CancellationTokenSource? _refreshDebounceCts;
 
@@ -1612,6 +1647,8 @@ public sealed partial class WorkspaceRepositories : IDisposable
                 includeDepsInCommitMessage: includeDepsInCommitMessage);
 
             isUpdating = false;
+            isPushing = true;
+            SetPushProgress("Preparing push...");
             await InvokeAsync(StateHasChanged);
             await RefreshFromSync();
         }
@@ -1643,6 +1680,8 @@ public sealed partial class WorkspaceRepositories : IDisposable
                 WorkspaceId, workspaceRepositories, CancellationToken.None);
             if (!hasUnpushed)
             {
+                isPushing = false;
+                await InvokeAsync(StateHasChanged);
                 ToastService.Show("Update complete. Nothing to push.");
                 return;
             }
@@ -1650,6 +1689,8 @@ public sealed partial class WorkspaceRepositories : IDisposable
             pushRepoIds = payload.Select(p => p.RepoId).Where(id => !taggedRepoIds.Contains(id)).ToHashSet();
             if (pushRepoIds.Count == 0)
             {
+                isPushing = false;
+                await InvokeAsync(StateHasChanged);
                 ToastService.Show("Update complete. Nothing to push.");
                 return;
             }
@@ -1663,6 +1704,8 @@ public sealed partial class WorkspaceRepositories : IDisposable
         }
         catch (Exception ex)
         {
+            isPushing = false;
+            await InvokeAsync(StateHasChanged);
             Logger.LogError(ex, "Update & Push: failed to get push plan for workspace {WorkspaceId}", WorkspaceId);
             ShowOperationError("Push Failed", "Update succeeded but push plan could not be determined. The GrayMoon Agent may be offline.");
             return;
@@ -2379,6 +2422,11 @@ public sealed partial class WorkspaceRepositories : IDisposable
 
             isCreatingBranches = false;
             isUpdating = false;
+            if (request.PushChanges)
+            {
+                isPushing = true;
+                SetPushProgress("Preparing push...");
+            }
             await InvokeAsync(StateHasChanged);
             await RefreshFromSync();
         }
@@ -2414,6 +2462,8 @@ public sealed partial class WorkspaceRepositories : IDisposable
                     WorkspaceId, workspaceRepositories, CancellationToken.None);
                 if (!hasUnpushed)
                 {
+                    isPushing = false;
+                    await InvokeAsync(StateHasChanged);
                     ToastService.Show("No repositories to push.");
                     return;
                 }
@@ -2421,6 +2471,8 @@ public sealed partial class WorkspaceRepositories : IDisposable
                 pushRepoIds = payload.Select(p => p.RepoId).Where(id => !taggedRepoIds.Contains(id)).ToHashSet();
                 if (pushRepoIds.Count == 0)
                 {
+                    isPushing = false;
+                    await InvokeAsync(StateHasChanged);
                     ToastService.Show("No repositories to push.");
                     return;
                 }
@@ -2434,6 +2486,8 @@ public sealed partial class WorkspaceRepositories : IDisposable
             }
             catch (Exception ex)
             {
+                isPushing = false;
+                await InvokeAsync(StateHasChanged);
                 Logger.LogError(ex, "New Feature: failed to get push plan for workspace {WorkspaceId}", WorkspaceId);
                 ShowOperationError("Push Failed", "Could not determine push plan. The GrayMoon Agent may be offline.");
                 return;
@@ -2442,8 +2496,6 @@ public sealed partial class WorkspaceRepositories : IDisposable
             _pushCts?.Cancel();
             _pushCts?.Dispose();
             _pushCts = new CancellationTokenSource();
-            isPushing = true;
-            StateHasChanged();
 
             try
             {

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
@@ -628,6 +628,8 @@ public sealed partial class WorkspaceRepositories : IDisposable
 
     private NewPullRequestModalState _newPrModal = new();
     private bool isCreatingPullRequests;
+    private NewFeatureModalState _newFeatureModal = new();
+    private OperationErrorModalState _operationErrorModal = new();
     private string createPrProgressMessage = "Creating Pull Requests...";
     private CancellationTokenSource? _createPrCts;
 
@@ -2112,6 +2114,232 @@ public sealed partial class WorkspaceRepositories : IDisposable
         _branchModal = _branchModal with { IsVisible = false };
     }
 
+    private async Task ShowNewFeatureModalAsync()
+    {
+        if (workspace == null || workspaceRepositories.Count == 0)
+            return;
+        try
+        {
+            await LoadCommonBranchesForBranchModalAsync(CancellationToken.None);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex, "Could not load common branches for new feature modal");
+        }
+        _newFeatureModal = _newFeatureModal with
+        {
+            IsVisible = true,
+            CommonBranchNames = _branchModal.CommonBranchNames,
+            DefaultDisplayText = _branchModal.DefaultDisplayText,
+        };
+        StateHasChanged();
+    }
+
+    private void CloseNewFeatureModal()
+    {
+        _newFeatureModal = _newFeatureModal with { IsVisible = false };
+    }
+
+    private void ShowOperationError(string title, string message)
+    {
+        _operationErrorModal = _operationErrorModal with { IsVisible = true, Title = title, Message = message };
+        _ = InvokeAsync(StateHasChanged);
+    }
+
+    private void CloseOperationErrorModal()
+    {
+        _operationErrorModal = _operationErrorModal with { IsVisible = false };
+        StateHasChanged();
+    }
+
+    private async Task HandleNewFeatureCreateAsync(NewFeatureRequest request)
+    {
+        if (workspace == null || isCreatingBranches || isSyncing || isUpdating || isPushing)
+            return;
+
+        CloseNewFeatureModal();
+
+        // Step 1: Create branches
+        var tagFilteredRepoIds = request.SkipReposOnTags
+            ? workspaceRepositories.Where(wr => !wr.IsOnTag).Select(wr => wr.RepositoryId).ToHashSet()
+            : (IReadOnlySet<int>?)null;
+
+        _createBranchesCts?.Cancel();
+        _createBranchesCts?.Dispose();
+        _createBranchesCts = new CancellationTokenSource();
+        isCreatingBranches = true;
+        SetCreateBranchesProgress("Creating branches...");
+        errorMessage = null;
+        StateHasChanged();
+
+        try
+        {
+            await Task.Yield();
+            await WorkspaceBranchHandler.CreateBranchesAsync(
+                WorkspaceId,
+                request.NewBranchName,
+                request.BaseBranch,
+                tagFilteredRepoIds,
+                (completed, total) =>
+                {
+                    SetCreateBranchesProgress($"Created {completed} of {total} branches");
+                    if (completed == total)
+                        _creatingBranchesAwaitingAgentTasks = true;
+                    _ = InvokeAsync(StateHasChanged);
+                },
+                _createBranchesCts.Token);
+            await RefreshFromSync();
+        }
+        catch (OperationCanceledException)
+        {
+            await ReloadWorkspaceDataAfterCancelAsync();
+            return;
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "New Feature: branch creation failed for workspace {WorkspaceId}", WorkspaceId);
+            ShowOperationError("Branch Creation Failed", "Could not create branches. The GrayMoon Agent may be offline. Start the Agent and try again.");
+            return;
+        }
+        finally
+        {
+            _creatingBranchesAwaitingAgentTasks = false;
+            isCreatingBranches = false;
+            await InvokeAsync(StateHasChanged);
+        }
+
+        // Step 2: Update dependencies
+        if (request.UpdateDependencies)
+        {
+            _updateCts?.Cancel();
+            _updateCts?.Dispose();
+            _updateCts = new CancellationTokenSource();
+            isUpdating = true;
+            SetUpdateProgress("Updating dependencies...");
+            errorMessage = null;
+            StateHasChanged();
+
+            try
+            {
+                await Task.Yield();
+                await WorkspaceUpdateHandler.RunUpdateAsync(
+                    WorkspaceId,
+                    _updateCts.Token,
+                    SetUpdateProgress,
+                    (repoId, msg) =>
+                    {
+                        repositoryErrors[repoId] = msg;
+                        _ = InvokeAsync(StateHasChanged);
+                    },
+                    onAppSideComplete: () => _updateAwaitingAgentTasks = true,
+                    repoIdsToUpdate: null,
+                    commitMessage: null,
+                    includeDepsInCommitMessage: true);
+                isUpdating = false;
+                await InvokeAsync(StateHasChanged);
+                await RefreshFromSync();
+            }
+            catch (OperationCanceledException)
+            {
+                isUpdating = false;
+                await ReloadWorkspaceDataAfterCancelAsync();
+                return;
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "New Feature: dependency update failed for workspace {WorkspaceId}", WorkspaceId);
+                ShowOperationError("Dependency Update Failed", "Dependency update failed. Check individual repository errors for details.");
+                return;
+            }
+            finally
+            {
+                _updateAwaitingAgentTasks = false;
+                isUpdating = false;
+                await InvokeAsync(StateHasChanged);
+            }
+        }
+
+        // Step 3: Push changes
+        if (request.PushChanges)
+        {
+            IReadOnlySet<int> pushRepoIds;
+            IReadOnlySet<string> requiredPackageIds;
+            try
+            {
+                var (payload, hasUnpushed) = await WorkspacePushHandler.GetPushPlanAsync(
+                    WorkspaceId, workspaceRepositories, CancellationToken.None);
+                if (!hasUnpushed)
+                {
+                    ToastService.Show("No repositories to push.");
+                    return;
+                }
+                var taggedRepoIds = workspaceRepositories.Where(wr => wr.IsOnTag).Select(wr => wr.RepositoryId).ToHashSet();
+                pushRepoIds = payload.Select(p => p.RepoId).Where(id => !taggedRepoIds.Contains(id)).ToHashSet();
+                if (pushRepoIds.Count == 0)
+                {
+                    ToastService.Show("No repositories to push.");
+                    return;
+                }
+                var depInfo = await WorkspaceDependencyService.GetPushDependencyInfoForRepoSetAsync(
+                    WorkspaceId, pushRepoIds, CancellationToken.None);
+                requiredPackageIds = depInfo?.PayloadForRepo?.RequiredPackages
+                    .Select(r => r.PackageId?.Trim())
+                    .Where(id => !string.IsNullOrEmpty(id))
+                    .Cast<string>()
+                    .ToHashSet(StringComparer.OrdinalIgnoreCase) ?? new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "New Feature: failed to get push plan for workspace {WorkspaceId}", WorkspaceId);
+                ShowOperationError("Push Failed", "Could not determine push plan. The GrayMoon Agent may be offline.");
+                return;
+            }
+
+            _pushCts?.Cancel();
+            _pushCts?.Dispose();
+            _pushCts = new CancellationTokenSource();
+            isPushing = true;
+            StateHasChanged();
+
+            try
+            {
+                await WorkspacePushHandler.RunPushWithDependenciesAsync(
+                    WorkspaceId,
+                    pushRepoIds,
+                    synchronizedPush: true,
+                    requiredPackageIds,
+                    SetPushProgress,
+                    ToastService.Show,
+                    onAppSideComplete: () => _pushAwaitingAgentTasks = true,
+                    _pushCts.Token);
+            }
+            catch (SynchronizedPushNotPossibleException ex)
+            {
+                ShowOperationError("Push Failed",
+                    $"Synchronized push could not complete: {ex.MissingPackagesCount} required package mapping(s) are missing. Check NuGet connector configuration and token, then retry.");
+                return;
+            }
+            catch (OperationCanceledException)
+            {
+                ToastService.Show("Push cancelled.");
+                return;
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "New Feature: push failed for workspace {WorkspaceId}", WorkspaceId);
+                ShowOperationError("Push Failed", "Push failed. Check individual repository errors for details.");
+                return;
+            }
+            finally
+            {
+                _pushAwaitingAgentTasks = false;
+                isPushing = false;
+                await RefreshFromSync();
+                await InvokeAsync(StateHasChanged);
+            }
+        }
+    }
+
     private async Task LoadCommonBranchesForBranchModalAsync(CancellationToken cancellationToken)
     {
         var data = await WorkspaceBranchHandler.GetCommonBranchesAsync(
@@ -2863,6 +3091,20 @@ public sealed partial class WorkspaceRepositories : IDisposable
         public int RepoId { get; init; }
         public string? BranchName { get; init; }
         public string? RepoName { get; init; }
+    }
+
+    private sealed record NewFeatureModalState
+    {
+        public bool IsVisible { get; init; }
+        public IReadOnlyList<string> CommonBranchNames { get; init; } = Array.Empty<string>();
+        public string DefaultDisplayText { get; init; } = "multiple";
+    }
+
+    private sealed record OperationErrorModalState
+    {
+        public bool IsVisible { get; init; }
+        public string Title { get; init; } = "Operation Failed";
+        public string Message { get; init; } = "";
     }
 }
 

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
@@ -2160,7 +2160,6 @@ public sealed partial class WorkspaceRepositories : IDisposable
 
         CloseNewFeatureModal();
 
-        // Step 1: Create branches
         var tagFilteredRepoIds = request.SkipReposOnTags
             ? workspaceRepositories.Where(wr => !wr.IsOnTag).Select(wr => wr.RepositoryId).ToHashSet()
             : (IReadOnlySet<int>?)null;
@@ -2169,95 +2168,68 @@ public sealed partial class WorkspaceRepositories : IDisposable
         _createBranchesCts?.Dispose();
         _createBranchesCts = new CancellationTokenSource();
         isCreatingBranches = true;
+        isUpdating = request.UpdateDependencies;
         SetCreateBranchesProgress("Creating branches...");
         errorMessage = null;
         StateHasChanged();
 
+        // Phases 1 + 2: branch creation (hooks suppressed, state persisted inline) then update.
+        // NewFeatureOrchestrator guarantees all CheckedOutTag fields are null before the update
+        // runs, so DependencyUpdateOrchestrator never skips previously tag-pinned repos.
         try
         {
             await Task.Yield();
-            await WorkspaceBranchHandler.CreateBranchesAsync(
+            await NewFeatureOrchestrator.RunAsync(
                 WorkspaceId,
                 request.NewBranchName,
                 request.BaseBranch,
                 tagFilteredRepoIds,
-                (completed, total) =>
+                request.UpdateDependencies,
+                commitMessage: null,
+                setProgress: msg =>
+                {
+                    if (msg.StartsWith("Creating", StringComparison.OrdinalIgnoreCase))
+                        SetCreateBranchesProgress(msg);
+                    else
+                        SetUpdateProgress(msg);
+                    _ = InvokeAsync(StateHasChanged);
+                },
+                reportBranchProgress: (completed, total) =>
                 {
                     SetCreateBranchesProgress($"Created {completed} of {total} branches");
-                    if (completed == total)
-                        _creatingBranchesAwaitingAgentTasks = true;
+                    _ = InvokeAsync(StateHasChanged);
+                },
+                setRepositoryError: (repoId, msg) =>
+                {
+                    repositoryErrors[repoId] = msg;
                     _ = InvokeAsync(StateHasChanged);
                 },
                 _createBranchesCts.Token);
+
+            isCreatingBranches = false;
+            isUpdating = false;
+            await InvokeAsync(StateHasChanged);
             await RefreshFromSync();
         }
         catch (OperationCanceledException)
         {
+            isCreatingBranches = false;
+            isUpdating = false;
             await ReloadWorkspaceDataAfterCancelAsync();
             return;
         }
         catch (Exception ex)
         {
-            Logger.LogError(ex, "New Feature: branch creation failed for workspace {WorkspaceId}", WorkspaceId);
-            ShowOperationError("Branch Creation Failed", "Could not create branches. The GrayMoon Agent may be offline. Start the Agent and try again.");
+            Logger.LogError(ex, "New Feature: orchestration failed for workspace {WorkspaceId}", WorkspaceId);
+            ShowOperationError("New Feature Failed", "Could not complete the New Feature workflow. The GrayMoon Agent may be offline or a dependency update failed. Check individual repository errors for details.");
             return;
         }
         finally
         {
-            _creatingBranchesAwaitingAgentTasks = false;
             isCreatingBranches = false;
+            isUpdating = false;
+            _updateAwaitingAgentTasks = false;
             await InvokeAsync(StateHasChanged);
-        }
-
-        // Step 2: Update dependencies
-        if (request.UpdateDependencies)
-        {
-            _updateCts?.Cancel();
-            _updateCts?.Dispose();
-            _updateCts = new CancellationTokenSource();
-            isUpdating = true;
-            SetUpdateProgress("Updating dependencies...");
-            errorMessage = null;
-            StateHasChanged();
-
-            try
-            {
-                await Task.Yield();
-                await WorkspaceUpdateHandler.RunUpdateAsync(
-                    WorkspaceId,
-                    _updateCts.Token,
-                    SetUpdateProgress,
-                    (repoId, msg) =>
-                    {
-                        repositoryErrors[repoId] = msg;
-                        _ = InvokeAsync(StateHasChanged);
-                    },
-                    onAppSideComplete: () => _updateAwaitingAgentTasks = true,
-                    repoIdsToUpdate: null,
-                    commitMessage: null,
-                    includeDepsInCommitMessage: true);
-                isUpdating = false;
-                await InvokeAsync(StateHasChanged);
-                await RefreshFromSync();
-            }
-            catch (OperationCanceledException)
-            {
-                isUpdating = false;
-                await ReloadWorkspaceDataAfterCancelAsync();
-                return;
-            }
-            catch (Exception ex)
-            {
-                Logger.LogError(ex, "New Feature: dependency update failed for workspace {WorkspaceId}", WorkspaceId);
-                ShowOperationError("Dependency Update Failed", "Dependency update failed. Check individual repository errors for details.");
-                return;
-            }
-            finally
-            {
-                _updateAwaitingAgentTasks = false;
-                isUpdating = false;
-                await InvokeAsync(StateHasChanged);
-            }
         }
 
         // Step 3: Push changes
@@ -2532,7 +2504,8 @@ public sealed partial class WorkspaceRepositories : IDisposable
                         _creatingBranchesAwaitingAgentTasks = true;
                     _ = InvokeAsync(StateHasChanged);
                 },
-                _createBranchesCts.Token);
+                syncState: false,
+                cancellationToken: _createBranchesCts.Token);
             await RefreshFromSync();
         }
         catch (OperationCanceledException)

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
@@ -2129,6 +2129,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
         _newFeatureModal = _newFeatureModal with
         {
             IsVisible = true,
+            WorkspaceName = workspace?.Name,
             CommonBranchNames = _branchModal.CommonBranchNames,
             DefaultDisplayText = _branchModal.DefaultDisplayText,
         };
@@ -3096,6 +3097,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
     private sealed record NewFeatureModalState
     {
         public bool IsVisible { get; init; }
+        public string? WorkspaceName { get; init; }
         public IReadOnlyList<string> CommonBranchNames { get; init; } = Array.Empty<string>();
         public string DefaultDisplayText { get; init; } = "multiple";
     }

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
@@ -97,6 +97,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
     private string workspaceBranchesCheckoutProgressMessage = "Checking out branch across workspace...";
     private CancellationTokenSource? _workspaceBranchesCheckoutCts;
     private UpdateModalState _updateModal = new();
+    private UpdateModalState _updateAndPushModal = new();
     private UpdateSingleRepoDependenciesModalState _updateSingleRepoModal = new();
     private PushWithDependenciesModalState _pushWithDependenciesModal = new();
     private ConfirmModalState _confirmModal = new();
@@ -531,6 +532,12 @@ public sealed partial class WorkspaceRepositories : IDisposable
     private void CloseUpdateModal()
     {
         _updateModal = _updateModal with { IsVisible = false };
+        StateHasChanged();
+    }
+
+    private void CloseUpdateAndPushModal()
+    {
+        _updateAndPushModal = _updateAndPushModal with { IsVisible = false };
         StateHasChanged();
     }
 
@@ -1515,6 +1522,163 @@ public sealed partial class WorkspaceRepositories : IDisposable
             _updateAwaitingAgentTasks = false;
             isUpdating = false;
             await InvokeAsync(StateHasChanged);
+        }
+    }
+
+    private async Task OnUpdateAndPushClickAsync()
+    {
+        if (workspace == null || workspaceRepositories.Count == 0 || isUpdating || isSyncing)
+            return;
+
+        if (workspaceRepositories.All(wr => wr.IsOnTag))
+        {
+            ToastService.Show("All repositories are on tags; checkout a branch first.");
+            return;
+        }
+
+        await using var scope = ServiceScopeFactory.CreateAsyncScope();
+        var workspaceGitService = scope.ServiceProvider.GetRequiredService<WorkspaceGitService>();
+        var (updatePlan, _) = await workspaceGitService.GetUpdatePlanAsync(WorkspaceId);
+        var repoIdsWithUpdates = updatePlan.Select(p => p.RepoId).ToHashSet();
+
+        var reposOnDefault = workspaceRepositories
+            .Where(wr => !wr.IsOnTag
+                && !string.IsNullOrWhiteSpace(wr.DefaultBranchName)
+                && string.Equals(wr.BranchName, wr.DefaultBranchName, StringComparison.Ordinal)
+                && repoIdsWithUpdates.Contains(wr.RepositoryId))
+            .ToList();
+
+        if (reposOnDefault.Count > 0)
+        {
+            var repoItems = reposOnDefault
+                .Select(wr => (wr.Repository?.RepositoryName ?? $"repo {wr.RepositoryId}", wr.DefaultBranchName!))
+                .ToList();
+            ShowDefaultBranchWarning(
+                "The following repositories are on their default branch. Update will commit dependency changes directly to the default (protected) branch.",
+                repoItems,
+                OpenUpdateAndPushModalAsync);
+            return;
+        }
+
+        await OpenUpdateAndPushModalAsync();
+    }
+
+    private async Task OpenUpdateAndPushModalAsync()
+    {
+        _updateAndPushModal = _updateAndPushModal with { IsVisible = true };
+        await InvokeAsync(StateHasChanged);
+    }
+
+    private async Task OnUpdateAndPushProceedAsync((string? CommitMessage, bool IncludeDeps) args)
+    {
+        _updateAndPushModal = _updateAndPushModal with
+        {
+            IsVisible = false,
+            LastCommitMessage = args.CommitMessage,
+            LastIncludeDeps = args.IncludeDeps
+        };
+        await RunUpdateAndPushCoreAsync(args.CommitMessage, args.IncludeDeps);
+    }
+
+    private async Task RunUpdateAndPushCoreAsync(string? commitMessage = null, bool includeDepsInCommitMessage = true)
+    {
+        if (workspace == null || workspaceRepositories.Count == 0 || isUpdating || isSyncing)
+            return;
+
+        _updateCts?.Cancel();
+        _updateCts?.Dispose();
+        _updateCts = new CancellationTokenSource();
+
+        isUpdating = true;
+        SetUpdateProgress("Updating dependencies...");
+        errorMessage = null;
+        try
+        {
+            StateHasChanged();
+            await Task.Yield();
+
+            await WorkspaceUpdateHandler.RunUpdateAsync(
+                WorkspaceId,
+                _updateCts.Token,
+                SetUpdateProgress,
+                (repoId, msg) =>
+                {
+                    repositoryErrors[repoId] = msg;
+                    _ = InvokeAsync(StateHasChanged);
+                },
+                onAppSideComplete: () => _updateAwaitingAgentTasks = true,
+                repoIdsToUpdate: null,
+                commitMessage: commitMessage,
+                includeDepsInCommitMessage: includeDepsInCommitMessage);
+
+            isUpdating = false;
+            await InvokeAsync(StateHasChanged);
+            await RefreshFromSync();
+        }
+        catch (OperationCanceledException)
+        {
+            isUpdating = false;
+            await ReloadWorkspaceDataAfterCancelAsync();
+            return;
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Update & Push: update failed for workspace {WorkspaceId}", WorkspaceId);
+            errorMessage = "Update failed. The GrayMoon Agent may be offline. Start the Agent and try again.";
+            return;
+        }
+        finally
+        {
+            _updateAwaitingAgentTasks = false;
+            isUpdating = false;
+            await InvokeAsync(StateHasChanged);
+        }
+
+        // Phase 2: determine push plan using fresh workspaceRepositories loaded by RefreshFromSync()
+        IReadOnlySet<int> pushRepoIds;
+        IReadOnlySet<string> requiredPackageIds;
+        try
+        {
+            var (payload, hasUnpushed) = await WorkspacePushHandler.GetPushPlanAsync(
+                WorkspaceId, workspaceRepositories, CancellationToken.None);
+            if (!hasUnpushed)
+            {
+                ToastService.Show("Update complete. Nothing to push.");
+                return;
+            }
+            var taggedRepoIds = workspaceRepositories.Where(wr => wr.IsOnTag).Select(wr => wr.RepositoryId).ToHashSet();
+            pushRepoIds = payload.Select(p => p.RepoId).Where(id => !taggedRepoIds.Contains(id)).ToHashSet();
+            if (pushRepoIds.Count == 0)
+            {
+                ToastService.Show("Update complete. Nothing to push.");
+                return;
+            }
+            var depInfo = await WorkspaceDependencyService.GetPushDependencyInfoForRepoSetAsync(
+                WorkspaceId, pushRepoIds, CancellationToken.None);
+            requiredPackageIds = depInfo?.PayloadForRepo?.RequiredPackages
+                .Select(r => r.PackageId?.Trim())
+                .Where(id => !string.IsNullOrEmpty(id))
+                .Cast<string>()
+                .ToHashSet(StringComparer.OrdinalIgnoreCase) ?? new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Update & Push: failed to get push plan for workspace {WorkspaceId}", WorkspaceId);
+            ShowOperationError("Push Failed", "Update succeeded but push plan could not be determined. The GrayMoon Agent may be offline.");
+            return;
+        }
+
+        // Phase 3: execute push
+        try
+        {
+            await ExecutePushAsync(pushRepoIds, synchronizedPush: true, requiredPackageIds);
+        }
+        catch (SynchronizedPushNotPossibleException ex)
+        {
+            ShowConfirm(
+                $"Synchronized push could not be completed because {ex.MissingPackagesCount} required package mappings are missing. Check NuGet connector configuration and token, then retry. Continue with normal push?",
+                () => ExecutePushAsync(pushRepoIds, synchronizedPush: false, requiredPackageIds),
+                confirmButtonText: "Continue");
         }
     }
 

--- a/src/GrayMoon.App/Components/Shared/WorkspaceRepositoriesHeader.razor
+++ b/src/GrayMoon.App/Components/Shared/WorkspaceRepositoriesHeader.razor
@@ -102,11 +102,47 @@
                 </ul>
             }
         </div>
-        <button class="btn @(HasUnmatchedDependencies ? "btn-danger" : "btn-outline-secondary")"
-                @onclick="@(() => OnUpdate.InvokeAsync())"
-                disabled="@UpdateDisabled">
-            Update
-        </button>
+        <div class="btn-group position-relative">
+            <button class="btn @(HasUnmatchedDependencies ? "btn-danger" : "btn-outline-secondary")"
+                    @onclick="HandleUpdatePrimaryClick"
+                    @onclick:stopPropagation
+                    disabled="@UpdateDisabled">
+                Update
+            </button>
+            <button type="button"
+                    class="btn @(HasUnmatchedDependencies ? "btn-danger" : "btn-outline-secondary") dropdown-toggle dropdown-toggle-split"
+                    aria-label="Toggle Update menu"
+                    aria-expanded="@(_updateMenuOpen ? "true" : "false")"
+                    @onclick="ToggleUpdateMenu"
+                    @onclick:stopPropagation
+                    disabled="@UpdateDisabled">
+                <span class="visually-hidden">Toggle Dropdown</span>
+            </button>
+            @if (_updateMenuOpen)
+            {
+                <div class="branch-menu-backdrop" @onclick="CloseUpdateMenu"></div>
+                <ul class="dropdown-menu show shadow branch-menu-list"
+                    role="menu">
+                    <li>
+                        <button class="dropdown-item" type="button"
+                                role="menuitem"
+                                @onclick="HandleUpdatePrimaryClick"
+                                disabled="@UpdateDisabled">
+                            Update
+                        </button>
+                    </li>
+                    <li><hr class="dropdown-divider branch-menu-divider" /></li>
+                    <li>
+                        <button class="dropdown-item" type="button"
+                                role="menuitem"
+                                @onclick="HandleUpdateAndPushClick"
+                                disabled="@UpdateDisabled">
+                            Update &amp; Push...
+                        </button>
+                    </li>
+                </ul>
+            }
+        </div>
         @if (HasIncomingCommits)
         {
             <button class="btn btn-danger"
@@ -154,6 +190,7 @@
     [Parameter] public EventCallback OnShowSwitchBranch { get; set; }
     [Parameter] public EventCallback OnNewPullRequest { get; set; }
     [Parameter] public EventCallback OnUpdate { get; set; }
+    [Parameter] public EventCallback OnUpdateAndPush { get; set; }
     [Parameter] public EventCallback OnPull { get; set; }
     [Parameter] public EventCallback OnPush { get; set; }
     [Parameter] public EventCallback OnSync { get; set; }
@@ -162,6 +199,7 @@
     [Parameter] public EventCallback<KeyboardEventArgs> OnSearchKeyDown { get; set; }
 
     private bool _branchMenuOpen;
+    private bool _updateMenuOpen;
 
     private bool UpdateDisabled =>
         WorkspaceName == null || RepositoriesCount == 0 || IsSyncing || IsUpdating || IsPushing || AgentTasksPendingCount > 0;
@@ -180,6 +218,22 @@
     private void CloseBranchMenu()
     {
         _branchMenuOpen = false;
+    }
+
+    private void ToggleUpdateMenu() => _updateMenuOpen = !_updateMenuOpen;
+
+    private void CloseUpdateMenu() => _updateMenuOpen = false;
+
+    private async Task HandleUpdatePrimaryClick()
+    {
+        CloseUpdateMenu();
+        await OnUpdate.InvokeAsync();
+    }
+
+    private async Task HandleUpdateAndPushClick()
+    {
+        CloseUpdateMenu();
+        await OnUpdateAndPush.InvokeAsync();
     }
 
     private async Task HandleBranchPrimaryClick()

--- a/src/GrayMoon.App/Components/Shared/WorkspaceRepositoriesHeader.razor
+++ b/src/GrayMoon.App/Components/Shared/WorkspaceRepositoriesHeader.razor
@@ -68,6 +68,15 @@
                     <li>
                         <button class="dropdown-item" type="button"
                                 role="menuitem"
+                                @onclick="HandleNewFeatureClick"
+                                disabled="@BranchActionsDisabled">
+                            New Feature
+                        </button>
+                    </li>
+                    <li><hr class="dropdown-divider branch-menu-divider" /></li>
+                    <li>
+                        <button class="dropdown-item" type="button"
+                                role="menuitem"
                                 @onclick="HandleNewBranchClick"
                                 disabled="@BranchActionsDisabled">
                             New Branch
@@ -140,6 +149,7 @@
     [Parameter] public bool IsOverlayVisible { get; set; }
 
     [Parameter] public EventCallback OnShowRepositories { get; set; }
+    [Parameter] public EventCallback OnNewFeature { get; set; }
     [Parameter] public EventCallback OnShowBranch { get; set; }
     [Parameter] public EventCallback OnShowSwitchBranch { get; set; }
     [Parameter] public EventCallback OnNewPullRequest { get; set; }
@@ -176,6 +186,12 @@
     {
         CloseBranchMenu();
         await OnShowBranch.InvokeAsync();
+    }
+
+    private async Task HandleNewFeatureClick()
+    {
+        CloseBranchMenu();
+        await OnNewFeature.InvokeAsync();
     }
 
     private async Task HandleNewBranchClick()

--- a/src/GrayMoon.App/Components/Shared/WorkspaceRepositoriesHeader.razor.css
+++ b/src/GrayMoon.App/Components/Shared/WorkspaceRepositoriesHeader.razor.css
@@ -31,3 +31,7 @@
     vertical-align: middle;
     margin-left: 0;
 }
+
+.btn-group > .btn-danger + .btn-danger.dropdown-toggle-split {
+    border-left-color: rgba(255, 255, 255, 0.4);
+}

--- a/src/GrayMoon.App/Models/Api/BranchesApiModels.cs
+++ b/src/GrayMoon.App/Models/Api/BranchesApiModels.cs
@@ -70,6 +70,34 @@ public sealed class CreateBranchResponse
 
     [JsonPropertyName("errorMessage")]
     public string? ErrorMessage { get; set; }
+
+    // Populated only when SkipHooks=true (inline sync path)
+    [JsonPropertyName("version")]
+    public string? Version { get; set; }
+
+    [JsonPropertyName("branch")]
+    public string? Branch { get; set; }
+
+    [JsonPropertyName("tag")]
+    public string? Tag { get; set; }
+
+    [JsonPropertyName("outgoingCommits")]
+    public int? OutgoingCommits { get; set; }
+
+    [JsonPropertyName("incomingCommits")]
+    public int? IncomingCommits { get; set; }
+
+    [JsonPropertyName("hasUpstream")]
+    public bool? HasUpstream { get; set; }
+
+    [JsonPropertyName("defaultBranchBehind")]
+    public int? DefaultBranchBehind { get; set; }
+
+    [JsonPropertyName("defaultBranchAhead")]
+    public int? DefaultBranchAhead { get; set; }
+
+    [JsonPropertyName("fetchError")]
+    public string? FetchError { get; set; }
 }
 
 /// <summary>Agent DeleteBranch response (camelCase).</summary>

--- a/src/GrayMoon.App/Program.cs
+++ b/src/GrayMoon.App/Program.cs
@@ -85,6 +85,7 @@ try
     builder.Services.AddScoped<WorkspacePushHandler>();
     builder.Services.AddScoped<WorkspaceDependencyService>();
     builder.Services.AddScoped<WorkspaceBranchHandler>();
+    builder.Services.AddScoped<NewFeatureOrchestrator>();
     builder.Services.AddScoped<IWorkspacePageService, WorkspacePageService>();
     builder.Services.AddScoped<IWorkspaceTopBarService, WorkspaceTopBarService>();
 

--- a/src/GrayMoon.App/Services/NewFeatureOrchestrator.cs
+++ b/src/GrayMoon.App/Services/NewFeatureOrchestrator.cs
@@ -1,0 +1,53 @@
+namespace GrayMoon.App.Services;
+
+/// <summary>
+/// Sequences the New Feature workflow: parallel branch creation with inline state sync (hooks
+/// suppressed), then dependency update. By the time each phase completes, the database reflects
+/// full, consistent state — no async hook syncs to race against.
+/// </summary>
+public sealed class NewFeatureOrchestrator(
+    WorkspaceBranchHandler branchHandler,
+    DependencyUpdateOrchestrator dependencyUpdateOrchestrator,
+    ILogger<NewFeatureOrchestrator> logger)
+{
+    public async Task RunAsync(
+        int workspaceId,
+        string newBranchName,
+        string baseBranch,
+        IReadOnlySet<int>? repositoryIds,
+        bool updateDependencies,
+        string? commitMessage,
+        Action<string> setProgress,
+        Action<int, int> reportBranchProgress,
+        Action<int, string> setRepositoryError,
+        CancellationToken cancellationToken)
+    {
+        logger.LogInformation("NewFeatureOrchestrator starting for workspace {WorkspaceId}: branch={Branch}, updateDeps={UpdateDeps}", workspaceId, newBranchName, updateDependencies);
+
+        setProgress("Creating branches...");
+        await branchHandler.CreateBranchesAsync(
+            workspaceId,
+            newBranchName,
+            baseBranch,
+            repositoryIds,
+            reportBranchProgress,
+            syncState: true,
+            cancellationToken);
+
+        if (updateDependencies)
+        {
+            setProgress("Updating dependencies...");
+            await dependencyUpdateOrchestrator.RunAsync(
+                workspaceId,
+                cancellationToken,
+                setProgress,
+                setRepositoryError,
+                onAppSideComplete: null,
+                repoIdsToUpdate: null,
+                commitMessage: commitMessage,
+                includeDepsInCommitMessage: true);
+        }
+
+        logger.LogInformation("NewFeatureOrchestrator completed for workspace {WorkspaceId}", workspaceId);
+    }
+}

--- a/src/GrayMoon.App/Services/WorkspaceBranchHandler.cs
+++ b/src/GrayMoon.App/Services/WorkspaceBranchHandler.cs
@@ -172,13 +172,14 @@ public sealed class WorkspaceBranchHandler(
         int repositoryId,
         string? currentBranchName,
         bool deleteRemoteBranch,
+        bool allowForceDeleteLocalBranch,
         string apiBaseUrl,
         CancellationToken cancellationToken)
     {
         var httpClient = httpClientFactory.CreateClient();
         var baseUrl = apiBaseUrl;
 
-        var apiRequest = new { workspaceId, repositoryId, currentBranchName, deleteRemoteBranch };
+        var apiRequest = new { workspaceId, repositoryId, currentBranchName, deleteRemoteBranch, allowForceDeleteLocalBranch };
         var json = JsonSerializer.Serialize(apiRequest);
         using var content = new StringContent(json, System.Text.Encoding.UTF8, "application/json");
         using var response = await httpClient.PostAsync($"{baseUrl}/api/branches/sync-to-default", content, cancellationToken);

--- a/src/GrayMoon.App/Services/WorkspaceBranchHandler.cs
+++ b/src/GrayMoon.App/Services/WorkspaceBranchHandler.cs
@@ -40,7 +40,8 @@ public sealed class WorkspaceBranchHandler(
         string baseBranch,
         IReadOnlySet<int>? repositoryIds,
         Action<int, int> reportProgress,
-        CancellationToken cancellationToken)
+        bool syncState = false,
+        CancellationToken cancellationToken = default)
     {
         await using var scope = serviceScopeFactory.CreateAsyncScope();
         var workspaceGitService = scope.ServiceProvider.GetRequiredService<WorkspaceGitService>();
@@ -51,6 +52,7 @@ public sealed class WorkspaceBranchHandler(
             baseBranch,
             onProgress: (completed, total) => reportProgress(completed, total),
             repositoryIds: repositoryIds,
+            syncState: syncState,
             cancellationToken: cancellationToken);
     }
 

--- a/src/GrayMoon.App/Services/WorkspaceGitService.cs
+++ b/src/GrayMoon.App/Services/WorkspaceGitService.cs
@@ -962,7 +962,7 @@ public class WorkspaceGitService(
         if (!persistDependencyLevel)
             await RecomputeAndBroadcastWorkspaceSyncedAsync(workspaceId, cancellationToken);
 
-        await _workspacePullRequestService.RefreshPullRequestsAsync(workspaceId, repoIds, cancellationToken);
+        await _workspacePullRequestService.RefreshPullRequestsAsync(workspaceId, repoIds, cancellationToken: cancellationToken);
 
         _logger.LogInformation("Persistence: saved WorkspaceRepository link versions. WorkspaceId={WorkspaceId}, RepoCount={RepoCount}",
             workspaceId, resultList.Count);

--- a/src/GrayMoon.App/Services/WorkspaceGitService.cs
+++ b/src/GrayMoon.App/Services/WorkspaceGitService.cs
@@ -1110,13 +1110,14 @@ public class WorkspaceGitService(
         await _dbContext.SaveChangesAsync(cancellationToken);
     }
 
-    /// <summary>Creates a new branch in all workspace repos (in parallel), then checks it out. baseBranch is "__default__" to use each repo's default, or a branch name. When <paramref name="repositoryIds"/> is set, only those repos are included.</summary>
+    /// <summary>Creates a new branch in all workspace repos (in parallel), then checks it out. baseBranch is "__default__" to use each repo's default, or a branch name. When <paramref name="repositoryIds"/> is set, only those repos are included. When <paramref name="syncState"/> is true, hooks are suppressed and the agent returns full state inline so the app can persist it without waiting for async hook syncs.</summary>
     public async Task CreateBranchesAsync(
         int workspaceId,
         string newBranchName,
         string baseBranch,
         Action<int, int>? onProgress = null,
         IReadOnlySet<int>? repositoryIds = null,
+        bool syncState = false,
         CancellationToken cancellationToken = default)
     {
         if (!_agentBridge.IsAgentConnected)
@@ -1172,14 +1173,36 @@ public class WorkspaceGitService(
                     repositoryName = repo.RepositoryName,
                     newBranchName,
                     baseBranchName,
-                    workspaceRoot
+                    workspaceRoot,
+                    repositoryId = wr.RepositoryId,
+                    skipHooks = syncState
                 };
                 var response = await _agentBridge.SendCommandAsync("CreateBranch", args, cancellationToken);
                 var createResponse = AgentResponseJson.DeserializeAgentResponse<CreateBranchResponse>(response.Data);
                 var success = createResponse?.Success ?? response.Success;
 
                 if (success)
-                    wr.BranchName = newBranchName;
+                {
+                    wr.BranchName = createResponse?.Branch ?? newBranchName;
+                    if (syncState && createResponse != null)
+                    {
+                        // Hooks were suppressed — persist all state returned inline so the next
+                        // step (dependency update) sees a complete, consistent database.
+                        wr.CheckedOutTag = null;
+                        if (createResponse.Version != null)
+                            wr.GitVersion = createResponse.Version;
+                        if (createResponse.OutgoingCommits.HasValue)
+                            wr.OutgoingCommits = createResponse.OutgoingCommits;
+                        if (createResponse.IncomingCommits.HasValue)
+                            wr.IncomingCommits = createResponse.IncomingCommits;
+                        if (createResponse.HasUpstream.HasValue)
+                            wr.BranchHasUpstream = createResponse.HasUpstream;
+                        if (createResponse.DefaultBranchBehind.HasValue)
+                            wr.DefaultBranchBehindCommits = createResponse.DefaultBranchBehind;
+                        if (createResponse.DefaultBranchAhead.HasValue)
+                            wr.DefaultBranchAheadCommits = createResponse.DefaultBranchAhead;
+                    }
+                }
             }
             finally
             {

--- a/src/GrayMoon.App/Services/WorkspacePullRequestService.cs
+++ b/src/GrayMoon.App/Services/WorkspacePullRequestService.cs
@@ -27,7 +27,7 @@ public sealed class WorkspacePullRequestService(
     }
 
     /// <summary>Fetches PR from API for the given repos and persists. Call after sync, refresh, push, or hooks.</summary>
-    public async Task RefreshPullRequestsAsync(int workspaceId, IReadOnlyList<int> repositoryIds, CancellationToken cancellationToken = default)
+    public async Task RefreshPullRequestsAsync(int workspaceId, IReadOnlyList<int> repositoryIds, bool force = false, CancellationToken cancellationToken = default)
     {
         if (repositoryIds.Count == 0) return;
 
@@ -49,7 +49,7 @@ public sealed class WorkspacePullRequestService(
             {
                 var branch = wr.BranchName!;
                 var cacheKey = (wr.RepositoryId, branch);
-                if (_cache.TryGetValue(cacheKey, out var cached) && DateTime.UtcNow - cached.FetchedAt < CacheTtl)
+                if (!force && _cache.TryGetValue(cacheKey, out var cached) && DateTime.UtcNow - cached.FetchedAt < CacheTtl)
                 {
                     logger.LogTrace("PR cache hit for repo {RepositoryId}, branch {Branch}", wr.RepositoryId, branch);
                     return;
@@ -79,6 +79,6 @@ public sealed class WorkspacePullRequestService(
             .Where(wr => wr.WorkspaceId == workspaceId)
             .Select(wr => wr.RepositoryId)
             .ToListAsync(cancellationToken);
-        await RefreshPullRequestsAsync(workspaceId, repoIds, cancellationToken);
+        await RefreshPullRequestsAsync(workspaceId, repoIds, cancellationToken: cancellationToken);
     }
 }


### PR DESCRIPTION
## Summary

Adds a **New Feature** workflow to the workspace repositories view that creates a branch across all repos in one step, with optional dependency updates and synchronized push. Also adds a standalone **Update & Push** action, consolidates loading overlays for smoother UX, and hardens branch creation/sync behavior in the agent.

### New Feature workflow
- New **Branch → New Feature** menu item opens a modal to configure:
  - Branch name and base branch (default or common branches)
  - Skip repos on tags (default: on)
  - Update dependencies (default: on)
  - Push changes via synchronized push (default: on when updating)
- Warns when the branch already exists in some repos and lets the user proceed (checks out existing branch)
- `NewFeatureOrchestrator` sequences: parallel branch creation → optional dependency update → optional synchronized push
- Uses `OperationErrorModal` for clear failure messaging when orchestration or push fails

### Agent & branch creation reliability
- `CreateBranch` supports `skipHooks` and returns full repo state inline (version, commit counts, upstream status) when hooks are suppressed
- App persists inline sync state immediately so dependency update does not race async post-checkout hooks
- New branches created with `--no-track` to avoid incorrect upstream tracking
- `skipUpstreamCheck` on fetch/commit counts for new, not-yet-tracked branches

### Update & Push
- New **Update → Update & Push...** dropdown action runs dependency update then synchronized push in one flow
- Reuses default-branch protection warning and commit message modal

### UX & sync-to-default improvements
- Replaces multiple stacked `LoadingOverlay` components with a single overlay and priority-based message/abort handling (smoother transitions between create → update → push phases)
- Sync-to-default: refreshes PR state before delete; force-deletes local branches (`-D`) when PR is **closed or merged** (previously merged only)
- New checkbox in sync-to-default options to control force local delete behavior

## Test plan

- [ ] Open workspace repositories → **Branch → New Feature** → create branch only (uncheck update/push) and verify all repos switch to the new branch
- [ ] Run full New Feature with update + push enabled; confirm overlay transitions cleanly and synchronized push completes
- [ ] Create a branch name that already exists in some repos; confirm warning and **Proceed** checks out existing branch in those repos
- [ ] With repos on tags, confirm **Skip repos on tags** excludes them from branch creation/update
- [ ] **Update → Update & Push...** → verify update completes, then push runs with synchronized push
- [ ] Sync-to-default on a repo with a closed (not merged) PR branch; confirm force delete works when checkbox is enabled
- [ ] Sync-to-default with force delete unchecked; confirm local branch is not force-deleted
- [ ] Cancel mid-operation (sync, push, update) and confirm overlay abort still works via single overlay
- [ ] Verify ordinary **New Branch** flow still works without inline sync (`syncState: false`)