### PR TITLE
Improve sync-to-default flow and defer package restore

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -4,8 +4,7 @@ on:
   push:
     branches: ["*"]
     tags: ["*"]
-  #pull_request:
-  #  branches: ["main"]
+  workflow_dispatch:
 
 env:
   # Push to Docker Hub only on main, on tag push, or when commit message contains "prerelease"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,16 +43,29 @@ GrayMoon is a **two-process** system — never combine them:
 
 - **GrayMoon.App** (`src/GrayMoon.App`) — ASP.NET Core 8 + Blazor Server, runs in Docker. Exposes the web UI and two SignalR hubs (`/hub/agent`, `/hubs/workspace-sync`). Never touches the local filesystem or runs git directly. SQLite database via EF Core at `/app/db` (volume-mounted). Uses `EnsureCreated()` — no incremental migrations yet.
 - **GrayMoon.Agent** (`src/GrayMoon.Agent`) — .NET console app / tool that runs on the developer's host machine. Connects to the App via SignalR, executes all git and filesystem operations, and exposes a local HTTP listener on `127.0.0.1:9191` for git hook callbacks.
-- **GrayMoon.Abstractions** (`src/GrayMoon.Abstractions`) — Shared interfaces and DTOs used by both App and Agent.
+- **GrayMoon.Abstractions** (`src/GrayMoon.Abstractions`) — Shared interfaces and DTOs used by both App and Agent. `Agent/AgentHubMethods.cs` contains all SignalR hub method name constants (`RequestCommand`, `ResponseCommand`, `SyncCommand`, etc.).
 - **GrayMoon.Common** (`src/GrayMoon.Common`) — Shared utilities (e.g. the boolean filter-search expression parser tested in `GrayMoon.Common.Tests`).
 
 ### App → Agent command flow
 
-The App sends commands to the Agent over SignalR using a `requestId` (GUID). `AgentBridge` calls `AgentResponseDelivery.WaitAsync(requestId)` (a `TaskCompletionSource`) then fires `RequestCommand` to the Agent. The Agent enqueues a `JobEnvelope` into a bounded `Channel<JobEnvelope>`, runs it in one of up to 8 concurrent workers, and calls back `ResponseCommand` with the same `requestId`. `AgentResponseDelivery.Complete` resolves the TCS, unblocking the App's awaiter.
+The App sends commands to the Agent over SignalR using a `requestId` (GUID). `AgentBridge` calls `AgentResponseDelivery.WaitAsync(requestId)` (a `TaskCompletionSource`) then fires `RequestCommand` to the Agent. The Agent enqueues a `JobEnvelope` into a bounded `Channel<JobEnvelope>`, runs it in one of up to 16 concurrent workers, and calls back `ResponseCommand` with the same `requestId`. `AgentResponseDelivery.Complete` resolves the TCS, unblocking the App's awaiter.
 
 ### Agent → App sync (hook-driven)
 
 Git hooks (`post-commit`, `post-checkout`, `post-merge`, `pre-push`) POST JSON to the Agent's local HTTP listener (`/hook/notify` or `/hook/push`). The Agent processes these as `NotifyJobs` and pushes partial state updates back to the App via `SyncCommand` on the SignalR connection. `SyncCommandHandler` persists only non-null fields (partial update semantics) then broadcasts `WorkspaceSynced` to all browser clients.
+
+### Agent command structure
+
+The Agent uses `System.CommandLine`. Each agent operation is a class in `src/GrayMoon.Agent/Commands/`. To add a new operation: create a command class there, register it in the CLI entry point, and add the corresponding hub method constant to `GrayMoon.Abstractions/Agent/AgentHubMethods.cs`.
+
+### App layer structure
+
+The App is organized into:
+- `Components/Pages/` — Blazor Server pages and interactive components
+- `Components/Shared/` and `Components/Modals/` — reusable UI components
+- `Services/` — 40+ domain services (GitHub API, workspace operations, push orchestration, dependency update, etc.)
+- `Data/` — EF Core `DbContext`, entity models, and repository classes
+- `Endpoints/` — REST API endpoints grouped by domain (Agent, Branch, Commit, Connector, Sync, Workspace)
 
 ### Dependency levels
 

