### PR TITLE
Add GHA failed-job re-run and improve workflow diagnostics

### DIFF
--- a/src/GrayMoon.App/Components/Modals/GhaLogsModal.razor
+++ b/src/GrayMoon.App/Components/Modals/GhaLogsModal.razor
@@ -42,9 +42,9 @@
                                 {
                                     var isSelected = navJob.Meta.Id == _selectedJobId;
                                     <button type="button"
-                                            class="gha-log-job__pill gha-log-job__pill--@(isSelected ? JobStatusClass(navJob.Meta) : "other")"
+                                            class="@PillClass(navJob.Meta, isSelected)"
                                             title="@navJob.Meta.Name"
-                                            @onclick="() => _selectedJobId = navJob.Meta.Id">
+                                            @onclick="() => SelectJob(navJob.Meta.Id)">
                                         <span class="gha-log-job__name">@navJob.Meta.Name</span>
                                     </button>
                                 }
@@ -286,6 +286,21 @@
         GhaLogLineKind.Debug   => "debug",
         _                      => "normal",
     };
+
+    private void SelectJob(long jobId)
+    {
+        _selectedJobId = jobId;
+        _filterErrors = false;
+        _filterWarnings = false;
+    }
+
+    private string PillClass(GitHubWorkflowJobDto job, bool isSelected)
+    {
+        var status = JobStatusClass(job);
+        return isSelected
+            ? $"gha-log-job__pill gha-log-job__pill--{status} gha-log-job__pill--selected"
+            : $"gha-log-job__pill gha-log-job__pill--{status}";
+    }
 
     private static string JobStatusClass(GitHubWorkflowJobDto job) =>
         job.Conclusion?.ToLowerInvariant() switch

--- a/src/GrayMoon.App/Components/Modals/GhaLogsModal.razor
+++ b/src/GrayMoon.App/Components/Modals/GhaLogsModal.razor
@@ -90,6 +90,11 @@
                                 @onclick="DownloadLogsAsync">
                             Download
                         </button>
+                        <button type="button" class="btn btn-outline-secondary"
+                                disabled="@(_jobs.Count == 0 || _isLoading)"
+                                @onclick="() => _allCollapsed = !_allCollapsed">
+                            @(_allCollapsed ? "Expand" : "Collapse")
+                        </button>
                         @{ var ec = ErrorCount; var wc = WarningCount; }
                         @if (ec > 0)
                         {
@@ -109,11 +114,18 @@
                         }
                     </div>
                     <div class="d-flex gap-2">
-                        <button type="button" class="btn btn-outline-secondary"
-                                disabled="@(_jobs.Count == 0 || _isLoading)"
-                                @onclick="() => _allCollapsed = !_allCollapsed">
-                            @(_allCollapsed ? "Expand" : "Collapse")
-                        </button>
+                        @if (IsSelectedJobFailed)
+                        {
+                            <button type="button" class="btn btn-danger"
+                                    disabled="@_isRerunning"
+                                    @onclick="RerunJobAsync">
+                                @if (_isRerunning)
+                                {
+                                    <span class="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true"></span>
+                                }
+                                Re-run Job
+                            </button>
+                        }
                         <button type="button" class="btn btn-outline-secondary" @onclick="CloseAsync">Close</button>
                     </div>
                 </div>
@@ -136,17 +148,22 @@
     private bool _wasVisible;
     private bool _isLoading;
     private bool _isLoadingMore;
+    private bool _isRerunning;
     private bool _allCollapsed;
     private bool _filterErrors;
     private bool _filterWarnings;
     private bool _loadTriggered;
     private bool _autoSelectInitialized;
+    private bool _scrollToFirstError;
     private string? _errorMessage;
     private long? _selectedJobId;
     private List<JobLogEntry> _jobs = [];
     private ElementReference _contentRef;
 
     private JobLogEntry? SelectedJob => _jobs.FirstOrDefault(j => j.Meta.Id == _selectedJobId);
+
+    private bool IsSelectedJobFailed => string.Equals(
+        SelectedJob?.Meta.Conclusion, "failure", StringComparison.OrdinalIgnoreCase);
 
     private int ErrorCount => SelectedJob == null ? 0 : SelectedJob.Entries.Count(e =>
         (e is GhaLogGroupEntry g && g.HasError) || (e is GhaLogLineEntry l && l.Kind == GhaLogLineKind.Error));
