### PR TITLE
Add background jobs for long-running workspace repository operations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,13 +2,15 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-## Line endings
+## Coding conventions
 
-Always use **Windows (CRLF)** in generated or edited code. Do not use LF-only.
+- **Line endings:** Always use **Windows (CRLF)** in generated or edited code. Do not use LF-only.
+- **Hyphens only:** Never use em dash (U+2014) or en dash (U+2013) anywhere - user-visible strings, UI markup, comments, XML docs, logs, CSS, or Markdown. ASCII hyphen-minus (`-`) only.
+- **Primary constructors:** Prefer C# 12 primary constructors (`public sealed class MyService(ILogger<MyService> logger)`) for classes that only capture constructor parameters. Keep an explicit constructor only when the body has non-trivial side effects.
 
 ## Task completion
 
-When you complete a task, write a single sentence summarizing what was done.
+When you complete a task, write a single sentence summarizing what was done. Keep it to one sentence - never write a multi-line summary.
 
 ## Commands
 
@@ -43,7 +45,7 @@ GrayMoon is a **two-process** system — never combine them:
 
 - **GrayMoon.App** (`src/GrayMoon.App`) — ASP.NET Core 8 + Blazor Server, runs in Docker. Exposes the web UI and two SignalR hubs (`/hub/agent` for App↔Agent commands, `/hubs/workspace-sync` for browser broadcast). Never touches the local filesystem or runs git directly. SQLite database via EF Core at `/app/db` (volume-mounted). Uses `EnsureCreated()` — no incremental migrations. **New DB columns must be nullable or have a default value.**
 - **GrayMoon.Agent** (`src/GrayMoon.Agent`) — .NET console app / tool that runs on the developer's host machine. Connects to the App via SignalR, executes all git and filesystem operations, and exposes a local HTTP listener on `127.0.0.1:9191` for git hook callbacks. Job queue: bounded channel with up to 16 concurrent workers.
-- **GrayMoon.Abstractions** (`src/GrayMoon.Abstractions`) — Shared interfaces and DTOs used by both App and Agent. `Agent/AgentHubMethods.cs` contains all SignalR hub method name constants (`RequestCommand`, `ResponseCommand`, `SyncCommand`, etc.).
+- **GrayMoon.Abstractions** (`src/GrayMoon.Abstractions`) — Shared interfaces and DTOs used by both App and Agent. `Agent/AgentHubMethods.cs` contains all SignalR hub method name constants (`RequestCommand`, `ResponseCommand`, `SyncCommand`, `CommandOutput`, `ReportSemVer`, `ReportQueueStatus`).
 - **GrayMoon.Common** (`src/GrayMoon.Common`) — Shared utilities including `CommandLineService` (process execution wrapper) and `Search/FilterSearchExpression` (boolean expression parser used by every UI grid).
 
 ### App → Agent command flow
@@ -95,6 +97,16 @@ Connector tokens are AES-256-GCM encrypted at rest via `AesGcmTokenProtector` (b
 ### Database schema
 
 Schema is owned by EF Core but applied via `EnsureCreated()`. Core tables: `Connectors`, `Repositories`, `Workspaces`, `WorkspaceRepositories` (join with live state), `WorkspaceRepositoryPullRequest` (1:1 with link), `WorkspaceProject`, `ProjectDependency`, `WorkspaceFile`, `WorkspaceFileVersionConfig`, `RepositoryBranch`, `Settings`.
+
+### Background job system
+
+Long-running App-side operations (restore, update, push orchestration) run as background jobs so they survive page navigation within the same browser tab.
+
+- **`BackgroundJobService`** (Blazor-circuit-scoped) — keyed by URL absolute path (`/workspace/123/repositories`). `StartJob` is idempotent: if a job for that key is already `Running` it returns the existing handle. Disposing the service (tab closed) cancels all jobs.
+- **`BackgroundJobHandle`** — state machine (`Running` → `Completed` / `Faulted` / `Aborted`). Exposes `ReportProgress(string)` for mid-job status updates, `Abort()` for user cancellation, and a `JobTerminalBuffer Terminal` that holds up to 800 log lines.
+- **`TerminalSinkContext`** — `AsyncLocal`-based ambient context. `AgentBridge.SendCommandAsync` checks `TerminalSinkContext.Current` and routes all `CommandOutput` streaming lines to the active job's terminal automatically, without threading the buffer through every service call. Wrap a job's `Task.Run` body with `using var _ = TerminalSinkContext.Use(handle.Terminal)`.
+- **`BackgroundJobOverlay`** layout component — reads `IBackgroundJobService.GetJob(currentPath)` on every navigation and renders `LoadingOverlay` when the job is `Running`. It also reads `AgentQueueStateService.GetTotalPendingCount()` to show pending agent tasks in the spinner.
+- **`AgentQueueStateService`** — receives `ReportQueueStatus` SignalR events from the Agent (total + per-workspace pending counts). Use `HasWorkspaceJobsPending(workspaceId)` to disable workspace actions while the agent queue is busy.
 
 ### CSS conventions for the loading overlay terminal
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,19 @@ Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManage
 
 ## What's new
 
+### Background jobs on the workspace repositories page
+
+Long-running workspace operations now run as **background jobs** instead of blocking the page with an inline loading overlay. Sync, push, dependency update, restore packages, branch checkout/switch, commit sync, sync-to-default, and pull-request creation all use the same job pipeline.
+
+- **Keep working in the app:** start an operation on the workspace **Repositories** page, then navigate to **Projects**, **Actions**, or another workspace view. The job keeps running on the server for your browser tab. When you return to **Repositories**, the loading overlay reappears with the same progress message and live terminal output.
+- **Page-scoped overlay:** the spinner and terminal sit over the main content area (not full-screen), so the sidebar and workspace navigation stay usable while a job runs.
+- **Per-job terminal:** agent command output and GitHub API request/response lines stream into that job's own terminal buffer. Toggle the terminal icon in the overlay top bar as before; output is not mixed with other pages or stale global logs.
+- **Abort:** use **Abort** on the overlay to cancel the in-flight job. Closing the browser tab cancels all running jobs for that session.
+- **One job per page:** only one running job is allowed per workspace repositories URL at a time. Starting the same kind of work again while one is already running reuses the existing handle instead of launching a duplicate.
+- **Safer grid refresh:** while a job is running, automatic grid refresh from agent hook sync is paused so in-progress operations are not overwritten by stale database reads.
+
+Initial page load and repository fetch still use a short inline overlay on the page itself; only orchestration work (git, restore, push, GitHub calls) runs as a background job.
+
 ### Raw log output in the GitHub Actions live terminal
 
 The right pane of the GitHub Actions live terminal (visible while a workflow run is in progress on the Workspace Actions page) now shows the actual log text from the current job instead of a formatted list of step-transition events.

--- a/src/GrayMoon.App/Components/Layout/BackgroundJobOverlay.razor
+++ b/src/GrayMoon.App/Components/Layout/BackgroundJobOverlay.razor
@@ -1,7 +1,6 @@
 @using GrayMoon.App.Services
 @inject IBackgroundJobService JobService
 @inject NavigationManager Nav
-@inject AgentQueueStateService AgentQueueStateService
 @rendermode @(new InteractiveServerRenderMode(prerender: false))
 @implements IDisposable
 
@@ -11,8 +10,6 @@
                     PageScoped="true"
                     Message="@_job.DisplayMessage"
                     TerminalBuffer="@_job.Terminal"
-                    ShowTaskCountInSpinner="true"
-                    PendingAgentTasksCount="@AgentQueueStateService.GetTotalPendingCount()"
                     OnAbort="@HandleAbort" />
 }
 

--- a/src/GrayMoon.App/Components/Layout/BackgroundJobOverlay.razor
+++ b/src/GrayMoon.App/Components/Layout/BackgroundJobOverlay.razor
@@ -2,6 +2,7 @@
 @inject IBackgroundJobService JobService
 @inject NavigationManager Nav
 @inject AgentQueueStateService AgentQueueStateService
+@rendermode @(new InteractiveServerRenderMode(prerender: false))
 @implements IDisposable
 
 @if (_job is { State: BackgroundJobState.Running })

--- a/src/GrayMoon.App/Components/Layout/BackgroundJobOverlay.razor
+++ b/src/GrayMoon.App/Components/Layout/BackgroundJobOverlay.razor
@@ -1,0 +1,59 @@
+@using GrayMoon.App.Services
+@inject IBackgroundJobService JobService
+@inject NavigationManager Nav
+@inject AgentQueueStateService AgentQueueStateService
+@implements IDisposable
+
+@if (_job is { State: BackgroundJobState.Running })
+{
+    <LoadingOverlay IsVisible="true"
+                    PageScoped="true"
+                    Message="@_job.DisplayMessage"
+                    TerminalBuffer="@_job.Terminal"
+                    ShowTaskCountInSpinner="true"
+                    PendingAgentTasksCount="@AgentQueueStateService.GetTotalPendingCount()"
+                    OnAbort="@HandleAbort" />
+}
+
+@code {
+    private BackgroundJobHandle? _job;
+
+    protected override void OnInitialized()
+    {
+        JobService.Changed += OnJobChanged;
+        Nav.LocationChanged += OnLocationChanged;
+        UpdateJob();
+    }
+
+    private void OnJobChanged()
+    {
+        _ = InvokeAsync(() =>
+        {
+            UpdateJob();
+            StateHasChanged();
+        });
+    }
+
+    private void OnLocationChanged(object? sender, Microsoft.AspNetCore.Components.Routing.LocationChangedEventArgs e)
+    {
+        _ = InvokeAsync(() =>
+        {
+            UpdateJob();
+            StateHasChanged();
+        });
+    }
+
+    private void UpdateJob()
+    {
+        var key = new Uri(Nav.Uri).AbsolutePath.ToLowerInvariant();
+        _job = JobService.GetJob(key);
+    }
+
+    private void HandleAbort() => _job?.Abort();
+
+    public void Dispose()
+    {
+        JobService.Changed -= OnJobChanged;
+        Nav.LocationChanged -= OnLocationChanged;
+    }
+}

--- a/src/GrayMoon.App/Components/Layout/MainLayout.razor
+++ b/src/GrayMoon.App/Components/Layout/MainLayout.razor
@@ -47,6 +47,7 @@
 
         <article class="content px-4">
             @Body
+            <BackgroundJobOverlay />
         </article>
     </main>
 </div>

--- a/src/GrayMoon.App/Components/Layout/MainLayout.razor.css
+++ b/src/GrayMoon.App/Components/Layout/MainLayout.razor.css
@@ -11,6 +11,11 @@ main {
     flex-direction: column;
 }
 
