### PR TITLE
Add workspace dotnet restore to clear stale NuGet cache after dependency rollouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ GrayMoon helps you work across many repositories as one coordinated workspace:
 - keep repository status and activity up to date while you work in your IDE (checkout/commit/push/merge events are tracked)
 - track versions and dependency drift
 - update `PackageReference` versions automatically
+- run `dotnet restore --force --no-cache` so NuGet does not fall back to stale cached packages after dependency changes
 - one-click sync back to default branch after merge (single repo or multiple repos by dependency level)
 - synchronize pushes to reduce CI failures caused by missing dependency versions
 - group repositories by dependency levels and type (services vs packages/libraries) for easier dependency visualization
@@ -33,6 +34,7 @@ GrayMoon is useful for:
 - You can see GitHub Actions results for the current branch across all repositories in a workspace.
 - You can create pull requests across one, several, or all workspace repositories from one dialog, with optional reviewers and draft support.
 - You can run coordinated dependency updates instead of editing each repo manually.
+- After package refs change, GrayMoon can force a fresh NuGet restore so local builds match the versions you just rolled out (not what happened to be cached).
 - You can create one feature branch (for example `feature/dependency-update`) across repos, auto-update package refs, auto-commit, and push together.
 - When rolling out changes, GrayMoon can push multiple repositories in parallel so the full workflow finishes faster than pushing repo-by-repo manually.
 - GrayMoon tracks changed files across repositories so you can avoid unnecessary PRs when changes are only dependency-version updates.
@@ -103,6 +105,16 @@ Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManage
 6. Continue working in your IDE while GrayMoon tracks changes in the background; GrayMoon UI does not need to stay open as long as the Docker app and agent services are running.
 
 ## What's new
+
+### Workspace `dotnet restore` for fresh NuGet resolution
+
+GrayMoon now runs `dotnet restore --force --no-cache` on workspace projects so dependency rollouts do not silently reuse stale local NuGet cache entries.
+
+- **Why it matters:** after GrayMoon updates `PackageReference` versions across repositories, `dotnet` can still resolve older packages from the global or local NuGet cache. That leads to mismatched builds, false confidence that a rollout worked, and confusing drift between what is in `.csproj` files and what MSBuild actually restores. Forcing restore without cache makes NuGet fetch the versions you just wrote instead of falling back to cached artifacts.
+- **Restore Packages (manual):** **Sync** is now a split button. Open the dropdown and choose **Restore Packages** to restore every tracked `.csproj` in the workspace (repos pinned to a tag are skipped). A loading overlay shows progress and can be cancelled.
+- **Automatic during Update:** after dependency versions are applied at each dependency level and before commits are created, GrayMoon restores the updated projects so commit and build state match the new package refs.
+- **Automatic during Push:** before each dependency level is pushed during synchronized push, GrayMoon restores projects that have cross-repository project references at that level, so downstream consumers pick up freshly published packages instead of cached ones.
+- **Best-effort by design:** per-project restore failures are logged but do not abort the wider Update, Push, or manual restore workflow.
 
 ### Boolean search filters across workspace and catalog pages
 

--- a/src/GrayMoon.Agent/Cli/Handlers/RunCommandHandler.cs
+++ b/src/GrayMoon.Agent/Cli/Handlers/RunCommandHandler.cs
@@ -124,6 +124,7 @@ internal static class RunCommandHandler
         builder.Services.AddSingleton<ICommandHandler<UpdateFileVersionsRequest, UpdateFileVersionsResponse>, UpdateFileVersionsCommand>();
         builder.Services.AddSingleton<ICommandHandler<GetFileContentsRequest, GetFileContentsResponse>, GetFileContentsCommand>();
         builder.Services.AddSingleton<ICommandHandler<ValidatePathRequest, ValidatePathResponse>, ValidatePathCommand>();
+        builder.Services.AddSingleton<ICommandHandler<DotnetRestoreRequest, DotnetRestoreResponse>, DotnetRestoreCommand>();
         builder.Services.AddSingleton<CheckoutHookSyncCommand>();
         builder.Services.AddSingleton<CommitHookSyncCommand>();
         builder.Services.AddSingleton<MergeHookSyncCommand>();