@@ -174,6 +191,7 @@
             _wasVisible = true;
             _isLoading = true;
             _isLoadingMore = false;
+            _isRerunning = false;
             _allCollapsed = false;
             _filterErrors = false;
             _filterWarnings = false;
@@ -202,6 +220,12 @@
         {
             _autoSelectInitialized = true;
             try { await JS.InvokeVoidAsync("ghaLogs.initAutoSelect", _contentRef); } catch { }
+        }
+
+        if (_scrollToFirstError)
+        {
+            _scrollToFirstError = false;
+            try { await JS.InvokeVoidAsync("ghaLogs.scrollToFirstError", _contentRef); } catch { }
         }
     }
 
@@ -269,6 +293,28 @@
         try { await JS.InvokeVoidAsync("ghaLogs.downloadText", filename, combined); } catch { }
     }
 
+    private async Task RerunJobAsync()
+    {
+        var job = SelectedJob;
+        if (job == null) return;
+        var connector = await ConnectorRepository.GetByNameAsync(ConnectorName);
+        if (connector == null) return;
+        _isRerunning = true;
+        try
+        {
+            await GitHubService.RerunJobAsync(connector, Owner, RepositoryName, job.Meta.Id);
+            await CloseAsync();
+        }
+        catch (Exception ex)
+        {
+            _errorMessage = ex.Message;
+        }
+        finally
+        {
+            _isRerunning = false;
+        }
+    }
+
     private async Task CloseAsync() => await OnClose.InvokeAsync();
 
     private async Task HandleKeyDown(KeyboardEventArgs e)
@@ -292,6 +338,9 @@
         _selectedJobId = jobId;
         _filterErrors = false;
         _filterWarnings = false;
+        var job = _jobs.FirstOrDefault(j => j.Meta.Id == jobId);
+        if (string.Equals(job?.Meta.Conclusion, "failure", StringComparison.OrdinalIgnoreCase))
+            _scrollToFirstError = true;
     }
 
     private string PillClass(GitHubWorkflowJobDto job, bool isSelected)

--- a/src/GrayMoon.App/Components/Modals/GhaLogsModal.razor
+++ b/src/GrayMoon.App/Components/Modals/GhaLogsModal.razor
@@ -142,6 +142,7 @@
     [Parameter] public long RunId { get; set; }
     [Parameter] public string? WorkflowDisplayName { get; set; }
     [Parameter] public EventCallback OnClose { get; set; }
+    [Parameter] public EventCallback OnRerunTriggered { get; set; }
 
     private record JobLogEntry(GitHubWorkflowJobDto Meta, List<GhaLogEntry> Entries, string? RawLog);
 
@@ -154,7 +155,7 @@
     private bool _filterWarnings;
     private bool _loadTriggered;
     private bool _autoSelectInitialized;
-    private bool _scrollToFirstError;
+    private bool _scrollToTopAfterRender;
     private string? _errorMessage;
     private long? _selectedJobId;
     private List<JobLogEntry> _jobs = [];
@@ -222,10 +223,10 @@
             try { await JS.InvokeVoidAsync("ghaLogs.initAutoSelect", _contentRef); } catch { }
         }
 
-        if (_scrollToFirstError)
+        if (_scrollToTopAfterRender)
         {
-            _scrollToFirstError = false;
-            try { await JS.InvokeVoidAsync("ghaLogs.scrollToFirstError", _contentRef); } catch { }
+            _scrollToTopAfterRender = false;
+            try { await JS.InvokeVoidAsync("ghaLogs.scrollContent", _contentRef, "Home"); } catch { }
         }
     }
 
@@ -243,7 +244,10 @@
             }
 
             var jobsResponse = await GitHubService.GetWorkflowRunJobsAsync(connector, Owner, RepositoryName, RunId);
