### PR TITLE
Show newer tag upgrades and add workspace file version updates

### DIFF
--- a/src/GrayMoon.Abstractions/Notifications/RepositorySyncNotification.cs
+++ b/src/GrayMoon.Abstractions/Notifications/RepositorySyncNotification.cs
@@ -21,6 +21,8 @@ public sealed class RepositorySyncNotification
     public string? ErrorMessage { get; init; }
     /// <summary>Remote branch names (with "origin/" prefix) currently present in local refs after fetch --prune. When set, the app prunes stale remote branches from the DB.</summary>
     public List<string>? RemoteBranches { get; init; }
+    /// <summary>All tag names ordered newest-first (SortIndex 0 = newest), populated on checkout-to-tag so the app can persist tag state and compute HasNewerTag. Null when not on a tag or when tag fetch was skipped.</summary>
+    public List<string>? RemoteTags { get; init; }
 }
 
 public sealed class RepositorySyncProjectNotification

--- a/src/GrayMoon.Agent/Abstractions/IGitService.cs
+++ b/src/GrayMoon.Agent/Abstractions/IGitService.cs
@@ -52,6 +52,8 @@ public interface IGitService
     Task<string?> GetDefaultBranchNameAsync(string repoPath, CancellationToken ct);
     /// <summary>Gets all tag names in the repository (newest first when supported, then alphabetical).</summary>
     Task<IReadOnlyList<string>> GetTagsAsync(string repoPath, CancellationToken ct);
+    /// <summary>Fetches only tags from origin (git fetch origin --tags). Does not touch branches. Returns (success, errorMessage).</summary>
+    Task<(bool Success, string? ErrorMessage)> FetchTagsAsync(string repoPath, string? bearerToken, CancellationToken ct);
     /// <summary>Checks out the specified tag (detached HEAD). Returns (success, errorMessage).</summary>
     Task<(bool Success, string? ErrorMessage)> CheckoutTagAsync(string repoPath, string tagName, CancellationToken ct);
     /// <summary>Returns the tag name HEAD currently points to when the repo is in a detached HEAD state AND that commit is the exact tip of a tag; otherwise null. Uses git symbolic-ref + describe --tags --exact-match.</summary>