--- a/src/GrayMoon.Agent/Commands/DotnetRestoreCommand.cs
+++ b/src/GrayMoon.Agent/Commands/DotnetRestoreCommand.cs
@@ -22,16 +22,32 @@ public sealed class DotnetRestoreCommand(IGitService git, ICommandLineService co
             if (!git.DirectoryExists(repoPath))
                 return new DotnetRestoreResponse { Success = true };
 
-            var result = await commandLine.RunAsync(
-                "dotnet", "restore --force --no-cache",
-                repoPath, null, cancellationToken,
-                streamStderrAsStdout: true);
+            var projectPaths = request.ProjectPaths;
+            if (projectPaths == null || projectPaths.Count == 0)
+                return new DotnetRestoreResponse { Success = true };
 
-            if (result.ExitCode != 0)
+            foreach (var relativePath in projectPaths)
             {
-                logger.LogWarning("dotnet restore exited {ExitCode} for {RepoName}: {Stderr}",
-                    result.ExitCode, repositoryName, result.Stderr);
-                return new DotnetRestoreResponse { Success = false, ErrorMessage = result.Stderr };
+                if (string.IsNullOrWhiteSpace(relativePath))
+                    continue;
+
+                var fullPath = Path.Combine(repoPath, relativePath);
+                try
+                {
+                    var result = await commandLine.RunAsync(
+                        "dotnet", $"restore --force --no-cache \"{fullPath}\"",
+                        repoPath, null, cancellationToken,
+                        streamStderrAsStdout: true);
+
+                    if (result.ExitCode != 0)
+                        logger.LogWarning("dotnet restore exited {ExitCode} for {ProjectPath}: {Stderr}",
+                            result.ExitCode, relativePath, result.Stderr);
+                }
+                catch (OperationCanceledException) { throw; }
+                catch (Exception ex)
+                {
+                    logger.LogWarning(ex, "dotnet restore failed for {ProjectPath}", relativePath);
+                }
             }
 
             return new DotnetRestoreResponse { Success = true };

--- a/src/GrayMoon.Agent/Commands/DotnetRestoreCommand.cs
+++ b/src/GrayMoon.Agent/Commands/DotnetRestoreCommand.cs
@@ -1,0 +1,49 @@
+using GrayMoon.Agent.Abstractions;
+using GrayMoon.Agent.Jobs.Requests;
+using GrayMoon.Agent.Jobs.Response;
+using GrayMoon.Common;
+using Microsoft.Extensions.Logging;
+
+namespace GrayMoon.Agent.Commands;
+
+public sealed class DotnetRestoreCommand(IGitService git, ICommandLineService commandLine, ILogger<DotnetRestoreCommand> logger)
+    : ICommandHandler<DotnetRestoreRequest, DotnetRestoreResponse>
+{
+    public async Task<DotnetRestoreResponse> ExecuteAsync(DotnetRestoreRequest request, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var workspaceName = request.WorkspaceName ?? throw new ArgumentException("workspaceName required");
+            var repositoryName = request.RepositoryName ?? throw new ArgumentException("repositoryName required");
+
+            var workspacePath = git.GetWorkspacePath(request.WorkspaceRoot!, workspaceName);
+            var repoPath = Path.Combine(workspacePath, repositoryName);
+
+            if (!git.DirectoryExists(repoPath))
+                return new DotnetRestoreResponse { Success = true };
+
+            var result = await commandLine.RunAsync(
+                "dotnet", "restore --force --no-cache",
+                repoPath, null, cancellationToken,
+                streamStderrAsStdout: true);
+
+            if (result.ExitCode != 0)
+            {
+                logger.LogWarning("dotnet restore exited {ExitCode} for {RepoName}: {Stderr}",
+                    result.ExitCode, repositoryName, result.Stderr);
+                return new DotnetRestoreResponse { Success = false, ErrorMessage = result.Stderr };
+            }
+
+            return new DotnetRestoreResponse { Success = true };
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "dotnet restore failed for {RepoName}", request.RepositoryName);
+            return new DotnetRestoreResponse { Success = false, ErrorMessage = ex.Message };
+        }
+    }
+}

--- a/src/GrayMoon.Agent/Jobs/Requests/DotnetRestoreRequest.cs
+++ b/src/GrayMoon.Agent/Jobs/Requests/DotnetRestoreRequest.cs
@@ -1,0 +1,12 @@
+using System.Text.Json.Serialization;
+
+namespace GrayMoon.Agent.Jobs.Requests;
+
+public sealed class DotnetRestoreRequest : WorkspaceCommandRequest
+{
+    [JsonPropertyName("workspaceName")]
+    public string? WorkspaceName { get; set; }
+
+    [JsonPropertyName("repositoryName")]
+    public string? RepositoryName { get; set; }
+}

--- a/src/GrayMoon.Agent/Jobs/Requests/DotnetRestoreRequest.cs
+++ b/src/GrayMoon.Agent/Jobs/Requests/DotnetRestoreRequest.cs
@@ -9,4 +9,7 @@ public sealed class DotnetRestoreRequest : WorkspaceCommandRequest
 
     [JsonPropertyName("repositoryName")]
     public string? RepositoryName { get; set; }
+
+    [JsonPropertyName("projectPaths")]
+    public IReadOnlyList<string>? ProjectPaths { get; set; }
 }

--- a/src/GrayMoon.Agent/Jobs/Response/DotnetRestoreResponse.cs
+++ b/src/GrayMoon.Agent/Jobs/Response/DotnetRestoreResponse.cs
@@ -1,0 +1,12 @@
+using System.Text.Json.Serialization;
+
+namespace GrayMoon.Agent.Jobs.Response;
+
+public sealed class DotnetRestoreResponse
+{
+    [JsonPropertyName("success")]
+    public bool Success { get; set; }
+
+    [JsonPropertyName("errorMessage")]
+    public string? ErrorMessage { get; set; }
+}

--- a/src/GrayMoon.Agent/Services/CommandDispatcher.cs
+++ b/src/GrayMoon.Agent/Services/CommandDispatcher.cs
@@ -29,7 +29,8 @@ public sealed class CommandDispatcher(
     ICommandHandler<SearchFilesRequest, SearchFilesResponse> searchFilesCommand,
     ICommandHandler<UpdateFileVersionsRequest, UpdateFileVersionsResponse> updateFileVersionsCommand,
     ICommandHandler<GetFileContentsRequest, GetFileContentsResponse> getFileContentsCommand,
-    ICommandHandler<ValidatePathRequest, ValidatePathResponse> validatePathCommand) : ICommandDispatcher
+    ICommandHandler<ValidatePathRequest, ValidatePathResponse> validatePathCommand,
+    ICommandHandler<DotnetRestoreRequest, DotnetRestoreResponse> dotnetRestoreCommand) : ICommandDispatcher
 {
     private readonly IReadOnlyDictionary<string, Func<object, CancellationToken, Task<object?>>> _executors = new Dictionary<string, Func<object, CancellationToken, Task<object?>>>(StringComparer.Ordinal)
     {
@@ -58,6 +59,7 @@ public sealed class CommandDispatcher(
         ["UpdateFileVersions"] = async (req, ct) => await updateFileVersionsCommand.ExecuteAsync((UpdateFileVersionsRequest)req, ct),
         ["GetFileContents"] = async (req, ct) => await getFileContentsCommand.ExecuteAsync((GetFileContentsRequest)req, ct),
         ["ValidatePath"] = async (req, ct) => await validatePathCommand.ExecuteAsync((ValidatePathRequest)req, ct),
+        ["DotnetRestore"] = async (req, ct) => await dotnetRestoreCommand.ExecuteAsync((DotnetRestoreRequest)req, ct),
     };
 
     public Task<object?> ExecuteAsync(string commandName, object request, CancellationToken cancellationToken = default)

--- a/src/GrayMoon.Agent/Services/CommandJobFactory.cs
+++ b/src/GrayMoon.Agent/Services/CommandJobFactory.cs
@@ -79,6 +79,8 @@ public sealed class CommandJobFactory
                 ?? throw new ArgumentException("Invalid GetFileContents args"),
             "ValidatePath" => JsonSerializer.Deserialize<ValidatePathRequest>(json, options)
                 ?? throw new ArgumentException("Invalid ValidatePath args"),
+            "DotnetRestore" => JsonSerializer.Deserialize<DotnetRestoreRequest>(json, options)
+                ?? throw new ArgumentException("Invalid DotnetRestore args"),
             _ => throw new NotSupportedException($"Unknown command: {command}")
         };
     }