--- a/src/GrayMoon.App/Api/Endpoints/BranchEndpoints.cs
+++ b/src/GrayMoon.App/Api/Endpoints/BranchEndpoints.cs
@@ -450,6 +450,15 @@ public static class BranchEndpoints
                     tags,
                     refreshResponse.CurrentTag,
                     CancellationToken.None);
+                if (string.IsNullOrWhiteSpace(refreshResponse.CurrentTag))
+                {
+                    var hasUpstream = ComputeBranchHasUpstream(refreshResponse.CurrentBranch, remoteBranches);
+                    if (hasUpstream.HasValue)
+                    {
+                        wr.BranchHasUpstream = hasUpstream.Value;
+                        await dbContext.SaveChangesAsync(CancellationToken.None);
+                    }
+                }
                 await hubContext.Clients.All.SendAsync("WorkspaceSynced", workspaceId);
             }
 

--- a/src/GrayMoon.App/Components/Modals/SyncToDefaultOptionsModal.razor
+++ b/src/GrayMoon.App/Components/Modals/SyncToDefaultOptionsModal.razor
@@ -20,16 +20,12 @@
                                 @foreach (var item in RepoItems)
                                 {
                                     <li class="mb-1">
-                                        <div>
-                                            <code>@item.RepoName</code>
-                                        </div>
-                                        <div class="text-muted ps-1">
-                                            @item.BranchName
-                                            @if (item.HasRemote)
-                                            {
-                                                <span class="badge bg-secondary ms-1" style="font-size:0.65em;">remote</span>
-                                            }
-                                        </div>
+                                        <code>@item.RepoName</code>
+                                        <span class="text-muted ms-2">@item.BranchName</span>
+                                        @if (item.HasRemote)
+                                        {
+                                            <span class="badge bg-secondary ms-1" style="font-size:0.65em;">remote</span>
+                                        }
                                     </li>
                                 }
                             </ul>

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor
@@ -137,7 +137,7 @@
                                                                        ColSpan="@TableColSpan"
                                                                        Group="@group"
                                                                        ActionsDisabled="@group.All(wr => wr.IsOnTag)"
-                                                                       OnSyncToDefault="() => ShowConfirmSyncToDefaultLevel(group.Select(wr => wr.RepositoryId).ToList())"
+                                                                       OnSyncToDefault="async () => await ShowConfirmSyncToDefaultLevel(group.Select(wr => wr.RepositoryId).ToList())"
                                                                        OnSyncCommits="() => ShowConfirmSyncCommitsLevel(group.Select(wr => wr.RepositoryId).ToList())"
                                                                        OnOpenPr="() => OpenPullRequestDialogForRepositoriesAsync(group.ToList())"
                                                                        OnSyncLevel="() => ShowConfirmSyncLevel(group.Select(wr => wr.RepositoryId).ToList())"

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
@@ -943,7 +943,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
             ShowConfirm($"Do you want to sync {filtered.Count} repositories in this level?", () => SyncLevelAsync(filtered));
     }
 
-    private void ShowConfirmSyncToDefaultLevel(List<int> repositoryIds)
+    private async Task ShowConfirmSyncToDefaultLevel(List<int> repositoryIds)
     {
         if (workspace == null || repositoryIds == null || repositoryIds.Count == 0)
             return;
@@ -968,12 +968,12 @@ public sealed partial class WorkspaceRepositories : IDisposable
             return;
         }
 
-        CheckBranchesAndConfirmSyncToDefaultLevel(nonDefaultRepoIds);
+        await CheckBranchesAndConfirmSyncToDefaultLevel(nonDefaultRepoIds);
     }
 