--- a/src/GrayMoon.Agent/Commands/CheckoutHookSyncCommand.cs
+++ b/src/GrayMoon.Agent/Commands/CheckoutHookSyncCommand.cs
@@ -52,6 +52,16 @@ public sealed class CheckoutHookSyncCommand(IGitService git, ICsProjFileService 
         if (currentTag != null)
             branch = "-";
 
+        // When on a tag, fetch remote tags so the app can compare and show an "upgrade" badge.
+        IReadOnlyList<string>? remoteTags = null;
+        if (currentTag != null && token != null)
+        {
+            var (fetchTagsSuccess, fetchTagsError) = await git.FetchTagsAsync(payload.RepositoryPath, token, cancellationToken);
+            if (!fetchTagsSuccess)
+                logger.LogWarning("CheckoutHookSync: tag fetch failed for repo {RepositoryId}: {Error}", payload.RepositoryId, fetchTagsError);
+            remoteTags = await git.GetTagsAsync(payload.RepositoryPath, cancellationToken);
+        }
+
         int? outgoing = null;
         int? incoming = null;
         int? defaultBehind = null;
@@ -113,7 +123,9 @@ public sealed class CheckoutHookSyncCommand(IGitService git, ICsProjFileService 
                 Projects = syncProjects,
                 ErrorMessage = fetchError,
                 // Include remote branches when fetch succeeded so the app can prune deleted remote branches from the DB
-                RemoteBranches = fetchError == null && remoteBranches != null ? remoteBranches.ToList() : null
+                RemoteBranches = fetchError == null && remoteBranches != null ? remoteBranches.ToList() : null,
+                // Include tag list when on a tag so the app can persist tags and compute HasNewerTag
+                RemoteTags = remoteTags?.ToList()
             };
             await connection.InvokeAsync(AgentHubMethods.SyncCommand, notification, cancellationToken);
             logger.LogInformation("CheckoutHookSync sent: workspace={WorkspaceId}, repo={RepoId}, version={Version}, branch={Branch}, ↑{Outgoing} ↓{Incoming}, hasUpstream={HasUpstream}",

--- a/src/GrayMoon.Agent/Commands/SyncRepositoryCommand.cs
+++ b/src/GrayMoon.Agent/Commands/SyncRepositoryCommand.cs
@@ -68,8 +68,13 @@ public sealed class SyncRepositoryCommand(IGitService git, ICsProjFileService cs
 
             // Detect tag/detached HEAD; if on a tag we don't have a real branch so wipe the GitVersion branch echo.
             var currentTag = await git.GetCheckedOutTagAsync(repoPath, cancellationToken);
+            IReadOnlyList<string>? allTags = null;
             if (currentTag != null)
+            {
                 branch = "-";
+                // FetchAsync(includeTags: true) already ran above, so local refs are up to date.
+                allTags = await git.GetTagsAsync(repoPath, cancellationToken);
+            }
 
             if (version != "-" && branch != "-")
                 git.WriteSyncHooks(repoPath, workspaceId, repositoryId);
@@ -118,6 +123,7 @@ public sealed class SyncRepositoryCommand(IGitService git, ICsProjFileService cs
                 Version = version,
                 Branch = branch,
                 Tag = currentTag,
+                Tags = allTags,
                 Projects = projects,
                 OutgoingCommits = outgoingCommits,
                 IncomingCommits = incomingCommits,

--- a/src/GrayMoon.Agent/Jobs/Response/SyncRepositoryResponse.cs
+++ b/src/GrayMoon.Agent/Jobs/Response/SyncRepositoryResponse.cs
@@ -49,4 +49,7 @@ public sealed class SyncRepositoryResponse
 
     [JsonPropertyName("defaultBranchAhead")]
     public int? DefaultBranchAhead { get; set; }
+
+    [JsonPropertyName("tags")]
+    public IReadOnlyList<string>? Tags { get; set; }
 }

--- a/src/GrayMoon.Agent/Services/GitService.cs
+++ b/src/GrayMoon.Agent/Services/GitService.cs
@@ -979,6 +979,46 @@ public sealed class GitService(IOptions<AgentOptions> options, ILogger<GitServic
         return tags;
     }
 
+    public async Task<(bool Success, string? ErrorMessage)> FetchTagsAsync(string repoPath, string? bearerToken, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(repoPath) || !Directory.Exists(repoPath))
+            return (true, null);
+
+        string args;
+        if (string.IsNullOrWhiteSpace(bearerToken))
+        {
+            args = "fetch origin --tags";
+        }
+        else
+        {
+            var credentials = "x-access-token:" + bearerToken;
+            var base64 = Convert.ToBase64String(Encoding.UTF8.GetBytes(credentials));
+            var headerValue = "Authorization: Basic " + base64;
+            var escaped = headerValue.Replace("\\", "\\\\").Replace("\"", "\\\"");
+            args = $"-c http.extraHeader=\"{escaped}\" fetch origin --tags";
+        }
+
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        var (exitCode, stdout, stderr) = await FetchRetryPipeline.ExecuteAsync(
+            async cancellationToken => await RunProcessAsync("git", args, repoPath, cancellationToken),
+            ct);
+        sw.Stop();
+        if (exitCode != 0)
+        {
+            var output = (stdout ?? "").Trim();
+            var errorOutput = (stderr ?? "").Trim();
+            var combined = string.IsNullOrWhiteSpace(output) ? errorOutput :
+                           string.IsNullOrWhiteSpace(errorOutput) ? output :
+                           $"{output}\n{errorOutput}";
+            if (string.IsNullOrWhiteSpace(combined))
+                combined = $"Git fetch tags failed (exit code {exitCode})";
+            logger.LogWarning("Git fetch tags failed in {ElapsedMs}ms for {RepoPath}. ExitCode={ExitCode}", sw.ElapsedMilliseconds, repoPath, exitCode);
+            return (false, combined);
+        }
+        logger.LogDebug("Git fetch tags completed in {ElapsedMs}ms for {RepoPath}", sw.ElapsedMilliseconds, repoPath);
+        return (true, null);
+    }
+
     public async Task<(bool Success, string? ErrorMessage)> CheckoutTagAsync(string repoPath, string tagName, CancellationToken ct)
     {
         if (string.IsNullOrWhiteSpace(repoPath) || !Directory.Exists(repoPath) || string.IsNullOrWhiteSpace(tagName))

--- a/src/GrayMoon.App/Components/App.razor
+++ b/src/GrayMoon.App/Components/App.razor
@@ -44,6 +44,10 @@
             if (element && element.scrollIntoView)
                 element.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
         };
+        window.scrollElementIntoViewById = (id) => {
+            const el = document.getElementById(id);
+            if (el) el.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+        };
         window.getAgentDownloadInfo = () => {
             const ua = navigator.userAgent.toLowerCase();
             const platform = (navigator.platform || '').toLowerCase();

--- a/src/GrayMoon.App/Components/Modals/SwitchBranchModal.razor
+++ b/src/GrayMoon.App/Components/Modals/SwitchBranchModal.razor
@@ -100,6 +100,7 @@
                                         @foreach (var tag in GetFilteredTags())
                                         {
                                             <div class="branch-item p-2 @(selectedBranch == tag ? "bg-light" : "")"
+                                                 id="@(tag == currentTag ? "switch-branch-current-tag" : null)"
                                                  style="cursor: pointer;"
                                                  @onclick='() => SelectBranch(tag)'>
                                                 <div class="d-flex align-items-center justify-content-between">
@@ -474,8 +475,11 @@
     [Parameter] public EventCallback<(int RepositoryId, string BranchName, bool IsTag)> OnCheckoutBranch { get; set; }
     [Parameter] public EventCallback<(int RepositoryId, string? RepositoryName, string CurrentBranchName, string DefaultBranch)> OnSyncToDefault { get; set; }
     [Parameter] public EventCallback<(int RepositoryId, string? RepositoryName, string NewBranchName, string BaseBranch, bool SetUpstream)> OnCreateBranch { get; set; }
+    /// <summary>Tab to activate when the modal opens. Null defaults to "local", but callers can pass "tags" to jump straight to the Tags tab (e.g. from the upgrade badge).</summary>
+    [Parameter] public string? InitialTab { get; set; }
 
     private string activeTab = "local";
+    private bool _scrollToCurrentTag;
     /// <summary>True for git's synthetic placeholder ref names that appear in detached HEAD state (e.g. <c>(HEAD detached at v1.0)</c>, <c>(no branch)</c>, <c>origin/(no branch)</c>). These must never be shown as selectable branches.</summary>
     private static bool IsSyntheticGitRefName(string? name)
     {
@@ -536,8 +540,8 @@
         {
             if (!_prevVisible)
             {
-                // Modal just opened: reset New Branch tab and always start on Locals
-                activeTab = "local";
+                // Modal just opened: reset to InitialTab when provided (e.g. "tags" from upgrade badge), otherwise Locals
+                activeTab = InitialTab ?? "local";
                 newBranchName = "";
                 selectedBaseBranch = "__default__";
                 showBasedOnDropdown = false;
@@ -615,6 +619,16 @@
             }
             catch { }
         }
+        // Scroll current tag into view when Tags tab opens so it is visible even if many newer tags are above it
+        if (IsVisible && _scrollToCurrentTag && activeTab == "tags" && !string.IsNullOrWhiteSpace(currentTag))
+        {
+            _scrollToCurrentTag = false;
+            try
+            {
+                await JSRuntime.InvokeVoidAsync("scrollElementIntoViewById", "switch-branch-current-tag");
+            }
+            catch { }
+        }
     }
 
     private async Task LoadBranchesAsync()
@@ -657,6 +671,7 @@
                 {
                     activeTab = "tags";
                     selectedBranch = currentTag;
+                    _scrollToCurrentTag = true;
                 }
                 else
                 {
@@ -747,7 +762,11 @@
             _focusFilterOnNextRender = true;
         // Reset selection so the radio matches the new tab's current item.
         if (tab == "tags")
+        {
             selectedBranch = currentTag;
+            if (!string.IsNullOrWhiteSpace(currentTag))
+                _scrollToCurrentTag = true;
+        }
         else if (tab == "local")
             selectedBranch = currentBranchLocal;
         else if (tab == "remote")
@@ -817,22 +836,10 @@
 
     private IEnumerable<string> GetFilteredTags()
     {
-        IEnumerable<string> filtered;
         if (string.IsNullOrWhiteSpace(branchFilter))
-            filtered = tags;
-        else
-        {
-            var term = branchFilter.Trim();
-            filtered = tags.Where(t => t.Contains(term, StringComparison.OrdinalIgnoreCase));
-        }
-        // Surface the current tag at the top of the list so users see what is pinned right away.
-        var list = filtered.ToList();
-        if (string.IsNullOrWhiteSpace(currentTag))
-            return list;
-        var current = list.FirstOrDefault(t => string.Equals(t, currentTag, StringComparison.OrdinalIgnoreCase));
-        if (current == null)
-            return list;
-        return list.Where(t => !string.Equals(t, current, StringComparison.OrdinalIgnoreCase)).Prepend(current);
+            return tags;
+        var term = branchFilter.Trim();
+        return tags.Where(t => t.Contains(term, StringComparison.OrdinalIgnoreCase));
     }
 
     private string GetFilterCountText()

--- a/src/GrayMoon.App/Components/Modals/SyncToDefaultOptionsModal.razor
+++ b/src/GrayMoon.App/Components/Modals/SyncToDefaultOptionsModal.razor
@@ -22,12 +22,14 @@
                                     <li class="mb-1">
                                         <div>
                                             <code>@item.RepoName</code>
+                                        </div>
+                                        <div class="text-muted ps-1">
+                                            @item.BranchName
                                             @if (item.HasRemote)
                                             {
                                                 <span class="badge bg-secondary ms-1" style="font-size:0.65em;">remote</span>
                                             }
                                         </div>
-                                        <div class="text-muted ps-1">@item.BranchName</div>
                                     </li>
                                 }
                             </ul>

--- a/src/GrayMoon.App/Components/Modals/UpdateDependenciesModal.razor
+++ b/src/GrayMoon.App/Components/Modals/UpdateDependenciesModal.razor
@@ -3,7 +3,7 @@
     <div class="modal show d-block" tabindex="-1" style="background-color: rgba(0,0,0,0.5);"
          @onkeydown="HandleKeyDown"
          @ref="modalElement">
-        <div class="modal-dialog">
+        <div class="modal-dialog modal-lg">
             <div class="modal-content">
                 <div class="modal-header">
                     <h5 class="modal-title">Update dependencies</h5>

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor
@@ -169,6 +169,7 @@
                                                                   OnSyncClick="() => SyncSingleRepoAsync(wr.RepositoryId)"
                                                                   OnCopyDependencies="CopyDependenciesToClipboard"
                                                                   OnCreatePr="OpenPullRequestDialogForRepositoryAsync"
+                                                                  OnUpgradeClick="ShowSwitchBranchModalOnTagsTab"
                                                                   OnDismissError="() => DismissRepositoryError(wr.RepositoryId)" />
                                     }
                                 }
@@ -216,6 +217,7 @@
                    RepositoryName="@_switchBranchModal.RepositoryName"
                    CurrentBranch="@_switchBranchModal.CurrentBranch"
                    RepositoryUrl="@_switchBranchModal.RepositoryUrl"
+                   InitialTab="@_switchBranchModal.InitialTab"
                    OnCancel="@CloseSwitchBranchModal"
                    OnBranchChanged="@OnBranchChangedAsync"
                    OnCheckoutBranch="@CheckoutBranchAsync"

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor
@@ -19,6 +19,7 @@
 @inject WorkspaceCommitSyncHandler WorkspaceCommitSyncHandler
 @inject WorkspaceSyncHandler WorkspaceSyncHandler
 @inject WorkspaceUpdateHandler WorkspaceUpdateHandler
+@inject WorkspaceFileVersionService FileVersionService
 @inject WorkspacePushHandler WorkspacePushHandler
 @inject WorkspaceDependencyService WorkspaceDependencyService
 @inject WorkspaceBranchHandler WorkspaceBranchHandler
@@ -53,6 +54,7 @@
                                     OnShowSwitchBranch='() => ShowBranchModalAsync("switchbranch")'
                                     OnNewPullRequest="OpenPullRequestDialogForAllRepositoriesAsync"
                                     OnUpdate="OnUpdateClickAsync"
+                                    OnUpdateFiles="OnUpdateFilesClickAsync"
                                     OnUpdateAndPush="OnUpdateAndPushClickAsync"
                                     OnPull="OnPullClickAsync"
                                     OnPush="OnPushClickAsync"

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
@@ -2282,8 +2282,28 @@ public sealed partial class WorkspaceRepositories : IDisposable
             RepositoryId = 0,
             RepositoryName = null,
             CurrentBranch = null,
-            RepositoryUrl = null
+            RepositoryUrl = null,
+            InitialTab = null
         };
+    }
+
+    private void ShowSwitchBranchModalOnTagsTab(WorkspaceRepositoryLink link)
+    {
+        var wr = workspaceRepositories.FirstOrDefault(r => r.RepositoryId == link.RepositoryId);
+        var repo = wr?.Repository;
+        if (repo == null)
+            return;
+
+        _switchBranchModal = _switchBranchModal with
+        {
+            IsVisible = true,
+            RepositoryId = link.RepositoryId,
+            RepositoryName = repo.RepositoryName,
+            CurrentBranch = null,
+            RepositoryUrl = repo.CloneUrl,
+            InitialTab = "tags"
+        };
+        StateHasChanged();
     }
 
     /// <summary>When every workspace repo has the same non-empty <see cref="WorkspaceRepositoryLink.BranchName"/>, returns that name; otherwise null.</summary>