--- a/src/GrayMoon.App/Components/Modals/SyncToDefaultOptionsModal.razor
+++ b/src/GrayMoon.App/Components/Modals/SyncToDefaultOptionsModal.razor
@@ -5,7 +5,7 @@
     <div class="modal show d-block" tabindex="-1" style="background-color: rgba(0,0,0,0.5);"
          @onkeydown="HandleKeyDown"
          @ref="_modalElement">
-        <div class="modal-dialog modal-dialog-scrollable default-branch-warning-modal">
+        <div class="modal-dialog modal-dialog-scrollable modal-lg default-branch-warning-modal">
             <div class="modal-content">
                 <div class="modal-header">
                     <h5 class="modal-title">Sync to Default</h5>
@@ -20,12 +20,14 @@
                                 @foreach (var item in RepoItems)
                                 {
                                     <li class="mb-1">
-                                        <code>@item.RepoName</code>
-                                        <span class="text-muted">(@item.BranchName)</span>
-                                        @if (item.HasRemote)
-                                        {
-                                            <span class="badge bg-secondary ms-1" style="font-size:0.65em;">remote</span>
-                                        }
+                                        <div>
+                                            <code>@item.RepoName</code>
+                                            @if (item.HasRemote)
+                                            {
+                                                <span class="badge bg-secondary ms-1" style="font-size:0.65em;">remote</span>
+                                            }
+                                        </div>
+                                        <div class="text-muted ps-1">@item.BranchName</div>
                                     </li>
                                 }
                             </ul>
@@ -47,7 +49,7 @@
                                checked="@AllowForceDeleteLocalBranch"
                                @onchange="OnAllowForceDeleteLocalChanged" />
                         <label class="form-check-label small" for="forceDeleteLocalCheck">
-                            Delete local branch@(RepoItems.Count > 1 ? "es" : "") and use force delete (-D) for closed/merged PRs
+                            Delete local branches
                         </label>
                     </div>
                 </div>

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor
@@ -45,7 +45,8 @@
                                     IsPushing="@isPushing"
                                     IsCommitSyncing="@isCommitSyncing"
                                     AgentTasksPendingCount="@AgentTasksPendingCount"
-                                    IsOverlayVisible="@(isLoading || isSyncing || isPushing || isUpdating || isCommitSyncing || isCheckingOut || isCreatingBranches || isCreatingBranch || isSyncingToDefault || isWorkspaceBranchesFetching || isWorkspaceBranchesCheckingOut || ShowRepositoriesFetchOverlay)"
+                                    IsRestoringPackages="@isRestoringPackages"
+                                    IsOverlayVisible="@(isLoading || isSyncing || isPushing || isUpdating || isCommitSyncing || isCheckingOut || isCreatingBranches || isCreatingBranch || isSyncingToDefault || isWorkspaceBranchesFetching || isWorkspaceBranchesCheckingOut || ShowRepositoriesFetchOverlay || isRestoringPackages)"
                                     OnShowRepositories="ShowRepositoriesModalAsync"
                                     OnNewFeature="ShowNewFeatureModalAsync"
                                     OnShowBranch="() => ShowBranchModalAsync()"
@@ -56,6 +57,7 @@
                                     OnPull="OnPullClickAsync"
                                     OnPush="OnPushClickAsync"
                                     OnSync="SyncAsync"
+                                    OnRestorePackages="@RestorePackagesAsync"
                                     OnSearchChanged="OnSearchChanged"
                                     OnClearSearch="ClearSearchFilter"
                                     OnSearchKeyDown="OnSearchKeyDown" />

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
@@ -96,6 +96,9 @@ public sealed partial class WorkspaceRepositories : IDisposable
     private bool isWorkspaceBranchesCheckingOut = false;
     private string workspaceBranchesCheckoutProgressMessage = "Checking out branch across workspace...";
     private CancellationTokenSource? _workspaceBranchesCheckoutCts;
+    private bool isRestoringPackages = false;
+    private string? restorePackagesProgressMessage;
+    private CancellationTokenSource? _restorePackagesCts;
     private UpdateModalState _updateModal = new();
     private UpdateModalState _updateAndPushModal = new();
     private UpdateSingleRepoDependenciesModalState _updateSingleRepoModal = new();
@@ -118,7 +121,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
         isLoading || isCreatingPullRequests || isSyncing || isPushing || isUpdating ||
         isCommitSyncing || isCheckingOut || ShowRepositoriesFetchOverlay ||
         isCreatingBranches || isCreatingBranch || isSyncingToDefault ||