+/* Required so position:absolute overlays inside <article> are bounded to the content area. */
+article.content {
+    position: relative;
+}
+
 
 .sidebar {
     background-color: var(--bg-secondary);

--- a/src/GrayMoon.App/Components/Layout/MainLayout.razor.css
+++ b/src/GrayMoon.App/Components/Layout/MainLayout.razor.css
@@ -11,7 +11,6 @@ main {
     flex-direction: column;
 }
 
-/* Required so position:absolute overlays inside <article> are bounded to the content area. */
 article.content {
     position: relative;
 }

--- a/src/GrayMoon.App/Components/Modals/OperationErrorModal.razor
+++ b/src/GrayMoon.App/Components/Modals/OperationErrorModal.razor
@@ -5,9 +5,9 @@
          @ref="modalElement">
         <div class="modal-dialog">
             <div class="modal-content">
-                <div class="modal-header bg-danger text-white">
+                <div class="modal-header" style="background-color: #555555; color: white;">
                     <h5 class="modal-title">
-                        <i class="bi bi-exclamation-triangle-fill me-2"></i>@Title
+                        <i class="bi bi-exclamation-triangle me-2"></i>@Title
                     </h5>
                 </div>
                 <div class="modal-body" style="white-space: pre-wrap; word-wrap: break-word;">

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor
@@ -26,6 +26,7 @@
 @inject NewFeatureOrchestrator NewFeatureOrchestrator
 @inject AgentQueueStateService AgentQueueStateService
 @inject IPullRequestService PullRequestService
+@inject IBackgroundJobService JobService
 @using WorkspaceModel = GrayMoon.App.Models.Workspace
 
 <PageTitle>Repositories - GrayMoon</PageTitle>
@@ -41,13 +42,13 @@
                                     IsPushRecommended="@isPushRecommended"
                                     HasIncomingCommits="@hasIncomingCommits"
                                     IsOutOfSync="@isOutOfSync"
-                                    IsSyncing="@isSyncing"
-                                    IsUpdating="@isUpdating"
-                                    IsPushing="@isPushing"
-                                    IsCommitSyncing="@isCommitSyncing"
+                                    IsSyncing="@IsJobRunning"
+                                    IsUpdating="@IsJobRunning"
+                                    IsPushing="@IsJobRunning"
+                                    IsCommitSyncing="@IsJobRunning"
                                     AgentTasksPendingCount="@AgentTasksPendingCount"
-                                    IsRestoringPackages="@isRestoringPackages"
-                                    IsOverlayVisible="@(isLoading || isSyncing || isPushing || isUpdating || isCommitSyncing || isCheckingOut || isCreatingBranches || isCreatingBranch || isSyncingToDefault || isWorkspaceBranchesFetching || isWorkspaceBranchesCheckingOut || ShowRepositoriesFetchOverlay || isRestoringPackages)"
+                                    IsRestoringPackages="@IsJobRunning"
+                                    IsOverlayVisible="@(isLoading || IsJobRunning || ShowRepositoriesFetchOverlay)"
                                     OnShowRepositories="ShowRepositoriesModalAsync"
                                     OnNewFeature="ShowNewFeatureModalAsync"
                                     OnShowBranch="() => ShowBranchModalAsync()"
@@ -156,8 +157,8 @@
                                                                   IsVersionClicked="@(wr.GitVersion != null && clickedVersions.Contains(wr.GitVersion))"
                                                                   IsDependencyBadgeClicked="@clickedDependencyBadges.Contains(wr.RepositoryId)"
                                                                   RepositoryError="@GetRepositoryError(wr.RepositoryId)"
-                                                                  IsSyncing="@isSyncing"
-                                                                  IsUpdating="@isUpdating"
+                                                                  IsSyncing="@IsJobRunning"
+                                                                  IsUpdating="@IsJobRunning"
                                                                   ColSpan="@TableColSpan"
                                                                   OnVersionClick="() => CopyVersionToClipboard(wr.GitVersion!)"
                                                                   OnVersionMouseLeave="() => OnVersionMouseLeave(wr.GitVersion)"
@@ -227,14 +228,14 @@
                    OnCreateBranch="@CreateSingleBranchAsync" />
 
 <UpdateDependenciesModal IsVisible="@_updateModal.IsVisible"
-                         IsBusy="@isUpdating"
+                         IsBusy="@IsJobRunning"
                          InitialCommitMessage="@_updateModal.LastCommitMessage"
                          InitialIncludeDeps="@_updateModal.LastIncludeDeps"
                          OnProceed="@OnUpdateProceedAsync"
                          OnCancel="@CloseUpdateModal" />
 
 <UpdateDependenciesModal IsVisible="@_updateAndPushModal.IsVisible"
-                         IsBusy="@isUpdating"
+                         IsBusy="@IsJobRunning"
                          InitialCommitMessage="@_updateAndPushModal.LastCommitMessage"
                          InitialIncludeDeps="@_updateAndPushModal.LastIncludeDeps"
                          OnProceed="@OnUpdateAndPushProceedAsync"
@@ -275,7 +276,7 @@
                            OnCancel="@CloseSyncToDefaultOptionsModal" />
 
 <NewPullRequestModal IsVisible="@_newPrModal.IsVisible"
-                     IsBusy="@isCreatingPullRequests"
+                     IsBusy="@IsJobRunning"
                      Targets="@_newPrModal.Targets"
                      OnCreate="HandleCreatePullRequestsAsync"
                      OnCancel="CloseNewPullRequestModal"
@@ -295,6 +296,12 @@
                      Message="@_operationErrorModal.Message"
                      OnClose="CloseOperationErrorModal" />
 
-<LoadingOverlay IsVisible="@IsAnyOverlayVisible"
-               Message="@ActiveOverlayMessage"
-               OnAbort="@ActiveOverlayAbort" />
+@if (isLoading)
+{
+    <LoadingOverlay IsVisible="true" PageScoped="true" Message="Loading workspace..." ShowCommandTerminal="false" />
+}
+@if (ShowRepositoriesFetchOverlay)
+{
+    <LoadingOverlay IsVisible="true" PageScoped="true" Message="@RepositoriesFetchOverlayMessage" ShowCommandTerminal="false"
+                   OnAbort="@EventCallback.Factory.Create(this, (Action)AbortFetchRepositories)" />
+}

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
@@ -868,7 +868,9 @@ public sealed partial class WorkspaceRepositories : IDisposable
             {
                 try
                 {
-                    await WorkspaceBranchHandler.FetchBranchesForWorkspaceAsync(
+                    await using var scope = ServiceScopeFactory.CreateAsyncScope();
+                    var branchHandler = scope.ServiceProvider.GetRequiredService<WorkspaceBranchHandler>();
+                    await branchHandler.FetchBranchesForWorkspaceAsync(
                         WorkspaceId,
                         safeRepoIds,
                         ApiBaseUrl,
@@ -1213,7 +1215,9 @@ public sealed partial class WorkspaceRepositories : IDisposable
         {
             try
             {
-                var (success, pushError) = await WorkspacePushHandler.PushSingleRepositoryWithUpstreamAsync(
+                await using var scope = ServiceScopeFactory.CreateAsyncScope();
+                var pushHandler = scope.ServiceProvider.GetRequiredService<WorkspacePushHandler>();
+                var (success, pushError) = await pushHandler.PushSingleRepositoryWithUpstreamAsync(
                     WorkspaceId,
                     repositoryId,
                     branchName,
@@ -1421,15 +1425,19 @@ public sealed partial class WorkspaceRepositories : IDisposable
         {
             try
             {
-                await WorkspaceUpdateHandler.RunUpdateAsync(
-                    WorkspaceId,
-                    ct,
-                    job.ReportProgress,
-                    (repoId, msg) => SafeInvoke(() => { repositoryErrors[repoId] = msg; }),
-                    onAppSideComplete: () => { },
-                    repoIdsToUpdate: null,
-                    commitMessage: commitMessage,
-                    includeDepsInCommitMessage: includeDepsInCommitMessage);
+                await using (var updateScope = ServiceScopeFactory.CreateAsyncScope())
+                {
+                    var updateHandler = updateScope.ServiceProvider.GetRequiredService<WorkspaceUpdateHandler>();
+                    await updateHandler.RunUpdateAsync(
+                        WorkspaceId,
+                        ct,
+                        job.ReportProgress,
+                        (repoId, msg) => SafeInvoke(() => { repositoryErrors[repoId] = msg; }),
+                        onAppSideComplete: () => { },
+                        repoIdsToUpdate: null,
+                        commitMessage: commitMessage,
+                        includeDepsInCommitMessage: includeDepsInCommitMessage);
+                }
 
                 await InvokeAsync(async () =>
                 {
@@ -1464,7 +1472,9 @@ public sealed partial class WorkspaceRepositories : IDisposable
         {
             try
             {
-                var (updated, failed, error, _) = await FileVersionService.UpdateAllVersionsAsync(
+                await using var scope = ServiceScopeFactory.CreateAsyncScope();
+                var fileVersionService = scope.ServiceProvider.GetRequiredService<WorkspaceFileVersionService>();
+                var (updated, failed, error, _) = await fileVersionService.UpdateAllVersionsAsync(
                     WorkspaceId, selectedRepositoryIds: null, cancellationToken: ct);
 
                 SafeInvoke(() =>
@@ -1833,7 +1843,9 @@ public sealed partial class WorkspaceRepositories : IDisposable
         {
             try
             {
-                repoGitInfos = await WorkspaceSyncHandler.RunSyncAsync(
+                await using var scope = ServiceScopeFactory.CreateAsyncScope();
+                var syncHandler = scope.ServiceProvider.GetRequiredService<WorkspaceSyncHandler>();
+                repoGitInfos = await syncHandler.RunSyncAsync(
                     WorkspaceId,
                     repositoryIds: null,
                     skipDependencyLevelPersistence: isRetryAfterError,
@@ -1914,7 +1926,9 @@ public sealed partial class WorkspaceRepositories : IDisposable
         {
             try
             {
-                repoGitInfos = await WorkspaceSyncHandler.RunSyncAsync(
+                await using var scope = ServiceScopeFactory.CreateAsyncScope();
+                var syncHandler = scope.ServiceProvider.GetRequiredService<WorkspaceSyncHandler>();
+                repoGitInfos = await syncHandler.RunSyncAsync(
                     WorkspaceId,
                     repositoryIds,
                     skipDependencyLevelPersistence: true,
@@ -1994,7 +2008,9 @@ public sealed partial class WorkspaceRepositories : IDisposable
         {
             try
             {
-                repoGitInfos = await WorkspaceSyncHandler.RunSyncAsync(
+                await using var scope = ServiceScopeFactory.CreateAsyncScope();
+                var syncHandler = scope.ServiceProvider.GetRequiredService<WorkspaceSyncHandler>();
+                repoGitInfos = await syncHandler.RunSyncAsync(
                     WorkspaceId,
                     new[] { repositoryId },
                     skipDependencyLevelPersistence: true,
@@ -2078,7 +2094,9 @@ public sealed partial class WorkspaceRepositories : IDisposable
         {
             try
             {
-                await WorkspaceCommitSyncHandler.CommitSyncAsync(
+                await using var scope = ServiceScopeFactory.CreateAsyncScope();
+                var commitSyncHandler = scope.ServiceProvider.GetRequiredService<WorkspaceCommitSyncHandler>();
+                await commitSyncHandler.CommitSyncAsync(
                     WorkspaceId,
                     repositoryId,
                     ApiBaseUrl,
@@ -2131,7 +2149,9 @@ public sealed partial class WorkspaceRepositories : IDisposable
         {
             try
             {
-                await WorkspaceCommitSyncHandler.CommitSyncLevelAsync(
+                await using var scope = ServiceScopeFactory.CreateAsyncScope();
+                var commitSyncHandler = scope.ServiceProvider.GetRequiredService<WorkspaceCommitSyncHandler>();
+                await commitSyncHandler.CommitSyncLevelAsync(
                     WorkspaceId,
                     repositoryIds,
                     ApiBaseUrl,
@@ -2456,7 +2476,9 @@ public sealed partial class WorkspaceRepositories : IDisposable
         {
             try
             {
-                var result = await WorkspaceBranchHandler.FetchBranchesForWorkspaceAsync(
+                await using var scope = ServiceScopeFactory.CreateAsyncScope();
+                var branchHandler = scope.ServiceProvider.GetRequiredService<WorkspaceBranchHandler>();
+                var result = await branchHandler.FetchBranchesForWorkspaceAsync(
                     WorkspaceId,
                     repoIds,
                     ApiBaseUrl,
@@ -2513,7 +2535,9 @@ public sealed partial class WorkspaceRepositories : IDisposable
         {
             try
             {
-                var result = await WorkspaceBranchHandler.CheckoutBranchForWorkspaceAsync(
+                await using var scope = ServiceScopeFactory.CreateAsyncScope();
+                var branchHandler = scope.ServiceProvider.GetRequiredService<WorkspaceBranchHandler>();
+                var result = await branchHandler.CheckoutBranchForWorkspaceAsync(
                     WorkspaceId,
                     repoIds,
                     branchName,
@@ -2579,7 +2603,9 @@ public sealed partial class WorkspaceRepositories : IDisposable
         {
             try
             {
-                await WorkspaceBranchHandler.CreateBranchesAsync(
+                await using var scope = ServiceScopeFactory.CreateAsyncScope();
+                var branchHandler = scope.ServiceProvider.GetRequiredService<WorkspaceBranchHandler>();
+                await branchHandler.CreateBranchesAsync(
                     WorkspaceId,
                     newBranchName,
                     baseBranch,
@@ -2632,7 +2658,9 @@ public sealed partial class WorkspaceRepositories : IDisposable
         {
             try
             {
-                var (success, err) = await WorkspaceBranchHandler.CreateSingleBranchAsync(
+                await using var scope = ServiceScopeFactory.CreateAsyncScope();
+                var branchHandler = scope.ServiceProvider.GetRequiredService<WorkspaceBranchHandler>();
+                var (success, err) = await branchHandler.CreateSingleBranchAsync(
                     WorkspaceId,
                     repositoryId,
                     newBranchName,
@@ -2730,7 +2758,9 @@ public sealed partial class WorkspaceRepositories : IDisposable
         {
             try
             {
-                var (success, errMsg) = await WorkspaceBranchHandler.SyncToDefaultSingleAsync(
+                await using var scope = ServiceScopeFactory.CreateAsyncScope();
+                var branchHandler = scope.ServiceProvider.GetRequiredService<WorkspaceBranchHandler>();
+                var (success, errMsg) = await branchHandler.SyncToDefaultSingleAsync(
                     WorkspaceId,
                     repositoryId,
                     currentBranchName,
@@ -2807,7 +2837,9 @@ public sealed partial class WorkspaceRepositories : IDisposable
                     try
                     {
                         var repoHasRemote = !resultByRepo.TryGetValue(repositoryId, out var repoCheck) || repoCheck.HasUpstream == true;
-                        var (success, errMsg) = await WorkspaceBranchHandler.SyncToDefaultSingleAsync(
+                        await using var taskScope = ServiceScopeFactory.CreateAsyncScope();
+                        var taskBranchHandler = taskScope.ServiceProvider.GetRequiredService<WorkspaceBranchHandler>();
+                        var (success, errMsg) = await taskBranchHandler.SyncToDefaultSingleAsync(
                             WorkspaceId,
                             repositoryId,
                             currentBranchName,
@@ -2874,7 +2906,9 @@ public sealed partial class WorkspaceRepositories : IDisposable
         {
             try
             {
-                var (success, errMsg) = await WorkspaceBranchHandler.CheckoutBranchAsync(
+                await using var scope = ServiceScopeFactory.CreateAsyncScope();
+                var branchHandler = scope.ServiceProvider.GetRequiredService<WorkspaceBranchHandler>();
+                var (success, errMsg) = await branchHandler.CheckoutBranchAsync(
                     WorkspaceId,
                     repositoryId,
                     branchName,

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
@@ -868,17 +868,24 @@ public sealed partial class WorkspaceRepositories : IDisposable
             {
                 try
                 {
-                    await using var scope = ServiceScopeFactory.CreateAsyncScope();
-                    var branchHandler = scope.ServiceProvider.GetRequiredService<WorkspaceBranchHandler>();
-                    await branchHandler.FetchBranchesForWorkspaceAsync(
-                        WorkspaceId,
-                        safeRepoIds,
-                        ApiBaseUrl,
-                        (done, total) =>
+                    var fetchDone = 0;
+                    using var fetchSemaphore = new System.Threading.SemaphoreSlim(8);
+                    await Task.WhenAll(safeRepoIds.Select(async repoId =>
+                    {
+                        await fetchSemaphore.WaitAsync(ct);
+                        try
                         {
-                            job.ReportProgress(done <= 0 ? "Fetching latest branch state..." : $"Fetched {done} of {total}...");
-                        },
-                        ct);
+                            await using var scope = ServiceScopeFactory.CreateAsyncScope();
+                            var gitService = scope.ServiceProvider.GetRequiredService<WorkspaceGitService>();
+                            await gitService.RefreshBranchesForRepositoryAsync(repoId, WorkspaceId, ct);
+                        }
+                        finally
+                        {
+                            fetchSemaphore.Release();
+                            var c = Interlocked.Increment(ref fetchDone);
+                            job.ReportProgress($"Fetched {c} of {safeRepoIds.Count}...");
+                        }
+                    }));
 
                     await InvokeAsync(async () =>
                     {
@@ -2476,19 +2483,28 @@ public sealed partial class WorkspaceRepositories : IDisposable
         {
             try
             {
-                await using var scope = ServiceScopeFactory.CreateAsyncScope();
-                var branchHandler = scope.ServiceProvider.GetRequiredService<WorkspaceBranchHandler>();
-                var result = await branchHandler.FetchBranchesForWorkspaceAsync(
-                    WorkspaceId,
-                    repoIds,
-                    ApiBaseUrl,
-                    (completed, total) =>
+                var fetchAllDone = 0;
+                var successCount = 0;
+                var failureCount = 0;
+                using var fetchAllSemaphore = new System.Threading.SemaphoreSlim(8);
+                await Task.WhenAll(repoIds.Select(async repoId =>
+                {
+                    await fetchAllSemaphore.WaitAsync(ct);
+                    try
                     {
-                        job.ReportProgress(completed <= 0
-                            ? "Fetching branches..."
-                            : $"Fetched branches in {completed} of {total} repositories...");
-                    },
-                    ct);
+                        await using var scope = ServiceScopeFactory.CreateAsyncScope();
+                        var gitService = scope.ServiceProvider.GetRequiredService<WorkspaceGitService>();
+                        var ok = await gitService.RefreshBranchesForRepositoryAsync(repoId, WorkspaceId, ct);
+                        if (ok) Interlocked.Increment(ref successCount);
+                        else Interlocked.Increment(ref failureCount);
+                    }
+                    finally
+                    {
+                        fetchAllSemaphore.Release();
+                        var c = Interlocked.Increment(ref fetchAllDone);
+                        job.ReportProgress($"Fetched branches in {c} of {repoIds.Count} repositories...");
+                    }
+                }));
 
                 await InvokeAsync(async () =>
                 {
@@ -2498,8 +2514,8 @@ public sealed partial class WorkspaceRepositories : IDisposable
                     StateHasChanged();
                 });
 
-                if (result.FailureCount > 0)
-                    SafeInvoke(() => ToastService.Show($"Fetched branches for {result.SuccessCount} repositories. {result.FailureCount} failed."));
+                if (failureCount > 0)
+                    SafeInvoke(() => ToastService.Show($"Fetched branches for {successCount} repositories. {failureCount} failed."));
             }
             catch (OperationCanceledException)
             {

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
@@ -1176,7 +1176,9 @@ public sealed partial class WorkspaceRepositories : IDisposable
     {
         try
         {
-            await WorkspacePushHandler.RunPushWithDependenciesAsync(
+            await using var scope = ServiceScopeFactory.CreateAsyncScope();
+            var pushHandler = scope.ServiceProvider.GetRequiredService<WorkspacePushHandler>();
+            await pushHandler.RunPushWithDependenciesAsync(
                 WorkspaceId,
                 repoIds,
                 synchronizedPush,
@@ -1554,24 +1556,26 @@ public sealed partial class WorkspaceRepositories : IDisposable
 
         JobService.StartJob(PageJobKey, "Updating dependencies...", async (job, ct) =>
         {
-            // Phase 1: update
+            // Phase 1: update - fresh scope so DbContext does not compete with circuit page loads
             try
             {
-                await WorkspaceUpdateHandler.RunUpdateAsync(
-                    WorkspaceId,
-                    ct,
-                    job.ReportProgress,
-                    (repoId, msg) => SafeInvoke(() => { repositoryErrors[repoId] = msg; }),
-                    onAppSideComplete: () => { },
-                    repoIdsToUpdate: null,
-                    commitMessage: commitMessage,
-                    includeDepsInCommitMessage: includeDepsInCommitMessage);
-
-                await InvokeAsync(async () =>
+                await using (var updateScope = ServiceScopeFactory.CreateAsyncScope())
                 {
-                    if (_disposed) return;
-                    await RefreshFromSync();
-                });
+                    var updateHandler = updateScope.ServiceProvider.GetRequiredService<WorkspaceUpdateHandler>();
+                    await updateHandler.RunUpdateAsync(
+                        WorkspaceId,
+                        ct,
+                        job.ReportProgress,
+                        (repoId, msg) => SafeInvoke(() => { repositoryErrors[repoId] = msg; }),
+                        onAppSideComplete: () => { },
+                        repoIdsToUpdate: null,
+                        commitMessage: commitMessage,
+                        includeDepsInCommitMessage: includeDepsInCommitMessage);
+                }
+
+                // Unconditional reload so workspaceRepositories is current for Phase 2
+                await ReloadWorkspaceDataFromFreshScopeAsync();
+                _ = InvokeAsync(() => { if (!_disposed) { ApplySyncStateFromWorkspace(); StateHasChanged(); } });
             }
             catch (OperationCanceledException)
             {
@@ -1585,13 +1589,16 @@ public sealed partial class WorkspaceRepositories : IDisposable
                 throw;
             }
 
-            // Phase 2: determine push plan using fresh workspaceRepositories loaded by RefreshFromSync
+            // Phase 2: determine push plan using fresh workspaceRepositories loaded above
             job.ReportProgress("Preparing push...");
             IReadOnlySet<int> pushRepoIds;
             IReadOnlySet<string> requiredPackageIds;
             try
             {
-                var (payload, hasUnpushed) = await WorkspacePushHandler.GetPushPlanAsync(
+                await using var planScope = ServiceScopeFactory.CreateAsyncScope();
+                var planPushHandler = planScope.ServiceProvider.GetRequiredService<WorkspacePushHandler>();
+                var planDepService = planScope.ServiceProvider.GetRequiredService<WorkspaceDependencyService>();
+                var (payload, hasUnpushed) = await planPushHandler.GetPushPlanAsync(
                     WorkspaceId, workspaceRepositories, ct);
                 if (!hasUnpushed)
                 {
@@ -1605,7 +1612,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
                     SafeInvoke(() => ToastService.Show("Update complete. Nothing to push."));
                     return;
                 }
-                var depInfo = await WorkspaceDependencyService.GetPushDependencyInfoForRepoSetAsync(
+                var depInfo = await planDepService.GetPushDependencyInfoForRepoSetAsync(
                     WorkspaceId, pushRepoIds, ct);
                 requiredPackageIds = depInfo?.PayloadForRepo?.RequiredPackages
                     .Select(r => r.PackageId?.Trim())
@@ -2312,26 +2319,29 @@ public sealed partial class WorkspaceRepositories : IDisposable
         {
             try
             {
-                await NewFeatureOrchestrator.RunAsync(
-                    WorkspaceId,
-                    request.NewBranchName,
-                    request.BaseBranch,
-                    tagFilteredRepoIds,
-                    request.UpdateDependencies,
-                    commitMessage: null,
-                    setProgress: msg => job.ReportProgress(msg),
-                    reportBranchProgress: (completed, total) =>
-                    {
-                        job.ReportProgress($"Created {completed} of {total} branches");
-                    },
-                    setRepositoryError: (repoId, msg) => SafeInvoke(() => { repositoryErrors[repoId] = msg; }),
-                    ct);
-
-                await InvokeAsync(async () =>
+                // Fresh scope so DbContext does not compete with circuit page loads
+                await using (var orchestratorScope = ServiceScopeFactory.CreateAsyncScope())
                 {
-                    if (_disposed) return;
-                    await RefreshFromSync();
-                });
+                    var orchestrator = orchestratorScope.ServiceProvider.GetRequiredService<NewFeatureOrchestrator>();
+                    await orchestrator.RunAsync(
+                        WorkspaceId,
+                        request.NewBranchName,
+                        request.BaseBranch,
+                        tagFilteredRepoIds,
+                        request.UpdateDependencies,
+                        commitMessage: null,
+                        setProgress: msg => job.ReportProgress(msg),
+                        reportBranchProgress: (completed, total) =>
+                        {
+                            job.ReportProgress($"Created {completed} of {total} branches");
+                        },
+                        setRepositoryError: (repoId, msg) => SafeInvoke(() => { repositoryErrors[repoId] = msg; }),
+                        ct);
+                }
+
+                // Unconditional reload so workspaceRepositories is current for Phase 3
+                await ReloadWorkspaceDataFromFreshScopeAsync();
+                _ = InvokeAsync(() => { if (!_disposed) { ApplySyncStateFromWorkspace(); StateHasChanged(); } });
             }
             catch (OperationCanceledException)
             {
@@ -2354,7 +2364,10 @@ public sealed partial class WorkspaceRepositories : IDisposable
             IReadOnlySet<string> requiredPackageIds;
             try
             {
-                var (payload, hasUnpushed) = await WorkspacePushHandler.GetPushPlanAsync(
+                await using var planScope = ServiceScopeFactory.CreateAsyncScope();
+                var planPushHandler = planScope.ServiceProvider.GetRequiredService<WorkspacePushHandler>();
+                var planDepService = planScope.ServiceProvider.GetRequiredService<WorkspaceDependencyService>();
+                var (payload, hasUnpushed) = await planPushHandler.GetPushPlanAsync(
                     WorkspaceId, workspaceRepositories, ct);
                 if (!hasUnpushed)
                 {
@@ -2368,7 +2381,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
                     SafeInvoke(() => ToastService.Show("No repositories to push."));
                     return;
                 }
-                var depInfo = await WorkspaceDependencyService.GetPushDependencyInfoForRepoSetAsync(
+                var depInfo = await planDepService.GetPushDependencyInfoForRepoSetAsync(
                     WorkspaceId, pushRepoIds, ct);
                 requiredPackageIds = depInfo?.PayloadForRepo?.RequiredPackages
                     .Select(r => r.PackageId?.Trim())

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
@@ -23,14 +23,6 @@ public sealed partial class WorkspaceRepositories : IDisposable
     private IReadOnlyDictionary<int, RepoGitVersionInfo> repoGitInfos = new Dictionary<int, RepoGitVersionInfo>();
     private string? errorMessage;
     private bool isLoading = true;
-    private bool isSyncing = false;
-    private string syncProgressMessage = "Synchronizing...";
-    private bool isUpdating = false;
-    private string updateProgressMessage = "Updating dependencies...";
-    private CancellationTokenSource? _updateCts;
-    private bool isPushing = false;
-    private string pushProgressMessage = "Pushing...";
-    private CancellationTokenSource? _pushCts;
     private IReadOnlySet<int>? pushPlanRepoIds = null;
     private bool? isOutOfSync = null;
     private bool hasUnmatchedDependencies => workspaceRepositories.Any(wr => !wr.IsOnTag && (wr.UnmatchedDeps ?? 0) > 0);
@@ -63,17 +55,10 @@ public sealed partial class WorkspaceRepositories : IDisposable
         ? "Fetching repositories..."
         : $"Fetched {_repositoriesModal.FetchedRepositoryCount} {(_repositoriesModal.FetchedRepositoryCount == 1 ? "repository" : "repositories")}";
     private Dictionary<int, RepoSyncStatus> repoSyncStatus = new();
-    private CancellationTokenSource? _syncCts;
     private IReadOnlyDictionary<int, IReadOnlyList<(string PackageId, string CurrentVersion, string NewVersion)>> _mismatchedDependencyLinesByRepo = new Dictionary<int, IReadOnlyList<(string, string, string)>>();
 
     /// <summary>All workspace-internal package dependencies of each repository (PackageId + version as written in the .csproj). Used to populate the dependency-badge tooltip for repositories whose dependencies are up to date.</summary>
     private IReadOnlyDictionary<int, IReadOnlyList<(string PackageId, string Version)>> _allDependencyLinesByRepo = new Dictionary<int, IReadOnlyList<(string, string)>>();
-    private bool isCommitSyncing = false;
-    private string commitSyncProgressMessage = "Synchronizing commits...";
-    private CancellationTokenSource? _commitSyncCts;
-    private bool isCheckingOut = false;
-    private string checkoutProgressMessage = "Checking out branch...";
-    private CancellationTokenSource? _checkoutCts;
     private Dictionary<int, string> repositoryErrors = new(); // repositoryId -> error message
     private HashSet<string> clickedVersions = new(); // Track clicked versions to hide hover until mouse leaves
     private HashSet<int> clickedDependencyBadges = new(); // Track clicked dependency badges to hide tooltip immediately
@@ -82,23 +67,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
     private RepositoriesModalState _repositoriesModal = new();
     private SwitchBranchModalState _switchBranchModal = new();
     private BranchModalState _branchModal = new();
-    private bool isCreatingBranches = false;
-    private string createBranchesProgressMessage = "Creating branches...";
-    private CancellationTokenSource? _createBranchesCts;
-    private bool isCreatingBranch = false;
-    private string createBranchMessage = "";
-    private bool isSyncingToDefault = false;
-    private string syncToDefaultMessage = "";
     private IReadOnlyList<(int RepoId, int? DefaultAhead, bool? HasUpstream)>? _syncToDefaultCheckResults = null;
-    private bool isWorkspaceBranchesFetching = false;
-    private string workspaceBranchesFetchProgressMessage = "Fetching branches across workspace...";
-    private CancellationTokenSource? _workspaceBranchesFetchCts;
-    private bool isWorkspaceBranchesCheckingOut = false;
-    private string workspaceBranchesCheckoutProgressMessage = "Checking out branch across workspace...";
-    private CancellationTokenSource? _workspaceBranchesCheckoutCts;
-    private bool isRestoringPackages = false;
-    private string? restorePackagesProgressMessage;
-    private CancellationTokenSource? _restorePackagesCts;
     private UpdateModalState _updateModal = new();
     private UpdateModalState _updateAndPushModal = new();
     private UpdateSingleRepoDependenciesModalState _updateSingleRepoModal = new();
@@ -108,51 +77,11 @@ public sealed partial class WorkspaceRepositories : IDisposable
     private SyncToDefaultOptionsModalState _syncToDefaultOptionsModal = new();
     private string searchTerm = string.Empty;
 
-    private bool _syncAwaitingAgentTasks;
-    private bool _pushAwaitingAgentTasks;
-    private bool _updateAwaitingAgentTasks;
-    private bool _commitSyncAwaitingAgentTasks;
-    private bool _syncToDefaultAwaitingAgentTasks;
-    private bool _creatingBranchesAwaitingAgentTasks;
+    private bool _disposed;
+    private string PageJobKey => new Uri(NavigationManager.Uri).AbsolutePath.ToLowerInvariant();
+    private bool IsJobRunning => JobService.IsRunning(PageJobKey);
 
     private int AgentTasksPendingCount => AgentQueueStateService.GetPendingCountForWorkspace(WorkspaceId);
-
-    private bool IsAnyOverlayVisible =>
-        isLoading || isCreatingPullRequests || isSyncing || isPushing || isUpdating ||
-        isCommitSyncing || isCheckingOut || ShowRepositoriesFetchOverlay ||
-        isCreatingBranches || isCreatingBranch || isSyncingToDefault ||
-        isWorkspaceBranchesFetching || isWorkspaceBranchesCheckingOut || isRestoringPackages;
-
-    private string? ActiveOverlayMessage =>
-        isLoading ? "Loading workspace..." :
-        isCreatingPullRequests ? createPrProgressMessage :
-        isSyncing ? GetOverlayMessage(syncProgressMessage, isSyncing, _syncAwaitingAgentTasks) :
-        isPushing ? GetOverlayMessage(pushProgressMessage, isPushing, _pushAwaitingAgentTasks) :
-        isUpdating ? GetOverlayMessage(updateProgressMessage, isUpdating, _updateAwaitingAgentTasks) :
-        isCommitSyncing ? GetOverlayMessage(commitSyncProgressMessage, isCommitSyncing, _commitSyncAwaitingAgentTasks) :
-        isCheckingOut ? checkoutProgressMessage :
-        ShowRepositoriesFetchOverlay ? RepositoriesFetchOverlayMessage :
-        isCreatingBranches ? GetOverlayMessage(createBranchesProgressMessage, isCreatingBranches, _creatingBranchesAwaitingAgentTasks) :
-        isCreatingBranch ? createBranchMessage :
-        isSyncingToDefault ? GetOverlayMessage(syncToDefaultMessage, isSyncingToDefault, _syncToDefaultAwaitingAgentTasks) :
-        isWorkspaceBranchesFetching ? workspaceBranchesFetchProgressMessage :
-        isWorkspaceBranchesCheckingOut ? workspaceBranchesCheckoutProgressMessage :
-        isRestoringPackages ? restorePackagesProgressMessage :
-        null;
-
-    // Returns default(EventCallback) (HasDelegate == false) for operations with no abort:
-    // isLoading, isCreatingPullRequests, isCreatingBranches, isCreatingBranch, isSyncingToDefault.
-    private EventCallback ActiveOverlayAbort =>
-        isSyncing ? EventCallback.Factory.Create(this, (Action)AbortSyncAsync) :
-        isPushing ? EventCallback.Factory.Create(this, (Action)AbortPushAsync) :
-        isUpdating ? EventCallback.Factory.Create(this, (Action)AbortUpdateAsync) :
-        isCommitSyncing ? EventCallback.Factory.Create(this, (Action)AbortCommitSyncAsync) :
-        isCheckingOut ? EventCallback.Factory.Create(this, (Action)AbortCheckoutAsync) :
-        ShowRepositoriesFetchOverlay ? EventCallback.Factory.Create(this, (Action)AbortFetchRepositories) :
-        isWorkspaceBranchesFetching ? EventCallback.Factory.Create(this, (Action)AbortWorkspaceBranchesFetchAsync) :
-        isWorkspaceBranchesCheckingOut ? EventCallback.Factory.Create(this, (Action)AbortWorkspaceBranchesCheckoutAsync) :
-        isRestoringPackages ? EventCallback.Factory.Create(this, (Action)AbortRestorePackages) :
-        default;
 
     private const int RefreshDebounceMs = 200;
     private CancellationTokenSource? _refreshDebounceCts;
@@ -167,6 +96,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
     protected override async Task OnInitializedAsync()
     {
         AgentQueueStateService.OnQueueStateChanged(OnQueueStateChanged);
+        JobService.Changed += OnJobServiceChanged;
         await LoadWorkspaceAsync();
         ApplySyncStateFromWorkspace();
     }
@@ -188,6 +118,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
             _hubConnection.On<int>("WorkspaceSynced", async (workspaceId) =>
             {
                 if (workspaceId != WorkspaceId) return;
+                if (IsJobRunning) return;
                 _refreshDebounceCts?.Cancel();
                 _refreshDebounceCts?.Dispose();
                 _refreshDebounceCts = new CancellationTokenSource();
@@ -235,37 +166,29 @@ public sealed partial class WorkspaceRepositories : IDisposable
 
     public void Dispose()
     {
+        _disposed = true;
         AgentQueueStateService.RemoveQueueStateChanged(OnQueueStateChanged);
+        JobService.Changed -= OnJobServiceChanged;
         _refreshDebounceCts?.Cancel();
         _refreshDebounceCts?.Dispose();
         _refreshDebounceCts = null;
         _ = _hubConnection?.StopAsync();
         _hubConnection?.DisposeAsync();
-        _syncCts?.Cancel();
-        _syncCts?.Dispose();
-        _updateCts?.Cancel();
-        _updateCts?.Dispose();
-        _pushCts?.Cancel();
-        _pushCts?.Dispose();
-        _commitSyncCts?.Cancel();
-        _commitSyncCts?.Dispose();
         _fetchRepositoriesCts?.Cancel();
         _fetchRepositoriesCts?.Dispose();
-        _createBranchesCts?.Cancel();
-        _createBranchesCts?.Dispose();
-        _workspaceBranchesFetchCts?.Cancel();
-        _workspaceBranchesFetchCts?.Dispose();
-        _workspaceBranchesCheckoutCts?.Cancel();
-        _workspaceBranchesCheckoutCts?.Dispose();
-        _restorePackagesCts?.Cancel();
-        _restorePackagesCts?.Dispose();
     }
 
-    /// <summary>Called when WorkspaceSynced is received (or after Update): reload from a fresh scope so the grid gets current DB values (no stale DbContext).</summary>
+    private void OnJobServiceChanged() => SafeInvoke(() => { });
+
+    private void SafeInvoke(Action callback)
+    {
+        if (_disposed) return;
+        _ = InvokeAsync(() => { if (!_disposed) { callback(); StateHasChanged(); } });
+    }
+
+    /// <summary>Called when WorkspaceSynced is received (or after an operation): reload from a fresh scope so the grid gets current DB values (no stale DbContext).</summary>
     private async Task RefreshFromSync()
     {
-        if (isSyncing || isUpdating)
-            return;
         await ReloadWorkspaceDataFromFreshScopeAsync();
         ApplySyncStateFromWorkspace();
         await InvokeAsync(StateHasChanged);
@@ -409,9 +332,10 @@ public sealed partial class WorkspaceRepositories : IDisposable
         }
     }
 
-    /// <summary>Reload workspace after abort/cancel using a fresh scope. Swallows ObjectDisposedException and InvalidOperationException so abort does not cascade errors when the circuit or context is already disposed.</summary>
+    /// <summary>Reload workspace after abort/cancel using a fresh scope. Safe to call from background job bodies. Swallows disposal exceptions so abort does not cascade errors when the circuit or context is already disposed.</summary>
     private async Task ReloadWorkspaceDataAfterCancelAsync()
     {
+        if (_disposed) return;
         try
         {
             await ReloadWorkspaceDataFromFreshScopeAsync();
@@ -424,8 +348,12 @@ public sealed partial class WorkspaceRepositories : IDisposable
         {
             Logger.LogDebug(ex, "Reload after cancel skipped (invalid operation, e.g. circuit disposed) for workspace {WorkspaceId}", WorkspaceId);
         }
-        ApplySyncStateFromWorkspace();
-        await InvokeAsync(StateHasChanged);
+        try
+        {
+            await InvokeAsync(() => { if (!_disposed) { ApplySyncStateFromWorkspace(); StateHasChanged(); } });
+        }
+        catch (ObjectDisposedException) { }
+        catch (InvalidOperationException) { }
     }
 
     /// <summary>Loads workspace using a new scope (fresh DbContext) so we get current DB values and avoid EF cache. Used by RefreshFromSync so the grid shows updated UnmatchedDeps after notify or Update.</summary>
@@ -499,76 +427,6 @@ public sealed partial class WorkspaceRepositories : IDisposable
     {
         searchTerm = e.Value?.ToString() ?? string.Empty;
         StateHasChanged();
-    }
-
-    private void AbortSyncAsync()
-    {
-        _syncCts?.Cancel();
-    }
-
-    private void AbortUpdateAsync()
-    {
-        _updateCts?.Cancel();
-    }
-
-    private void SetSyncProgress(string message)
-    {
-        syncProgressMessage = message;
-        _ = InvokeAsync(StateHasChanged);
-    }
-
-    private void SetUpdateProgress(string message)
-    {
-        updateProgressMessage = message;
-        _ = InvokeAsync(StateHasChanged);
-    }
-
-    private void SetPushProgress(string message)
-    {
-        _ = InvokeAsync(() =>
-        {
-            pushProgressMessage = message;
-            StateHasChanged();
-        });
-    }
-
-    private void SetCommitSyncProgress(string message)
-    {
-        commitSyncProgressMessage = message;
-        _ = InvokeAsync(StateHasChanged);
-    }
-
-    private void SetCheckoutProgress(string message)
-    {
-        checkoutProgressMessage = message;
-        _ = InvokeAsync(StateHasChanged);
-    }
-
-    private void SetCreateBranchesProgress(string message)
-    {
-        createBranchesProgressMessage = message;
-        _ = InvokeAsync(StateHasChanged);
-    }
-
-    /// <summary>Returns \"Waiting for x agent jobs\" when overlay is visible, workflow set the awaiting flag, and agent jobs are pending; otherwise returns progressMessage.</summary>
-    private string GetOverlayMessage(string progressMessage, bool overlayVisible, bool awaitingAgentTasks)
-    {
-        if (!overlayVisible) return progressMessage;
-        if (!awaitingAgentTasks) return progressMessage;
-        if (AgentTasksPendingCount == 0) return progressMessage;
-        return AgentTasksPendingCount == 1
-            ? "Waiting for the agent to complete 1 task..."
-            : $"Waiting for the agent to complete {AgentTasksPendingCount} tasks...";
-    }
-
-    private void AbortPushAsync()
-    {
-        _pushCts?.Cancel();
-    }
-
-    private void AbortCommitSyncAsync()
-    {
-        _commitSyncCts?.Cancel();
     }
 
     private void CloseUpdateModal()
@@ -678,11 +536,8 @@ public sealed partial class WorkspaceRepositories : IDisposable
     // --- New Pull Request dialog -----------------------------------------------------------
 
     private NewPullRequestModalState _newPrModal = new();
-    private bool isCreatingPullRequests;
     private NewFeatureModalState _newFeatureModal = new();
     private OperationErrorModalState _operationErrorModal = new();
-    private string createPrProgressMessage = "Creating Pull Requests...";
-    private CancellationTokenSource? _createPrCts;
 
     private Task OpenPullRequestDialogForAllRepositoriesAsync()
         => OpenPullRequestDialogCoreAsync(workspaceRepositories);
@@ -738,7 +593,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
     private void CloseNewPullRequestModal()
     {
         _newPrModal = _newPrModal with { IsVisible = false };
-        _createPrCts?.Cancel();
+        JobService.GetJob(PageJobKey)?.Abort();
         StateHasChanged();
     }
 
@@ -808,104 +663,98 @@ public sealed partial class WorkspaceRepositories : IDisposable
         return Task.CompletedTask;
     }
 
-    private async Task ExecuteCreatePullRequestsAsync(IReadOnlyList<CreatePullRequestRequest> requests)
+    private Task ExecuteCreatePullRequestsAsync(IReadOnlyList<CreatePullRequestRequest> requests)
     {
-        if (requests.Count == 0) return;
-
-        _createPrCts?.Cancel();
-        _createPrCts = new CancellationTokenSource();
-        var ct = _createPrCts.Token;
+        if (requests.Count == 0 || IsJobRunning)
+            return Task.CompletedTask;
 
         var total = requests.Count;
         _newPrModal = _newPrModal with { IsVisible = false };
-        isCreatingPullRequests = true;
-        createPrProgressMessage = total == 1
-            ? "Creating 1 pull request..."
-            : $"Creating {total} pull requests...";
-        StateHasChanged();
 
-        var progress = new Progress<CreatePullRequestProgress>(p =>
+        JobService.StartJob(PageJobKey, total == 1 ? "Creating 1 pull request..." : $"Creating {total} pull requests...", async (job, ct) =>
         {
-            createPrProgressMessage = p.Created == 0
-                ? (p.Total == 1
-                    ? "Creating 1 pull request..."
-                    : $"Creating {p.Total} pull requests...")
-                : $"Created {p.Created} of {p.Total} pull requests";
-            _ = InvokeAsync(StateHasChanged);
+            var progress = new Progress<CreatePullRequestProgress>(p =>
+            {
+                job.ReportProgress(p.Created == 0
+                    ? (p.Total == 1 ? "Creating 1 pull request..." : $"Creating {p.Total} pull requests...")
+                    : $"Created {p.Created} of {p.Total} pull requests");
+            });
+
+            IReadOnlyList<CreatePullRequestResult> results;
+            try
+            {
+                results = await PullRequestService.CreatePullRequestsAsync(requests, progress, ct);
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "Create pull requests failed");
+                SafeInvoke(() => ToastService.ShowError($"Failed to create pull requests: {ex.Message}"));
+                throw;
+            }
+
+            var successCount = results.Count(r => r.Success);
+            var failedCount = results.Count - successCount;
+
+            SafeInvoke(() =>
+            {
+                if (successCount > 0 && failedCount == 0)
+                {
+                    ToastService.Show($"Created {successCount} of {total} pull requests.");
+                }
+                else if (successCount > 0)
+                {
+                    ToastService.Show($"Created {successCount} of {total} pull requests.");
+                    var firstFailure = results.First(r => !r.Success);
+                    ToastService.ShowError($"{firstFailure.RepositoryName}: {firstFailure.ErrorMessage}");
+                }
+                else
+                {
+                    var firstFailure = results.FirstOrDefault(r => !r.Success);
+                    var msg = firstFailure?.ErrorMessage ?? "Pull request creation failed.";
+                    ToastService.ShowError($"No pull requests were created. {msg}");
+                }
+            });
+
+            var firstSuccess = results.FirstOrDefault(r => r.Success);
+            if (successCount == 1 && firstSuccess?.PullRequestUrl is { Length: > 0 } url)
+            {
+                try
+                {
+                    await InvokeAsync(async () =>
+                    {
+                        if (_disposed) return;
+                        await JSRuntime.InvokeVoidAsync("graymoonOpenUrls", new[] { url });
+                    });
+                }
+                catch (Exception ex)
+                {
+                    Logger.LogDebug(ex, "Failed to open created PR URL");
+                }
+            }
+
+            var refreshedIds = results.Where(r => r.Success).Select(r => r.RepositoryId).ToList();
+            if (refreshedIds.Count > 0)
+            {
+                try
+                {
+                    await using var scope = ServiceScopeFactory.CreateAsyncScope();
+                    var workspacePrService = scope.ServiceProvider.GetRequiredService<WorkspacePullRequestService>();
+                    await workspacePrService.RefreshPullRequestsAsync(WorkspaceId, refreshedIds, cancellationToken: ct);
+                    var freshPrs = await workspacePrService.GetPersistedPullRequestsForWorkspaceAsync(WorkspaceId, ct);
+                    SafeInvoke(() => { prByRepositoryId = freshPrs; });
+                }
+                catch (Exception ex)
+                {
+                    Logger.LogDebug(ex, "Failed to refresh pull requests after creation");
+                }
+            }
         });
 
-        IReadOnlyList<CreatePullRequestResult> results;
-        try
-        {
-            results = await PullRequestService.CreatePullRequestsAsync(requests, progress, ct);
-        }
-        catch (OperationCanceledException)
-        {
-            isCreatingPullRequests = false;
-            StateHasChanged();
-            return;
-        }
-        catch (Exception ex)
-        {
-            Logger.LogError(ex, "Create pull requests failed");
-            ToastService.ShowError($"Failed to create pull requests: {ex.Message}");
-            isCreatingPullRequests = false;
-            StateHasChanged();
-            return;
-        }
-
-        isCreatingPullRequests = false;
-
-        var successCount = results.Count(r => r.Success);
-        var failedCount = results.Count - successCount;
-
-        if (successCount > 0 && failedCount == 0)
-        {
-            ToastService.Show($"Created {successCount} of {total} pull requests.");
-        }
-        else if (successCount > 0)
-        {
-            ToastService.Show($"Created {successCount} of {total} pull requests.");
-            var firstFailure = results.First(r => !r.Success);
-            ToastService.ShowError($"{firstFailure.RepositoryName}: {firstFailure.ErrorMessage}");
-        }
-        else
-        {
-            var firstFailure = results.FirstOrDefault(r => !r.Success);
-            var msg = firstFailure?.ErrorMessage ?? "Pull request creation failed.";
-            ToastService.ShowError($"No pull requests were created. {msg}");
-        }
-
-        var firstSuccess = results.FirstOrDefault(r => r.Success);
-        if (successCount == 1 && firstSuccess?.PullRequestUrl is { Length: > 0 } url)
-        {
-            try
-            {
-                await JSRuntime.InvokeVoidAsync("graymoonOpenUrls", new[] { url });
-            }
-            catch (Exception ex)
-            {
-                Logger.LogDebug(ex, "Failed to open created PR URL");
-            }
-        }
-
-        var refreshedIds = results.Where(r => r.Success).Select(r => r.RepositoryId).ToList();
-        if (refreshedIds.Count > 0)
-        {
-            try
-            {
-                await using var scope = ServiceScopeFactory.CreateAsyncScope();
-                var workspacePrService = scope.ServiceProvider.GetRequiredService<WorkspacePullRequestService>();
-                await workspacePrService.RefreshPullRequestsAsync(WorkspaceId, refreshedIds, cancellationToken: CancellationToken.None);
-                prByRepositoryId = await workspacePrService.GetPersistedPullRequestsForWorkspaceAsync(WorkspaceId, CancellationToken.None);
-            }
-            catch (Exception ex)
-            {
-                Logger.LogDebug(ex, "Failed to refresh pull requests after creation");
-            }
-        }
-
-        StateHasChanged();
+        return Task.CompletedTask;
     }
 
     private sealed record NewPullRequestModalState
@@ -971,106 +820,103 @@ public sealed partial class WorkspaceRepositories : IDisposable
         await CheckBranchesAndConfirmSyncToDefaultLevel(nonDefaultRepoIds);
     }
 
-    private async Task CheckBranchesAndConfirmSyncToDefaultLevel(List<int> repositoryIds)
+    private Task CheckBranchesAndConfirmSyncToDefaultLevel(List<int> repositoryIds)
     {
-        if (workspace == null || repositoryIds == null || repositoryIds.Count == 0 || isSyncingToDefault || isWorkspaceBranchesFetching)
-            return;
+        if (workspace == null || repositoryIds == null || repositoryIds.Count == 0 || IsJobRunning)
+            return Task.CompletedTask;
 
         _syncToDefaultCheckResults = null;
 
-        try
+        // Synchronous pre-check using persisted state (no agent call needed)
+        var checkResults = repositoryIds
+            .Select(repoId =>
+            {
+                var wr = workspaceRepositories.FirstOrDefault(w => w.RepositoryId == repoId);
+                return (RepoId: repoId, DefaultAhead: wr?.DefaultBranchAheadCommits, HasUpstream: wr?.BranchHasUpstream);
+            })
+            .ToList();
+        var safeRepoIds = checkResults
+            .Where(r => (r.DefaultAhead ?? 0) == 0 || IsPrMergedForRepo(r.RepoId))
+            .Select(r => r.RepoId)
+            .ToList();
+        var blocked = checkResults
+            .Where(r => (r.DefaultAhead ?? 0) > 0 && !IsPrMergedForRepo(r.RepoId))
+            .ToList();
+
+        foreach (var r in blocked)
         {
-            // Use persisted workspace link state (updated by hooks); no agent GetCommitCounts call.
-            var checkResults = repositoryIds
-                .Select(repoId =>
+            var name = workspaceRepositories.FirstOrDefault(w => w.RepositoryId == r.RepoId)?.Repository?.RepositoryName ?? r.RepoId.ToString();
+            ToastService.Show($"{name}: skipped sync to default (commits ahead of default, PR not merged).");
+        }
+
+        if (safeRepoIds.Count == 0)
+        {
+            if (blocked.Count == 0)
+                ToastService.Show("No repositories to sync.");
+            return Task.CompletedTask;
+        }
+
+        _syncToDefaultCheckResults = checkResults.Where(r => safeRepoIds.Contains(r.RepoId)).ToList();
+        var safeCount = safeRepoIds.Count;
+        var dialogMessage = safeCount == 1
+            ? "This will checkout the default branch, remove the current branch locally, and pull the latest. Uncommitted local changes can block checkout."
+            : $"This will sync {safeCount} repositories to their default branch: checkout default, remove the current branch locally, and pull. Uncommitted local changes can block checkout for that repo.";
+
+        JobService.StartJob(PageJobKey,
+            safeCount == 1 ? "Fetching latest branch state..." : $"Fetching latest branch state for {safeCount} repositories...",
+            async (job, ct) =>
+            {
+                try
                 {
-                    var wr = workspaceRepositories.FirstOrDefault(w => w.RepositoryId == repoId);
-                    return (RepoId: repoId, DefaultAhead: wr?.DefaultBranchAheadCommits, HasUpstream: wr?.BranchHasUpstream);
-                })
-                .ToList();
-            var safeRepoIds = checkResults
-                .Where(r => (r.DefaultAhead ?? 0) == 0 || IsPrMergedForRepo(r.RepoId))
-                .Select(r => r.RepoId)
-                .ToList();
-            var blocked = checkResults
-                .Where(r => (r.DefaultAhead ?? 0) > 0 && !IsPrMergedForRepo(r.RepoId))
-                .ToList();
+                    await WorkspaceBranchHandler.FetchBranchesForWorkspaceAsync(
+                        WorkspaceId,
+                        safeRepoIds,
+                        ApiBaseUrl,
+                        (done, total) =>
+                        {
+                            job.ReportProgress(done <= 0 ? "Fetching latest branch state..." : $"Fetched {done} of {total}...");
+                        },
+                        ct);
 
-            foreach (var r in blocked)
-            {
-                var name = workspaceRepositories.FirstOrDefault(w => w.RepositoryId == r.RepoId)?.Repository?.RepositoryName ?? r.RepoId.ToString();
-                ToastService.Show($"{name}: skipped sync to default (commits ahead of default, PR not merged).");
-            }
-
-            if (safeRepoIds.Count == 0)
-            {
-                if (blocked.Count == 0)
-                    ToastService.Show("No repositories to sync.");
-                return;
-            }
-
-            _syncToDefaultCheckResults = checkResults.Where(r => safeRepoIds.Contains(r.RepoId)).ToList();
-            var safeCount = safeRepoIds.Count;
-            var message = safeCount == 1
-                ? "This will checkout the default branch, remove the current branch locally, and pull the latest. Uncommitted local changes can block checkout."
-                : $"This will sync {safeCount} repositories to their default branch: checkout default, remove the current branch locally, and pull. Uncommitted local changes can block checkout for that repo.";
-
-            // Fetch to get up-to-date remote branch state before showing the dialog
-            _workspaceBranchesFetchCts?.Cancel();
-            _workspaceBranchesFetchCts?.Dispose();
-            _workspaceBranchesFetchCts = new CancellationTokenSource();
-            isWorkspaceBranchesFetching = true;
-            workspaceBranchesFetchProgressMessage = safeCount == 1 ? "Fetching latest branch state..." : $"Fetching latest branch state for {safeCount} repositories...";
-            await InvokeAsync(StateHasChanged);
-
-            try
-            {
-                await WorkspaceBranchHandler.FetchBranchesForWorkspaceAsync(
-                    WorkspaceId,
-                    safeRepoIds,
-                    ApiBaseUrl,
-                    (done, total) =>
+                    await InvokeAsync(async () =>
                     {
-                        workspaceBranchesFetchProgressMessage = done <= 0 ? "Fetching latest branch state..." : $"Fetched {done} of {total}...";
-                        _ = InvokeAsync(StateHasChanged);
-                    },
-                    _workspaceBranchesFetchCts.Token);
-                await RefreshFromSync();
-            }
-            catch (OperationCanceledException)
-            {
-                ToastService.Show("Fetch cancelled.");
-                return;
-            }
-            finally
-            {
-                isWorkspaceBranchesFetching = false;
-                await InvokeAsync(StateHasChanged);
-            }
+                        if (_disposed) return;
+                        await RefreshFromSync();
 
-            // Rebuild check results with fresh HasUpstream from DB (remote branch may have been deleted)
-            _syncToDefaultCheckResults = _syncToDefaultCheckResults
-                .Select(r =>
-                {
-                    var wr2 = workspaceRepositories.FirstOrDefault(w => w.RepositoryId == r.RepoId);
-                    return (r.RepoId, r.DefaultAhead, HasUpstream: wr2?.BranchHasUpstream);
-                })
-                .ToList();
+                        // Rebuild check results with fresh HasUpstream from DB
+                        _syncToDefaultCheckResults = _syncToDefaultCheckResults?
+                            .Select(r =>
+                            {
+                                var wr2 = workspaceRepositories.FirstOrDefault(w => w.RepositoryId == r.RepoId);
+                                return (r.RepoId, r.DefaultAhead, HasUpstream: wr2?.BranchHasUpstream);
+                            })
+                            .ToList();
 
-            var repoItems = _syncToDefaultCheckResults
-                .Select(r =>
+                        var repoItems = _syncToDefaultCheckResults?
+                            .Select(r =>
+                            {
+                                var wr2 = workspaceRepositories.FirstOrDefault(w => w.RepositoryId == r.RepoId);
+                                return (RepoName: wr2?.Repository?.RepositoryName ?? r.RepoId.ToString(), BranchName: wr2?.BranchName ?? "", HasRemote: r.HasUpstream == true);
+                            })
+                            .ToList() ?? new();
+                        ShowSyncToDefaultOptions(dialogMessage, repoItems, (deleteRemote, allowForce) => SyncToDefaultLevelAsync(safeRepoIds, deleteRemote, allowForce));
+                        StateHasChanged();
+                    });
+                }
+                catch (OperationCanceledException)
                 {
-                    var wr2 = workspaceRepositories.FirstOrDefault(w => w.RepositoryId == r.RepoId);
-                    return (RepoName: wr2?.Repository?.RepositoryName ?? r.RepoId.ToString(), BranchName: wr2?.BranchName ?? "", HasRemote: r.HasUpstream == true);
-                })
-                .ToList();
-            ShowSyncToDefaultOptions(message, repoItems, (deleteRemote, allowForce) => SyncToDefaultLevelAsync(safeRepoIds, deleteRemote, allowForce));
-        }
-        catch (Exception ex)
-        {
-            Logger.LogError(ex, "Error checking branches for sync to default");
-            ToastService.Show("Failed to prepare sync to default.");
-        }
+                    SafeInvoke(() => ToastService.Show("Fetch cancelled."));
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    Logger.LogError(ex, "Error checking branches for sync to default");
+                    SafeInvoke(() => ToastService.Show("Failed to prepare sync to default."));
+                    throw;
+                }
+            });
+
+        return Task.CompletedTask;
     }
 
     /// <summary>
@@ -1090,7 +936,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
 
     private async Task ShowConfirmUpdateDependenciesAsync(int repositoryId, int unmatchedCount)
     {
-        if (workspace == null || isUpdating || isSyncing)
+        if (workspace == null || IsJobRunning)
             return;
         if (IsRepoOnTag(repositoryId))
         {
@@ -1148,50 +994,49 @@ public sealed partial class WorkspaceRepositories : IDisposable
         _updateSingleRepoModal = _updateSingleRepoModal with { IsVisible = false, Payload = null };
     }
 
-    private async Task OnUpdateSingleRepositoryDependenciesProceedAsync()
+    private Task OnUpdateSingleRepositoryDependenciesProceedAsync()
     {
         if (_updateSingleRepoModal.Payload == null)
-            return;
+            return Task.CompletedTask;
         var repositoryId = _updateSingleRepoModal.RepositoryId;
         CloseUpdateSingleRepositoryDependenciesModal();
 
-        _updateCts?.Cancel();
-        _updateCts?.Dispose();
-        _updateCts = new CancellationTokenSource();
-        isUpdating = true;
-        SetUpdateProgress("Updating repository...");
         repositoryErrors.Remove(repositoryId);
-        try
+
+        JobService.StartJob(PageJobKey, "Updating repository...", async (job, ct) =>
         {
-            await InvokeAsync(StateHasChanged);
-            await using (var scope = ServiceScopeFactory.CreateAsyncScope())
+            try
             {
+                await using var scope = ServiceScopeFactory.CreateAsyncScope();
                 var updateHandler = scope.ServiceProvider.GetRequiredService<WorkspaceUpdateHandler>();
                 await updateHandler.RunUpdateAsync(
                     WorkspaceId,
-                    _updateCts.Token,
-                    SetUpdateProgress,
-                    (repoId, msg) => { repositoryErrors[repoId] = msg; _ = InvokeAsync(StateHasChanged); },
-                    onAppSideComplete: () => _updateAwaitingAgentTasks = true,
+                    ct,
+                    job.ReportProgress,
+                    (repoId, msg) => SafeInvoke(() => { repositoryErrors[repoId] = msg; }),
+                    onAppSideComplete: () => { },
                     repoIdsToUpdate: new HashSet<int> { repositoryId });
+
+                await InvokeAsync(async () =>
+                {
+                    if (_disposed) return;
+                    await RefreshFromSync();
+                });
             }
-            await RefreshFromSync();
-        }
-        catch (OperationCanceledException)
-        {
-            ToastService.Show("Update cancelled.");
-        }
-        catch (Exception ex)
-        {
-            Logger.LogError(ex, "Update dependencies failed for repository {RepositoryId}", repositoryId);
-            ToastService.Show(ex.Message);
-        }
-        finally
-        {
-            _updateAwaitingAgentTasks = false;
-            isUpdating = false;
-            await InvokeAsync(StateHasChanged);
-        }
+            catch (OperationCanceledException)
+            {
+                await ReloadWorkspaceDataAfterCancelAsync();
+                throw;
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "Update dependencies failed for repository {RepositoryId}", repositoryId);
+                SafeInvoke(() => ToastService.Show(ex.Message));
+                throw;
+            }
+        });
+
+        return Task.CompletedTask;
     }
 
     private void ShowConfirmSyncCommits(int repositoryId)
@@ -1202,7 +1047,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
     /// <summary>When user clicks the Commits badge and there are incoming commits: run Pull (commit sync) only, with same merge/error handling as CommitSyncAsync.</summary>
     private void OnPullBadgeClickAsync(int repositoryId)
     {
-        if (workspace == null || isCommitSyncing || isSyncing || isUpdating)
+        if (workspace == null || IsJobRunning)
             return;
         if (IsRepoOnTag(repositoryId))
         {
@@ -1215,7 +1060,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
     /// <summary>When user clicks the not-upstreamed badge: check dependencies. Show modal only if at least one dependency repo needs push; otherwise push directly.</summary>
     private async Task OnPushBadgeClickAsync(int repositoryId, string? branchName)
     {
-        if (workspace == null || isPushing || isSyncing || isUpdating)
+        if (workspace == null || IsJobRunning)
             return;
         if (IsRepoOnTag(repositoryId))
         {
@@ -1283,10 +1128,10 @@ public sealed partial class WorkspaceRepositories : IDisposable
     }
 
     /// <summary>Proceed from PushWithDependencies modal: synchronized push = sync registries then level-order push with wait; otherwise push all repos in parallel (MaxParallelOperations).</summary>
-    private async Task OnPushWithDependenciesProceedAsync(bool synchronizedPush)
+    private Task OnPushWithDependenciesProceedAsync(bool synchronizedPush)
     {
         if (_pushWithDependenciesModal.Info == null || workspace == null)
-            return;
+            return Task.CompletedTask;
 
         var repoIds = _pushWithDependenciesModal.RepoIdsToPush != null
             ? _pushWithDependenciesModal.RepoIdsToPush
@@ -1298,35 +1143,37 @@ public sealed partial class WorkspaceRepositories : IDisposable
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
         ClosePushWithDependenciesModal();
 
-        try
+        JobService.StartJob(PageJobKey, "Preparing push...", async (job, ct) =>
         {
-            await ExecutePushAsync(repoIds, synchronizedPush, requiredPackageIds);
-        }
-        catch (SynchronizedPushNotPossibleException ex)
-        {
-            ShowConfirm(
-                $"Synchronized push could not be completed because {ex.MissingPackagesCount} required package mappings are missing. Check NuGet connector configuration and token, then retry. Continue with normal push?",
-                async () => await ExecutePushAsync(
-                    repoIds,
-                    synchronizedPush: false,
-                    requiredPackageIds: requiredPackageIds),
-                confirmButtonText: "Continue");
-        }
+            try
+            {
+                await ExecutePushCoreAsync(job, ct, repoIds, synchronizedPush, requiredPackageIds);
+            }
+            catch (SynchronizedPushNotPossibleException ex)
+            {
+                // Job completes normally; user confirms to start a new push job without synchronized mode.
+                SafeInvoke(() => ShowConfirm(
+                    $"Synchronized push could not be completed because {ex.MissingPackagesCount} required package mappings are missing. Check NuGet connector configuration and token, then retry. Continue with normal push?",
+                    () =>
+                    {
+                        JobService.StartJob(PageJobKey, "Preparing push...", (j, c) =>
+                            ExecutePushCoreAsync(j, c, repoIds, synchronizedPush: false, requiredPackageIds));
+                        return Task.CompletedTask;
+                    },
+                    confirmButtonText: "Continue"));
+            }
+        });
+
+        return Task.CompletedTask;
     }
 
-    private async Task<bool> ExecutePushAsync(
+    private async Task ExecutePushCoreAsync(
+        BackgroundJobHandle job,
+        CancellationToken ct,
         IReadOnlySet<int> repoIds,
         bool synchronizedPush,
         IReadOnlySet<string> requiredPackageIds)
     {
-        if (workspace == null)
-            return false;
-
-        _pushCts?.Cancel();
-        _pushCts?.Dispose();
-        _pushCts = new CancellationTokenSource();
-        isPushing = true;
-
         try
         {
             await WorkspacePushHandler.RunPushWithDependenciesAsync(
@@ -1334,76 +1181,76 @@ public sealed partial class WorkspaceRepositories : IDisposable
                 repoIds,
                 synchronizedPush,
                 requiredPackageIds,
-                SetPushProgress,
+                job.ReportProgress,
                 ToastService.Show,
-                onAppSideComplete: () => _pushAwaitingAgentTasks = true,
-                _pushCts.Token);
-            return true;
+                onAppSideComplete: () => { },
+                ct);
         }
         catch (OperationCanceledException)
         {
-            ToastService.Show("Push cancelled.");
-            return false;
+            SafeInvoke(() => ToastService.Show("Push cancelled."));
+            throw;
         }
         finally
         {
-            _pushAwaitingAgentTasks = false;
-            isPushing = false;
-            // Reload from a fresh DB scope so the grid reflects the post-push commit counts
-            // written by UpdateCommitCountsAndUpstreamAfterPushAsync. This runs on the Blazor
-            // renderer context (finally is on the same await chain as the UI event handler),
-            // making it the single authoritative post-push refresh point.
-            await RefreshFromSync();
-            await InvokeAsync(StateHasChanged);
+            await InvokeAsync(async () =>
+            {
+                if (_disposed) return;
+                await RefreshFromSync();
+            });
         }
     }
 
     /// <summary>Push with upstream for a single repository (e.g. when user clicks the not-upstreamed badge). Uses the page overlay.</summary>
-    private async Task PushSingleRepositoryWithUpstreamAsync(int repositoryId, string? branchName)
+    private Task PushSingleRepositoryWithUpstreamAsync(int repositoryId, string? branchName)
     {
-        if (workspace == null || isPushing || isSyncing || isUpdating)
-            return;
+        if (workspace == null || IsJobRunning)
+            return Task.CompletedTask;
 
-        _pushCts?.Cancel();
-        _pushCts?.Dispose();
-        _pushCts = new CancellationTokenSource();
-        isPushing = true;
-        SetPushProgress("Setting upstream...");
+        JobService.StartJob(PageJobKey, "Setting upstream...", async (job, ct) =>
+        {
+            try
+            {
+                var (success, pushError) = await WorkspacePushHandler.PushSingleRepositoryWithUpstreamAsync(
+                    WorkspaceId,
+                    repositoryId,
+                    branchName,
+                    job.ReportProgress,
+                    ct);
 
-        try
-        {
-            var (success, errorMessage) = await WorkspacePushHandler.PushSingleRepositoryWithUpstreamAsync(
-                WorkspaceId,
-                repositoryId,
-                branchName,
-                SetPushProgress,
-                _pushCts.Token);
+                if (success)
+                {
+                    await InvokeAsync(async () =>
+                    {
+                        if (_disposed) return;
+                        await RefreshFromSync();
+                    });
+                }
+                else
+                {
+                    SafeInvoke(() => ToastService.Show(pushError ?? "Push failed."));
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                SafeInvoke(() => ToastService.Show("Push cancelled."));
+                throw;
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "Push with upstream failed for repository {RepositoryId}", repositoryId);
+                SafeInvoke(() => ToastService.Show(ex.Message));
+                throw;
+            }
+        });
 
-            if (success)
-                await RefreshFromSync();
-            else
-                ToastService.Show(errorMessage ?? "Push failed.");
-        }
-        catch (OperationCanceledException)
-        {
-            ToastService.Show("Push cancelled.");
-        }
-        catch (Exception ex)
-        {
-            Logger.LogError(ex, "Push with upstream failed for repository {RepositoryId}", repositoryId);
-            ToastService.Show(ex.Message);
-        }
-        finally
-        {
-            isPushing = false;
-            await InvokeAsync(StateHasChanged);
-        }
+        return Task.CompletedTask;
     }
 
     /// <summary>Push button click: get push plan; filter to repos with unpushed commits or no upstream branch; show modal only if at least one dependency repo needs push; otherwise push immediately.</summary>
     private async Task OnPushClickAsync()
     {
-        if (workspace == null || workspaceRepositories.Count == 0 || isPushing || isSyncing || isUpdating)
+        if (workspace == null || workspaceRepositories.Count == 0 || IsJobRunning)
             return;
 
         try
@@ -1470,7 +1317,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
     /// <summary>Pull button click (when any repo has incoming commits): run commit sync (Pull) only for repos with incoming commits. Uses same overlay and merge/error handling as CommitSyncAsync/CommitSyncLevelAsync.</summary>
     private void OnPullClickAsync()
     {
-        if (workspace == null || workspaceRepositories.Count == 0 || isCommitSyncing || isSyncing || isUpdating)
+        if (workspace == null || workspaceRepositories.Count == 0 || IsJobRunning)
             return;
 
         var repoIdsWithIncoming = workspaceRepositories
@@ -1496,7 +1343,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
     /// <summary>Update button click: get update plan; if no updates, toast; else show modal (single vs multi-level).</summary>
     private async Task OnUpdateClickAsync()
     {
-        if (workspace == null || workspaceRepositories.Count == 0 || isUpdating || isSyncing)
+        if (workspace == null || workspaceRepositories.Count == 0 || IsJobRunning)
             return;
 
         if (workspaceRepositories.All(wr => wr.IsOnTag))
@@ -1561,97 +1408,91 @@ public sealed partial class WorkspaceRepositories : IDisposable
     }
 
     /// <summary>Runs update (refresh, sync deps, commit per level, refresh version). Overlay shows progress.</summary>
-    private async Task RunUpdateCoreAsync(string? commitMessage = null, bool includeDepsInCommitMessage = true)
+    private Task RunUpdateCoreAsync(string? commitMessage = null, bool includeDepsInCommitMessage = true)
     {
-        if (workspace == null || workspaceRepositories.Count == 0 || isUpdating || isSyncing)
-            return;
+        if (workspace == null || workspaceRepositories.Count == 0 || IsJobRunning)
+            return Task.CompletedTask;
 
-        _updateCts?.Cancel();
-        _updateCts?.Dispose();
-        _updateCts = new CancellationTokenSource();
-
-        isUpdating = true;
-        SetUpdateProgress("Updating dependencies...");
         errorMessage = null;
-        try
-        {
-            StateHasChanged();
-            await Task.Yield();
 
-            await WorkspaceUpdateHandler.RunUpdateAsync(
-                WorkspaceId,
-                _updateCts.Token,
-                SetUpdateProgress,
-                (repoId, msg) =>
+        JobService.StartJob(PageJobKey, "Updating dependencies...", async (job, ct) =>
+        {
+            try
+            {
+                await WorkspaceUpdateHandler.RunUpdateAsync(
+                    WorkspaceId,
+                    ct,
+                    job.ReportProgress,
+                    (repoId, msg) => SafeInvoke(() => { repositoryErrors[repoId] = msg; }),
+                    onAppSideComplete: () => { },
+                    repoIdsToUpdate: null,
+                    commitMessage: commitMessage,
+                    includeDepsInCommitMessage: includeDepsInCommitMessage);
+
+                await InvokeAsync(async () =>
                 {
-                    repositoryErrors[repoId] = msg;
-                    _ = InvokeAsync(StateHasChanged);
-                },
-                onAppSideComplete: () => _updateAwaitingAgentTasks = true,
-                repoIdsToUpdate: null,
-                commitMessage: commitMessage,
-                includeDepsInCommitMessage: includeDepsInCommitMessage);
+                    if (_disposed) return;
+                    await RefreshFromSync();
+                });
+            }
+            catch (OperationCanceledException)
+            {
+                await ReloadWorkspaceDataAfterCancelAsync();
+                throw;
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "Error updating dependencies for workspace {WorkspaceId}", WorkspaceId);
+                SafeInvoke(() => errorMessage = "Update failed. The GrayMoon Agent may be offline. Start the Agent and try again.");
+                throw;
+            }
+        });
 
-            isUpdating = false;
-            await InvokeAsync(StateHasChanged);
-            await RefreshFromSync();
-        }
-        catch (OperationCanceledException)
-        {
-            isUpdating = false;
-            await ReloadWorkspaceDataAfterCancelAsync();
-        }
-        catch (Exception ex)
-        {
-            Logger.LogError(ex, "Error updating dependencies for workspace {WorkspaceId}", WorkspaceId);
-            errorMessage = "Update failed. The GrayMoon Agent may be offline. Start the Agent and try again.";
-        }
-        finally
-        {
-            _updateAwaitingAgentTasks = false;
-            isUpdating = false;
-            await InvokeAsync(StateHasChanged);
-        }
+        return Task.CompletedTask;
     }
 
-    private async Task OnUpdateFilesClickAsync()
+    private Task OnUpdateFilesClickAsync()
     {
-        if (workspace == null || workspaceRepositories.Count == 0 || isUpdating || isSyncing)
-            return;
-        _updateCts?.Cancel();
-        _updateCts?.Dispose();
-        _updateCts = new CancellationTokenSource();
-        isUpdating = true;
-        updateProgressMessage = "Updating file versions...";
+        if (workspace == null || workspaceRepositories.Count == 0 || IsJobRunning)
+            return Task.CompletedTask;
+
         errorMessage = null;
-        StateHasChanged();
-        try
+
+        JobService.StartJob(PageJobKey, "Updating file versions...", async (job, ct) =>
         {
-            var (updated, failed, error, _) = await FileVersionService.UpdateAllVersionsAsync(
-                WorkspaceId, selectedRepositoryIds: null, cancellationToken: _updateCts.Token);
-            if (error != null)
-                errorMessage = error;
-            else if (failed > 0)
-                errorMessage = $"Updated {updated} line(s). {failed} file(s) could not be updated - check logs.";
-            else
-                ToastService.Show("Versions updated in configured files.");
-        }
-        catch (OperationCanceledException) { /* user aborted */ }
-        catch (Exception ex)
-        {
-            Logger.LogError(ex, "Error updating file versions for WorkspaceId={WorkspaceId}", WorkspaceId);
-            errorMessage = "Failed to update file versions. Please try again.";
-        }
-        finally
-        {
-            isUpdating = false;
-            await InvokeAsync(StateHasChanged);
-        }
+            try
+            {
+                var (updated, failed, error, _) = await FileVersionService.UpdateAllVersionsAsync(
+                    WorkspaceId, selectedRepositoryIds: null, cancellationToken: ct);
+
+                SafeInvoke(() =>
+                {
+                    if (error != null)
+                        errorMessage = error;
+                    else if (failed > 0)
+                        errorMessage = $"Updated {updated} line(s). {failed} file(s) could not be updated - check logs.";
+                    else
+                        ToastService.Show("Versions updated in configured files.");
+                });
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "Error updating file versions for WorkspaceId={WorkspaceId}", WorkspaceId);
+                SafeInvoke(() => errorMessage = "Failed to update file versions. Please try again.");
+                throw;
+            }
+        });
+
+        return Task.CompletedTask;
     }
 
     private async Task OnUpdateAndPushClickAsync()
     {
-        if (workspace == null || workspaceRepositories.Count == 0 || isUpdating || isSyncing)
+        if (workspace == null || workspaceRepositories.Count == 0 || IsJobRunning)
             return;
 
         if (workspaceRepositories.All(wr => wr.IsOnTag))
@@ -1704,184 +1545,166 @@ public sealed partial class WorkspaceRepositories : IDisposable
         await RunUpdateAndPushCoreAsync(args.CommitMessage, args.IncludeDeps);
     }
 
-    private async Task RunUpdateAndPushCoreAsync(string? commitMessage = null, bool includeDepsInCommitMessage = true)
+    private Task RunUpdateAndPushCoreAsync(string? commitMessage = null, bool includeDepsInCommitMessage = true)
     {
-        if (workspace == null || workspaceRepositories.Count == 0 || isUpdating || isSyncing)
-            return;
+        if (workspace == null || workspaceRepositories.Count == 0 || IsJobRunning)
+            return Task.CompletedTask;
 
-        _updateCts?.Cancel();
-        _updateCts?.Dispose();
-        _updateCts = new CancellationTokenSource();
-
-        isUpdating = true;
-        SetUpdateProgress("Updating dependencies...");
         errorMessage = null;
-        try
-        {
-            StateHasChanged();
-            await Task.Yield();
 
-            await WorkspaceUpdateHandler.RunUpdateAsync(
-                WorkspaceId,
-                _updateCts.Token,
-                SetUpdateProgress,
-                (repoId, msg) =>
+        JobService.StartJob(PageJobKey, "Updating dependencies...", async (job, ct) =>
+        {
+            // Phase 1: update
+            try
+            {
+                await WorkspaceUpdateHandler.RunUpdateAsync(
+                    WorkspaceId,
+                    ct,
+                    job.ReportProgress,
+                    (repoId, msg) => SafeInvoke(() => { repositoryErrors[repoId] = msg; }),
+                    onAppSideComplete: () => { },
+                    repoIdsToUpdate: null,
+                    commitMessage: commitMessage,
+                    includeDepsInCommitMessage: includeDepsInCommitMessage);
+
+                await InvokeAsync(async () =>
                 {
-                    repositoryErrors[repoId] = msg;
-                    _ = InvokeAsync(StateHasChanged);
-                },
-                onAppSideComplete: () => _updateAwaitingAgentTasks = true,
-                repoIdsToUpdate: null,
-                commitMessage: commitMessage,
-                includeDepsInCommitMessage: includeDepsInCommitMessage);
-
-            isUpdating = false;
-            isPushing = true;
-            SetPushProgress("Preparing push...");
-            await InvokeAsync(StateHasChanged);
-            await RefreshFromSync();
-        }
-        catch (OperationCanceledException)
-        {
-            isUpdating = false;
-            await ReloadWorkspaceDataAfterCancelAsync();
-            return;
-        }
-        catch (Exception ex)
-        {
-            Logger.LogError(ex, "Update & Push: update failed for workspace {WorkspaceId}", WorkspaceId);
-            errorMessage = "Update failed. The GrayMoon Agent may be offline. Start the Agent and try again.";
-            return;
-        }
-        finally
-        {
-            _updateAwaitingAgentTasks = false;
-            isUpdating = false;
-            await InvokeAsync(StateHasChanged);
-        }
-
-        // Phase 2: determine push plan using fresh workspaceRepositories loaded by RefreshFromSync()
-        IReadOnlySet<int> pushRepoIds;
-        IReadOnlySet<string> requiredPackageIds;
-        try
-        {
-            var (payload, hasUnpushed) = await WorkspacePushHandler.GetPushPlanAsync(
-                WorkspaceId, workspaceRepositories, CancellationToken.None);
-            if (!hasUnpushed)
+                    if (_disposed) return;
+                    await RefreshFromSync();
+                });
+            }
+            catch (OperationCanceledException)
             {
-                isPushing = false;
-                await InvokeAsync(StateHasChanged);
-                ToastService.Show("Update complete. Nothing to push.");
+                await ReloadWorkspaceDataAfterCancelAsync();
+                throw;
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "Update & Push: update failed for workspace {WorkspaceId}", WorkspaceId);
+                SafeInvoke(() => errorMessage = "Update failed. The GrayMoon Agent may be offline. Start the Agent and try again.");
+                throw;
+            }
+
+            // Phase 2: determine push plan using fresh workspaceRepositories loaded by RefreshFromSync
+            job.ReportProgress("Preparing push...");
+            IReadOnlySet<int> pushRepoIds;
+            IReadOnlySet<string> requiredPackageIds;
+            try
+            {
+                var (payload, hasUnpushed) = await WorkspacePushHandler.GetPushPlanAsync(
+                    WorkspaceId, workspaceRepositories, ct);
+                if (!hasUnpushed)
+                {
+                    SafeInvoke(() => ToastService.Show("Update complete. Nothing to push."));
+                    return;
+                }
+                var taggedRepoIds = workspaceRepositories.Where(wr => wr.IsOnTag).Select(wr => wr.RepositoryId).ToHashSet();
+                pushRepoIds = payload.Select(p => p.RepoId).Where(id => !taggedRepoIds.Contains(id)).ToHashSet();
+                if (pushRepoIds.Count == 0)
+                {
+                    SafeInvoke(() => ToastService.Show("Update complete. Nothing to push."));
+                    return;
+                }
+                var depInfo = await WorkspaceDependencyService.GetPushDependencyInfoForRepoSetAsync(
+                    WorkspaceId, pushRepoIds, ct);
+                requiredPackageIds = depInfo?.PayloadForRepo?.RequiredPackages
+                    .Select(r => r.PackageId?.Trim())
+                    .Where(id => !string.IsNullOrEmpty(id))
+                    .Cast<string>()
+                    .ToHashSet(StringComparer.OrdinalIgnoreCase) ?? new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "Update & Push: failed to get push plan for workspace {WorkspaceId}", WorkspaceId);
+                SafeInvoke(() => ShowOperationError("Push Failed", "Update succeeded but push plan could not be determined. The GrayMoon Agent may be offline."));
+                throw;
+            }
+
+            // Phase 3: execute push
+            try
+            {
+                await ExecutePushCoreAsync(job, ct, pushRepoIds, synchronizedPush: true, requiredPackageIds);
+            }
+            catch (SynchronizedPushNotPossibleException ex)
+            {
+                SafeInvoke(() => ShowConfirm(
+                    $"Synchronized push could not be completed because {ex.MissingPackagesCount} required package mappings are missing. Check NuGet connector configuration and token, then retry. Continue with normal push?",
+                    () =>
+                    {
+                        JobService.StartJob(PageJobKey, "Preparing push...", async (j, c) =>
+                        {
+                            await ExecutePushCoreAsync(j, c, pushRepoIds, synchronizedPush: false, requiredPackageIds);
+                            await RestorePackagesCoreAsync(j, c);
+                        });
+                        return Task.CompletedTask;
+                    },
+                    confirmButtonText: "Continue"));
                 return;
             }
-            var taggedRepoIds = workspaceRepositories.Where(wr => wr.IsOnTag).Select(wr => wr.RepositoryId).ToHashSet();
-            pushRepoIds = payload.Select(p => p.RepoId).Where(id => !taggedRepoIds.Contains(id)).ToHashSet();
-            if (pushRepoIds.Count == 0)
-            {
-                isPushing = false;
-                await InvokeAsync(StateHasChanged);
-                ToastService.Show("Update complete. Nothing to push.");
-                return;
-            }
-            var depInfo = await WorkspaceDependencyService.GetPushDependencyInfoForRepoSetAsync(
-                WorkspaceId, pushRepoIds, CancellationToken.None);
-            requiredPackageIds = depInfo?.PayloadForRepo?.RequiredPackages
-                .Select(r => r.PackageId?.Trim())
-                .Where(id => !string.IsNullOrEmpty(id))
-                .Cast<string>()
-                .ToHashSet(StringComparer.OrdinalIgnoreCase) ?? new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        }
-        catch (Exception ex)
-        {
-            isPushing = false;
-            await InvokeAsync(StateHasChanged);
-            Logger.LogError(ex, "Update & Push: failed to get push plan for workspace {WorkspaceId}", WorkspaceId);
-            ShowOperationError("Push Failed", "Update succeeded but push plan could not be determined. The GrayMoon Agent may be offline.");
-            return;
-        }
 
-        // Phase 3: execute push
-        bool pushCompleted = false;
-        try
-        {
-            pushCompleted = await ExecutePushAsync(pushRepoIds, synchronizedPush: true, requiredPackageIds);
-        }
-        catch (SynchronizedPushNotPossibleException ex)
-        {
-            ShowConfirm(
-                $"Synchronized push could not be completed because {ex.MissingPackagesCount} required package mappings are missing. Check NuGet connector configuration and token, then retry. Continue with normal push?",
-                async () => await ExecutePushAsync(pushRepoIds, synchronizedPush: false, requiredPackageIds),
-                confirmButtonText: "Continue");
-        }
+            // Phase 4: restore packages after successful push
+            await RestorePackagesCoreAsync(job, ct);
+        });
 
-        if (pushCompleted)
-            await RestorePackagesAsync();
+        return Task.CompletedTask;
     }
 
     private async Task HandleDependencyBadgeKeydown(KeyboardEventArgs e, int repositoryId, int unmatchedDeps)
     {
-        if ((e.Key == "Enter" || e.Key == " ") && !isUpdating && !isSyncing)
+        if ((e.Key == "Enter" || e.Key == " ") && !IsJobRunning)
             await ShowConfirmUpdateDependenciesAsync(repositoryId, unmatchedDeps);
     }
 
     /// <summary>Update dependencies for a single repository only (refresh projects, sync deps, no commit). Same as Update but scoped to one repo.</summary>
-    private async Task UpdateSingleRepositoryAsync(int repositoryId)
+    private Task UpdateSingleRepositoryAsync(int repositoryId)
     {
-        if (workspace == null || isUpdating || isSyncing)
-            return;
+        if (workspace == null || IsJobRunning)
+            return Task.CompletedTask;
         if (IsRepoOnTag(repositoryId))
         {
             ToastService.Show(TagBlockedActionMessage);
-            return;
+            return Task.CompletedTask;
         }
 
-        _updateCts?.Cancel();
-        _updateCts?.Dispose();
-        _updateCts = new CancellationTokenSource();
-
-        isUpdating = true;
-        SetUpdateProgress("Updating repository...");
-        errorMessage = null;
         repositoryErrors.Remove(repositoryId);
-        try
-        {
-            StateHasChanged();
-            await Task.Yield();
 
-            await using (var scope = ServiceScopeFactory.CreateAsyncScope())
+        JobService.StartJob(PageJobKey, "Updating repository...", async (job, ct) =>
+        {
+            try
             {
+                await using var scope = ServiceScopeFactory.CreateAsyncScope();
                 var workspaceGitService = scope.ServiceProvider.GetRequiredService<WorkspaceGitService>();
                 await workspaceGitService.RunUpdateSingleRepositoryAsync(
                     WorkspaceId,
                     repositoryId,
-                    onProgressMessage: SetUpdateProgress,
-                    onRepoError: (repoId, msg) =>
-                    {
-                        repositoryErrors[repoId] = msg;
-                        InvokeAsync(StateHasChanged);
-                    },
-                    cancellationToken: _updateCts.Token);
-            }
+                    onProgressMessage: job.ReportProgress,
+                    onRepoError: (repoId, msg) => SafeInvoke(() => { repositoryErrors[repoId] = msg; }),
+                    cancellationToken: ct);
 
-            isUpdating = false;
-            await InvokeAsync(StateHasChanged);
-            await RefreshFromSync();
-        }
-        catch (OperationCanceledException)
-        {
-            isUpdating = false;
-            await ReloadWorkspaceDataAfterCancelAsync();
-        }
-        catch (Exception ex)
-        {
-            Logger.LogError(ex, "Error updating repository {RepositoryId} in workspace {WorkspaceId}", repositoryId, WorkspaceId);
-            repositoryErrors[repositoryId] = "Update failed. The GrayMoon Agent may be offline. Start the Agent and try again.";
-        }
-        finally
-        {
-            isUpdating = false;
-            await InvokeAsync(StateHasChanged);
-        }
+                await InvokeAsync(async () =>
+                {
+                    if (_disposed) return;
+                    await RefreshFromSync();
+                });
+            }
+            catch (OperationCanceledException)
+            {
+                await ReloadWorkspaceDataAfterCancelAsync();
+                throw;
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "Error updating repository {RepositoryId} in workspace {WorkspaceId}", repositoryId, WorkspaceId);
+                SafeInvoke(() => { repositoryErrors[repositoryId] = "Update failed. The GrayMoon Agent may be offline. Start the Agent and try again."; });
+                throw;
+            }
+        });
+
+        return Task.CompletedTask;
     }
 
     private async Task ShowRepositoriesModalAsync()
@@ -1991,352 +1814,349 @@ public sealed partial class WorkspaceRepositories : IDisposable
     }
 
     /// <summary>Sync repos only (git, version, branch, commit counts). Does not read or write .csproj; dependency mismatches are resolved only by Update. Runs in a fresh scope so DbContext is not stale and PersistVersionsAsync â†’ dependency recompute sees current state.</summary>
-    private async Task SyncAsync()
+    private Task SyncAsync()
     {
-        if (workspace == null || workspaceRepositories.Count == 0 || isSyncing)
-        {
-            return;
-        }
+        if (workspace == null || workspaceRepositories.Count == 0 || IsJobRunning)
+            return Task.CompletedTask;
 
-        _syncCts?.Cancel();
-        _syncCts = new CancellationTokenSource();
-
-        isSyncing = true;
-        SetSyncProgress("Synchronizing...");
         var isRetryAfterError = !string.IsNullOrEmpty(errorMessage);
         errorMessage = null;
-        try
+
+        JobService.StartJob(PageJobKey, "Synchronizing...", async (job, ct) =>
         {
-            StateHasChanged();
-            await Task.Yield();
-
-            repoGitInfos = await WorkspaceSyncHandler.RunSyncAsync(
-                WorkspaceId,
-                repositoryIds: null,
-                skipDependencyLevelPersistence: isRetryAfterError,
-                cancellationToken: _syncCts.Token,
-                setProgress: SetSyncProgress,
-                updateRepoGitInfo: (repoId, info) =>
-                {
-                    var wr = workspaceRepositories.FirstOrDefault(w => w.RepositoryId == repoId);
-                    if (wr != null)
-                    {
-                        wr.GitVersion = info.Version == "-" ? null : info.Version;
-                        wr.BranchName = info.Branch == "-" ? null : info.Branch;
-                        wr.Projects = info.Projects;
-                        wr.OutgoingCommits = info.OutgoingCommits;
-                        wr.IncomingCommits = info.IncomingCommits;
-                    }
-                    _ = InvokeAsync(StateHasChanged);
-                },
-                setRepoSyncStatus: (repoId, status) => repoSyncStatus[repoId] = status,
-                onAppSideComplete: () => _syncAwaitingAgentTasks = true);
-
-            await ReloadWorkspaceDataAsync();
-            ApplySyncStateFromWorkspace();
-            isOutOfSync = repoSyncStatus.Values.Any(v => v != RepoSyncStatus.InSync);
-
-            foreach (var (repoId, info) in repoGitInfos)
+            try
             {
-                if (!string.IsNullOrWhiteSpace(info.ErrorMessage))
-                    repositoryErrors[repoId] = info.ErrorMessage;
-                else
-                    repositoryErrors.Remove(repoId);
+                repoGitInfos = await WorkspaceSyncHandler.RunSyncAsync(
+                    WorkspaceId,
+                    repositoryIds: null,
+                    skipDependencyLevelPersistence: isRetryAfterError,
+                    cancellationToken: ct,
+                    setProgress: job.ReportProgress,
+                    updateRepoGitInfo: (repoId, info) =>
+                    {
+                        SafeInvoke(() =>
+                        {
+                            var wr = workspaceRepositories.FirstOrDefault(w => w.RepositoryId == repoId);
+                            if (wr != null)
+                            {
+                                wr.GitVersion = info.Version == "-" ? null : info.Version;
+                                wr.BranchName = info.Branch == "-" ? null : info.Branch;
+                                wr.Projects = info.Projects;
+                                wr.OutgoingCommits = info.OutgoingCommits;
+                                wr.IncomingCommits = info.IncomingCommits;
+                            }
+                        });
+                    },
+                    setRepoSyncStatus: (repoId, status) => repoSyncStatus[repoId] = status,
+                    onAppSideComplete: () => { });
+
+                await InvokeAsync(async () =>
+                {
+                    if (_disposed) return;
+                    await ReloadWorkspaceDataAsync();
+                    ApplySyncStateFromWorkspace();
+                    isOutOfSync = repoSyncStatus.Values.Any(v => v != RepoSyncStatus.InSync);
+                    foreach (var (repoId, info) in repoGitInfos)
+                    {
+                        if (!string.IsNullOrWhiteSpace(info.ErrorMessage))
+                            repositoryErrors[repoId] = info.ErrorMessage;
+                        else
+                            repositoryErrors.Remove(repoId);
+                    }
+                    StateHasChanged();
+                });
             }
-        }
-        catch (OperationCanceledException)
-        {
-            await ReloadWorkspaceDataAfterCancelAsync();
-        }
-        catch (AgentNotConnectedException ex)
-        {
-            Logger.LogError(ex, "Error syncing workspace {WorkspaceId}", WorkspaceId);
-            errorMessage = $"Sync failed. {ex.Message}";
-        }
-        catch (ConnectorHealthException ex)
-        {
-            Logger.LogError(ex, "Error syncing workspace {WorkspaceId}", WorkspaceId);
-            errorMessage = $"Sync failed. {ex.Message}";
-        }
-        catch (Exception ex)
-        {
-            Logger.LogError(ex, "Error syncing workspace {WorkspaceId}", WorkspaceId);
-            errorMessage = "Sync failed. An unexpected error occurred. Check the logs for details.";
-        }
-        finally
-        {
-            _syncAwaitingAgentTasks = false;
-            isSyncing = false;
-            await InvokeAsync(StateHasChanged);
-        }
+            catch (OperationCanceledException)
+            {
+                await ReloadWorkspaceDataAfterCancelAsync();
+                throw;
+            }
+            catch (AgentNotConnectedException ex)
+            {
+                Logger.LogError(ex, "Error syncing workspace {WorkspaceId}", WorkspaceId);
+                SafeInvoke(() => errorMessage = $"Sync failed. {ex.Message}");
+                throw;
+            }
+            catch (ConnectorHealthException ex)
+            {
+                Logger.LogError(ex, "Error syncing workspace {WorkspaceId}", WorkspaceId);
+                SafeInvoke(() => errorMessage = $"Sync failed. {ex.Message}");
+                throw;
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "Error syncing workspace {WorkspaceId}", WorkspaceId);
+                SafeInvoke(() => errorMessage = "Sync failed. An unexpected error occurred. Check the logs for details.");
+                throw;
+            }
+        });
+
+        return Task.CompletedTask;
     }
 
     /// <summary>Sync (refresh version, branch, commits) for the given repositories in a level. Uses skipDependencyLevelPersistence so merge does not persist with partial edges; PersistVersionsAsync then recomputes levels from full DB. Same overlay and error handling as SyncAsync.</summary>
-    private async Task SyncLevelAsync(List<int> repositoryIds)
+    private Task SyncLevelAsync(List<int> repositoryIds)
     {
-        if (workspace == null || repositoryIds == null || repositoryIds.Count == 0 || isSyncing)
-            return;
+        if (workspace == null || repositoryIds == null || repositoryIds.Count == 0 || IsJobRunning)
+            return Task.CompletedTask;
 
-        _syncCts?.Cancel();
-        _syncCts = new CancellationTokenSource();
-
-        isSyncing = true;
-        SetSyncProgress($"Synchronizing {repositoryIds.Count} {(repositoryIds.Count == 1 ? "repository" : "repositories")}...");
+        var msg = $"Synchronizing {repositoryIds.Count} {(repositoryIds.Count == 1 ? "repository" : "repositories")}...";
         errorMessage = null;
-        try
+
+        JobService.StartJob(PageJobKey, msg, async (job, ct) =>
         {
-            StateHasChanged();
-            await Task.Yield();
-
-            repoGitInfos = await WorkspaceSyncHandler.RunSyncAsync(
-                WorkspaceId,
-                repositoryIds,
-                skipDependencyLevelPersistence: true,
-                cancellationToken: _syncCts.Token,
-                setProgress: SetSyncProgress,
-                updateRepoGitInfo: (repoId, info) =>
-                {
-                    var wr = workspaceRepositories.FirstOrDefault(w => w.RepositoryId == repoId);
-                    if (wr != null)
-                    {
-                        wr.GitVersion = info.Version == "-" ? null : info.Version;
-                        wr.BranchName = info.Branch == "-" ? null : info.Branch;
-                        wr.Projects = info.Projects;
-                        wr.OutgoingCommits = info.OutgoingCommits;
-                        wr.IncomingCommits = info.IncomingCommits;
-                    }
-                    _ = InvokeAsync(StateHasChanged);
-                },
-                setRepoSyncStatus: (repoId, status) => repoSyncStatus[repoId] = status,
-                onAppSideComplete: () => _syncAwaitingAgentTasks = true);
-
-            await ReloadWorkspaceDataAsync();
-            ApplySyncStateFromWorkspace();
-            isOutOfSync = repoSyncStatus.Values.Any(v => v != RepoSyncStatus.InSync);
-
-            foreach (var (repoId, info) in repoGitInfos)
+            try
             {
-                if (!string.IsNullOrWhiteSpace(info.ErrorMessage))
-                    repositoryErrors[repoId] = info.ErrorMessage;
-                else
-                    repositoryErrors.Remove(repoId);
+                repoGitInfos = await WorkspaceSyncHandler.RunSyncAsync(
+                    WorkspaceId,
+                    repositoryIds,
+                    skipDependencyLevelPersistence: true,
+                    cancellationToken: ct,
+                    setProgress: job.ReportProgress,
+                    updateRepoGitInfo: (repoId, info) =>
+                    {
+                        SafeInvoke(() =>
+                        {
+                            var wr = workspaceRepositories.FirstOrDefault(w => w.RepositoryId == repoId);
+                            if (wr != null)
+                            {
+                                wr.GitVersion = info.Version == "-" ? null : info.Version;
+                                wr.BranchName = info.Branch == "-" ? null : info.Branch;
+                                wr.Projects = info.Projects;
+                                wr.OutgoingCommits = info.OutgoingCommits;
+                                wr.IncomingCommits = info.IncomingCommits;
+                            }
+                        });
+                    },
+                    setRepoSyncStatus: (repoId, status) => repoSyncStatus[repoId] = status,
+                    onAppSideComplete: () => { });
+
+                await InvokeAsync(async () =>
+                {
+                    if (_disposed) return;
+                    await ReloadWorkspaceDataAsync();
+                    ApplySyncStateFromWorkspace();
+                    isOutOfSync = repoSyncStatus.Values.Any(v => v != RepoSyncStatus.InSync);
+                    foreach (var (repoId, info) in repoGitInfos)
+                    {
+                        if (!string.IsNullOrWhiteSpace(info.ErrorMessage))
+                            repositoryErrors[repoId] = info.ErrorMessage;
+                        else
+                            repositoryErrors.Remove(repoId);
+                    }
+                    StateHasChanged();
+                });
             }
-        }
-        catch (OperationCanceledException)
-        {
-            await ReloadWorkspaceDataAfterCancelAsync();
-        }
-        catch (AgentNotConnectedException ex)
-        {
-            Logger.LogError(ex, "Error syncing level for workspace {WorkspaceId}", WorkspaceId);
-            errorMessage = $"Sync failed. {ex.Message}";
-        }
-        catch (ConnectorHealthException ex)
-        {
-            Logger.LogError(ex, "Error syncing level for workspace {WorkspaceId}", WorkspaceId);
-            errorMessage = $"Sync failed. {ex.Message}";
-        }
-        catch (Exception ex)
-        {
-            Logger.LogError(ex, "Error syncing level for workspace {WorkspaceId}", WorkspaceId);
-            errorMessage = "Sync failed. An unexpected error occurred. Check the logs for details.";
-        }
-        finally
-        {
-            _syncAwaitingAgentTasks = false;
-            isSyncing = false;
-            await InvokeAsync(StateHasChanged);
-        }
+            catch (OperationCanceledException)
+            {
+                await ReloadWorkspaceDataAfterCancelAsync();
+                throw;
+            }
+            catch (AgentNotConnectedException ex)
+            {
+                Logger.LogError(ex, "Error syncing level for workspace {WorkspaceId}", WorkspaceId);
+                SafeInvoke(() => errorMessage = $"Sync failed. {ex.Message}");
+                throw;
+            }
+            catch (ConnectorHealthException ex)
+            {
+                Logger.LogError(ex, "Error syncing level for workspace {WorkspaceId}", WorkspaceId);
+                SafeInvoke(() => errorMessage = $"Sync failed. {ex.Message}");
+                throw;
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "Error syncing level for workspace {WorkspaceId}", WorkspaceId);
+                SafeInvoke(() => errorMessage = "Sync failed. An unexpected error occurred. Check the logs for details.");
+                throw;
+            }
+        });
+
+        return Task.CompletedTask;
     }
 
     /// <summary>Sync a single repository (same as Sync button but for one repo). Levels are recomputed after persist via full DB graph (see PersistVersionsAsync when skipDependencyLevelPersistence).</summary>
-    private async Task SyncSingleRepoAsync(int repositoryId)
+    private Task SyncSingleRepoAsync(int repositoryId)
     {
-        if (workspace == null || workspaceRepositories.Count == 0 || isSyncing)
-            return;
+        if (workspace == null || workspaceRepositories.Count == 0 || IsJobRunning)
+            return Task.CompletedTask;
 
-        _syncCts?.Cancel();
-        _syncCts = new CancellationTokenSource();
-
-        isSyncing = true;
-        SetSyncProgress("Synchronizing repository...");
         errorMessage = null;
-        try
+
+        JobService.StartJob(PageJobKey, "Synchronizing repository...", async (job, ct) =>
         {
-            StateHasChanged();
-            await Task.Yield();
-
-            repoGitInfos = await WorkspaceSyncHandler.RunSyncAsync(
-                WorkspaceId,
-                new[] { repositoryId },
-                skipDependencyLevelPersistence: true,
-                cancellationToken: _syncCts.Token,
-                setProgress: SetSyncProgress,
-                updateRepoGitInfo: (repoId, info) =>
-                {
-                    var wr = workspaceRepositories.FirstOrDefault(w => w.RepositoryId == repoId);
-                    if (wr != null)
-                    {
-                        wr.GitVersion = info.Version == "-" ? null : info.Version;
-                        wr.BranchName = info.Branch == "-" ? null : info.Branch;
-                        wr.Projects = info.Projects;
-                        wr.OutgoingCommits = info.OutgoingCommits;
-                        wr.IncomingCommits = info.IncomingCommits;
-                    }
-                    _ = InvokeAsync(StateHasChanged);
-                },
-                setRepoSyncStatus: (repoId, status) => repoSyncStatus[repoId] = status,
-                onAppSideComplete: () => _syncAwaitingAgentTasks = true);
-            await ReloadWorkspaceDataAsync();
-            ApplySyncStateFromWorkspace();
-            isOutOfSync = repoSyncStatus.Values.Any(v => v != RepoSyncStatus.InSync);
-
-            foreach (var (repoId, info) in repoGitInfos)
+            try
             {
-                if (!string.IsNullOrWhiteSpace(info.ErrorMessage))
-                    repositoryErrors[repoId] = info.ErrorMessage;
-                else
-                    repositoryErrors.Remove(repoId);
+                repoGitInfos = await WorkspaceSyncHandler.RunSyncAsync(
+                    WorkspaceId,
+                    new[] { repositoryId },
+                    skipDependencyLevelPersistence: true,
+                    cancellationToken: ct,
+                    setProgress: job.ReportProgress,
+                    updateRepoGitInfo: (repoId, info) =>
+                    {
+                        SafeInvoke(() =>
+                        {
+                            var wr = workspaceRepositories.FirstOrDefault(w => w.RepositoryId == repoId);
+                            if (wr != null)
+                            {
+                                wr.GitVersion = info.Version == "-" ? null : info.Version;
+                                wr.BranchName = info.Branch == "-" ? null : info.Branch;
+                                wr.Projects = info.Projects;
+                                wr.OutgoingCommits = info.OutgoingCommits;
+                                wr.IncomingCommits = info.IncomingCommits;
+                            }
+                        });
+                    },
+                    setRepoSyncStatus: (repoId, status) => repoSyncStatus[repoId] = status,
+                    onAppSideComplete: () => { });
+
+                await InvokeAsync(async () =>
+                {
+                    if (_disposed) return;
+                    await ReloadWorkspaceDataAsync();
+                    ApplySyncStateFromWorkspace();
+                    isOutOfSync = repoSyncStatus.Values.Any(v => v != RepoSyncStatus.InSync);
+                    foreach (var (repoId, info) in repoGitInfos)
+                    {
+                        if (!string.IsNullOrWhiteSpace(info.ErrorMessage))
+                            repositoryErrors[repoId] = info.ErrorMessage;
+                        else
+                            repositoryErrors.Remove(repoId);
+                    }
+                    StateHasChanged();
+                });
             }
-        }
-        catch (OperationCanceledException)
-        {
-            await ReloadWorkspaceDataAfterCancelAsync();
-        }
-        catch (AgentNotConnectedException ex)
-        {
-            Logger.LogError(ex, "Error syncing repository {RepositoryId} in workspace {WorkspaceId}", repositoryId, WorkspaceId);
-            errorMessage = $"Sync failed. {ex.Message}";
-        }
-        catch (ConnectorHealthException ex)
-        {
-            Logger.LogError(ex, "Error syncing repository {RepositoryId} in workspace {WorkspaceId}", repositoryId, WorkspaceId);
-            errorMessage = $"Sync failed. {ex.Message}";
-        }
-        catch (Exception ex)
-        {
-            Logger.LogError(ex, "Error syncing repository {RepositoryId} in workspace {WorkspaceId}", repositoryId, WorkspaceId);
-            errorMessage = "Sync failed. An unexpected error occurred. Check the logs for details.";
-        }
-        finally
-        {
-            _syncAwaitingAgentTasks = false;
-            isSyncing = false;
-            await InvokeAsync(StateHasChanged);
-        }
+            catch (OperationCanceledException)
+            {
+                await ReloadWorkspaceDataAfterCancelAsync();
+                throw;
+            }
+            catch (AgentNotConnectedException ex)
+            {
+                Logger.LogError(ex, "Error syncing repository {RepositoryId} in workspace {WorkspaceId}", repositoryId, WorkspaceId);
+                SafeInvoke(() => errorMessage = $"Sync failed. {ex.Message}");
+                throw;
+            }
+            catch (ConnectorHealthException ex)
+            {
+                Logger.LogError(ex, "Error syncing repository {RepositoryId} in workspace {WorkspaceId}", repositoryId, WorkspaceId);
+                SafeInvoke(() => errorMessage = $"Sync failed. {ex.Message}");
+                throw;
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "Error syncing repository {RepositoryId} in workspace {WorkspaceId}", repositoryId, WorkspaceId);
+                SafeInvoke(() => errorMessage = "Sync failed. An unexpected error occurred. Check the logs for details.");
+                throw;
+            }
+        });
+
+        return Task.CompletedTask;
     }
 
-    private async Task CommitSyncAsync(int repositoryId)
+    private Task CommitSyncAsync(int repositoryId)
     {
-        if (workspace == null || isCommitSyncing || isSyncing || isUpdating)
-            return;
+        if (workspace == null || IsJobRunning)
+            return Task.CompletedTask;
         if (IsRepoOnTag(repositoryId))
         {
             ToastService.Show(TagBlockedActionMessage);
-            return;
+            return Task.CompletedTask;
         }
 
-        _commitSyncCts?.Cancel();
-        _commitSyncCts?.Dispose();
-        _commitSyncCts = new CancellationTokenSource();
-
-        isCommitSyncing = true;
-        SetCommitSyncProgress("Synchronizing commits...");
         errorMessage = null;
-        try
-        {
-            StateHasChanged();
-            await Task.Yield();
 
-            await WorkspaceCommitSyncHandler.CommitSyncAsync(
-                WorkspaceId,
-                repositoryId,
-                ApiBaseUrl,
-                _commitSyncCts.Token,
-                async message =>
-                {
-                    SetCommitSyncProgress(message);
-                    await Task.CompletedTask;
-                },
-                (id, err) =>
-                {
-                    if (err is null)
-                        repositoryErrors.Remove(id);
-                    else
-                        repositoryErrors[id] = err;
-                },
-                msg => errorMessage = msg);
+        JobService.StartJob(PageJobKey, "Synchronizing commits...", async (job, ct) =>
+        {
+            try
+            {
+                await WorkspaceCommitSyncHandler.CommitSyncAsync(
+                    WorkspaceId,
+                    repositoryId,
+                    ApiBaseUrl,
+                    ct,
+                    async message =>
+                    {
+                        job.ReportProgress(message);
+                        await Task.CompletedTask;
+                    },
+                    (id, err) => SafeInvoke(() =>
+                    {
+                        if (err is null)
+                            repositoryErrors.Remove(id);
+                        else
+                            repositoryErrors[id] = err;
+                    }),
+                    msg => SafeInvoke(() => errorMessage = msg));
 
-            await RefreshFromSync();
-        }
-        catch (OperationCanceledException)
-        {
-            await ReloadWorkspaceDataAfterCancelAsync();
-        }
-        finally
-        {
-            isCommitSyncing = false;
-            await InvokeAsync(StateHasChanged);
-        }
+                await InvokeAsync(async () =>
+                {
+                    if (_disposed) return;
+                    await RefreshFromSync();
+                });
+            }
+            catch (OperationCanceledException)
+            {
+                await ReloadWorkspaceDataAfterCancelAsync();
+                throw;
+            }
+        });
+
+        return Task.CompletedTask;
     }
 
-    private async Task CommitSyncLevelAsync(List<int> repositoryIds)
+    private Task CommitSyncLevelAsync(List<int> repositoryIds)
     {
-        if (workspace == null || isCommitSyncing || isSyncing || isUpdating || repositoryIds == null || repositoryIds.Count == 0)
-            return;
+        if (workspace == null || IsJobRunning || repositoryIds == null || repositoryIds.Count == 0)
+            return Task.CompletedTask;
 
         repositoryIds = repositoryIds.Where(id => !IsRepoOnTag(id)).ToList();
         if (repositoryIds.Count == 0)
         {
             ToastService.Show("All repositories are on tags; checkout a branch first.");
-            return;
+            return Task.CompletedTask;
         }
 
-        _commitSyncCts?.Cancel();
-        _commitSyncCts?.Dispose();
-        _commitSyncCts = new CancellationTokenSource();
-
-        isCommitSyncing = true;
-        SetCommitSyncProgress("Synchronizing commits...");
         errorMessage = null;
-        try
-        {
-            StateHasChanged();
-            await Task.Yield();
 
-            await WorkspaceCommitSyncHandler.CommitSyncLevelAsync(
-                WorkspaceId,
-                repositoryIds,
-                ApiBaseUrl,
-                _commitSyncCts.Token,
-                async (completed, total) =>
-                {
-                    SetCommitSyncProgress($"Synchronized commits {completed} of {total}");
-                    if (completed == total)
-                        _commitSyncAwaitingAgentTasks = true;
-                    await InvokeAsync(StateHasChanged);
-                },
-                (id, err) =>
-                {
-                    if (err is null)
-                        repositoryErrors.Remove(id);
-                    else
-                        repositoryErrors[id] = err;
-                },
-                msg => errorMessage = msg);
+        JobService.StartJob(PageJobKey, "Synchronizing commits...", async (job, ct) =>
+        {
+            try
+            {
+                await WorkspaceCommitSyncHandler.CommitSyncLevelAsync(
+                    WorkspaceId,
+                    repositoryIds,
+                    ApiBaseUrl,
+                    ct,
+                    async (completed, total) =>
+                    {
+                        job.ReportProgress($"Synchronized commits {completed} of {total}");
+                        await Task.CompletedTask;
+                    },
+                    (id, err) => SafeInvoke(() =>
+                    {
+                        if (err is null)
+                            repositoryErrors.Remove(id);
+                        else
+                            repositoryErrors[id] = err;
+                    }),
+                    msg => SafeInvoke(() => errorMessage = msg));
 
-            await RefreshFromSync();
-        }
-        catch (OperationCanceledException)
-        {
-            await ReloadWorkspaceDataAfterCancelAsync();
-        }
-        finally
-        {
-            _commitSyncAwaitingAgentTasks = false;
-            isCommitSyncing = false;
-            await InvokeAsync(StateHasChanged);
-        }
+                await InvokeAsync(async () =>
+                {
+                    if (_disposed) return;
+                    await RefreshFromSync();
+                });
+            }
+            catch (OperationCanceledException)
+            {
+                await ReloadWorkspaceDataAfterCancelAsync();
+                throw;
+            }
+        });
+
+        return Task.CompletedTask;
     }
 
     private void ShowSwitchBranchModal(int repositoryId, string? currentBranch, string? cloneUrl)
@@ -2473,183 +2293,116 @@ public sealed partial class WorkspaceRepositories : IDisposable
         StateHasChanged();
     }
 
-    private async Task HandleNewFeatureCreateAsync(NewFeatureRequest request)
+    private Task HandleNewFeatureCreateAsync(NewFeatureRequest request)
     {
-        if (workspace == null || isCreatingBranches || isSyncing || isUpdating || isPushing)
-            return;
+        if (workspace == null || IsJobRunning)
+            return Task.CompletedTask;
 
         CloseNewFeatureModal();
+        errorMessage = null;
 
         var tagFilteredRepoIds = request.SkipReposOnTags
             ? workspaceRepositories.Where(wr => !wr.IsOnTag).Select(wr => wr.RepositoryId).ToHashSet()
             : (IReadOnlySet<int>?)null;
 
-        _createBranchesCts?.Cancel();
-        _createBranchesCts?.Dispose();
-        _createBranchesCts = new CancellationTokenSource();
-        isCreatingBranches = true;
-        isUpdating = false;
-        SetCreateBranchesProgress("Creating branches...");
-        errorMessage = null;
-        StateHasChanged();
-
-        // Phases 1 + 2: branch creation (hooks suppressed, state persisted inline) then update.
+        // Phases 1 + 2: branch creation (hooks suppressed, state persisted inline) then optional update.
         // NewFeatureOrchestrator guarantees all CheckedOutTag fields are null before the update
         // runs, so DependencyUpdateOrchestrator never skips previously tag-pinned repos.
-        try
+        JobService.StartJob(PageJobKey, "Creating branches...", async (job, ct) =>
         {
-            await Task.Yield();
-            await NewFeatureOrchestrator.RunAsync(
-                WorkspaceId,
-                request.NewBranchName,
-                request.BaseBranch,
-                tagFilteredRepoIds,
-                request.UpdateDependencies,
-                commitMessage: null,
-                setProgress: msg =>
-                {
-                    if (msg.StartsWith("Creating", StringComparison.OrdinalIgnoreCase))
-                    {
-                        SetCreateBranchesProgress(msg);
-                    }
-                    else
-                    {
-                        // Transition overlay: branch creation phase done, update phase starting.
-                        isCreatingBranches = false;
-                        isUpdating = true;
-                        SetUpdateProgress(msg);
-                    }
-                    _ = InvokeAsync(StateHasChanged);
-                },
-                reportBranchProgress: (completed, total) =>
-                {
-                    SetCreateBranchesProgress($"Created {completed} of {total} branches");
-                    _ = InvokeAsync(StateHasChanged);
-                },
-                setRepositoryError: (repoId, msg) =>
-                {
-                    repositoryErrors[repoId] = msg;
-                    _ = InvokeAsync(StateHasChanged);
-                },
-                _createBranchesCts.Token);
-
-            isCreatingBranches = false;
-            isUpdating = false;
-            if (request.PushChanges)
+            try
             {
-                isPushing = true;
-                SetPushProgress("Preparing push...");
-            }
-            await InvokeAsync(StateHasChanged);
-            await RefreshFromSync();
-        }
-        catch (OperationCanceledException)
-        {
-            isCreatingBranches = false;
-            isUpdating = false;
-            await ReloadWorkspaceDataAfterCancelAsync();
-            return;
-        }
-        catch (Exception ex)
-        {
-            Logger.LogError(ex, "New Feature: orchestration failed for workspace {WorkspaceId}", WorkspaceId);
-            ShowOperationError("New Feature Failed", "Could not complete the New Feature workflow. The GrayMoon Agent may be offline or a dependency update failed. Check individual repository errors for details.");
-            return;
-        }
-        finally
-        {
-            isCreatingBranches = false;
-            isUpdating = false;
-            _updateAwaitingAgentTasks = false;
-            await InvokeAsync(StateHasChanged);
-        }
+                await NewFeatureOrchestrator.RunAsync(
+                    WorkspaceId,
+                    request.NewBranchName,
+                    request.BaseBranch,
+                    tagFilteredRepoIds,
+                    request.UpdateDependencies,
+                    commitMessage: null,
+                    setProgress: msg => job.ReportProgress(msg),
+                    reportBranchProgress: (completed, total) =>
+                    {
+                        job.ReportProgress($"Created {completed} of {total} branches");
+                    },
+                    setRepositoryError: (repoId, msg) => SafeInvoke(() => { repositoryErrors[repoId] = msg; }),
+                    ct);
 
-        // Step 3: Push changes
-        if (request.PushChanges)
-        {
+                await InvokeAsync(async () =>
+                {
+                    if (_disposed) return;
+                    await RefreshFromSync();
+                });
+            }
+            catch (OperationCanceledException)
+            {
+                await ReloadWorkspaceDataAfterCancelAsync();
+                throw;
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "New Feature: orchestration failed for workspace {WorkspaceId}", WorkspaceId);
+                SafeInvoke(() => ShowOperationError("New Feature Failed", "Could not complete the New Feature workflow. The GrayMoon Agent may be offline or a dependency update failed. Check individual repository errors for details."));
+                throw;
+            }
+
+            if (!request.PushChanges)
+                return;
+
+            // Phase 3: determine push plan and execute push
+            job.ReportProgress("Preparing push...");
             IReadOnlySet<int> pushRepoIds;
             IReadOnlySet<string> requiredPackageIds;
             try
             {
                 var (payload, hasUnpushed) = await WorkspacePushHandler.GetPushPlanAsync(
-                    WorkspaceId, workspaceRepositories, CancellationToken.None);
+                    WorkspaceId, workspaceRepositories, ct);
                 if (!hasUnpushed)
                 {
-                    isPushing = false;
-                    await InvokeAsync(StateHasChanged);
-                    ToastService.Show("No repositories to push.");
+                    SafeInvoke(() => ToastService.Show("No repositories to push."));
                     return;
                 }
                 var taggedRepoIds = workspaceRepositories.Where(wr => wr.IsOnTag).Select(wr => wr.RepositoryId).ToHashSet();
                 pushRepoIds = payload.Select(p => p.RepoId).Where(id => !taggedRepoIds.Contains(id)).ToHashSet();
                 if (pushRepoIds.Count == 0)
                 {
-                    isPushing = false;
-                    await InvokeAsync(StateHasChanged);
-                    ToastService.Show("No repositories to push.");
+                    SafeInvoke(() => ToastService.Show("No repositories to push."));
                     return;
                 }
                 var depInfo = await WorkspaceDependencyService.GetPushDependencyInfoForRepoSetAsync(
-                    WorkspaceId, pushRepoIds, CancellationToken.None);
+                    WorkspaceId, pushRepoIds, ct);
                 requiredPackageIds = depInfo?.PayloadForRepo?.RequiredPackages
                     .Select(r => r.PackageId?.Trim())
                     .Where(id => !string.IsNullOrEmpty(id))
                     .Cast<string>()
                     .ToHashSet(StringComparer.OrdinalIgnoreCase) ?? new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
             catch (Exception ex)
             {
-                isPushing = false;
-                await InvokeAsync(StateHasChanged);
                 Logger.LogError(ex, "New Feature: failed to get push plan for workspace {WorkspaceId}", WorkspaceId);
-                ShowOperationError("Push Failed", "Could not determine push plan. The GrayMoon Agent may be offline.");
-                return;
+                SafeInvoke(() => ShowOperationError("Push Failed", "Could not determine push plan. The GrayMoon Agent may be offline."));
+                throw;
             }
-
-            _pushCts?.Cancel();
-            _pushCts?.Dispose();
-            _pushCts = new CancellationTokenSource();
 
             try
             {
-                await WorkspacePushHandler.RunPushWithDependenciesAsync(
-                    WorkspaceId,
-                    pushRepoIds,
-                    synchronizedPush: true,
-                    requiredPackageIds,
-                    SetPushProgress,
-                    ToastService.Show,
-                    onAppSideComplete: () => _pushAwaitingAgentTasks = true,
-                    _pushCts.Token);
+                await ExecutePushCoreAsync(job, ct, pushRepoIds, synchronizedPush: true, requiredPackageIds);
             }
             catch (SynchronizedPushNotPossibleException ex)
             {
-                ShowOperationError("Push Failed",
-                    $"Synchronized push could not complete: {ex.MissingPackagesCount} required package mapping(s) are missing. Check NuGet connector configuration and token, then retry.");
+                SafeInvoke(() => ShowOperationError("Push Failed",
+                    $"Synchronized push could not complete: {ex.MissingPackagesCount} required package mapping(s) are missing. Check NuGet connector configuration and token, then retry."));
                 return;
-            }
-            catch (OperationCanceledException)
-            {
-                ToastService.Show("Push cancelled.");
-                return;
-            }
-            catch (Exception ex)
-            {
-                Logger.LogError(ex, "New Feature: push failed for workspace {WorkspaceId}", WorkspaceId);
-                ShowOperationError("Push Failed", "Push failed. Check individual repository errors for details.");
-                return;
-            }
-            finally
-            {
-                _pushAwaitingAgentTasks = false;
-                isPushing = false;
-                await RefreshFromSync();
-                await InvokeAsync(StateHasChanged);
             }
 
-            // Only reached on success (all catch blocks return early)
-            await RestorePackagesAsync();
-        }
+            // Phase 4: restore packages after successful push
+            await RestorePackagesCoreAsync(job, ct);
+        });
+
+        return Task.CompletedTask;
     }
 
     private async Task LoadCommonBranchesForBranchModalAsync(CancellationToken cancellationToken)
@@ -2674,79 +2427,66 @@ public sealed partial class WorkspaceRepositories : IDisposable
         };
     }
 
-    private void AbortWorkspaceBranchesFetchAsync()
+    private Task FetchCommonBranchesAcrossWorkspaceAsync()
     {
-        _workspaceBranchesFetchCts?.Cancel();
-    }
-
-    private void AbortWorkspaceBranchesCheckoutAsync()
-    {
-        _workspaceBranchesCheckoutCts?.Cancel();
-    }
-
-    private async Task FetchCommonBranchesAcrossWorkspaceAsync()
-    {
-        if (workspace == null || isWorkspaceBranchesFetching || isSyncing || isUpdating || isCommitSyncing || isCheckingOut)
-            return;
+        if (workspace == null || IsJobRunning)
+            return Task.CompletedTask;
 
         var repoIds = workspaceRepositories
             .Select(wr => wr.RepositoryId)
             .Distinct()
             .ToList();
         if (repoIds.Count == 0)
-            return;
+            return Task.CompletedTask;
 
-        _workspaceBranchesFetchCts?.Cancel();
-        _workspaceBranchesFetchCts?.Dispose();
-        _workspaceBranchesFetchCts = new CancellationTokenSource();
-
-        isWorkspaceBranchesFetching = true;
-        workspaceBranchesFetchProgressMessage = "Fetching branches...";
-        await InvokeAsync(StateHasChanged);
-
-        try
+        JobService.StartJob(PageJobKey, "Fetching branches...", async (job, ct) =>
         {
-            var result = await WorkspaceBranchHandler.FetchBranchesForWorkspaceAsync(
-                WorkspaceId,
-                repoIds,
-                ApiBaseUrl,
-                (completed, total) =>
+            try
+            {
+                var result = await WorkspaceBranchHandler.FetchBranchesForWorkspaceAsync(
+                    WorkspaceId,
+                    repoIds,
+                    ApiBaseUrl,
+                    (completed, total) =>
+                    {
+                        job.ReportProgress(completed <= 0
+                            ? "Fetching branches..."
+                            : $"Fetched branches in {completed} of {total} repositories...");
+                    },
+                    ct);
+
+                await InvokeAsync(async () =>
                 {
-                    workspaceBranchesFetchProgressMessage = completed <= 0
-                        ? "Fetching branches..."
-                        : $"Fetched branches in {completed} of {total} repositories...";
-                    _ = InvokeAsync(StateHasChanged);
-                },
-                _workspaceBranchesFetchCts.Token);
+                    if (_disposed) return;
+                    await RefreshFromSync();
+                    await LoadCommonBranchesForBranchModalAsync(CancellationToken.None);
+                    StateHasChanged();
+                });
 
-            await RefreshFromSync();
-            await LoadCommonBranchesForBranchModalAsync(CancellationToken.None);
-            await InvokeAsync(StateHasChanged);
+                if (result.FailureCount > 0)
+                    SafeInvoke(() => ToastService.Show($"Fetched branches for {result.SuccessCount} repositories. {result.FailureCount} failed."));
+            }
+            catch (OperationCanceledException)
+            {
+                SafeInvoke(() => ToastService.Show("Fetch branches cancelled."));
+                throw;
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "Error fetching branches across workspace {WorkspaceId}", WorkspaceId);
+                SafeInvoke(() => ToastService.Show("Failed to fetch branches across workspace."));
+                throw;
+            }
+        });
 
-            if (result.FailureCount > 0)
-                ToastService.Show($"Fetched branches for {result.SuccessCount} repositories. {result.FailureCount} failed.");
-        }
-        catch (OperationCanceledException)
-        {
-            ToastService.Show("Fetch branches cancelled.");
-        }
-        catch (Exception ex)
-        {
-            Logger.LogError(ex, "Error fetching branches across workspace {WorkspaceId}", WorkspaceId);
-            ToastService.Show("Failed to fetch branches across workspace.");
-        }
-        finally
-        {
-            isWorkspaceBranchesFetching = false;
-            await InvokeAsync(StateHasChanged);
-        }
+        return Task.CompletedTask;
     }
 
-    private async Task CheckoutCommonBranchAcrossWorkspaceAsync((string BranchName, bool SkipReposOnTags) args)
+    private Task CheckoutCommonBranchAcrossWorkspaceAsync((string BranchName, bool SkipReposOnTags) args)
     {
         var (branchName, skipReposOnTags) = args;
-        if (workspace == null || string.IsNullOrWhiteSpace(branchName) || isWorkspaceBranchesCheckingOut || isSyncing || isUpdating || isCommitSyncing || isCheckingOut)
-            return;
+        if (workspace == null || string.IsNullOrWhiteSpace(branchName) || IsJobRunning)
+            return Task.CompletedTask;
 
         var repoIds = workspaceRepositories
             .Where(wr => !skipReposOnTags || !wr.IsOnTag)
@@ -2754,114 +2494,110 @@ public sealed partial class WorkspaceRepositories : IDisposable
             .Distinct()
             .ToList();
         if (repoIds.Count == 0)
-            return;
+            return Task.CompletedTask;
 
-        _workspaceBranchesCheckoutCts?.Cancel();
-        _workspaceBranchesCheckoutCts?.Dispose();
-        _workspaceBranchesCheckoutCts = new CancellationTokenSource();
-
-        isWorkspaceBranchesCheckingOut = true;
-        workspaceBranchesCheckoutProgressMessage = "Checking out...";
-        await InvokeAsync(StateHasChanged);
-
-        try
+        JobService.StartJob(PageJobKey, "Checking out...", async (job, ct) =>
         {
-            var result = await WorkspaceBranchHandler.CheckoutBranchForWorkspaceAsync(
-                WorkspaceId,
-                repoIds,
-                branchName,
-                ApiBaseUrl,
-                (completed, total) =>
-                {
-                    workspaceBranchesCheckoutProgressMessage = completed <= 0
-                        ? "Checking out..."
-                        : $"Checked out {completed} of {total} branches";
-                    _ = InvokeAsync(StateHasChanged);
-                },
-                _workspaceBranchesCheckoutCts.Token);
-
-            foreach (var repoId in repoIds)
+            try
             {
-                if (result.ErrorsByRepositoryId.TryGetValue(repoId, out var error))
-                    repositoryErrors[repoId] = error;
-                else
-                    repositoryErrors.Remove(repoId);
-            }
+                var result = await WorkspaceBranchHandler.CheckoutBranchForWorkspaceAsync(
+                    WorkspaceId,
+                    repoIds,
+                    branchName,
+                    ApiBaseUrl,
+                    (completed, total) =>
+                    {
+                        job.ReportProgress(completed <= 0
+                            ? "Checking out..."
+                            : $"Checked out {completed} of {total} branches");
+                    },
+                    ct);
 
-            await RefreshFromSync();
-            if (result.FailureCount > 0)
-                ToastService.Show($"Checked out branch in {result.SuccessCount} repositories. {result.FailureCount} failed.");
-        }
-        catch (OperationCanceledException)
-        {
-            ToastService.Show("Checkout cancelled.");
-        }
-        catch (Exception ex)
-        {
-            Logger.LogError(ex, "Error checking out branch {BranchName} across workspace {WorkspaceId}", branchName, WorkspaceId);
-            ToastService.Show("Failed to check out branch across workspace.");
-        }
-        finally
-        {
-            isWorkspaceBranchesCheckingOut = false;
-            await InvokeAsync(StateHasChanged);
-        }
+                SafeInvoke(() =>
+                {
+                    foreach (var repoId in repoIds)
+                    {
+                        if (result.ErrorsByRepositoryId.TryGetValue(repoId, out var error))
+                            repositoryErrors[repoId] = error;
+                        else
+                            repositoryErrors.Remove(repoId);
+                    }
+                });
+
+                await InvokeAsync(async () =>
+                {
+                    if (_disposed) return;
+                    await RefreshFromSync();
+                });
+
+                if (result.FailureCount > 0)
+                    SafeInvoke(() => ToastService.Show($"Checked out branch in {result.SuccessCount} repositories. {result.FailureCount} failed."));
+            }
+            catch (OperationCanceledException)
+            {
+                SafeInvoke(() => ToastService.Show("Checkout cancelled."));
+                throw;
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "Error checking out branch {BranchName} across workspace {WorkspaceId}", branchName, WorkspaceId);
+                SafeInvoke(() => ToastService.Show("Failed to check out branch across workspace."));
+                throw;
+            }
+        });
+
+        return Task.CompletedTask;
     }
 
-    private async Task CreateBranchesAsync((string NewBranchName, string BaseBranch, bool SkipReposOnTags) args)
+    private Task CreateBranchesAsync((string NewBranchName, string BaseBranch, bool SkipReposOnTags) args)
     {
         var (newBranchName, baseBranch, skipReposOnTags) = args;
-        if (workspace == null || string.IsNullOrWhiteSpace(newBranchName) || isCreatingBranches || isSyncing || isUpdating)
-            return;
+        if (workspace == null || string.IsNullOrWhiteSpace(newBranchName) || IsJobRunning)
+            return Task.CompletedTask;
 
         CloseBranchModal();
-        _createBranchesCts?.Cancel();
-        _createBranchesCts?.Dispose();
-        _createBranchesCts = new CancellationTokenSource();
-
-        isCreatingBranches = true;
-        SetCreateBranchesProgress("Creating branches...");
         errorMessage = null;
-        StateHasChanged();
 
         var tagFilteredRepoIds = skipReposOnTags
             ? workspaceRepositories.Where(wr => !wr.IsOnTag).Select(wr => wr.RepositoryId).ToHashSet()
             : (IReadOnlySet<int>?)null;
 
-        try
+        JobService.StartJob(PageJobKey, "Creating branches...", async (job, ct) =>
         {
-            await Task.Yield();
-            await WorkspaceBranchHandler.CreateBranchesAsync(
-                WorkspaceId,
-                newBranchName,
-                baseBranch,
-                tagFilteredRepoIds,
-                (completed, total) =>
+            try
+            {
+                await WorkspaceBranchHandler.CreateBranchesAsync(
+                    WorkspaceId,
+                    newBranchName,
+                    baseBranch,
+                    tagFilteredRepoIds,
+                    (completed, total) =>
+                    {
+                        job.ReportProgress($"Created {completed} of {total} branches");
+                    },
+                    syncState: false,
+                    cancellationToken: ct);
+
+                await InvokeAsync(async () =>
                 {
-                    SetCreateBranchesProgress($"Created {completed} of {total} branches");
-                    if (completed == total)
-                        _creatingBranchesAwaitingAgentTasks = true;
-                    _ = InvokeAsync(StateHasChanged);
-                },
-                syncState: false,
-                cancellationToken: _createBranchesCts.Token);
-            await RefreshFromSync();
-        }
-        catch (OperationCanceledException)
-        {
-            await ReloadWorkspaceDataAfterCancelAsync();
-        }
-        catch (Exception ex)
-        {
-            Logger.LogError(ex, "Error creating branches for workspace {WorkspaceId}", WorkspaceId);
-            errorMessage = "Create branches failed. The GrayMoon Agent may be offline. Start the Agent and try again.";
-        }
-        finally
-        {
-            _creatingBranchesAwaitingAgentTasks = false;
-            isCreatingBranches = false;
-            await InvokeAsync(StateHasChanged);
-        }
+                    if (_disposed) return;
+                    await RefreshFromSync();
+                });
+            }
+            catch (OperationCanceledException)
+            {
+                await ReloadWorkspaceDataAfterCancelAsync();
+                throw;
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "Error creating branches for workspace {WorkspaceId}", WorkspaceId);
+                SafeInvoke(() => errorMessage = "Create branches failed. The GrayMoon Agent may be offline. Start the Agent and try again.");
+                throw;
+            }
+        });
+
+        return Task.CompletedTask;
     }
 
     private async Task OnBranchChangedAsync()
@@ -2870,55 +2606,59 @@ public sealed partial class WorkspaceRepositories : IDisposable
         await RefreshFromSync();
     }
 
-    private async Task CreateSingleBranchAsync((int RepositoryId, string? RepositoryName, string NewBranchName, string BaseBranch, bool SetUpstream) request)
+    private Task CreateSingleBranchAsync((int RepositoryId, string? RepositoryName, string NewBranchName, string BaseBranch, bool SetUpstream) request)
     {
         var (repositoryId, repositoryName, newBranchName, baseBranch, setUpstream) = request;
-        if (workspace == null || isCreatingBranch || isSyncing || isUpdating)
-            return;
+        if (workspace == null || IsJobRunning)
+            return Task.CompletedTask;
 
         CloseSwitchBranchModal();
-        isCreatingBranch = true;
-        createBranchMessage = "Creating branch...";
         errorMessage = null;
-        await InvokeAsync(StateHasChanged);
 
-        try
+        JobService.StartJob(PageJobKey, "Creating branch...", async (job, ct) =>
         {
-            var (success, err) = await WorkspaceBranchHandler.CreateSingleBranchAsync(
-                WorkspaceId,
-                repositoryId,
-                newBranchName,
-                baseBranch,
-                setUpstream,
-                ApiBaseUrl,
-                CancellationToken.None);
-            if (!success)
+            try
             {
-                errorMessage = err ?? "Create branch failed. The GrayMoon Agent may be offline. Start the Agent and try again.";
+                var (success, err) = await WorkspaceBranchHandler.CreateSingleBranchAsync(
+                    WorkspaceId,
+                    repositoryId,
+                    newBranchName,
+                    baseBranch,
+                    setUpstream,
+                    ApiBaseUrl,
+                    ct);
+
+                if (!success)
+                {
+                    SafeInvoke(() => errorMessage = err ?? "Create branch failed. The GrayMoon Agent may be offline. Start the Agent and try again.");
+                }
+                else
+                {
+                    if (err != null)
+                        SafeInvoke(() => errorMessage = err);
+
+                    await InvokeAsync(async () =>
+                    {
+                        if (_disposed) return;
+                        await RefreshFromSync();
+                    });
+                }
             }
-            else
+            catch (Exception ex)
             {
-                if (err != null)
-                    errorMessage = err;
-                await RefreshFromSync();
+                Logger.LogError(ex, "Error creating branch for repository {RepositoryId}", repositoryId);
+                SafeInvoke(() => errorMessage = "An error occurred while creating branch.");
+                throw;
             }
-        }
-        catch (Exception ex)
-        {
-            Logger.LogError(ex, "Error creating branch for repository {RepositoryId}", repositoryId);
-            errorMessage = "An error occurred while creating branch.";
-        }
-        finally
-        {
-            isCreatingBranch = false;
-            await InvokeAsync(StateHasChanged);
-        }
+        });
+
+        return Task.CompletedTask;
     }
 
     private async Task SyncToDefaultFromModalAsync((int RepositoryId, string? RepositoryName, string CurrentBranchName, string DefaultBranch) request)
     {
         var (repositoryId, repositoryName, currentBranchName, defaultBranch) = request;
-        if (workspace == null || isSyncingToDefault || isSyncing || isUpdating)
+        if (workspace == null || IsJobRunning)
             return;
         if (string.IsNullOrWhiteSpace(repositoryName))
             return;
@@ -2964,222 +2704,201 @@ public sealed partial class WorkspaceRepositories : IDisposable
         }
     }
 
-    private async Task SyncToDefaultSingleRepoAfterCheckAsync(int repositoryId, string repositoryName, string currentBranchName, bool deleteRemoteBranch = false, string? defaultBranchName = null, bool allowForceDeleteLocalBranch = true)
+    private Task SyncToDefaultSingleRepoAfterCheckAsync(int repositoryId, string repositoryName, string currentBranchName, bool deleteRemoteBranch = false, string? defaultBranchName = null, bool allowForceDeleteLocalBranch = true)
     {
-        if (workspace == null || isSyncingToDefault || isSyncing || isUpdating)
-            return;
+        if (workspace == null || IsJobRunning)
+            return Task.CompletedTask;
 
-        isSyncingToDefault = true;
-        syncToDefaultMessage = string.IsNullOrWhiteSpace(defaultBranchName) ? "Synchronizing to default branch..." : $"Synchronizing to {defaultBranchName}...";
-        errorMessage = null;
-        await InvokeAsync(StateHasChanged);
+        var message = string.IsNullOrWhiteSpace(defaultBranchName)
+            ? "Synchronizing to default branch..."
+            : $"Synchronizing to {defaultBranchName}...";
 
-        try
+        JobService.StartJob(PageJobKey, message, async (job, ct) =>
         {
-            var (success, errMsg) = await WorkspaceBranchHandler.SyncToDefaultSingleAsync(
-                WorkspaceId,
-                repositoryId,
-                currentBranchName,
-                deleteRemoteBranch,
-                allowForceDeleteLocalBranch,
-                ApiBaseUrl,
-                CancellationToken.None);
-
-            if (success)
+            try
             {
-                repositoryErrors.Remove(repositoryId);
-                await RefreshFromSync();
+                var (success, errMsg) = await WorkspaceBranchHandler.SyncToDefaultSingleAsync(
+                    WorkspaceId,
+                    repositoryId,
+                    currentBranchName,
+                    deleteRemoteBranch,
+                    allowForceDeleteLocalBranch,
+                    ApiBaseUrl,
+                    ct);
+
+                if (success)
+                {
+                    SafeInvoke(() => repositoryErrors.Remove(repositoryId));
+                    await InvokeAsync(async () =>
+                    {
+                        if (_disposed) return;
+                        await RefreshFromSync();
+                    });
+                }
+                else if (errMsg != null)
+                {
+                    SafeInvoke(() => { repositoryErrors[repositoryId] = errMsg; });
+                }
             }
-            else if (errMsg != null)
+            catch (Exception ex)
             {
-                repositoryErrors[repositoryId] = errMsg;
+                Logger.LogError(ex, "Error syncing to default branch for repository {RepositoryId}", repositoryId);
+                SafeInvoke(() => { repositoryErrors[repositoryId] = "An error occurred while syncing to default branch. The GrayMoon Agent may be offline."; });
+                throw;
             }
-        }
-        catch (Exception ex)
-        {
-            Logger.LogError(ex, "Error syncing to default branch for repository {RepositoryId}", repositoryId);
-            repositoryErrors[repositoryId] = "An error occurred while syncing to default branch. The GrayMoon Agent may be offline.";
-        }
-        finally
-        {
-            _syncToDefaultAwaitingAgentTasks = false;
-            isSyncingToDefault = false;
-            await InvokeAsync(StateHasChanged);
-        }
+        });
+
+        return Task.CompletedTask;
     }
 
-    private async Task SyncToDefaultLevelAsync(List<int> repositoryIds, bool deleteRemoteBranch = false, bool allowForceDeleteLocalBranch = true)
+    private Task SyncToDefaultLevelAsync(List<int> repositoryIds, bool deleteRemoteBranch = false, bool allowForceDeleteLocalBranch = true)
     {
-        if (workspace == null || repositoryIds == null || repositoryIds.Count == 0 || isSyncingToDefault || isSyncing || isUpdating)
-            return;
+        if (workspace == null || repositoryIds == null || repositoryIds.Count == 0 || IsJobRunning)
+            return Task.CompletedTask;
 
         repositoryIds = repositoryIds.Where(id => !IsRepoOnTag(id)).ToList();
         if (repositoryIds.Count == 0)
         {
             ToastService.Show("All repositories are on tags; checkout a branch first.");
-            return;
+            return Task.CompletedTask;
         }
 
         var checkResults = _syncToDefaultCheckResults;
         _syncToDefaultCheckResults = null;
-
-        isSyncingToDefault = true;
-        var total = repositoryIds.Count;
-        syncToDefaultMessage = total > 1 ? "Synchronizing to default branch..." : "Synchronizing to default branch...";
         errorMessage = null;
-        await InvokeAsync(StateHasChanged);
 
-        var maxParallel = Math.Max(1, WorkspaceOptions?.Value?.MaxParallelOperations ?? 16);
-        var resultByRepo = checkResults?.ToDictionary(r => r.RepoId) ?? new Dictionary<int, (int RepoId, int? DefaultAhead, bool? HasUpstream)>();
-        var completedCount = 0;
-
-        try
+        JobService.StartJob(PageJobKey, "Synchronizing to default branch...", async (job, ct) =>
         {
-            using var semaphore = new SemaphoreSlim(maxParallel, maxParallel);
+            var total = repositoryIds.Count;
+            var maxParallel = Math.Max(1, WorkspaceOptions?.Value?.MaxParallelOperations ?? 16);
+            var resultByRepo = checkResults?.ToDictionary(r => r.RepoId) ?? new Dictionary<int, (int RepoId, int? DefaultAhead, bool? HasUpstream)>();
+            var completedCount = 0;
 
-            var tasks = repositoryIds.Select(async repositoryId =>
+            try
             {
-                var wr = workspaceRepositories.FirstOrDefault(w => w.RepositoryId == repositoryId);
-                var currentBranchName = wr?.BranchName;
-                if (string.IsNullOrWhiteSpace(currentBranchName))
+                using var semaphore = new SemaphoreSlim(maxParallel, maxParallel);
+
+                var tasks = repositoryIds.Select(async repositoryId =>
                 {
-                    var c = Interlocked.Increment(ref completedCount);
-                    if (total > 1)
+                    var wr = workspaceRepositories.FirstOrDefault(w => w.RepositoryId == repositoryId);
+                    var currentBranchName = wr?.BranchName;
+                    if (string.IsNullOrWhiteSpace(currentBranchName))
                     {
-                        syncToDefaultMessage = $"Synchronized {c} of {total} to default branch";
-                        if (c == total)
-                            _syncToDefaultAwaitingAgentTasks = true;
-                        await InvokeAsync(StateHasChanged);
+                        var c = Interlocked.Increment(ref completedCount);
+                        if (total > 1)
+                            job.ReportProgress($"Synchronized {c} of {total} to default branch");
+                        return (repositoryId, true, (string?)null);
                     }
-                    return (repositoryId, true, (string?)null);
-                }
 
-                await semaphore.WaitAsync();
-                try
-                {
-                    var repoHasRemote = !resultByRepo.TryGetValue(repositoryId, out var repoCheck) || repoCheck.HasUpstream == true;
-                    var (success, errMsg) = await WorkspaceBranchHandler.SyncToDefaultSingleAsync(
-                        WorkspaceId,
-                        repositoryId,
-                        currentBranchName,
-                        deleteRemoteBranch && repoHasRemote,
-                        allowForceDeleteLocalBranch,
-                        ApiBaseUrl,
-                        CancellationToken.None);
-
-                    return (repositoryId, success, errMsg);
-                }
-                finally
-                {
-                    semaphore.Release();
-                    var c = Interlocked.Increment(ref completedCount);
-                    if (total > 1)
+                    await semaphore.WaitAsync(ct);
+                    try
                     {
-                        syncToDefaultMessage = $"Synchronized {c} of {total} to default branch";
-                        if (c == total)
-                            _syncToDefaultAwaitingAgentTasks = true;
-                        await InvokeAsync(StateHasChanged);
-                    }
-                }
-            });
+                        var repoHasRemote = !resultByRepo.TryGetValue(repositoryId, out var repoCheck) || repoCheck.HasUpstream == true;
+                        var (success, errMsg) = await WorkspaceBranchHandler.SyncToDefaultSingleAsync(
+                            WorkspaceId,
+                            repositoryId,
+                            currentBranchName,
+                            deleteRemoteBranch && repoHasRemote,
+                            allowForceDeleteLocalBranch,
+                            ApiBaseUrl,
+                            ct);
 
-            var results = await Task.WhenAll(tasks);
-            var successCount = results.Count(r => r.Item2);
-            foreach (var (repoId, success, errMsg) in results)
-            {
-                if (success)
+                        return (repositoryId, success, errMsg);
+                    }
+                    finally
+                    {
+                        semaphore.Release();
+                        var c = Interlocked.Increment(ref completedCount);
+                        if (total > 1)
+                            job.ReportProgress($"Synchronized {c} of {total} to default branch");
+                    }
+                });
+
+                var results = await Task.WhenAll(tasks);
+                SafeInvoke(() =>
                 {
-                    repositoryErrors.Remove(repoId);
-                }
-                else if (errMsg != null)
+                    foreach (var (repoId, success, errMsg) in results)
+                    {
+                        if (success)
+                        {
+                            repositoryErrors.Remove(repoId);
+                        }
+                        else if (errMsg != null)
+                        {
+                            repositoryErrors[repoId] = errMsg;
+                            var repoName = workspaceRepositories.FirstOrDefault(w => w.RepositoryId == repoId)?.Repository?.RepositoryName ?? repoId.ToString();
+                            ToastService.Show($"{repoName}: {errMsg}");
+                        }
+                    }
+                });
+
+                await InvokeAsync(async () =>
                 {
-                    repositoryErrors[repoId] = errMsg;
-                    var repoName = workspaceRepositories.FirstOrDefault(w => w.RepositoryId == repoId)?.Repository?.RepositoryName ?? repoId.ToString();
-                    ToastService.Show($"{repoName}: {errMsg}");
-                }
+                    if (_disposed) return;
+                    await RefreshFromSync();
+                });
             }
-            if (total > 1)
+            catch (Exception ex)
             {
-                syncToDefaultMessage = $"Synchronized {successCount} of {total} to default branch";
-                if (successCount == total)
-                    _syncToDefaultAwaitingAgentTasks = true;
+                Logger.LogError(ex, "Error syncing to default branch for level");
+                SafeInvoke(() => errorMessage = "An error occurred while syncing to default branch. The GrayMoon Agent may be offline.");
+                throw;
             }
-            await InvokeAsync(StateHasChanged);
-            await RefreshFromSync();
-        }
-        catch (Exception ex)
-        {
-            Logger.LogError(ex, "Error syncing to default branch for level");
-            errorMessage = "An error occurred while syncing to default branch. The GrayMoon Agent may be offline.";
-        }
-        finally
-        {
-            _syncToDefaultAwaitingAgentTasks = false;
-            isSyncingToDefault = false;
-            await InvokeAsync(StateHasChanged);
-        }
+        });
+
+        return Task.CompletedTask;
     }
 
-    private async Task CheckoutBranchAsync((int RepositoryId, string BranchName, bool IsTag) request)
+    private Task CheckoutBranchAsync((int RepositoryId, string BranchName, bool IsTag) request)
     {
         var (repositoryId, branchName, isTag) = request;
-        if (workspace == null || isCheckingOut || isSyncing || isUpdating || isCommitSyncing)
-            return;
-
-        _checkoutCts?.Cancel();
-        _checkoutCts?.Dispose();
-        _checkoutCts = new CancellationTokenSource();
-
-        isCheckingOut = true;
-
-        SetCheckoutProgress(isTag ? "Checking out tag..." : "Checking out branch...");
+        if (workspace == null || IsJobRunning)
+            return Task.CompletedTask;
 
         errorMessage = null;
-        try
+
+        JobService.StartJob(PageJobKey, isTag ? "Checking out tag..." : "Checking out branch...", async (job, ct) =>
         {
-            StateHasChanged();
-            await Task.Yield();
-
-            var (success, errMsg) = await WorkspaceBranchHandler.CheckoutBranchAsync(
-                WorkspaceId,
-                repositoryId,
-                branchName,
-                isTag,
-                ApiBaseUrl,
-                _checkoutCts.Token);
-
-            if (success)
+            try
             {
-                repositoryErrors.Remove(repositoryId);
+                var (success, errMsg) = await WorkspaceBranchHandler.CheckoutBranchAsync(
+                    WorkspaceId,
+                    repositoryId,
+                    branchName,
+                    isTag,
+                    ApiBaseUrl,
+                    ct);
+
+                SafeInvoke(() =>
+                {
+                    if (success)
+                        repositoryErrors.Remove(repositoryId);
+                    else
+                        repositoryErrors[repositoryId] = errMsg ?? (isTag ? "Failed to checkout tag." : "Failed to checkout branch.");
+                });
+
+                await InvokeAsync(async () =>
+                {
+                    if (_disposed) return;
+                    await RefreshFromSync();
+                });
             }
-            else
+            catch (OperationCanceledException)
             {
-                repositoryErrors[repositoryId] = errMsg ?? (isTag ? "Failed to checkout tag." : "Failed to checkout branch.");
+                await ReloadWorkspaceDataAfterCancelAsync();
+                throw;
             }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "Error checking out {Kind} for repository {RepositoryId}", isTag ? "tag" : "branch", repositoryId);
+                SafeInvoke(() => { repositoryErrors[repositoryId] = isTag
+                    ? "Failed to checkout tag. The GrayMoon Agent may be offline. Start the Agent and try again."
+                    : "Failed to checkout branch. The GrayMoon Agent may be offline. Start the Agent and try again."; });
+                throw;
+            }
+        });
 
-            await RefreshFromSync();
-        }
-        catch (OperationCanceledException)
-        {
-            await ReloadWorkspaceDataAfterCancelAsync();
-        }
-        catch (Exception ex)
-        {
-            Logger.LogError(ex, "Error checking out {Kind} for repository {RepositoryId}", isTag ? "tag" : "branch", repositoryId);
-            repositoryErrors[repositoryId] = isTag
-                ? "Failed to checkout tag. The GrayMoon Agent may be offline. Start the Agent and try again."
-                : "Failed to checkout branch. The GrayMoon Agent may be offline. Start the Agent and try again.";
-        }
-        finally
-        {
-            isCheckingOut = false;
-            await InvokeAsync(StateHasChanged);
-        }
-    }
-
-    private void AbortCheckoutAsync()
-    {
-        _checkoutCts?.Cancel();
+        return Task.CompletedTask;
     }
 
     private void DismissRepositoryError(int repositoryId)
@@ -3426,61 +3145,51 @@ public sealed partial class WorkspaceRepositories : IDisposable
         public string Message { get; init; } = "";
     }
 
-    private void SetRestorePackagesProgress(string message)
+    private Task RestorePackagesAsync()
     {
-        restorePackagesProgressMessage = message;
-        _ = InvokeAsync(StateHasChanged);
+        if (workspace == null || IsJobRunning)
+            return Task.CompletedTask;
+
+        JobService.StartJob(PageJobKey, "Restoring packages...", async (job, ct) =>
+            await RestorePackagesCoreAsync(job, ct));
+
+        return Task.CompletedTask;
     }
 
-    private void AbortRestorePackages() => _restorePackagesCts?.Cancel();
-
-    private async Task RestorePackagesAsync()
+    private async Task RestorePackagesCoreAsync(BackgroundJobHandle job, CancellationToken ct)
     {
-        if (workspace == null || isRestoringPackages)
-            return;
-
-        _restorePackagesCts?.Cancel();
-        _restorePackagesCts?.Dispose();
-        _restorePackagesCts = new CancellationTokenSource();
-
-        isRestoringPackages = true;
-        SetRestorePackagesProgress("Restoring packages...");
+        job.ReportProgress("Restoring packages...");
         try
         {
-            StateHasChanged();
-            await Task.Yield();
-
             int count;
             await using (var scope = ServiceScopeFactory.CreateAsyncScope())
             {
                 var workspaceGitService = scope.ServiceProvider.GetRequiredService<WorkspaceGitService>();
                 count = await workspaceGitService.RestoreAllWorkspacePackagesAsync(
                     WorkspaceId,
-                    SetRestorePackagesProgress,
-                    _restorePackagesCts.Token);
+                    job.ReportProgress,
+                    ct);
             }
 
             if (count > 0)
-                ToastService.Show($"Restored packages in {count} {(count == 1 ? "project" : "projects")}");
+                SafeInvoke(() => ToastService.Show($"Restored packages in {count} {(count == 1 ? "project" : "projects")}"));
         }
         catch (OperationCanceledException)
         {
-            ToastService.Show("Restore cancelled.");
+            SafeInvoke(() => ToastService.Show("Restore cancelled."));
+            throw;
         }
         catch (AgentNotConnectedException ex)
         {
             Logger.LogError(ex, "Restore packages failed (agent not connected) for workspace {WorkspaceId}", WorkspaceId);
-            ToastService.ShowError($"Restore failed. {ex.Message}");
+            SafeInvoke(() => ToastService.ShowError($"Restore failed. {ex.Message}"));
+            throw;
         }
         catch (Exception ex)
         {
             Logger.LogError(ex, "Restore packages failed for workspace {WorkspaceId}", WorkspaceId);
-            ToastService.ShowError($"Restore failed: {ex.Message}");
-        }
-        finally
-        {
-            isRestoringPackages = false;
-            await InvokeAsync(StateHasChanged);
+            SafeInvoke(() => ToastService.ShowError($"Restore failed: {ex.Message}"));
+            throw;
         }
     }
 }

--- a/src/GrayMoon.App/Components/Shared/GhaWorkflowLiveTerminal.razor
+++ b/src/GrayMoon.App/Components/Shared/GhaWorkflowLiveTerminal.razor
@@ -39,7 +39,7 @@
                                 <span class="loading-overlay-terminal__text actions-gha-terminal__step-text">@line</span>
                                 @if (!string.IsNullOrWhiteSpace(timing))
                                 {
-                                    <span class="actions-gha-terminal__step-timing">@timing</span>
+                                    <span class="actions-gha-terminal__step-timing@(i == _spinnerBoardIdx ? " actions-gha-terminal__step-timing--active" : "")">@timing</span>
                                 }
                             }
                         </p>
@@ -64,9 +64,7 @@
 
     // Spinner — runs on its own 200ms loop, independent of the API poll
     private static readonly char[] SpinnerFrames = ['⠋', '⠙', '⠸', '⠴', '⠦', '⠧'];
-    private const int MaxDots = 60;
     private int _spinnerFrame;
-    private int _spinnerDots;
     private string? _spinnerStepKey;
     private int _spinnerBoardIdx = -1;  // board slot index of current in-progress step (-1 = none)
     private string _spinnerText = "";   // "  ...⠙" suffix appended to the in-progress slot
@@ -133,10 +131,7 @@
                         return;
 
                     _spinnerFrame = (_spinnerFrame + 1) % SpinnerFrames.Length;
-                    if (_spinnerFrame == 0 && _spinnerDots < MaxDots)
-                        _spinnerDots++;
-
-                    _spinnerText = $"  {new string('⠒', _spinnerDots)}{SpinnerFrames[_spinnerFrame]}";
+                    _spinnerText = $"  {SpinnerFrames[_spinnerFrame]}";
                     StateHasChanged();
                 });
             }
@@ -231,7 +226,6 @@
                     // New step started — reset spinner
                     _spinnerStepKey = stepKey;
                     _spinnerFrame   = 0;
-                    _spinnerDots    = 0;
                     _spinnerText    = "";
                 }
                 newSpinnerIdx  = i;

--- a/src/GrayMoon.App/Components/Shared/GhaWorkflowLiveTerminal.razor.css
+++ b/src/GrayMoon.App/Components/Shared/GhaWorkflowLiveTerminal.razor.css
@@ -114,3 +114,7 @@
     padding-left: 0.65rem;
     opacity: 0.65;
 }
+
+.actions-gha-terminal__step-timing--active {
+    opacity: 1;
+}

--- a/src/GrayMoon.App/Components/Shared/LoadingOverlay.razor
+++ b/src/GrayMoon.App/Components/Shared/LoadingOverlay.razor
@@ -54,10 +54,6 @@
                 <div class="spinner-border" role="status">
                     <span class="visually-hidden">Loading...</span>
                 </div>
-                @if (IsVisible && ShowTaskCountInSpinner && DisplayTaskCount > 0)
-                {
-                    <span class="loading-overlay-spinner-count" aria-hidden="true">@DisplayTaskCount</span>
-                }
             </div>
             @if (hasMessage)
             {
@@ -87,12 +83,6 @@
     [Parameter] public string? Message { get; set; }
     [Parameter] public EventCallback OnAbort { get; set; }
 
-    /// <summary>When set, used for spinner count (e.g. workspace-scoped). When null, fall back to total pending.</summary>
-    [Parameter] public int? PendingAgentTasksCount { get; set; }
-
-    /// <summary>When true, show task count inside spinner. Default false.</summary>
-    [Parameter] public bool ShowTaskCountInSpinner { get; set; } = false;
-
     /// <summary>When false, the live command terminal is never shown regardless of user toggle.</summary>
     [Parameter] public bool ShowCommandTerminal { get; set; } = true;
 
@@ -105,8 +95,6 @@
     private JobTerminalBuffer? _subscribedBuffer;
 
     private bool ShouldShowCommandTerminal => ShowCommandTerminal && CommandTerminalOverlayPreference.IsVisible;
-
-    private int DisplayTaskCount => !IsVisible ? 0 : (PendingAgentTasksCount ?? AgentQueueStateService.GetTotalPendingCount());
 
     private ElementReference _terminalScroll;
     private IReadOnlyList<OverlayTerminalLine> _terminalLines = Array.Empty<OverlayTerminalLine>();

--- a/src/GrayMoon.App/Components/Shared/LoadingOverlay.razor
+++ b/src/GrayMoon.App/Components/Shared/LoadingOverlay.razor
@@ -29,10 +29,6 @@
         </div>
     }
     <div class="loading-overlay__brand">
-        <span class="navbar-brand-content">
-            <img src="moon.svg" alt="GrayMoon" class="navbar-brand-icon" />
-            <span class="navbar-brand-title">GrayMoon</span>
-        </span>
         @if (ShowCommandTerminal)
         {
             <button type="button"

--- a/src/GrayMoon.App/Components/Shared/LoadingOverlay.razor
+++ b/src/GrayMoon.App/Components/Shared/LoadingOverlay.razor
@@ -9,7 +9,7 @@
 @implements IAsyncDisposable
 @implements IDisposable
 
-<div class="loading-overlay @(IsVisible ? "show" : "") @(MatrixPreference.UseMatrixEffect ? "loading-overlay--matrix" : "loading-overlay--simple") @(!OverlayUiSettings.TransparentBackdrop ? "loading-overlay--backdrop-opaque" : "")" aria-hidden="@(!IsVisible)">
+<div class="loading-overlay @(PageScoped ? "loading-overlay--page" : "") @(IsVisible ? "show" : "") @(MatrixPreference.UseMatrixEffect ? "loading-overlay--matrix" : "loading-overlay--simple") @(!OverlayUiSettings.TransparentBackdrop ? "loading-overlay--backdrop-opaque" : "")" aria-hidden="@(!IsVisible)">
     @if (MatrixPreference.UseMatrixEffect)
     {
         <canvas id="@_canvasId" class="matrix-canvas"></canvas>
@@ -100,6 +100,14 @@
     /// <summary>When false, the live command terminal is never shown regardless of user toggle.</summary>
     [Parameter] public bool ShowCommandTerminal { get; set; } = true;
 
+    /// <summary>When true, the overlay is scoped to the article content area (position:absolute) instead of full-screen (position:fixed).</summary>
+    [Parameter] public bool PageScoped { get; set; }
+
+    /// <summary>When set, terminal output is read from this per-job buffer instead of the global OverlayCommandTerminalService.</summary>
+    [Parameter] public JobTerminalBuffer? TerminalBuffer { get; set; }
+
+    private JobTerminalBuffer? _subscribedBuffer;
+
     private bool ShouldShowCommandTerminal => ShowCommandTerminal && CommandTerminalOverlayPreference.IsVisible;
 
     private int DisplayTaskCount => !IsVisible ? 0 : (PendingAgentTasksCount ?? AgentQueueStateService.GetTotalPendingCount());
@@ -129,12 +137,22 @@
 
     protected override void OnParametersSet()
     {
+        // Manage subscription to the per-job TerminalBuffer (swapped when parameter changes).
+        if (TerminalBuffer != _subscribedBuffer)
+        {
+            if (_subscribedBuffer != null)
+                _subscribedBuffer.Changed -= OnJobTerminalChanged;
+            _subscribedBuffer = TerminalBuffer;
+            if (_subscribedBuffer != null)
+                _subscribedBuffer.Changed += OnJobTerminalChanged;
+        }
+
         if (IsVisible && !_prevIsVisibleForTerminal)
         {
-            if (AgentQueueStateService.GetTotalPendingCount() == 0)
+            if (TerminalBuffer == null && AgentQueueStateService.GetTotalPendingCount() == 0)
                 CommandTerminal.Clear();
 
-            _terminalLines = CommandTerminal.GetSnapshot();
+            _terminalLines = TerminalBuffer?.GetSnapshot() ?? CommandTerminal.GetSnapshot();
             _lastScrolledLineCount = -1;
         }
 
@@ -148,11 +166,18 @@
         OverlayUiSettings.Changed += OnOverlayUiSettingsChanged;
         AgentQueueStateService.OnQueueStateChanged(OnQueueStateChanged);
         CommandTerminal.Changed += OnTerminalChanged;
-        _terminalLines = CommandTerminal.GetSnapshot();
+        _terminalLines = TerminalBuffer?.GetSnapshot() ?? CommandTerminal.GetSnapshot();
+    }
+
+    private void OnJobTerminalChanged()
+    {
+        _terminalLines = _subscribedBuffer?.GetSnapshot() ?? Array.Empty<OverlayTerminalLine>();
+        _ = InvokeAsync(StateHasChanged);
     }
 
     private void OnTerminalChanged(object? sender, EventArgs e)
     {
+        if (TerminalBuffer != null) return; // job buffer takes precedence
         _terminalLines = CommandTerminal.GetSnapshot();
         _ = InvokeAsync(StateHasChanged);
     }
@@ -278,6 +303,8 @@
         OverlayUiSettings.Changed -= OnOverlayUiSettingsChanged;
         AgentQueueStateService.RemoveQueueStateChanged(OnQueueStateChanged);
         CommandTerminal.Changed -= OnTerminalChanged;
+        if (_subscribedBuffer != null)
+            _subscribedBuffer.Changed -= OnJobTerminalChanged;
     }
 
     public async ValueTask DisposeAsync()

--- a/src/GrayMoon.App/Program.cs
+++ b/src/GrayMoon.App/Program.cs
@@ -86,6 +86,7 @@ try
     builder.Services.AddScoped<WorkspaceDependencyService>();
     builder.Services.AddScoped<WorkspaceBranchHandler>();
     builder.Services.AddScoped<NewFeatureOrchestrator>();
+    builder.Services.AddScoped<IBackgroundJobService, BackgroundJobService>();
     builder.Services.AddScoped<IWorkspacePageService, WorkspacePageService>();
     builder.Services.AddScoped<IWorkspaceTopBarService, WorkspaceTopBarService>();
 

--- a/src/GrayMoon.App/Services/AgentBridge.cs
+++ b/src/GrayMoon.App/Services/AgentBridge.cs
@@ -15,7 +15,6 @@ public interface IAgentBridge
 public sealed class AgentBridge(
     IHubContext<AgentHub> hubContext,
     AgentConnectionTracker connectionTracker,
-    OverlayCommandTerminalService overlayCommandTerminal,
     ILogger<AgentBridge> logger) : IAgentBridge
 {
     public bool IsAgentConnected => connectionTracker.GetAgentConnectionId() != null;
@@ -29,7 +28,9 @@ public sealed class AgentBridge(
         var requestId = Guid.NewGuid().ToString("N");
         var argsJson = args != null ? JsonSerializer.SerializeToElement(args) : (JsonElement?)null;
 
-        var task = AgentResponseDelivery.WaitAsync(requestId, cancellationToken, overlayCommandTerminal.Append);
+        var sink = TerminalSinkContext.Current;
+        Action<AgentCommandStreamLine>? onLine = sink != null ? sink.Append : null;
+        var task = AgentResponseDelivery.WaitAsync(requestId, cancellationToken, onLine);
 
         try
         {

--- a/src/GrayMoon.App/Services/BackgroundJobHandle.cs
+++ b/src/GrayMoon.App/Services/BackgroundJobHandle.cs
@@ -1,0 +1,71 @@
+namespace GrayMoon.App.Services;
+
+public enum BackgroundJobState
+{
+    Running,
+    Completed,
+    Faulted,
+    Aborted,
+}
+
+/// <summary>
+/// Represents a single in-progress background job. Owned by BackgroundJobService.
+/// Pages capture this to report progress; the layout overlay reads it to display status.
+/// </summary>
+public sealed class BackgroundJobHandle
+{
+    private readonly CancellationTokenSource _cts = new();
+
+    public string JobKey { get; }
+    public string DisplayMessage { get; private set; }
+    public BackgroundJobState State { get; private set; } = BackgroundJobState.Running;
+    public Exception? Fault { get; private set; }
+    public JobTerminalBuffer Terminal { get; } = new();
+    public CancellationToken CancellationToken => _cts.Token;
+
+    public event Action? Changed;
+
+    internal BackgroundJobHandle(string jobKey, string displayMessage)
+    {
+        JobKey = jobKey;
+        DisplayMessage = displayMessage;
+    }
+
+    public void ReportProgress(string message)
+    {
+        DisplayMessage = message;
+        Changed?.Invoke();
+    }
+
+    public void Abort()
+    {
+        _cts.Cancel();
+        State = BackgroundJobState.Aborted;
+        Changed?.Invoke();
+    }
+
+    internal void MarkCompleted()
+    {
+        State = BackgroundJobState.Completed;
+        Changed?.Invoke();
+    }
+
+    internal void MarkFaulted(Exception ex)
+    {
+        Fault = ex;
+        State = BackgroundJobState.Faulted;
+        Changed?.Invoke();
+    }
+
+    internal void MarkAborted()
+    {
+        State = BackgroundJobState.Aborted;
+        Changed?.Invoke();
+    }
+
+    internal void Dispose()
+    {
+        _cts.Cancel();
+        _cts.Dispose();
+    }
+}

--- a/src/GrayMoon.App/Services/BackgroundJobService.cs
+++ b/src/GrayMoon.App/Services/BackgroundJobService.cs
@@ -1,0 +1,88 @@
+using System.Collections.Concurrent;
+
+namespace GrayMoon.App.Services;
+
+public interface IBackgroundJobService
+{
+    /// <summary>Returns the most recent job for this key, or null if none.</summary>
+    BackgroundJobHandle? GetJob(string jobKey);
+
+    /// <summary>True when a job for this key is in Running state.</summary>
+    bool IsRunning(string jobKey);
+
+    /// <summary>
+    /// Starts a new background job for jobKey. If a Running job already exists for the key,
+    /// returns it unchanged. Otherwise creates a new handle, stores it, and launches the work.
+    /// </summary>
+    BackgroundJobHandle StartJob(string jobKey, string displayMessage,
+        Func<BackgroundJobHandle, CancellationToken, Task> work);
+
+    /// <summary>Fires on any job state change (start, progress, complete, fault, abort). Raised on a background thread.</summary>
+    event Action? Changed;
+}
+
+/// <summary>
+/// Scoped per Blazor circuit. Tracks background jobs by URL-path key; jobs survive page navigation
+/// within the same browser tab. Disposing the service (tab closed) cancels all running jobs.
+/// </summary>
+public sealed class BackgroundJobService : IBackgroundJobService, IDisposable
+{
+    private readonly ConcurrentDictionary<string, BackgroundJobHandle> _jobs = new(StringComparer.OrdinalIgnoreCase);
+
+    public event Action? Changed;
+
+    public BackgroundJobHandle? GetJob(string jobKey)
+        => _jobs.TryGetValue(jobKey, out var h) ? h : null;
+
+    public bool IsRunning(string jobKey)
+        => _jobs.TryGetValue(jobKey, out var h) && h.State == BackgroundJobState.Running;
+
+    public BackgroundJobHandle StartJob(string jobKey, string displayMessage,
+        Func<BackgroundJobHandle, CancellationToken, Task> work)
+    {
+        if (_jobs.TryGetValue(jobKey, out var existing) && existing.State == BackgroundJobState.Running)
+            return existing;
+
+        var handle = new BackgroundJobHandle(jobKey, displayMessage);
+        handle.Changed += RaiseChanged;
+        _jobs[jobKey] = handle;
+
+        _ = Task.Run(async () =>
+        {
+            using var _ = TerminalSinkContext.Use(handle.Terminal);
+            try
+            {
+                await work(handle, handle.CancellationToken);
+                handle.MarkCompleted();
+            }
+            catch (OperationCanceledException)
+            {
+                handle.MarkAborted();
+            }
+            catch (Exception ex)
+            {
+                handle.MarkFaulted(ex);
+            }
+            finally
+            {
+                RaiseChanged();
+            }
+        });
+
+        RaiseChanged();
+        return handle;
+    }
+
+    private void RaiseChanged()
+    {
+        var handler = Changed;
+        handler?.Invoke();
+    }
+
+    public void Dispose()
+    {
+        foreach (var handle in _jobs.Values)
+            handle.Dispose();
+        _jobs.Clear();
+    }
+}

--- a/src/GrayMoon.App/Services/DependencyUpdateOrchestrator.cs
+++ b/src/GrayMoon.App/Services/DependencyUpdateOrchestrator.cs
@@ -13,7 +13,8 @@ public sealed class DependencyUpdateOrchestrator(
     WorkspaceGitService workspaceGitService,
     WorkspaceFileVersionService fileVersionService,
     WorkspaceRepository workspaceRepository,
-    IOptions<WorkspaceOptions> workspaceOptions)
+    IOptions<WorkspaceOptions> workspaceOptions,
+    IServiceScopeFactory scopeFactory)
 {
     private readonly int _maxConcurrent = Math.Max(1, workspaceOptions?.Value?.MaxParallelOperations ?? 8);
 
@@ -209,7 +210,9 @@ public sealed class DependencyUpdateOrchestrator(
             await refreshSemaphore.WaitAsync(cancellationToken);
             try
             {
-                var (refreshSuccess, refreshError) = await workspaceGitService.SyncSingleRepositoryAsync(repoId, workspaceId, cancellationToken);
+                await using var scope = scopeFactory.CreateAsyncScope();
+                var svc = scope.ServiceProvider.GetRequiredService<WorkspaceGitService>();
+                var (refreshSuccess, refreshError) = await svc.SyncSingleRepositoryAsync(repoId, workspaceId, cancellationToken);
                 var c = Interlocked.Increment(ref completedRefresh);
                 setProgress($"Updating version {c} of {totalRefresh}...");
                 return (RepoId: repoId, Success: refreshSuccess, Error: refreshError);

--- a/src/GrayMoon.App/Services/GitHubOverlayLoggingHandler.cs
+++ b/src/GrayMoon.App/Services/GitHubOverlayLoggingHandler.cs
@@ -11,8 +11,7 @@ namespace GrayMoon.App.Services;
 /// response bodies. Never reads request bodies or any auth header. Append failures are
 /// swallowed so the HTTP pipeline is never affected by terminal issues.
 /// </summary>
-internal sealed partial class GitHubOverlayLoggingHandler(OverlayCommandTerminalService overlayTerminal)
-    : DelegatingHandler
+internal sealed partial class GitHubOverlayLoggingHandler : DelegatingHandler
 {
     private const string Label = "github";
     private const int MaxBodyChars = 80;
@@ -138,7 +137,7 @@ internal sealed partial class GitHubOverlayLoggingHandler(OverlayCommandTerminal
     {
         try
         {
-            overlayTerminal.Append(Label, kind, text);
+            TerminalSinkContext.Current?.Append(Label, kind, text);
         }
         catch
         {

--- a/src/GrayMoon.App/Services/JobTerminalBuffer.cs
+++ b/src/GrayMoon.App/Services/JobTerminalBuffer.cs
@@ -1,0 +1,44 @@
+using GrayMoon.Abstractions.Agent;
+
+namespace GrayMoon.App.Services;
+
+/// <summary>Bounded in-memory terminal buffer owned by a single background job.</summary>
+public sealed class JobTerminalBuffer
+{
+    private const int MaxLines = 800;
+    private readonly object _lock = new();
+    private readonly List<OverlayTerminalLine> _lines = [];
+
+    public event Action? Changed;
+
+    public IReadOnlyList<OverlayTerminalLine> GetSnapshot()
+    {
+        lock (_lock)
+            return _lines.ToList();
+    }
+
+    public void Append(AgentCommandStreamLine line)
+    {
+        lock (_lock)
+        {
+            _lines.Add(new OverlayTerminalLine(line.StreamLabel, line.Kind, line.Text));
+            while (_lines.Count > MaxLines)
+                _lines.RemoveAt(0);
+        }
+
+        Changed?.Invoke();
+    }
+
+    public void Append(string? streamLabel, AgentCommandStreamKind kind, string text)
+    {
+        Append(new AgentCommandStreamLine(streamLabel, kind, text));
+    }
+
+    public void Clear()
+    {
+        lock (_lock)
+            _lines.Clear();
+
+        Changed?.Invoke();
+    }
+}

--- a/src/GrayMoon.App/Services/TerminalSinkContext.cs
+++ b/src/GrayMoon.App/Services/TerminalSinkContext.cs
@@ -1,0 +1,24 @@
+namespace GrayMoon.App.Services;
+
+/// <summary>
+/// Ambient context that routes agent command stream output to the currently executing background job's terminal.
+/// Uses AsyncLocal so each concurrent job task has its own sink without threading parameters through every service.
+/// </summary>
+public static class TerminalSinkContext
+{
+    private static readonly AsyncLocal<JobTerminalBuffer?> _current = new();
+
+    public static JobTerminalBuffer? Current => _current.Value;
+
+    /// <summary>Sets the ambient sink for the current async call chain. Dispose to clear.</summary>
+    public static IDisposable Use(JobTerminalBuffer sink)
+    {
+        _current.Value = sink;
+        return new ClearOnDispose();
+    }
+
+    private sealed class ClearOnDispose : IDisposable
+    {
+        public void Dispose() => _current.Value = null;
+    }
+}

--- a/src/GrayMoon.App/Services/WorkspaceGitService.cs
+++ b/src/GrayMoon.App/Services/WorkspaceGitService.cs
@@ -1278,9 +1278,13 @@ public class WorkspaceGitService(
         if (useDefaultBase)
         {
             var wrIds = links.Select(l => l.WorkspaceRepositoryId).ToList();
-            defaultBranchByWrId = await _dbContext.RepositoryBranches
+            var defaultRows = await _dbContext.RepositoryBranches
                 .Where(rb => wrIds.Contains(rb.WorkspaceRepositoryId) && rb.IsDefault)
-                .ToDictionaryAsync(rb => rb.WorkspaceRepositoryId, rb => rb.BranchName, cancellationToken);
+                .Select(rb => new { rb.WorkspaceRepositoryId, rb.BranchName })
+                .ToListAsync(cancellationToken);
+            defaultBranchByWrId = new Dictionary<int, string>();
+            foreach (var row in defaultRows)
+                defaultBranchByWrId.TryAdd(row.WorkspaceRepositoryId, row.BranchName);
         }
 
         async Task ProcessOne(WorkspaceRepositoryLink wr)

--- a/src/GrayMoon.App/Services/WorkspaceGitService.cs
+++ b/src/GrayMoon.App/Services/WorkspaceGitService.cs
@@ -754,6 +754,56 @@ public class WorkspaceGitService(
         return (true, null);
     }
 
+    /// <summary>Refreshes branches for a single repository by calling the agent directly. Routes CommandOutput to TerminalSinkContext when called within a background job.</summary>
+    public async Task<bool> RefreshBranchesForRepositoryAsync(int repositoryId, int workspaceId, CancellationToken cancellationToken = default)
+    {
+        var repo = await _repositoryRepository.GetByIdAsync(repositoryId, cancellationToken);
+        if (repo == null) return false;
+
+        var wr = await _dbContext.WorkspaceRepositories
+            .FirstOrDefaultAsync(x => x.WorkspaceId == workspaceId && x.RepositoryId == repositoryId, cancellationToken);
+        if (wr == null) return false;
+
+        var workspace = await _workspaceRepository.GetByIdAsync(workspaceId);
+        if (workspace == null) return false;
+
+        var workspaceRoot = await _workspaceService.GetRootPathForWorkspaceAsync(workspace, cancellationToken);
+        var response = await _agentBridge.SendCommandAsync("RefreshBranches", new
+        {
+            workspaceName = workspace.Name,
+            repositoryId = repo.RepositoryId,
+            repositoryName = repo.RepositoryName,
+            workspaceRoot
+        }, cancellationToken);
+
+        if (!response.Success) return false;
+
+        var refreshResponse = AgentResponseJson.DeserializeAgentResponse<BranchesResponse>(response.Data);
+        if (refreshResponse == null) return false;
+
+        var localBranches = refreshResponse.LocalBranches.Where(b => !string.IsNullOrWhiteSpace(b)).ToList();
+        var remoteBranches = refreshResponse.RemoteBranches.Where(b => !string.IsNullOrWhiteSpace(b)).ToList();
+        var tags = refreshResponse.Tags.Where(t => !string.IsNullOrWhiteSpace(t)).ToList();
+
+        await PersistBranchesAsync(wr.WorkspaceRepositoryId, localBranches, remoteBranches, refreshResponse.DefaultBranch, tags, refreshResponse.CurrentTag, cancellationToken);
+
+        if (string.IsNullOrWhiteSpace(refreshResponse.CurrentTag))
+        {
+            var branch = refreshResponse.CurrentBranch?.Trim();
+            if (!string.IsNullOrWhiteSpace(branch))
+            {
+                var hasUpstream = remoteBranches.Any(r => !string.IsNullOrEmpty(r) &&
+                    (string.Equals(r, branch, StringComparison.OrdinalIgnoreCase)
+                     || string.Equals(r, "origin/" + branch, StringComparison.OrdinalIgnoreCase)
+                     || r.EndsWith("/" + branch, StringComparison.OrdinalIgnoreCase)));
+                wr.BranchHasUpstream = hasUpstream;
+                await _dbContext.SaveChangesAsync(cancellationToken);
+            }
+        }
+
+        return true;
+    }
+
     public async Task<IReadOnlyDictionary<int, RepoSyncStatus>> GetRepoSyncStatusAsync(
         int workspaceId,
         Action<int, RepoSyncStatus>? onProgress = null,
@@ -1223,6 +1273,16 @@ public class WorkspaceGitService(
         using var semaphore = new SemaphoreSlim(_maxConcurrent);
         var workspaceRoot = await _workspaceService.GetRootPathForWorkspaceAsync(workspace, cancellationToken);
 
+        // Prefetch all default branches before the parallel section to avoid concurrent DbContext reads
+        Dictionary<int, string>? defaultBranchByWrId = null;
+        if (useDefaultBase)
+        {
+            var wrIds = links.Select(l => l.WorkspaceRepositoryId).ToList();
+            defaultBranchByWrId = await _dbContext.RepositoryBranches
+                .Where(rb => wrIds.Contains(rb.WorkspaceRepositoryId) && rb.IsDefault)
+                .ToDictionaryAsync(rb => rb.WorkspaceRepositoryId, rb => rb.BranchName, cancellationToken);
+        }
+
         async Task ProcessOne(WorkspaceRepositoryLink wr)
         {
             await semaphore.WaitAsync(cancellationToken);
@@ -1235,11 +1295,7 @@ public class WorkspaceGitService(
                 string baseBranchName;
                 if (useDefaultBase)
                 {
-                    var defaultRow = await _dbContext.RepositoryBranches
-                        .Where(rb => rb.WorkspaceRepositoryId == wr.WorkspaceRepositoryId && rb.IsDefault)
-                        .Select(rb => rb.BranchName)
-                        .FirstOrDefaultAsync(cancellationToken);
-                    baseBranchName = defaultRow ?? "main";
+                    baseBranchName = defaultBranchByWrId?.GetValueOrDefault(wr.WorkspaceRepositoryId) ?? "main";
                 }
                 else
                 {

--- a/src/GrayMoon.App/Services/WorkspacePushService.cs
+++ b/src/GrayMoon.App/Services/WorkspacePushService.cs
@@ -192,6 +192,11 @@ public sealed class WorkspacePushService(
                 }
                 var lastPollUtc = DateTime.MinValue;
 
+                // Prefetch all connectors for this level once to avoid concurrent DbContext reads in the polling loop
+                var connectorByIdForLevel = new Dictionary<int, Connector?>();
+                foreach (var cid in requiredForLevel.Select(r => r.MatchedConnectorId!.Value).Distinct())
+                    connectorByIdForLevel[cid] = await _connectorRepository!.GetByIdAsync(cid);
+
                 while (getFoundCount() < totalDeps)
                 {
                     linkedToken.ThrowIfCancellationRequested();
@@ -254,7 +259,7 @@ public sealed class WorkspacePushService(
                                 await Task.WhenAll(chunk.Select(async i =>
                                 {
                                     var req = requiredForLevel[i];
-                                    var connector = await _connectorRepository.GetByIdAsync(req.MatchedConnectorId!.Value);
+                                    connectorByIdForLevel.TryGetValue(req.MatchedConnectorId!.Value, out var connector);
                                     if (connector == null)
                                     {
                                         _logger.LogWarning("Push wait: package {PackageId} {Version} has no connector (MatchedConnectorId={ConnectorId}).", req.PackageId, req.Version, req.MatchedConnectorId);
@@ -666,6 +671,7 @@ public sealed class WorkspacePushService(
         var total = repos.Count;
         using var semaphore = new SemaphoreSlim(_maxConcurrent);
         var workspaceRoot = await _workspaceService.GetRootPathForWorkspaceAsync(workspace, cancellationToken);
+        var rejectedRepos = new System.Collections.Concurrent.ConcurrentBag<(int RepoId, string RepoName)>();
         var pushTasks = repos.Select(async repo =>
         {
             await semaphore.WaitAsync(cancellationToken);
@@ -689,7 +695,7 @@ public sealed class WorkspacePushService(
                 {
                     var rawErr = response.Error ?? AgentResponseJson.DeserializeAgentResponse<PushRepositoryResponse>(response.Data!)?.ErrorMessage;
                     if (IsNonFastForwardRejection(rawErr))
-                        await FetchAfterRejectionAsync(workspace.WorkspaceId, repo.RepoId, repo.RepoName, workspace.Name, workspaceRoot, cancellationToken);
+                        rejectedRepos.Add((repo.RepoId, repo.RepoName));
                     onRepoError?.Invoke(repo.RepoId, FormatPushError(rawErr));
                 }
                 var c = Interlocked.Increment(ref completed);
@@ -703,6 +709,8 @@ public sealed class WorkspacePushService(
             }
         });
         await Task.WhenAll(pushTasks);
+        foreach (var (repoId, repoName) in rejectedRepos)
+            await FetchAfterRejectionAsync(workspace.WorkspaceId, repoId, repoName, workspace.Name, workspaceRoot, cancellationToken);
     }
 
     private static bool IsNonFastForwardRejection(string? err) =>

--- a/src/GrayMoon.App/wwwroot/app.css
+++ b/src/GrayMoon.App/wwwroot/app.css
@@ -56,6 +56,17 @@
     --warning: #dcdcaa;
     --error: #f48771;
     --info: #4fc1ff;
+
+    /* Layout dimensions (mobile-first; overridden at >= 641px) */
+    --sidebar-width: 0px;
+    --topbar-height: 2.75rem;
+}
+
+@media (min-width: 641px) {
+    :root {
+        --sidebar-width: 180px;
+        --topbar-height: 3.5rem;
+    }
 }
 
 html, body {

--- a/src/GrayMoon.App/wwwroot/css/loading-overlay.css
+++ b/src/GrayMoon.App/wwwroot/css/loading-overlay.css
@@ -17,10 +17,13 @@
   transition: opacity 140ms ease;
 }
 
-/* Page-scoped variant: fixed to the full viewport so short content pages are fully covered. */
+/* Page-scoped variant: fixed below the top bar and right of the sidebar, always full remaining height. */
 .loading-overlay--page {
   position: fixed;
-  inset: 0;
+  top: var(--topbar-height);
+  left: var(--sidebar-width);
+  right: 0;
+  bottom: 0;
   /* z-index below Bootstrap modals (1050+) so dialogs stay interactive above the overlay */
   z-index: 100;
 }

--- a/src/GrayMoon.App/wwwroot/css/loading-overlay.css
+++ b/src/GrayMoon.App/wwwroot/css/loading-overlay.css
@@ -17,9 +17,9 @@
   transition: opacity 140ms ease;
 }
 
-/* Page-scoped variant: constrained to the article content area (article.content must have position:relative). */
+/* Page-scoped variant: fixed to the full viewport so short content pages are fully covered. */
 .loading-overlay--page {
-  position: absolute;
+  position: fixed;
   inset: 0;
   /* z-index below Bootstrap modals (1050+) so dialogs stay interactive above the overlay */
   z-index: 100;
@@ -293,20 +293,6 @@
   position: absolute;
   inset: 0;
   margin: 0;
-}
-
-.loading-overlay-spinner-count {
-  position: absolute;
-  inset: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-family: "Nunito", sans-serif;
-  font-size: 0.75rem;
-  font-weight: 700;
-  color: #555;
-  line-height: 1;
-  pointer-events: none;
 }
 
 .loading-overlay__message {

--- a/src/GrayMoon.App/wwwroot/css/loading-overlay.css
+++ b/src/GrayMoon.App/wwwroot/css/loading-overlay.css
@@ -201,6 +201,17 @@
   color: rgba(220, 190, 72, 0.9) !important;
 }
 
+/* Active (in-progress) step elapsed time - matches step text color; !important to beat running-row td { color } inheritance */
+.grid-page-body .table.actions-table tbody tr.actions-row-running-terminal .actions-gha-terminal .loading-overlay-terminal:not(.loading-overlay-terminal--scheme-yellow) .actions-gha-terminal__step-timing--active {
+  color: rgba(120, 210, 150, 0.88) !important;
+  opacity: 1 !important;
+}
+
+.grid-page-body .table.actions-table tbody tr.actions-row-running-terminal .actions-gha-terminal .loading-overlay-terminal--scheme-yellow .actions-gha-terminal__step-timing--active {
+  color: rgba(220, 190, 72, 0.9) !important;
+  opacity: 1 !important;
+}
+
 /* Brand at top-left of overlay - same position and font as sidebar header; above full-height terminal */
 .loading-overlay__brand {
   position: absolute;

--- a/src/GrayMoon.App/wwwroot/css/loading-overlay.css
+++ b/src/GrayMoon.App/wwwroot/css/loading-overlay.css
@@ -17,6 +17,14 @@
   transition: opacity 140ms ease;
 }
 
+/* Page-scoped variant: constrained to the article content area (article.content must have position:relative). */
+.loading-overlay--page {
+  position: absolute;
+  inset: 0;
+  /* z-index below Bootstrap modals (1050+) so dialogs stay interactive above the overlay */
+  z-index: 100;
+}
+
 .loading-overlay.show {
   opacity: 1;
   pointer-events: all; /* blocks clicks while loading */


### PR DESCRIPTION
# Summary
- Introduce a Blazor-circuit-scoped background job pipeline (`BackgroundJobService`, `BackgroundJobHandle`, `JobTerminalBuffer`, `TerminalSinkContext`) so sync, push, dependency update, restore, branch checkout, commit sync, sync-to-default, and PR creation survive navigation within the same tab
- Route agent command output and GitHub overlay logging into per-job terminal buffers via ambient `TerminalSinkContext`; refactor `WorkspaceRepositories` to start jobs instead of blocking with inline overlays
- Add layout-level `BackgroundJobOverlay` that re-shows progress and live terminal output when returning to the repositories page; limit the spinner to the main content area so sidebar navigation stays usable
- Pause automatic grid refresh from agent hook sync while a job is running to avoid stale reads overwriting in-progress work
- Document the background job model in README and CLAUDE.md
## Test plan
- [ ] Start sync, push, dependency update, or restore on workspace Repositories, navigate to Projects or Actions, then return and confirm the overlay reappears with the same progress and terminal output
- [ ] Confirm the overlay covers only the main content pane, not the full viewport or sidebar
- [ ] Verify agent commands and GitHub API lines stream into the job terminal; toggle terminal visibility and use Abort to cancel
- [ ] Confirm only one running job per repositories URL and that closing the tab cancels jobs for that session
- [ ] While a job runs, trigger agent hook sync and confirm the grid does not refresh until the job completes
- [ ] Smoke-test initial page load and repository fetch inline overlays (non-background paths)