@@ -3275,6 +3295,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
         public string? RepositoryName { get; init; }
         public string? CurrentBranch { get; init; }
         public string? RepositoryUrl { get; init; }
+        public string? InitialTab { get; init; }
     }
 
     private sealed record UpdateModalState

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
@@ -1569,6 +1569,41 @@ public sealed partial class WorkspaceRepositories : IDisposable
         }
     }
 
+    private async Task OnUpdateFilesClickAsync()
+    {
+        if (workspace == null || workspaceRepositories.Count == 0 || isUpdating || isSyncing)
+            return;
+        _updateCts?.Cancel();
+        _updateCts?.Dispose();
+        _updateCts = new CancellationTokenSource();
+        isUpdating = true;
+        updateProgressMessage = "Updating file versions...";
+        errorMessage = null;
+        StateHasChanged();
+        try
+        {
+            var (updated, failed, error, _) = await FileVersionService.UpdateAllVersionsAsync(
+                WorkspaceId, selectedRepositoryIds: null, cancellationToken: _updateCts.Token);
+            if (error != null)
+                errorMessage = error;
+            else if (failed > 0)
+                errorMessage = $"Updated {updated} line(s). {failed} file(s) could not be updated - check logs.";
+            else
+                ToastService.Show("Versions updated in configured files.");
+        }
+        catch (OperationCanceledException) { /* user aborted */ }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error updating file versions for WorkspaceId={WorkspaceId}", WorkspaceId);
+            errorMessage = "Failed to update file versions. Please try again.";
+        }
+        finally
+        {
+            isUpdating = false;
+            await InvokeAsync(StateHasChanged);
+        }
+    }
+
     private async Task OnUpdateAndPushClickAsync()
     {
         if (workspace == null || workspaceRepositories.Count == 0 || isUpdating || isSyncing)

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositoriesRow.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositoriesRow.razor
@@ -83,7 +83,9 @@
                             DefaultBranchAheadCommits="@Link.DefaultBranchAheadCommits"
                             IsPrVerified="@IsPrVerified"
                             IsOnTag="@Link.IsOnTag"
-                            OnCreateClick="@(() => OnCreatePr.InvokeAsync(Link))" />
+                            HasNewerTag="@(Link.HasNewerTag == true)"
+                            OnCreateClick="@(() => OnCreatePr.InvokeAsync(Link))"
+                            OnUpgradeClick="@(() => OnUpgradeClick.InvokeAsync(Link))" />
                 </span>
                 <span class="metrics-block metrics-deps">
                     @if (depCount == 0)
@@ -235,6 +237,7 @@
     [Parameter] public EventCallback OnDismissError { get; set; }
     [Parameter] public EventCallback OnPrBadgeMouseEnter { get; set; }
     [Parameter] public EventCallback<WorkspaceRepositoryLink> OnCreatePr { get; set; }
+    [Parameter] public EventCallback<WorkspaceRepositoryLink> OnUpgradeClick { get; set; }
     /// <summary>Fired when the user clicks the Copy button on the dependency-mismatch tooltip. Payload is the formatted text to copy to the clipboard.</summary>
     [Parameter] public EventCallback<string> OnCopyDependencies { get; set; }
 

--- a/src/GrayMoon.App/Components/Shared/PRBadge.razor
+++ b/src/GrayMoon.App/Components/Shared/PRBadge.razor
@@ -2,7 +2,18 @@
 @using Microsoft.AspNetCore.Components.Web
 
 @* PR column badge: none (dark gray), create (yellow, black text), #number (green), merged (purple), closed (red). Default "none" until data loads. *@
-@if (IsOnTag)
+@if (IsOnTag && HasNewerTag)
+{
+    <span class="badge pr-badge pr-badge-create"
+          role="button"
+          tabindex="0"
+          title="Newer tag available — click to upgrade"
+          style="cursor: pointer;"
+          @onclick="HandleUpgradeClick"
+          @onclick:preventDefault
+          @onclick:stopPropagation>upgrade</span>
+}
+else if (IsOnTag)
 {
     <span>&nbsp;</span>
 }
@@ -89,11 +100,21 @@ else
     [Parameter] public bool IsPrVerified { get; set; }
     /// <summary>True when the repository is checked out at a tag (detached HEAD); PRs require a branch, so render blank.</summary>
     [Parameter] public bool IsOnTag { get; set; }
+    /// <summary>True when the repo is on a tag and at least one newer tag exists. Shows the yellow "upgrade" badge.</summary>
+    [Parameter] public bool HasNewerTag { get; set; }
+    /// <summary>Raised when the user clicks the yellow "upgrade" badge.</summary>
+    [Parameter] public EventCallback OnUpgradeClick { get; set; }
 
     private async Task HandleCreateClick()
     {
         if (OnCreateClick.HasDelegate)
             await OnCreateClick.InvokeAsync();
+    }
+
+    private async Task HandleUpgradeClick()
+    {
+        if (OnUpgradeClick.HasDelegate)
+            await OnUpgradeClick.InvokeAsync();
     }
 
     private static string GetOpenPrMergeabilityClass(PullRequestInfo pr)

--- a/src/GrayMoon.App/Components/Shared/WorkspaceRepositoriesHeader.razor
+++ b/src/GrayMoon.App/Components/Shared/WorkspaceRepositoriesHeader.razor
@@ -135,6 +135,15 @@
                     <li>
                         <button class="dropdown-item" type="button"
                                 role="menuitem"
+                                @onclick="HandleUpdateFilesClick"
+                                disabled="@UpdateDisabled">
+                            Update Files
+                        </button>
+                    </li>
+                    <li><hr class="dropdown-divider branch-menu-divider" /></li>
+                    <li>
+                        <button class="dropdown-item" type="button"
+                                role="menuitem"
                                 @onclick="HandleUpdateAndPushClick"
                                 disabled="@UpdateDisabled">
                             Update &amp; Push...
@@ -218,6 +227,7 @@
     [Parameter] public EventCallback OnShowSwitchBranch { get; set; }
     [Parameter] public EventCallback OnNewPullRequest { get; set; }
     [Parameter] public EventCallback OnUpdate { get; set; }
+    [Parameter] public EventCallback OnUpdateFiles { get; set; }
     [Parameter] public EventCallback OnUpdateAndPush { get; set; }
     [Parameter] public EventCallback OnPull { get; set; }
     [Parameter] public EventCallback OnPush { get; set; }
@@ -268,6 +278,12 @@
     {
         CloseUpdateMenu();
         await OnUpdate.InvokeAsync();
+    }
+
+    private async Task HandleUpdateFilesClick()
+    {
+        CloseUpdateMenu();
+        await OnUpdateFiles.InvokeAsync();
     }
 
     private async Task HandleUpdateAndPushClick()

--- a/src/GrayMoon.App/Migrations.cs
+++ b/src/GrayMoon.App/Migrations.cs
@@ -39,6 +39,7 @@ public static class Migrations
         await MigrateWorkspaceRepositoriesCheckedOutTagAsync(dbContext);
         await MigrateRepositoryBranchesIsTagAsync(dbContext);
         await MigrateRepositoryBranchesSortIndexAsync(dbContext);
+        await MigrateWorkspaceRepositoriesHasNewerTagAsync(dbContext);
     }
 
     public static async Task MigrateRepositoriesTopicsAsync(AppDbContext dbContext)