-        isWorkspaceBranchesFetching || isWorkspaceBranchesCheckingOut;
+        isWorkspaceBranchesFetching || isWorkspaceBranchesCheckingOut || isRestoringPackages;
 
     private string? ActiveOverlayMessage =>
         isLoading ? "Loading workspace..." :
@@ -134,6 +137,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
         isSyncingToDefault ? GetOverlayMessage(syncToDefaultMessage, isSyncingToDefault, _syncToDefaultAwaitingAgentTasks) :
         isWorkspaceBranchesFetching ? workspaceBranchesFetchProgressMessage :
         isWorkspaceBranchesCheckingOut ? workspaceBranchesCheckoutProgressMessage :
+        isRestoringPackages ? restorePackagesProgressMessage :
         null;
 
     // Returns default(EventCallback) (HasDelegate == false) for operations with no abort:
@@ -147,6 +151,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
         ShowRepositoriesFetchOverlay ? EventCallback.Factory.Create(this, (Action)AbortFetchRepositories) :
         isWorkspaceBranchesFetching ? EventCallback.Factory.Create(this, (Action)AbortWorkspaceBranchesFetchAsync) :
         isWorkspaceBranchesCheckingOut ? EventCallback.Factory.Create(this, (Action)AbortWorkspaceBranchesCheckoutAsync) :
+        isRestoringPackages ? EventCallback.Factory.Create(this, (Action)AbortRestorePackages) :
         default;
 
     private const int RefreshDebounceMs = 200;
@@ -252,6 +257,8 @@ public sealed partial class WorkspaceRepositories : IDisposable
         _workspaceBranchesFetchCts?.Dispose();
         _workspaceBranchesCheckoutCts?.Cancel();
         _workspaceBranchesCheckoutCts?.Dispose();
+        _restorePackagesCts?.Cancel();
+        _restorePackagesCts?.Dispose();
     }
 
     /// <summary>Called when WorkspaceSynced is received (or after Update): reload from a fresh scope so the grid gets current DB values (no stale DbContext).</summary>
@@ -3308,6 +3315,64 @@ public sealed partial class WorkspaceRepositories : IDisposable
         public bool IsVisible { get; init; }
         public string Title { get; init; } = "Operation Failed";
         public string Message { get; init; } = "";
+    }
+
+    private void SetRestorePackagesProgress(string message)
+    {
+        restorePackagesProgressMessage = message;
+        _ = InvokeAsync(StateHasChanged);
+    }
+
+    private void AbortRestorePackages() => _restorePackagesCts?.Cancel();
+
+    private async Task RestorePackagesAsync()
+    {
+        if (workspace == null || isRestoringPackages)
+            return;
+
+        _restorePackagesCts?.Cancel();
+        _restorePackagesCts?.Dispose();
+        _restorePackagesCts = new CancellationTokenSource();
+
+        isRestoringPackages = true;
+        SetRestorePackagesProgress("Restoring packages...");
+        try
+        {
+            StateHasChanged();
+            await Task.Yield();
+
+            int count;
+            await using (var scope = ServiceScopeFactory.CreateAsyncScope())
+            {
+                var workspaceGitService = scope.ServiceProvider.GetRequiredService<WorkspaceGitService>();
+                count = await workspaceGitService.RestoreAllWorkspacePackagesAsync(
+                    WorkspaceId,
+                    SetRestorePackagesProgress,
+                    _restorePackagesCts.Token);
+            }
+
+            if (count > 0)
+                ToastService.Show($"Restored packages in {count} {(count == 1 ? "project" : "projects")}");
+        }
+        catch (OperationCanceledException)
+        {
+            ToastService.Show("Restore cancelled.");
+        }
+        catch (AgentNotConnectedException ex)
+        {
+            Logger.LogError(ex, "Restore packages failed (agent not connected) for workspace {WorkspaceId}", WorkspaceId);
+            ToastService.ShowError($"Restore failed. {ex.Message}");
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Restore packages failed for workspace {WorkspaceId}", WorkspaceId);
+            ToastService.ShowError($"Restore failed: {ex.Message}");
+        }
+        finally
+        {
+            isRestoringPackages = false;
+            await InvokeAsync(StateHasChanged);
+        }
     }
 }
 

--- a/src/GrayMoon.App/Components/Shared/WorkspaceRepositoriesHeader.razor
+++ b/src/GrayMoon.App/Components/Shared/WorkspaceRepositoriesHeader.razor
@@ -160,14 +160,14 @@
             </button>
         }
         <div class="btn-group position-relative">
-            <button class="btn @(IsOutOfSync == true ? "btn-danger" : "btn-primary")"
+            <button class="btn @(IsOutOfSync == true ? "btn-danger" : "btn-outline-primary")"
                     @onclick="@(() => OnSync.InvokeAsync())"
                     @onclick:stopPropagation
                     disabled="@(IsSyncing || IsUpdating || IsPushing || IsRestoringPackages || RepositoriesCount == 0)">
                 Sync
             </button>
             <button type="button"
-                    class="btn @(IsOutOfSync == true ? "btn-danger" : "btn-primary") dropdown-toggle dropdown-toggle-split"
+                    class="btn @(IsOutOfSync == true ? "btn-danger" : "btn-outline-primary") dropdown-toggle dropdown-toggle-split"
                     aria-label="Toggle Sync menu"
                     aria-expanded="@(_syncMenuOpen ? "true" : "false")"
                     @onclick="ToggleSyncMenu"
@@ -178,7 +178,7 @@
             @if (_syncMenuOpen)
             {
                 <div class="branch-menu-backdrop" @onclick="CloseSyncMenu"></div>
-                <ul class="dropdown-menu show shadow branch-menu-list"
+                <ul class="dropdown-menu show shadow branch-menu-list dropdown-menu-end"
                     role="menu">
                     <li>
                         <button class="dropdown-item" type="button"

--- a/src/GrayMoon.App/Components/Shared/WorkspaceRepositoriesHeader.razor
+++ b/src/GrayMoon.App/Components/Shared/WorkspaceRepositoriesHeader.razor
@@ -160,14 +160,14 @@
             </button>
         }
         <div class="btn-group position-relative">