-            var jobs = jobsResponse?.Jobs ?? [];
+            var jobs = (jobsResponse?.Jobs ?? [])
+                .OrderBy(j => j.StartedAt ?? j.CreatedAt ?? DateTimeOffset.MaxValue)
+                .ThenBy(j => j.Id)
+                .ToList();
 
             for (int jobIdx = 0; jobIdx < jobs.Count; jobIdx++)
             {
@@ -303,7 +307,7 @@
         try
         {
             await GitHubService.RerunJobAsync(connector, Owner, RepositoryName, job.Meta.Id);
-            await CloseAsync();
+            await OnRerunTriggered.InvokeAsync();
         }
         catch (Exception ex)
         {
@@ -336,11 +340,11 @@
     private void SelectJob(long jobId)
     {
         _selectedJobId = jobId;
-        _filterErrors = false;
         _filterWarnings = false;
         var job = _jobs.FirstOrDefault(j => j.Meta.Id == jobId);
-        if (string.Equals(job?.Meta.Conclusion, "failure", StringComparison.OrdinalIgnoreCase))
-            _scrollToFirstError = true;
+        var isFailed = string.Equals(job?.Meta.Conclusion, "failure", StringComparison.OrdinalIgnoreCase);
+        _filterErrors = isFailed;
+        _scrollToTopAfterRender = true;
     }
 
     private string PillClass(GitHubWorkflowJobDto job, bool isSelected)

--- a/src/GrayMoon.App/Components/Modals/GhaLogsModal.razor.css
+++ b/src/GrayMoon.App/Components/Modals/GhaLogsModal.razor.css
@@ -135,16 +135,23 @@
 }
 
 .gha-log-job__pill:hover {
-    filter: brightness(1.15);
+    filter: brightness(1.2);
 }
 
-/* Non-current job pills: gray */
-.gha-log-job__pill--other {
-    background: #383838;
-    color: rgba(255, 255, 255, 0.5);
+/* Non-current job pills: dimmed */
+.gha-log-job__pill:not(.gha-log-job__pill--selected) {
+    opacity: 0.5;
 }
 
-/* Status-colored pills (current job) */
+/* Selected pill: full brightness + subtle ring */
+.gha-log-job__pill--selected {
+    opacity: 1;
+    outline: 2px solid rgba(255, 255, 255, 0.35);
+    outline-offset: 1px;
+}
+
+/* Status-colored pills */
+.gha-log-job__pill--other   { background: #383838; color: rgba(255, 255, 255, 0.5); }
 .gha-log-job__pill--success { background: #238636; color: #fff; }
 .gha-log-job__pill--failure { background: #da3633; color: #fff; }
 .gha-log-job__pill--aborted { background: #8957e5; color: #fff; }

--- a/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor
@@ -114,11 +114,47 @@
                 </div>
                 @if (HasFailedRows)
                 {
-                    <button class="btn btn-danger"
-                            @onclick="RerunAllFailedAsync"
-                            disabled="@(isRerunningAll || isRefreshing || isLoading)">
-                        Re-run
-                    </button>
+                    <div class="btn-group position-relative">
+                        <button class="btn btn-danger"
+                                @onclick="RerunAllFailedAsync"
+                                @onclick:stopPropagation
+                                disabled="@(isRerunningAll || isRefreshing || isLoading)">
+                            Re-run
+                        </button>
+                        <button type="button"
+                                class="btn btn-danger dropdown-toggle dropdown-toggle-split"
+                                aria-label="Toggle Re-run menu"
+                                aria-expanded="@(_rerunMenuOpen ? "true" : "false")"
+                                @onclick="ToggleRerunMenu"
+                                @onclick:stopPropagation
+                                disabled="@(isRerunningAll || isRefreshing || isLoading)">
+                            <span class="visually-hidden">Toggle Dropdown</span>
+                        </button>
+                        @if (_rerunMenuOpen)
+                        {
+                            <div class="branch-menu-backdrop" @onclick="CloseRerunMenu"></div>
+                            <ul class="dropdown-menu show shadow branch-menu-list"
+                                role="menu">
+                                <li>
+                                    <button class="dropdown-item" type="button"
+                                            role="menuitem"
+                                            @onclick="async () => { CloseRerunMenu(); await RerunAllFailedAsync(); }"
+                                            disabled="@(isRerunningAll || isRefreshing || isLoading)">
+                                        Re-run
+                                    </button>
+                                </li>
+                                <li><hr class="dropdown-divider branch-menu-divider" /></li>
+                                <li>
+                                    <button class="dropdown-item" type="button"
+                                            role="menuitem"
+                                            @onclick="async () => { CloseRerunMenu(); await RerunAllFailedJobsOnlyAsync(); }"
+                                            disabled="@(isRerunningAll || isRefreshing || isLoading)">
+                                        Re-run Failed Jobs Only
+                                    </button>
+                                </li>
+                            </ul>
+                        }
+                    </div>
                 }
                 <button class="btn btn-outline-secondary"
                         @onclick="RefreshAllAsync"

--- a/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor
@@ -138,7 +138,7 @@
                                 <li>
                                     <button class="dropdown-item" type="button"
                                             role="menuitem"
-                                            @onclick="async () => { CloseRerunMenu(); await RerunAllFailedAsync(); }"
+                                            @onclick="HandleRerunAllClick"
                                             disabled="@(isRerunningAll || isRefreshing || isLoading)">
                                         Re-run
                                     </button>
@@ -147,7 +147,7 @@
                                 <li>
                                     <button class="dropdown-item" type="button"
                                             role="menuitem"
-                                            @onclick="async () => { CloseRerunMenu(); await RerunAllFailedJobsOnlyAsync(); }"
+                                            @onclick="HandleRerunFailedJobsOnlyClick"
                                             disabled="@(isRerunningAll || isRefreshing || isLoading)">
                                         Re-run Failed Jobs Only
                                     </button>

--- a/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor
@@ -376,4 +376,5 @@
               RepositoryName="@(_logsRepo ?? "")"
               RunId="@_logsRunId"
               WorkflowDisplayName="@_logsWorkflowName"
-              OnClose="CloseLogsModal" />
+              OnClose="CloseLogsModal"
+              OnRerunTriggered="OnLogsRerunTriggered" />

--- a/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor.cs
@@ -91,6 +91,8 @@ public sealed partial class WorkspaceActions : IDisposable
     private long _logsRunId;
     private string? _logsWorkflowName;
 
+    private bool _rerunMenuOpen;
+
     private enum ActionLineFilterBucket
     {
         Failed,
@@ -206,6 +208,18 @@ public sealed partial class WorkspaceActions : IDisposable
             ApplyActionLatches(row);
             await InvokeAsync(StateHasChanged);
         }
+    }
+
+    internal void ToggleRerunMenu()
+    {
+        _rerunMenuOpen = !_rerunMenuOpen;
+        StateHasChanged();
+    }
+
+    internal void CloseRerunMenu()
+    {
+        _rerunMenuOpen = false;
+        StateHasChanged();
     }
 
     internal void ToggleShowErrors()
@@ -1145,6 +1159,83 @@ public sealed partial class WorkspaceActions : IDisposable
             await Task.WhenAll(tasks);
             Logger.LogInformation(
                 "GHA Re-run all finished (API phase): WorkspaceId={WorkspaceId} attempted={Count}",
+                WorkspaceId,
+                failedPairs.Count);
+        }
+        finally
+        {
+            isRerunningAll = false;
+            await InvokeAsync(StateHasChanged);
+            _ = RefreshAllAsync();
+        }
+    }
+
+    internal async Task RerunAllFailedJobsOnlyAsync()
+    {
+        var failedPairs = new List<(WorkspaceActionRow Row, WorkflowActionLine Line)>();
+        foreach (var row in rows)
+        {
+            foreach (var line in row.WorkflowLines)
+            {
+                if (IsLineFailedForBranch(row, line) && (line.Action?.RunId ?? 0) > 0)
+                    failedPairs.Add((row, line));
+            }
+        }
+
+        if (failedPairs.Count == 0) return;
+
+        Logger.LogInformation(
+            "GHA Re-run failed jobs only requested: WorkspaceId={WorkspaceId} count={Count}",
+            WorkspaceId,
+            failedPairs.Count);
+
+        _rerunTotal = failedPairs.Count;
+        _rerunCompleted = 0;
+        isRerunningAll = true;
+        await InvokeAsync(StateHasChanged);
+
+        try
+        {
+            using var semaphore = new SemaphoreSlim(MaxConcurrency, MaxConcurrency);
+            var tasks = failedPairs.Select(async pair =>
+            {
+                await semaphore.WaitAsync(_cts.Token);
+                try
+                {
+                    var actionEntry = BuildActionEntry(pair.Row, pair.Line);
+                    Logger.LogInformation(
+                        "GHA Re-run failed jobs only: invoking {Owner}/{Repo} workflow={WorkflowName} RunId={RunId}",
+                        actionEntry.Owner,
+                        actionEntry.RepositoryName,
+                        actionEntry.WorkflowName,
+                        actionEntry.RunId);
+                    await GitHubActionsService.RerunFailedJobsOnlyAsync(actionEntry);
+                    Logger.LogInformation(
+                        "GHA Re-run failed jobs only: API ok {Owner}/{Repo} workflow={WorkflowName} RunId={RunId}",
+                        actionEntry.Owner,
+                        actionEntry.RepositoryName,
+                        actionEntry.WorkflowName,
+                        actionEntry.RunId);
+                }
+                catch (Exception ex)
+                {
+                    Logger.LogError(ex,
+                        "GHA Re-run failed jobs only item failed: WorkspaceId={WorkspaceId} {Owner}/{Repo} RunId={RunId}",
+                        WorkspaceId,
+                        pair.Row.Repo.OrgName,
+                        pair.Row.Repo.RepositoryName,
+                        pair.Line.Action?.RunId);
+                }
+                finally
+                {
+                    semaphore.Release();
+                    Interlocked.Increment(ref _rerunCompleted);
+                    await InvokeAsync(StateHasChanged);
+                }
+            });
+            await Task.WhenAll(tasks);
+            Logger.LogInformation(
+                "GHA Re-run failed jobs only finished (API phase): WorkspaceId={WorkspaceId} attempted={Count}",
                 WorkspaceId,
                 failedPairs.Count);
         }

--- a/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor.cs
@@ -176,6 +176,38 @@ public sealed partial class WorkspaceActions : IDisposable
         StateHasChanged();
     }
 
+    internal void OnLogsRerunTriggered()
+    {
+        var runId = _logsRunId;
+        var row = rows.FirstOrDefault(r => r.WorkflowLines.Any(l => l.Action?.RunId == runId));
+        var line = row?.WorkflowLines.FirstOrDefault(l => l.Action?.RunId == runId);
+        var workflowId = line?.Action?.WorkflowId ?? 0;
+
+        CloseLogsModal();
+
+        if (row == null || workflowId <= 0) return;
+
+        var latch = GetOrCreateLatch(row, workflowId);
+        latch.RerunPending = true;
+        ApplyActionLatches(row);
+        StateHasChanged();
+        _ = TryRefreshAfterJobRerunAsync(row, workflowId);
+    }
+
+    private async Task TryRefreshAfterJobRerunAsync(WorkspaceActionRow row, long workflowId)
+    {
+        try
+        {
+            await TryRefreshUntilWorkflowLineRunningAsync(row, workflowId, "GHA Re-run (job)", CancellationToken.None);
+        }
+        finally
+        {
+            EndRerunLatch(row, workflowId);
+            ApplyActionLatches(row);
+            await InvokeAsync(StateHasChanged);
+        }
+    }
+
     internal void ToggleShowErrors()
     {
         _showErrors = !_showErrors;

--- a/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor.cs
@@ -222,6 +222,18 @@ public sealed partial class WorkspaceActions : IDisposable
         StateHasChanged();
     }
 
+    internal async Task HandleRerunAllClick()
+    {
+        CloseRerunMenu();
+        await RerunAllFailedAsync();
+    }
+
+    internal async Task HandleRerunFailedJobsOnlyClick()
+    {
+        CloseRerunMenu();
+        await RerunAllFailedJobsOnlyAsync();
+    }
+
     internal void ToggleShowErrors()
     {
         _showErrors = !_showErrors;

--- a/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor.css
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor.css
@@ -1,3 +1,42 @@
+/* Dropdown menu positioning (mirrors WorkspaceRepositoriesHeader.razor.css) */
+.branch-menu-list {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: auto;
+    margin-top: 0.125rem;
+    z-index: 1051;
+    min-width: 100%;
+}
+
+.branch-menu-backdrop {
+    position: fixed;
+    inset: 0;
+    background: transparent;
+    z-index: 1050;
+}
+
+.branch-menu-divider {
+    border-top-color: var(--border-color, #6c757d);
+    opacity: 0.9;
+    margin: 0.25rem 0;
+}
+
+.dropdown-toggle-split {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.dropdown-toggle-split::after {
+    vertical-align: middle;
+    margin-left: 0;
+}
+
+.btn-group > .btn-danger + .btn-danger.dropdown-toggle-split {
+    border-left-color: rgba(255, 255, 255, 0.4);
+}
+
 /*
  * Title row: use same baseline alignment as app.css .workspace-repos-header .workspace-repos-title-row
  * (do not override with flex-end - that sat the subtitle lower than the h2 text).

--- a/src/GrayMoon.App/Components/Shared/GhaWorkflowLiveTerminal.razor
+++ b/src/GrayMoon.App/Components/Shared/GhaWorkflowLiveTerminal.razor
@@ -63,7 +63,7 @@
     private string? _stepProgress;
 
     // Spinner — runs on its own 200ms loop, independent of the API poll
-    private static readonly char[] SpinnerFrames = ['⠋', '⠙', '⠸', '⠴', '⠦', '⠧'];
+    private static readonly char[] SpinnerFrames = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧'];
     private int _spinnerFrame;
     private string? _spinnerStepKey;
     private int _spinnerBoardIdx = -1;  // board slot index of current in-progress step (-1 = none)
@@ -75,7 +75,7 @@
     private Task? _spinnerTask;
 
     private const int BodyLineCount = 8;
-    private const int SpinnerFrameMs = 200; // 6 frames × 200ms = 1.2s per revolution
+    private const int SpinnerFrameMs = 200; // 8 frames × 200ms = 1.6s per revolution
 
     protected override void OnInitialized()
     {

--- a/src/GrayMoon.App/Models/GitHubDtos.cs
+++ b/src/GrayMoon.App/Models/GitHubDtos.cs
@@ -131,6 +131,12 @@ public sealed class GitHubWorkflowJobDto
     [JsonPropertyName("conclusion")]
     public string? Conclusion { get; set; }
 
+    [JsonPropertyName("created_at")]
+    public DateTimeOffset? CreatedAt { get; set; }
+
+    [JsonPropertyName("started_at")]
+    public DateTimeOffset? StartedAt { get; set; }
+
     [JsonPropertyName("steps")]
     public List<GitHubWorkflowJobStepDto> Steps { get; set; } = new();
 }

--- a/src/GrayMoon.App/Services/GitHubActionsService.cs
+++ b/src/GrayMoon.App/Services/GitHubActionsService.cs
@@ -325,6 +325,24 @@ public class GitHubActionsService(
         await gitHubService.RerunWorkflowRunAsync(connector, action.Owner, action.RepositoryName, action.RunId);
     }
 
+    public async Task RerunFailedJobsOnlyAsync(GitHubActionEntry action)
+    {
+        if (action.RunId <= 0)
+            throw new InvalidOperationException("Workflow run id is not available.");
+
+        if (string.IsNullOrWhiteSpace(action.Owner) || string.IsNullOrWhiteSpace(action.RepositoryName))
+            throw new InvalidOperationException("Workflow owner and repository are required.");
+
+        var connector = await connectorRepository.GetByNameAsync(action.ConnectorName);
+        if (connector == null)
+        {
+            logger.LogWarning("Connector {ConnectorName} not found for rerun failed jobs.", action.ConnectorName);
+            throw new InvalidOperationException("Connector not found for this action.");
+        }
+
+        await gitHubService.RerunFailedJobsAsync(connector, action.Owner, action.RepositoryName, action.RunId);
+    }
+
     public async Task RunWorkflowAsync(GitHubActionEntry action)
     {
         if (action.WorkflowId <= 0)

--- a/src/GrayMoon.App/Services/GitHubService.cs
+++ b/src/GrayMoon.App/Services/GitHubService.cs
@@ -339,6 +339,12 @@ public class GitHubService : IConnectorService
         await PostAsync(connector, $"repos/{owner}/{repo}/actions/runs/{runId}/rerun", payload: null, cancellationToken: cancellationToken);
     }
 
+    public async Task RerunJobAsync(Connector connector, string owner, string repo, long jobId, CancellationToken cancellationToken = default)
+    {
+        EnsureConnectorConfigured(connector);
+        await PostAsync(connector, $"repos/{owner}/{repo}/actions/jobs/{jobId}/rerun", payload: null, cancellationToken: cancellationToken);
+    }
+
     /// <summary>POST /repos/{owner}/{repo}/actions/runs/{run_id}/cancel - cancels an in-progress workflow run.</summary>
     /// <remarks>409 when the run already finished is treated as success (UI/API lag vs GitHub).</remarks>
     public async Task CancelWorkflowRunAsync(Connector connector, string owner, string repo, long runId, CancellationToken cancellationToken = default)

--- a/src/GrayMoon.App/Services/GitHubService.cs
+++ b/src/GrayMoon.App/Services/GitHubService.cs
@@ -345,6 +345,20 @@ public class GitHubService : IConnectorService
         await PostAsync(connector, $"repos/{owner}/{repo}/actions/jobs/{jobId}/rerun", payload: null, cancellationToken: cancellationToken);
     }
 
+    public async Task RerunFailedJobsAsync(Connector connector, string owner, string repo, long runId, CancellationToken cancellationToken = default)
+    {
+        EnsureConnectorConfigured(connector);
+
+        if (string.IsNullOrWhiteSpace(owner))
+            throw new ArgumentException("Owner is required.", nameof(owner));
+        if (string.IsNullOrWhiteSpace(repo))
+            throw new ArgumentException("Repository is required.", nameof(repo));
+        if (runId <= 0)
+            throw new ArgumentException("Workflow run id is required.", nameof(runId));
+
+        await PostAsync(connector, $"repos/{owner}/{repo}/actions/runs/{runId}/rerun-failed-jobs", payload: null, cancellationToken: cancellationToken);
+    }
+
     /// <summary>POST /repos/{owner}/{repo}/actions/runs/{run_id}/cancel - cancels an in-progress workflow run.</summary>
     /// <remarks>409 when the run already finished is treated as success (UI/API lag vs GitHub).</remarks>
     public async Task CancelWorkflowRunAsync(Connector connector, string owner, string repo, long runId, CancellationToken cancellationToken = default)

--- a/src/GrayMoon.App/wwwroot/css/loading-overlay.css
+++ b/src/GrayMoon.App/wwwroot/css/loading-overlay.css
@@ -212,18 +212,17 @@
   opacity: 1 !important;
 }
 
-/* Brand at top-left of overlay - same position and font as sidebar header; above full-height terminal */
+/* Terminal toggle - top-right of overlay; above full-height terminal */
 .loading-overlay__brand {
   position: absolute;
   top: 0;
-  left: 0;
+  right: 0;
   height: var(--loading-overlay-top-bar-height, 3.5rem);
   display: flex;
   align-items: center;
-  justify-content: flex-start;
+  justify-content: flex-end;
   gap: 0.35rem;
-  padding-left: 0.75rem;
-  padding-right: 1rem;
+  padding-right: 0.75rem;
   z-index: 3;
   color: var(--text-primary, #cccccc);
   pointer-events: none;

--- a/src/GrayMoon.App/wwwroot/js/ghaLogs.js
+++ b/src/GrayMoon.App/wwwroot/js/ghaLogs.js
@@ -36,6 +36,13 @@ window.ghaLogs = {
         };
     },
 
+    scrollToFirstError: function (el) {
+        if (!el) return;
+        const first = el.querySelector('.gha-log-group--error, .gha-log-line--error');
+        if (!first) return;
+        first.scrollIntoView({ block: 'start', behavior: 'instant' });
+    },
+
     downloadText: function (filename, content) {
         const blob = new Blob([content], { type: 'text/plain' });
         const url = URL.createObjectURL(blob);

--- a/src/GrayMoon.App/wwwroot/js/ghaLogs.js
+++ b/src/GrayMoon.App/wwwroot/js/ghaLogs.js
@@ -36,13 +36,6 @@ window.ghaLogs = {
         };
     },
 
-    scrollToFirstError: function (el) {
-        if (!el) return;
-        const first = el.querySelector('.gha-log-group--error, .gha-log-line--error');
-        if (!first) return;
-        first.scrollIntoView({ block: 'start', behavior: 'instant' });
-    },
-
     downloadText: function (filename, content) {
         const blob = new Blob([content], { type: 'text/plain' });
         const url = URL.createObjectURL(blob);


### PR DESCRIPTION
## Summary

- Add GitHub API support and UI to re-run a single failed job from the logs modal and to re-run only failed jobs across failed workflow runs
- Split workspace Actions Re-run into a dropdown with full re-run and Re-run Failed Jobs Only options, with refresh/latch handling after job-level re-runs
- Order GHA log jobs by start time, auto-filter errors and scroll to top when selecting a failed job, and refine job pill selection styling
- Move the loading overlay terminal toggle to the top-right and smooth the live workflow terminal spinner

## Test plan

- [ ] Open logs for a failed workflow run; confirm jobs sort by start time and selecting a failed job enables error filtering and scrolls to the top
- [ ] Re-run a single failed job from the logs modal and confirm the workflow row refreshes and action latches clear correctly
- [ ] Use Re-run Failed Jobs Only on workspace actions with multiple failed runs and confirm only failed jobs are re-triggered
- [ ] Use the full Re-run option from the dropdown and confirm existing re-run behavior still works
- [ ] Trigger a loading overlay with terminal output and confirm the toggle sits at the top-right