@@ -1001,6 +1002,32 @@ public static class Migrations
                 if (!hasColumn)
                 {
                     cmd.CommandText = "ALTER TABLE RepositoryBranches ADD COLUMN IsTag INTEGER NOT NULL DEFAULT 0";
+                    await cmd.ExecuteNonQueryAsync();
+                }
+            }
+        }
+        catch
+        {
+            // Migration may already be applied or table doesn't exist yet
+        }
+    }
+
+    /// <summary>Adds HasNewerTag column to WorkspaceRepositories so the UI can show an "upgrade" badge when a newer tag exists for a tag-pinned repo.</summary>
+    public static async Task MigrateWorkspaceRepositoriesHasNewerTagAsync(AppDbContext dbContext)
+    {
+        try
+        {
+            var conn = dbContext.Database.GetDbConnection();
+            if (conn.State != System.Data.ConnectionState.Open)
+                await conn.OpenAsync();
+
+            await using (var cmd = conn.CreateCommand())
+            {
+                cmd.CommandText = "SELECT COUNT(*) FROM pragma_table_info('WorkspaceRepositories') WHERE name='HasNewerTag'";
+                var hasColumn = Convert.ToInt32(await cmd.ExecuteScalarAsync()) > 0;
+                if (!hasColumn)
+                {
+                    cmd.CommandText = "ALTER TABLE WorkspaceRepositories ADD COLUMN HasNewerTag INTEGER";
                     await cmd.ExecuteNonQueryAsync();
                 }
             }

--- a/src/GrayMoon.App/Models/WorkspaceRepositoryLink.cs
+++ b/src/GrayMoon.App/Models/WorkspaceRepositoryLink.cs
@@ -35,6 +35,9 @@ public class WorkspaceRepositoryLink
     [NotMapped]
     public bool IsOnTag => !string.IsNullOrWhiteSpace(CheckedOutTag);
 
+    /// <summary>True when the repository is on a tag and at least one newer tag exists (i.e. the checked-out tag is not the most recently created). Null when unknown or not on a tag. Updated when tags are fetched during checkout sync.</summary>
+    public bool? HasNewerTag { get; set; }
+
     /// <summary>Repository's default branch name (e.g. main, master, develop). Set during sync from agent and reused for divergence / PR URLs and sync-to-default logic.</summary>
     [MaxLength(200)]
     public string? DefaultBranchName { get; set; }

--- a/src/GrayMoon.App/Services/SyncCommandHandler.cs
+++ b/src/GrayMoon.App/Services/SyncCommandHandler.cs
@@ -47,6 +47,7 @@ public sealed class SyncCommandHandler(
         {
             // Real branch reported: clear any persisted tag so we resume normal branch behavior.
             wr.CheckedOutTag = null;
+            wr.HasNewerTag = null;
             if (n.OutgoingCommits.HasValue) wr.OutgoingCommits = n.OutgoingCommits;
             if (n.IncomingCommits.HasValue) wr.IncomingCommits = n.IncomingCommits;
             if (n.HasUpstream.HasValue) wr.BranchHasUpstream = n.HasUpstream.Value;
@@ -68,6 +69,20 @@ public sealed class SyncCommandHandler(
         }
 
         await dbContext.SaveChangesAsync();
+
+        // Persist tags and compute HasNewerTag when the agent includes a tag list (checkout-to-tag sync)
+        if (n.RemoteTags != null)
+        {
+            var workspaceGitService = scope.ServiceProvider.GetRequiredService<WorkspaceGitService>();
+            await workspaceGitService.PersistBranchesAsync(
+                wr.WorkspaceRepositoryId,
+                localBranches: null,
+                remoteBranches: null,
+                defaultBranchName: null,
+                tags: n.RemoteTags,
+                currentTag: n.Tag,
+                cancellationToken: default);
+        }
 
         // Prune remote branches from DB that no longer exist in git (fetch --prune ran on the agent side)
         if (n.RemoteBranches != null)

--- a/src/GrayMoon.App/Services/WorkspaceGitService.cs
+++ b/src/GrayMoon.App/Services/WorkspaceGitService.cs
@@ -1168,11 +1168,20 @@ public class WorkspaceGitService(
                     link.IncomingCommits = null;
                     link.DefaultBranchBehindCommits = null;
                     link.DefaultBranchAheadCommits = null;
+                    // Determine if a newer tag exists: SortIndex 0 = newest. If currentTag is not at index 0, there is a newer tag.
+                    var tagIdx = -1;
+                    for (var i = 0; i < tags.Count; i++)
+                    {
+                        if (string.Equals(tags[i], currentTag, StringComparison.OrdinalIgnoreCase))
+                        { tagIdx = i; break; }
+                    }
+                    link.HasNewerTag = tagIdx > 0;
                 }
                 else if (!string.IsNullOrWhiteSpace(link.CheckedOutTag))
                 {
                     // Tag list refreshed but we are no longer on a tag; clear the pinned state.
                     link.CheckedOutTag = null;
+                    link.HasNewerTag = null;
                 }
             }
         }


### PR DESCRIPTION
## Summary

- Detect when a repository checked out on a tag has a newer tag available, surface an upgrade badge in the grid, and open the switch branch modal on the tags tab to checkout the newer tag
- Fetch and persist remote tags during repository sync so tag state and `HasNewerTag` stay accurate after fetch/checkout
- Add a workspace header action to update configured file versions across repositories via `WorkspaceFileVersionService`
- Widen switch branch and update dependencies modals for clearer tag and dependency workflows

## Test plan

- [ ] Sync a repo checked out on a tag and confirm the upgrade badge appears when a newer tag exists on the remote
- [ ] Click the upgrade badge and confirm the switch branch modal opens on the tags tab with newer tags listed
- [ ] Run **Update files** from the workspace header and confirm configured file versions update with success or error feedback
- [ ] Open switch branch and update dependencies modals and confirm the wider layout is usable
- [ ] Re-sync after a tag push on the remote and confirm the upgrade badge clears or updates correctly