-            <button class="btn @(IsOutOfSync == true ? "btn-danger" : "btn-outline-primary")"
+            <button class="btn @(IsOutOfSync == true ? "btn-danger" : "btn-primary")"
                     @onclick="@(() => OnSync.InvokeAsync())"
                     @onclick:stopPropagation
                     disabled="@(IsSyncing || IsUpdating || IsPushing || IsRestoringPackages || RepositoriesCount == 0)">
                 Sync
             </button>
             <button type="button"
-                    class="btn @(IsOutOfSync == true ? "btn-danger" : "btn-outline-primary") dropdown-toggle dropdown-toggle-split"
+                    class="btn @(IsOutOfSync == true ? "btn-danger" : "btn-primary") dropdown-toggle dropdown-toggle-split"
                     aria-label="Toggle Sync menu"
                     aria-expanded="@(_syncMenuOpen ? "true" : "false")"
                     @onclick="ToggleSyncMenu"
@@ -178,7 +178,7 @@
             @if (_syncMenuOpen)
             {
                 <div class="branch-menu-backdrop" @onclick="CloseSyncMenu"></div>
-                <ul class="dropdown-menu show shadow branch-menu-list dropdown-menu-end"
+                <ul class="dropdown-menu show shadow branch-menu-list branch-menu-list-end"
                     role="menu">
                     <li>
                         <button class="dropdown-item" type="button"

--- a/src/GrayMoon.App/Components/Shared/WorkspaceRepositoriesHeader.razor
+++ b/src/GrayMoon.App/Components/Shared/WorkspaceRepositoriesHeader.razor
@@ -159,11 +159,38 @@
                 Push
             </button>
         }
-        <button class="btn @(IsOutOfSync == true ? "btn-danger" : "btn-primary")"
-                @onclick="@(() => OnSync.InvokeAsync())"
-                disabled="@(IsSyncing || IsUpdating || IsPushing || RepositoriesCount == 0)">
-            Sync
-        </button>
+        <div class="btn-group position-relative">
+            <button class="btn @(IsOutOfSync == true ? "btn-danger" : "btn-primary")"
+                    @onclick="@(() => OnSync.InvokeAsync())"
+                    @onclick:stopPropagation
+                    disabled="@(IsSyncing || IsUpdating || IsPushing || IsRestoringPackages || RepositoriesCount == 0)">
+                Sync
+            </button>
+            <button type="button"
+                    class="btn @(IsOutOfSync == true ? "btn-danger" : "btn-primary") dropdown-toggle dropdown-toggle-split"
+                    aria-label="Toggle Sync menu"
+                    aria-expanded="@(_syncMenuOpen ? "true" : "false")"
+                    @onclick="ToggleSyncMenu"
+                    @onclick:stopPropagation
+                    disabled="@(IsSyncing || IsUpdating || IsPushing || IsRestoringPackages || RepositoriesCount == 0)">
+                <span class="visually-hidden">Toggle Dropdown</span>
+            </button>
+            @if (_syncMenuOpen)
+            {
+                <div class="branch-menu-backdrop" @onclick="CloseSyncMenu"></div>
+                <ul class="dropdown-menu show shadow branch-menu-list"
+                    role="menu">
+                    <li>
+                        <button class="dropdown-item" type="button"
+                                role="menuitem"
+                                @onclick="HandleRestorePackagesClick"
+                                disabled="@(IsSyncing || IsUpdating || IsPushing || IsRestoringPackages || RepositoriesCount == 0)">
+                            Restore Packages
+                        </button>
+                    </li>
+                </ul>
+            }
+        </div>
     </div>
 </div>
 
@@ -181,6 +208,7 @@
     [Parameter] public bool IsUpdating { get; set; }
     [Parameter] public bool IsPushing { get; set; }
     [Parameter] public bool IsCommitSyncing { get; set; }
+    [Parameter] public bool IsRestoringPackages { get; set; }
     [Parameter] public int AgentTasksPendingCount { get; set; }
     [Parameter] public bool IsOverlayVisible { get; set; }
 
@@ -194,12 +222,14 @@
     [Parameter] public EventCallback OnPull { get; set; }
     [Parameter] public EventCallback OnPush { get; set; }
     [Parameter] public EventCallback OnSync { get; set; }
+    [Parameter] public EventCallback OnRestorePackages { get; set; }
     [Parameter] public EventCallback<ChangeEventArgs> OnSearchChanged { get; set; }
     [Parameter] public EventCallback OnClearSearch { get; set; }
     [Parameter] public EventCallback<KeyboardEventArgs> OnSearchKeyDown { get; set; }
 
     private bool _branchMenuOpen;
     private bool _updateMenuOpen;
+    private bool _syncMenuOpen;
 
     private bool UpdateDisabled =>
         WorkspaceName == null || RepositoriesCount == 0 || IsSyncing || IsUpdating || IsPushing || AgentTasksPendingCount > 0;
@@ -223,6 +253,16 @@
     private void ToggleUpdateMenu() => _updateMenuOpen = !_updateMenuOpen;
 
     private void CloseUpdateMenu() => _updateMenuOpen = false;
+
+    private void ToggleSyncMenu() => _syncMenuOpen = !_syncMenuOpen;
+
+    private void CloseSyncMenu() => _syncMenuOpen = false;
+
+    private async Task HandleRestorePackagesClick()
+    {
+        CloseSyncMenu();
+        await OnRestorePackages.InvokeAsync();
+    }
 
     private async Task HandleUpdatePrimaryClick()
     {

--- a/src/GrayMoon.App/Components/Shared/WorkspaceRepositoriesHeader.razor.css
+++ b/src/GrayMoon.App/Components/Shared/WorkspaceRepositoriesHeader.razor.css
@@ -32,6 +32,12 @@
     margin-left: 0;
 }
 