-    private void CheckBranchesAndConfirmSyncToDefaultLevel(List<int> repositoryIds)
+    private async Task CheckBranchesAndConfirmSyncToDefaultLevel(List<int> repositoryIds)
     {
-        if (workspace == null || repositoryIds == null || repositoryIds.Count == 0 || isSyncingToDefault)
+        if (workspace == null || repositoryIds == null || repositoryIds.Count == 0 || isSyncingToDefault || isWorkspaceBranchesFetching)
             return;
 
         _syncToDefaultCheckResults = null;
@@ -1014,6 +1014,49 @@ public sealed partial class WorkspaceRepositories : IDisposable
             var message = safeCount == 1
                 ? "This will checkout the default branch, remove the current branch locally, and pull the latest. Uncommitted local changes can block checkout."
                 : $"This will sync {safeCount} repositories to their default branch: checkout default, remove the current branch locally, and pull. Uncommitted local changes can block checkout for that repo.";
+
+            // Fetch to get up-to-date remote branch state before showing the dialog
+            _workspaceBranchesFetchCts?.Cancel();
+            _workspaceBranchesFetchCts?.Dispose();
+            _workspaceBranchesFetchCts = new CancellationTokenSource();
+            isWorkspaceBranchesFetching = true;
+            workspaceBranchesFetchProgressMessage = safeCount == 1 ? "Fetching latest branch state..." : $"Fetching latest branch state for {safeCount} repositories...";
+            await InvokeAsync(StateHasChanged);
+
+            try
+            {
+                await WorkspaceBranchHandler.FetchBranchesForWorkspaceAsync(
+                    WorkspaceId,
+                    safeRepoIds,
+                    ApiBaseUrl,
+                    (done, total) =>
+                    {
+                        workspaceBranchesFetchProgressMessage = done <= 0 ? "Fetching latest branch state..." : $"Fetched {done} of {total}...";
+                        _ = InvokeAsync(StateHasChanged);
+                    },
+                    _workspaceBranchesFetchCts.Token);
+                await RefreshFromSync();
+            }
+            catch (OperationCanceledException)
+            {
+                ToastService.Show("Fetch cancelled.");
+                return;
+            }
+            finally
+            {
+                isWorkspaceBranchesFetching = false;
+                await InvokeAsync(StateHasChanged);
+            }
+
+            // Rebuild check results with fresh HasUpstream from DB (remote branch may have been deleted)
+            _syncToDefaultCheckResults = _syncToDefaultCheckResults
+                .Select(r =>
+                {
+                    var wr2 = workspaceRepositories.FirstOrDefault(w => w.RepositoryId == r.RepoId);
+                    return (r.RepoId, r.DefaultAhead, HasUpstream: wr2?.BranchHasUpstream);
+                })
+                .ToList();
+
             var repoItems = _syncToDefaultCheckResults
                 .Select(r =>
                 {
@@ -3005,11 +3048,12 @@ public sealed partial class WorkspaceRepositories : IDisposable
                 await semaphore.WaitAsync();
                 try
                 {
+                    var repoHasRemote = !resultByRepo.TryGetValue(repositoryId, out var repoCheck) || repoCheck.HasUpstream == true;
                     var (success, errMsg) = await WorkspaceBranchHandler.SyncToDefaultSingleAsync(
                         WorkspaceId,
                         repositoryId,
                         currentBranchName,
-                        deleteRemoteBranch,
+                        deleteRemoteBranch && repoHasRemote,
                         allowForceDeleteLocalBranch,
                         ApiBaseUrl,
                         CancellationToken.None);

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
@@ -1306,7 +1306,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
         {
             ShowConfirm(
                 $"Synchronized push could not be completed because {ex.MissingPackagesCount} required package mappings are missing. Check NuGet connector configuration and token, then retry. Continue with normal push?",
-                () => ExecutePushAsync(
+                async () => await ExecutePushAsync(
                     repoIds,
                     synchronizedPush: false,
                     requiredPackageIds: requiredPackageIds),
@@ -1314,13 +1314,13 @@ public sealed partial class WorkspaceRepositories : IDisposable
         }
     }
 
-    private async Task ExecutePushAsync(
+    private async Task<bool> ExecutePushAsync(
         IReadOnlySet<int> repoIds,
         bool synchronizedPush,
         IReadOnlySet<string> requiredPackageIds)
     {
         if (workspace == null)
-            return;
+            return false;
 
         _pushCts?.Cancel();
         _pushCts?.Dispose();
@@ -1338,10 +1338,12 @@ public sealed partial class WorkspaceRepositories : IDisposable
                 ToastService.Show,
                 onAppSideComplete: () => _pushAwaitingAgentTasks = true,
                 _pushCts.Token);
+            return true;
         }
         catch (OperationCanceledException)
         {
             ToastService.Show("Push cancelled.");
+            return false;
         }
         finally
         {
@@ -1799,17 +1801,21 @@ public sealed partial class WorkspaceRepositories : IDisposable
         }
 
         // Phase 3: execute push
+        bool pushCompleted = false;
         try
         {
-            await ExecutePushAsync(pushRepoIds, synchronizedPush: true, requiredPackageIds);
+            pushCompleted = await ExecutePushAsync(pushRepoIds, synchronizedPush: true, requiredPackageIds);
         }
         catch (SynchronizedPushNotPossibleException ex)
         {
             ShowConfirm(
                 $"Synchronized push could not be completed because {ex.MissingPackagesCount} required package mappings are missing. Check NuGet connector configuration and token, then retry. Continue with normal push?",
-                () => ExecutePushAsync(pushRepoIds, synchronizedPush: false, requiredPackageIds),
+                async () => await ExecutePushAsync(pushRepoIds, synchronizedPush: false, requiredPackageIds),
                 confirmButtonText: "Continue");
         }
+
+        if (pushCompleted)
+            await RestorePackagesAsync();
     }
 
     private async Task HandleDependencyBadgeKeydown(KeyboardEventArgs e, int repositoryId, int unmatchedDeps)
@@ -2640,6 +2646,9 @@ public sealed partial class WorkspaceRepositories : IDisposable
                 await RefreshFromSync();
                 await InvokeAsync(StateHasChanged);
             }
+
+            // Only reached on success (all catch blocks return early)
+            await RestorePackagesAsync();
         }
     }
 

--- a/src/GrayMoon.App/Services/DependencyUpdateOrchestrator.cs
+++ b/src/GrayMoon.App/Services/DependencyUpdateOrchestrator.cs
@@ -101,17 +101,6 @@ public sealed class DependencyUpdateOrchestrator(
             if (hadError)
                 break;
 
-            levelProgress("Restoring packages...");
-            await workspaceGitService.RestoreDependenciesAsync(
-                workspaceId,
-                reposAtLevel.Select(r => (
-                    r.RepoName,
-                    (IReadOnlyList<string>)r.ProjectUpdates
-                        .Select(p => p.ProjectPath!)
-                        .Where(p => !string.IsNullOrWhiteSpace(p))
-                        .ToList())),
-                cancellationToken);
-
             levelProgress("Committing...");
             var commitResults = await workspaceGitService.CommitDependencyUpdatesAsync(
                 workspaceId,


### PR DESCRIPTION
## Summary

- Fetch remote branch state before bulk sync-to-default so the confirmation dialog reflects current upstream status and stale `BranchHasUpstream` values are refreshed after branch refresh
- Skip remote branch deletion during sync-to-default when a repository has no upstream, and persist `BranchHasUpstream` when branch metadata is refreshed without a tag
- Run package restore only after successful sync-to-default or synchronized push instead of after each dependency-update level; enable manual Docker build runs via `workflow_dispatch`

## Test plan

- [ ] Sync multiple repos to default and confirm a fetch progress message appears before the options dialog; cancel fetch and verify the flow stops cleanly
- [ ] Sync a repo with no upstream to default and confirm remote branch delete is not attempted
- [ ] Complete a synchronized push and confirm packages are restored only after a successful push
- [ ] Run a dependency update across multiple levels and confirm package restore no longer runs between levels
- [ ] Trigger the Docker build workflow manually from GitHub Actions (`workflow_dispatch`)