-.btn-group > .btn-danger + .btn-danger.dropdown-toggle-split {
+.btn-group > .btn-danger + .btn-danger.dropdown-toggle-split,
+.btn-group > .btn-primary + .btn-primary.dropdown-toggle-split {
     border-left-color: rgba(255, 255, 255, 0.4);
+}
+
+.branch-menu-list-end {
+    right: 0;
+    left: auto;
 }

--- a/src/GrayMoon.App/Services/DependencyUpdateOrchestrator.cs
+++ b/src/GrayMoon.App/Services/DependencyUpdateOrchestrator.cs
@@ -101,6 +101,11 @@ public sealed class DependencyUpdateOrchestrator(
             if (hadError)
                 break;
 
+            await workspaceGitService.RestoreDependenciesAsync(
+                workspaceId,
+                reposAtLevel.Select(r => r.RepoName),
+                cancellationToken);
+
             levelProgress("Committing...");
             var commitResults = await workspaceGitService.CommitDependencyUpdatesAsync(
                 workspaceId,

--- a/src/GrayMoon.App/Services/DependencyUpdateOrchestrator.cs
+++ b/src/GrayMoon.App/Services/DependencyUpdateOrchestrator.cs
@@ -101,6 +101,7 @@ public sealed class DependencyUpdateOrchestrator(
             if (hadError)
                 break;
 
+            levelProgress("Restoring packages...");
             await workspaceGitService.RestoreDependenciesAsync(
                 workspaceId,
                 reposAtLevel.Select(r => (

--- a/src/GrayMoon.App/Services/DependencyUpdateOrchestrator.cs
+++ b/src/GrayMoon.App/Services/DependencyUpdateOrchestrator.cs
@@ -103,7 +103,12 @@ public sealed class DependencyUpdateOrchestrator(
 
             await workspaceGitService.RestoreDependenciesAsync(
                 workspaceId,
-                reposAtLevel.Select(r => r.RepoName),
+                reposAtLevel.Select(r => (
+                    r.RepoName,
+                    (IReadOnlyList<string>)r.ProjectUpdates
+                        .Select(p => p.ProjectPath!)
+                        .Where(p => !string.IsNullOrWhiteSpace(p))
+                        .ToList())),
                 cancellationToken);
 
             levelProgress("Committing...");

--- a/src/GrayMoon.App/Services/WorkspaceGitService.cs
+++ b/src/GrayMoon.App/Services/WorkspaceGitService.cs
@@ -444,6 +444,47 @@ public class WorkspaceGitService(
         await Task.WhenAll(tasks);
     }
 
+    /// <summary>
+    /// Fires <c>dotnet restore --force --no-cache</c> for all tracked project files across all workspace
+    /// repositories, skipping repos pinned to a tag. Best-effort: individual restore errors are logged and swallowed.
+    /// Returns the total number of project files targeted for restore.
+    /// </summary>
+    public async Task<int> RestoreAllWorkspacePackagesAsync(
+        int workspaceId,
+        Action<string> setProgress,
+        CancellationToken cancellationToken)
+    {
+        if (!_agentBridge.IsAgentConnected)
+            throw new AgentNotConnectedException();
+
+        setProgress("Restoring packages...");
+
+        var workspace = await _workspaceRepository.GetByIdAsync(workspaceId);
+        if (workspace == null)
+            return 0;
+
+        var tagPinnedIds = workspace.Repositories
+            .Where(l => !string.IsNullOrWhiteSpace(l.CheckedOutTag))
+            .Select(l => l.RepositoryId)
+            .ToHashSet();
+
+        var projects = await _workspaceProjectRepository.GetByWorkspaceIdAsync(workspaceId);
+        var repoGroups = projects
+            .Where(p => p.Repository != null
+                        && !string.IsNullOrWhiteSpace(p.ProjectFilePath)
+                        && !tagPinnedIds.Contains(p.RepositoryId))
+            .GroupBy(p => (p.RepositoryId, RepoName: p.Repository!.RepositoryName))
+            .Select(g => (g.Key.RepoName, ProjectPaths: (IReadOnlyList<string>)g.Select(p => p.ProjectFilePath!).ToList()))
+            .ToList();
+
+        var totalCount = repoGroups.Sum(r => r.ProjectPaths.Count);
+        if (totalCount == 0)
+            return 0;
+
+        await RestoreDependenciesAsync(workspaceId, repoGroups, cancellationToken);
+        return totalCount;
+    }
+
     /// <summary>Broadcasts WorkspaceSynced so the grid refreshes. Call after SyncDependenciesAsync (which already recomputes and persists UnmatchedDeps).</summary>
     public async Task RecomputeAndBroadcastWorkspaceSyncedAsync(int workspaceId, CancellationToken cancellationToken = default)
     {

--- a/src/GrayMoon.App/Services/WorkspaceGitService.cs
+++ b/src/GrayMoon.App/Services/WorkspaceGitService.cs
@@ -415,6 +415,33 @@ public class WorkspaceGitService(
         return toSync.Count;
     }
 
+    /// <summary>
+    /// Fires <c>dotnet restore --force --no-cache</c> for each named repo in the workspace.
+    /// Best-effort: errors are logged and swallowed so the caller's workflow is never interrupted.
+    /// </summary>
+    public async Task RestoreDependenciesAsync(int workspaceId, IEnumerable<string> repoNames, CancellationToken cancellationToken)
+    {
+        var workspace = await _workspaceRepository.GetByIdAsync(workspaceId);
+        if (workspace == null) return;
+        var workspaceRoot = await _workspaceService.GetRootPathForWorkspaceAsync(workspace, cancellationToken);
+        var tasks = repoNames.Select(async repositoryName =>
+        {
+            try
+            {
+                await _agentBridge.SendCommandAsync(
+                    "DotnetRestore",
+                    new { workspaceName = workspace.Name, repositoryName, workspaceRoot },
+                    cancellationToken);
+            }
+            catch (OperationCanceledException) { throw; }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "dotnet restore failed for {RepoName} in workspace {WorkspaceName}, continuing", repositoryName, workspace.Name);
+            }
+        });
+        await Task.WhenAll(tasks);
+    }
+
     /// <summary>Broadcasts WorkspaceSynced so the grid refreshes. Call after SyncDependenciesAsync (which already recomputes and persists UnmatchedDeps).</summary>
     public async Task RecomputeAndBroadcastWorkspaceSyncedAsync(int workspaceId, CancellationToken cancellationToken = default)
     {

--- a/src/GrayMoon.App/Services/WorkspaceGitService.cs
+++ b/src/GrayMoon.App/Services/WorkspaceGitService.cs
@@ -416,29 +416,31 @@ public class WorkspaceGitService(
     }
 
     /// <summary>
-    /// Fires <c>dotnet restore --force --no-cache</c> for each named repo in the workspace.
+    /// Fires <c>dotnet restore --force --no-cache &lt;project.csproj&gt;</c> for each specified project file.
     /// Best-effort: errors are logged and swallowed so the caller's workflow is never interrupted.
     /// </summary>
-    public async Task RestoreDependenciesAsync(int workspaceId, IEnumerable<string> repoNames, CancellationToken cancellationToken)
+    public async Task RestoreDependenciesAsync(int workspaceId, IEnumerable<(string RepoName, IReadOnlyList<string> ProjectPaths)> repos, CancellationToken cancellationToken)
     {
         var workspace = await _workspaceRepository.GetByIdAsync(workspaceId);
         if (workspace == null) return;
         var workspaceRoot = await _workspaceService.GetRootPathForWorkspaceAsync(workspace, cancellationToken);
-        var tasks = repoNames.Select(async repositoryName =>
-        {
-            try
+        var tasks = repos
+            .Where(r => r.ProjectPaths.Count > 0)
+            .Select(async r =>
             {
-                await _agentBridge.SendCommandAsync(
-                    "DotnetRestore",
-                    new { workspaceName = workspace.Name, repositoryName, workspaceRoot },
-                    cancellationToken);
-            }
-            catch (OperationCanceledException) { throw; }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex, "dotnet restore failed for {RepoName} in workspace {WorkspaceName}, continuing", repositoryName, workspace.Name);
-            }
-        });
+                try
+                {
+                    await _agentBridge.SendCommandAsync(
+                        "DotnetRestore",
+                        new { workspaceName = workspace.Name, repositoryName = r.RepoName, projectPaths = r.ProjectPaths, workspaceRoot },
+                        cancellationToken);
+                }
+                catch (OperationCanceledException) { throw; }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "dotnet restore failed for {RepoName} in workspace {WorkspaceName}, continuing", r.RepoName, workspace.Name);
+                }
+            });
         await Task.WhenAll(tasks);
     }
 

--- a/src/GrayMoon.App/Services/WorkspacePushService.cs
+++ b/src/GrayMoon.App/Services/WorkspacePushService.cs
@@ -288,6 +288,8 @@ public sealed class WorkspacePushService(
                 }
             }
 
+            await TryRestoreReposAtLevelAsync(workspace.Name, workspaceRoot, reposAtLevel, cancellationToken);
+
             levelProgress?.Invoke($"Pushing {reposAtLevel.Count} {(reposAtLevel.Count == 1 ? "repository" : "repositories")}...");
             await PushReposAsync(
                 workspace,
@@ -587,6 +589,30 @@ public sealed class WorkspacePushService(
             foreach (var line in update.NewLines)
                 _overlayCommandTerminalService.Append(label, AgentCommandStreamKind.Stdout, line);
         }
+    }
+
+    private async Task TryRestoreReposAtLevelAsync(
+        string workspaceName,
+        string? workspaceRoot,
+        IReadOnlyList<PushRepoPayload> repos,
+        CancellationToken cancellationToken)
+    {
+        var tasks = repos.Select(async repo =>
+        {
+            try
+            {
+                await _agentBridge.SendCommandAsync(
+                    "DotnetRestore",
+                    new { workspaceName, repositoryName = repo.RepoName, workspaceRoot },
+                    cancellationToken);
+            }
+            catch (OperationCanceledException) { throw; }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "dotnet restore failed for {RepoName} in workspace {WorkspaceName}, continuing", repo.RepoName, workspaceName);
+            }
+        });
+        await Task.WhenAll(tasks);
     }
 
     private async Task PushReposAsync(

--- a/src/GrayMoon.App/Services/WorkspacePushService.cs
+++ b/src/GrayMoon.App/Services/WorkspacePushService.cs
@@ -288,6 +288,7 @@ public sealed class WorkspacePushService(
                 }
             }
 
+            levelProgress?.Invoke("Restoring packages...");
             await TryRestoreReposAtLevelAsync(workspaceId, workspace.Name, workspaceRoot, reposAtLevel, cancellationToken);
 
             levelProgress?.Invoke($"Pushing {reposAtLevel.Count} {(reposAtLevel.Count == 1 ? "repository" : "repositories")}...");

--- a/src/GrayMoon.App/Services/WorkspacePushService.cs
+++ b/src/GrayMoon.App/Services/WorkspacePushService.cs
@@ -288,7 +288,7 @@ public sealed class WorkspacePushService(
                 }
             }
 
-            await TryRestoreReposAtLevelAsync(workspace.Name, workspaceRoot, reposAtLevel, cancellationToken);
+            await TryRestoreReposAtLevelAsync(workspaceId, workspace.Name, workspaceRoot, reposAtLevel, cancellationToken);
 
             levelProgress?.Invoke($"Pushing {reposAtLevel.Count} {(reposAtLevel.Count == 1 ? "repository" : "repositories")}...");
             await PushReposAsync(
@@ -592,24 +592,61 @@ public sealed class WorkspacePushService(
     }
 
     private async Task TryRestoreReposAtLevelAsync(
+        int workspaceId,
         string workspaceName,
         string? workspaceRoot,
         IReadOnlyList<PushRepoPayload> repos,
         CancellationToken cancellationToken)
     {
-        var tasks = repos.Select(async repo =>
+        var repoIdSet = repos.Select(r => r.RepoId).ToHashSet();
+        var repoNameById = repos.ToDictionary(r => r.RepoId, r => r.RepoName);
+
+        var projects = await _dbContext.WorkspaceProjects
+            .AsNoTracking()
+            .Where(p => p.WorkspaceId == workspaceId && repoIdSet.Contains(p.RepositoryId))
+            .ToListAsync(cancellationToken);
+
+        if (projects.Count == 0) return;
+
+        var projectIdToRepoId = projects.ToDictionary(p => p.ProjectId, p => p.RepositoryId);
+        var projectIdSet = projectIdToRepoId.Keys.ToHashSet();
+
+        var deps = await _dbContext.ProjectDependencies
+            .AsNoTracking()
+            .Where(d => projectIdSet.Contains(d.DependentProjectId))
+            .ToListAsync(cancellationToken);
+
+        var projectFilePathById = projects.ToDictionary(p => p.ProjectId, p => p.ProjectFilePath);
+
+        var pathsByRepoId = new Dictionary<int, List<string>>();
+        foreach (var dep in deps)
         {
+            var depRepoId = projectIdToRepoId.GetValueOrDefault(dep.DependentProjectId, -1);
+            var refRepoId = projectIdToRepoId.GetValueOrDefault(dep.ReferencedProjectId, -1);
+            if (depRepoId < 0 || refRepoId < 0 || depRepoId == refRepoId) continue;
+            if (!projectFilePathById.TryGetValue(dep.DependentProjectId, out var filePath) || string.IsNullOrWhiteSpace(filePath)) continue;
+            if (!pathsByRepoId.TryGetValue(depRepoId, out var list))
+                pathsByRepoId[depRepoId] = list = [];
+            if (!list.Contains(filePath))
+                list.Add(filePath);
+        }
+
+        if (pathsByRepoId.Count == 0) return;
+
+        var tasks = pathsByRepoId.Select(async kvp =>
+        {
+            if (!repoNameById.TryGetValue(kvp.Key, out var repositoryName)) return;
             try
             {
                 await _agentBridge.SendCommandAsync(
                     "DotnetRestore",
-                    new { workspaceName, repositoryName = repo.RepoName, workspaceRoot },
+                    new { workspaceName, repositoryName, projectPaths = (IReadOnlyList<string>)kvp.Value, workspaceRoot },
                     cancellationToken);
             }
             catch (OperationCanceledException) { throw; }
             catch (Exception ex)
             {
-                _logger.LogWarning(ex, "dotnet restore failed for {RepoName} in workspace {WorkspaceName}, continuing", repo.RepoName, workspaceName);
+                _logger.LogWarning(ex, "dotnet restore failed for {RepoName} in workspace {WorkspaceName}, continuing", repositoryName, workspaceName);
             }
         });
         await Task.WhenAll(tasks);


### PR DESCRIPTION
## Summary

- Adds a new Agent `DotnetRestore` command that runs `dotnet restore --force --no-cache` for specified `.csproj` paths in a workspace repository (best-effort: per-project failures are logged and do not fail the overall command).
- Exposes **Restore Packages** from the workspace Sync dropdown to restore all tracked projects across the workspace (repos pinned to a tag are skipped).
- Automatically restores packages during **Update** (after applying dependency changes, before commit) and **Push** (per dependency level, before pushing repos with cross-repo project references).
- UI polish: progress overlay with cancel for restore, Sync split-button dropdown styling, and clearer layout in the Sync to Default confirmation dialog.

## Why this helps

Coordinated dependency rollouts update `PackageReference` versions in `.csproj` files, but MSBuild/NuGet can still resolve **older packages from the local or global NuGet cache**. That creates stale dependencies: the repo looks updated on disk while builds still compile against cached artifacts. Symptoms include false confidence that a rollout worked, local/CI drift, and downstream repos not picking up newly published package versions during synchronized push.

Using `--force --no-cache` forces NuGet to re-resolve from feeds instead of falling back to cache, so restored packages match the versions GrayMoon just wrote. Running restore automatically before commit (Update) and before push (synchronized Push) keeps workspace state aligned with the intended dependency graph without a manual `dotnet restore` in every repo.

## Test plan

- [ ] Connect Agent and open a workspace with multiple tracked `.csproj` files
- [ ] Use **Sync > Restore Packages** and confirm overlay progress, success toast with project count, and cancel works mid-run
- [ ] After bumping package refs, confirm restore pulls the new versions (not cached ones) - e.g. clear or inspect NuGet cache if needed
- [ ] Run **Update** on repos with mismatched internal dependencies; confirm "Restoring packages..." appears before commit
- [ ] Run **Push** (or Update & Push) across dependency levels; confirm restore runs before each level's push
- [ ] Pin a repo to a tag and confirm it is excluded from workspace-wide restore
- [ ] Disconnect Agent and confirm restore shows a clear error instead of hanging
- [ ] Verify Sync to Default dialog shows repo name and branch on separate lines and fits comfortably at `modal-lg`