### PR TITLE
Add global workspace action notification panel

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ Git hooks (`post-commit`, `post-checkout`, `post-merge`, `pre-push`) POST JSON t
 
 ### Agent command structure
 
-The Agent uses `System.CommandLine`. Each agent operation is a class in `src/GrayMoon.Agent/Commands/`. To add a new operation: create a command class there, register it in the CLI entry point, and add the corresponding hub method constant to `GrayMoon.Abstractions/Agent/AgentHubMethods.cs`.
+The Agent uses `System.CommandLine`. Each agent operation implements `ICommandHandler<TRequest, TResponse>` in `src/GrayMoon.Agent/Commands/`. To add a new command: (1) define request/response DTOs, (2) create the handler class, (3) register it via `AddSingleton<ICommandHandler<TRequest, TResponse>, YourCommand>()` in `RunCommandHandler.cs`, (4) add it to the dispatcher dictionary in `CommandDispatcher.cs`, (5) add the hub method constant to `AgentHubMethods.cs`, (6) call via `AgentBridge.SendCommandAsync` on the App side.
 
 ### App layer structure
 
@@ -98,6 +98,8 @@ Connector tokens are AES-256-GCM encrypted at rest via `AesGcmTokenProtector` (b
 
 Schema is owned by EF Core but applied via `EnsureCreated()`. Core tables: `Connectors`, `Repositories`, `Workspaces`, `WorkspaceRepositories` (join with live state), `WorkspaceRepositoryPullRequest` (1:1 with link), `WorkspaceProject`, `ProjectDependency`, `WorkspaceFile`, `WorkspaceFileVersionConfig`, `RepositoryBranch`, `Settings`.
 
+After `EnsureCreated()`, startup calls `Migrations.RunAllAsync(dbContext)` (`src/GrayMoon.App/Migrations.cs`). Each migration is an idempotent `ALTER TABLE` guarded by `pragma_table_info()`. Add new columns there - no EF Core migration assembly is used.
+
 ### Background job system
 
 Long-running App-side operations (restore, update, push orchestration) run as background jobs so they survive page navigation within the same browser tab.
@@ -107,6 +109,14 @@ Long-running App-side operations (restore, update, push orchestration) run as ba
 - **`TerminalSinkContext`** — `AsyncLocal`-based ambient context. `AgentBridge.SendCommandAsync` checks `TerminalSinkContext.Current` and routes all `CommandOutput` streaming lines to the active job's terminal automatically, without threading the buffer through every service call. Wrap a job's `Task.Run` body with `using var _ = TerminalSinkContext.Use(handle.Terminal)`.
 - **`BackgroundJobOverlay`** layout component — reads `IBackgroundJobService.GetJob(currentPath)` on every navigation and renders `LoadingOverlay` when the job is `Running`. It also reads `AgentQueueStateService.GetTotalPendingCount()` to show pending agent tasks in the spinner.
 - **`AgentQueueStateService`** — receives `ReportQueueStatus` SignalR events from the Agent (total + per-workspace pending counts). Use `HasWorkspaceJobsPending(workspaceId)` to disable workspace actions while the agent queue is busy.
+
+### Toast service
+
+`IToastService` (singleton). Call `Show(message)` / `ShowError(message)` from any service or component. The `Toast` component auto-dismisses after 2.5 s (normal) or 6 s (error).
+
+### REST API registration
+
+`ApiEndpointRegistration.MapApiEndpoints()` is called in `Program.cs`. Each feature adds a static extension method (e.g., `MapWorkspaceEndpoints()`). Add new API groups there rather than scattering `app.Map*` calls.
 
 ### CSS conventions for the loading overlay terminal
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,18 @@ Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManage
 
 ## What's new
 
+### Global workspace action notifications
+
+A floating notification panel now appears anywhere in the app when a tracked workspace has pending actions - dependency updates, commits ready to push, or incoming commits to pull.
+
+- **Works from any page:** the panel appears in the bottom corner of the UI even when you are on the Projects, Actions, or Connectors pages - you do not need to navigate back to the workspace repositories view to act on it.
+- **Suppressed on the workspace page itself:** when you are already on the workspace repositories page, notifications for that workspace are hidden to avoid duplicating what is already visible in the grid.
+- **Up to two notifications at once:** if multiple workspaces need attention, the most recent two are shown. Older ones drop off as new ones arrive.
+- **Three conditions trigger a card:** unmatched dependency versions (orange dependency badge), outgoing commits with no upstream or commits ahead of remote (push recommended), or incoming commits on the default branch.
+- **One-click actions without navigating away:** each card shows the relevant action buttons - **Update** or **Update & Push** for dependency mismatches, **Push** for outgoing commits, **Pull** for incoming commits on the default branch. All run as background jobs using the same pipeline as the workspace repositories page.
+- **Dismiss per workspace:** use the x button on a card to dismiss it. The card reappears if the workspace syncs again with pending actions.
+- **Notifications update automatically:** the panel subscribes to the workspace sync hub and recomputes state each time any repository sync event arrives, so cards appear and disappear without a page reload.
+
 ### Background jobs on the workspace repositories page
 
 Long-running workspace operations now run as **background jobs** instead of blocking the page with an inline loading overlay. Sync, push, dependency update, restore packages, branch checkout/switch, commit sync, sync-to-default, and pull-request creation all use the same job pipeline.

--- a/src/GrayMoon.App/Components/Layout/MainLayout.razor
+++ b/src/GrayMoon.App/Components/Layout/MainLayout.razor
@@ -12,6 +12,7 @@
 @inject NavigationManager NavigationManager
 
 <Toast />
+<WorkspaceActionNotificationPanel />
 
 <div class="page">
     <div class="sidebar" id="sidebar">

--- a/src/GrayMoon.App/Components/Shared/WorkspaceActionNotificationPanel.razor
+++ b/src/GrayMoon.App/Components/Shared/WorkspaceActionNotificationPanel.razor
@@ -1,0 +1,408 @@
+@rendermode @(new InteractiveServerRenderMode(prerender: false))
+@implements IDisposable
+@using GrayMoon.App.Repositories
+@using Microsoft.AspNetCore.SignalR.Client
+@inject WorkspacePendingActionsService PendingActionsService
+@inject IServiceScopeFactory ServiceScopeFactory
+@inject NavigationManager NavigationManager
+@inject IBackgroundJobService JobService
+@inject IToastService ToastService
+@inject ILogger<WorkspaceActionNotificationPanel> Logger
+
+@{
+    var currentPath = new Uri(NavigationManager.Uri).AbsolutePath.ToLowerInvariant();
+    var suppressedId = GetSuppressedWorkspaceId(currentPath);
+    var visible = PendingActionsService.Notifications.Where(n => n.WorkspaceId != suppressedId).ToList();
+}
+
+@if (visible.Count > 0)
+{
+    <div class="workspace-action-panel">
+        @foreach (var n in visible)
+        {
+            <div class="workspace-action-card">
+                <div class="workspace-action-card__header">
+                    <span class="workspace-action-card__title">@n.WorkspaceName</span>
+                    <button class="btn-close btn-close-white"
+                            style="font-size: 0.7rem; flex-shrink: 0;"
+                            aria-label="Dismiss"
+                            @onclick="() => PendingActionsService.Dismiss(n.WorkspaceId)">
+                    </button>
+                </div>
+                <p class="workspace-action-card__desc">@GetDescription(n)</p>
+                <div class="workspace-action-card__actions">
+                    @if (n.HasUnmatchedDependencies)
+                    {
+                        <div class="btn-group position-relative">
+                            <button class="btn btn-danger btn-sm"
+                                    disabled="@IsJobRunning"
+                                    @onclick="() => _ = RunUpdateAsync(n.WorkspaceId)">
+                                Update
+                            </button>
+                            <button type="button"
+                                    class="btn btn-danger btn-sm dropdown-toggle dropdown-toggle-split"
+                                    aria-label="Toggle Update menu"
+                                    aria-expanded="@(_openUpdateMenus.Contains(n.WorkspaceId) ? "true" : "false")"
+                                    disabled="@IsJobRunning"
+                                    @onclick="() => ToggleUpdateMenu(n.WorkspaceId)"
+                                    @onclick:stopPropagation>
+                                <span class="visually-hidden">Toggle Dropdown</span>
+                            </button>
+                            @if (_openUpdateMenus.Contains(n.WorkspaceId))
+                            {
+                                <div class="branch-menu-backdrop" @onclick="() => CloseUpdateMenu(n.WorkspaceId)"></div>
+                                <ul class="dropdown-menu show shadow branch-menu-list" role="menu">
+                                    <li>
+                                        <button class="dropdown-item" type="button" role="menuitem"
+                                                disabled="@IsJobRunning"
+                                                @onclick="() => { CloseUpdateMenu(n.WorkspaceId); _ = RunUpdateAsync(n.WorkspaceId); }">
+                                            Update
+                                        </button>
+                                    </li>
+                                    <li><hr class="dropdown-divider branch-menu-divider" /></li>
+                                    <li>
+                                        <button class="dropdown-item" type="button" role="menuitem"
+                                                disabled="@IsJobRunning"
+                                                @onclick="() => { CloseUpdateMenu(n.WorkspaceId); _ = RunUpdateAndPushAsync(n.WorkspaceId); }">
+                                            Update &amp; Push
+                                        </button>
+                                    </li>
+                                </ul>
+                            }
+                        </div>
+                    }
+                    @if (n.HasIncomingCommits)
+                    {
+                        <button class="btn btn-danger btn-sm"
+                                disabled="@IsJobRunning"
+                                @onclick="() => _ = RunPullAsync(n.WorkspaceId)">
+                            Pull
+                        </button>
+                    }
+                    else if (n.IsPushRecommended)
+                    {
+                        <button class="btn btn-warning btn-sm"
+                                disabled="@IsJobRunning"
+                                @onclick="() => _ = RunPushAsync(n.WorkspaceId)">
+                            Push
+                        </button>
+                    }
+                </div>
+            </div>
+        }
+    </div>
+}
+
+@code {
+    private HubConnection? _hubConnection;
+    private bool _disposed;
+    private readonly HashSet<int> _openUpdateMenus = new();
+
+    private string CurrentPageJobKey => new Uri(NavigationManager.Uri).AbsolutePath.ToLowerInvariant();
+    private bool IsJobRunning => JobService.IsRunning(CurrentPageJobKey);
+
+    private static int GetSuppressedWorkspaceId(string lowerPath)
+    {
+        var segments = lowerPath.Trim('/').Split('/');
+        if (segments.Length == 2
+            && segments[0] == "workspaces"
+            && int.TryParse(segments[1], out var id))
+            return id;
+        return -1;
+    }
+
+    private void ToggleUpdateMenu(int workspaceId)
+    {
+        if (!_openUpdateMenus.Remove(workspaceId))
+            _openUpdateMenus.Add(workspaceId);
+    }
+
+    private void CloseUpdateMenu(int workspaceId) => _openUpdateMenus.Remove(workspaceId);
+
+    private static string GetDescription(WorkspaceNotification n)
+    {
+        var parts = new List<string>(3);
+        if (n.HasUnmatchedDependencies) parts.Add("dependency updates pending");
+        if (n.HasIncomingCommits) parts.Add("incoming commits to pull");
+        else if (n.IsPushRecommended) parts.Add("commits ready to push");
+        return string.Join(", ", parts);
+    }
+
+    protected override void OnInitialized()
+    {
+        PendingActionsService.Changed += OnServiceChanged;
+        JobService.Changed += OnServiceChanged;
+        NavigationManager.LocationChanged += OnLocationChanged;
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (!firstRender) return;
+
+        _hubConnection = new HubConnectionBuilder()
+            .WithUrl(NavigationManager.ToAbsoluteUri("/hubs/workspace-sync"))
+            .WithAutomaticReconnect()
+            .Build();
+
+        _hubConnection.On<int>("WorkspaceSynced", async (workspaceId) =>
+        {
+            try
+            {
+                await using var scope = ServiceScopeFactory.CreateAsyncScope();
+                var workspaceRepo = scope.ServiceProvider.GetRequiredService<WorkspaceRepository>();
+                var workspace = await workspaceRepo.GetByIdAsync(workspaceId);
+                if (workspace == null)
+                {
+                    PendingActionsService.OnWorkspaceSynced(null, workspaceId);
+                    return;
+                }
+                var links = workspace.Repositories.ToList();
+                var notification = WorkspacePendingActionsService.ComputeNotification(workspaceId, workspace.Name, links);
+                PendingActionsService.OnWorkspaceSynced(notification, workspaceId);
+            }
+            catch (Exception ex)
+            {
+                Logger.LogDebug(ex, "Failed to process WorkspaceSynced for workspace {WorkspaceId}", workspaceId);
+            }
+        });
+
+        try { await _hubConnection.StartAsync(); }
+        catch (Exception ex) { Logger.LogDebug(ex, "Notification panel hub connection failed"); }
+    }
+
+    private void OnServiceChanged()
+    {
+        if (_disposed) return;
+        _ = InvokeAsync(StateHasChanged);
+    }
+
+    private void OnLocationChanged(object? sender, LocationChangedEventArgs e)
+    {
+        if (_disposed) return;
+        _openUpdateMenus.Clear();
+        _ = InvokeAsync(StateHasChanged);
+    }
+
+    public void Dispose()
+    {
+        _disposed = true;
+        PendingActionsService.Changed -= OnServiceChanged;
+        JobService.Changed -= OnServiceChanged;
+        NavigationManager.LocationChanged -= OnLocationChanged;
+        _ = _hubConnection?.StopAsync();
+        _ = _hubConnection?.DisposeAsync().AsTask();
+    }
+
+    private Task RunUpdateAsync(int workspaceId)
+    {
+        if (IsJobRunning) return Task.CompletedTask;
+        JobService.StartJob(CurrentPageJobKey, "Updating dependencies...", async (job, ct) =>
+        {
+            try
+            {
+                await using var scope = ServiceScopeFactory.CreateAsyncScope();
+                var updateHandler = scope.ServiceProvider.GetRequiredService<WorkspaceUpdateHandler>();
+                await updateHandler.RunUpdateAsync(
+                    workspaceId,
+                    ct,
+                    job.ReportProgress,
+                    (_, _) => { },
+                    onAppSideComplete: () => { },
+                    repoIdsToUpdate: null,
+                    commitMessage: null,
+                    includeDepsInCommitMessage: true);
+            }
+            catch (OperationCanceledException) { throw; }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "Notification panel Update failed for workspace {WorkspaceId}", workspaceId);
+                if (!_disposed) _ = InvokeAsync(() => ToastService.ShowError("Update failed. Start the Agent and try again."));
+                throw;
+            }
+        });
+        return Task.CompletedTask;
+    }
+
+    private Task RunUpdateAndPushAsync(int workspaceId)
+    {
+        if (IsJobRunning) return Task.CompletedTask;
+        JobService.StartJob(CurrentPageJobKey, "Updating dependencies...", async (job, ct) =>
+        {
+            List<WorkspaceRepositoryLink> freshLinks;
+            try
+            {
+                await using var updateScope = ServiceScopeFactory.CreateAsyncScope();
+                var updateHandler = updateScope.ServiceProvider.GetRequiredService<WorkspaceUpdateHandler>();
+                await updateHandler.RunUpdateAsync(
+                    workspaceId,
+                    ct,
+                    job.ReportProgress,
+                    (_, _) => { },
+                    onAppSideComplete: () => { },
+                    repoIdsToUpdate: null,
+                    commitMessage: null,
+                    includeDepsInCommitMessage: true);
+
+                await using var reloadScope = ServiceScopeFactory.CreateAsyncScope();
+                var workspaceRepo = reloadScope.ServiceProvider.GetRequiredService<WorkspaceRepository>();
+                var ws = await workspaceRepo.GetByIdAsync(workspaceId);
+                freshLinks = ws?.Repositories.ToList() ?? new List<WorkspaceRepositoryLink>();
+            }
+            catch (OperationCanceledException) { throw; }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "Notification panel Update & Push (update phase) failed for workspace {WorkspaceId}", workspaceId);
+                if (!_disposed) _ = InvokeAsync(() => ToastService.ShowError("Update failed. Start the Agent and try again."));
+                throw;
+            }
+
+            job.ReportProgress("Preparing push...");
+            try
+            {
+                await ExecutePushAsync(workspaceId, freshLinks, job, ct);
+            }
+            catch (OperationCanceledException) { throw; }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "Notification panel Update & Push (push phase) failed for workspace {WorkspaceId}", workspaceId);
+                if (!_disposed) _ = InvokeAsync(() => ToastService.ShowError("Push failed after update."));
+                throw;
+            }
+        });
+        return Task.CompletedTask;
+    }
+
+    private Task RunPushAsync(int workspaceId)
+    {
+        if (IsJobRunning) return Task.CompletedTask;
+        JobService.StartJob(CurrentPageJobKey, "Preparing push...", async (job, ct) =>
+        {
+            try
+            {
+                await using var scope = ServiceScopeFactory.CreateAsyncScope();
+                var workspaceRepo = scope.ServiceProvider.GetRequiredService<WorkspaceRepository>();
+                var ws = await workspaceRepo.GetByIdAsync(workspaceId);
+                if (ws == null) return;
+                var links = ws.Repositories.ToList();
+                await ExecutePushAsync(workspaceId, links, job, ct);
+            }
+            catch (OperationCanceledException) { throw; }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "Notification panel Push failed for workspace {WorkspaceId}", workspaceId);
+                if (!_disposed) _ = InvokeAsync(() => ToastService.ShowError("Push failed."));
+                throw;
+            }
+        });
+        return Task.CompletedTask;
+    }
+
+    private async Task ExecutePushAsync(
+        int workspaceId,
+        List<WorkspaceRepositoryLink> links,
+        BackgroundJobHandle job,
+        CancellationToken ct)
+    {
+        await using var scope = ServiceScopeFactory.CreateAsyncScope();
+        var pushHandler = scope.ServiceProvider.GetRequiredService<WorkspacePushHandler>();
+        var depService = scope.ServiceProvider.GetRequiredService<WorkspaceDependencyService>();
+
+        var (payload, hasUnpushed) = await pushHandler.GetPushPlanAsync(workspaceId, links, ct);
+        if (!hasUnpushed)
+        {
+            if (!_disposed) _ = InvokeAsync(() => ToastService.Show("Nothing to push."));
+            return;
+        }
+
+        var taggedIds = links.Where(wr => wr.IsOnTag).Select(wr => wr.RepositoryId).ToHashSet();
+        var pushRepoIds = payload.Select(p => p.RepoId).Where(id => !taggedIds.Contains(id)).ToHashSet();
+        if (pushRepoIds.Count == 0)
+        {
+            if (!_disposed) _ = InvokeAsync(() => ToastService.Show("Nothing to push."));
+            return;
+        }
+
+        var repoIdsThatNeedPush = links
+            .Where(wr => !wr.IsOnTag && (wr.OutgoingCommits ?? 0) > 0)
+            .Select(wr => wr.RepositoryId)
+            .ToHashSet();
+        var depInfo = await depService.GetPushDependencyInfoForRepoSetAsync(workspaceId, pushRepoIds, ct);
+        bool synchronizedPush = WorkspaceDependencyService.ShouldShowSynchronizedPushModal(depInfo, repoIdsThatNeedPush);
+
+        var requiredPackageIds = depInfo?.PayloadForRepo?.RequiredPackages
+            .Select(r => r.PackageId?.Trim())
+            .Where(id => !string.IsNullOrEmpty(id))
+            .Cast<string>()
+            .ToHashSet(StringComparer.OrdinalIgnoreCase) ?? new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        await pushHandler.RunPushWithDependenciesAsync(
+            workspaceId,
+            pushRepoIds,
+            synchronizedPush,
+            requiredPackageIds,
+            job.ReportProgress,
+            ToastService.Show,
+            onAppSideComplete: () => { },
+            ct);
+    }
+
+    private Task RunPullAsync(int workspaceId)
+    {
+        if (IsJobRunning) return Task.CompletedTask;
+        var apiBaseUrl = NavigationManager.BaseUri.TrimEnd('/');
+        JobService.StartJob(CurrentPageJobKey, "Synchronizing commits...", async (job, ct) =>
+        {
+            try
+            {
+                await using var scope = ServiceScopeFactory.CreateAsyncScope();
+                var workspaceRepo = scope.ServiceProvider.GetRequiredService<WorkspaceRepository>();
+                var ws = await workspaceRepo.GetByIdAsync(workspaceId);
+                if (ws == null) return;
+                var links = ws.Repositories.ToList();
+
+                var repoIds = links
+                    .Where(wr =>
+                        !wr.IsOnTag
+                        && (wr.IncomingCommits ?? 0) > 0
+                        && !string.IsNullOrWhiteSpace(wr.BranchName)
+                        && !string.IsNullOrWhiteSpace(wr.DefaultBranchName)
+                        && string.Equals(wr.BranchName, wr.DefaultBranchName, StringComparison.Ordinal))
+                    .Select(wr => wr.RepositoryId)
+                    .ToList();
+                if (repoIds.Count == 0) return;
+
+                var commitSyncHandler = scope.ServiceProvider.GetRequiredService<WorkspaceCommitSyncHandler>();
+                if (repoIds.Count == 1)
+                {
+                    await commitSyncHandler.CommitSyncAsync(
+                        workspaceId,
+                        repoIds[0],
+                        apiBaseUrl,
+                        ct,
+                        msg => { job.ReportProgress(msg); return Task.CompletedTask; },
+                        (_, _) => { },
+                        _ => { });
+                }
+                else
+                {
+                    await commitSyncHandler.CommitSyncLevelAsync(
+                        workspaceId,
+                        repoIds,
+                        apiBaseUrl,
+                        ct,
+                        (done, total) => { job.ReportProgress($"Pulled {done} of {total}"); return Task.CompletedTask; },
+                        (_, _) => { },
+                        _ => { });
+                }
+            }
+            catch (OperationCanceledException) { throw; }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "Notification panel Pull failed for workspace {WorkspaceId}", workspaceId);
+                if (!_disposed) _ = InvokeAsync(() => ToastService.ShowError("Pull failed."));
+                throw;
+            }
+        });
+        return Task.CompletedTask;
+    }
+}

--- a/src/GrayMoon.App/Components/Shared/WorkspaceActionNotificationPanel.razor
+++ b/src/GrayMoon.App/Components/Shared/WorkspaceActionNotificationPanel.razor
@@ -12,7 +12,10 @@
 @{
     var currentPath = new Uri(NavigationManager.Uri).AbsolutePath.ToLowerInvariant();
     var suppressedId = GetSuppressedWorkspaceId(currentPath);
-    var visible = PendingActionsService.Notifications.Where(n => n.WorkspaceId != suppressedId).ToList();
+    var visible = PendingActionsService.Notifications
+        .Where(n => n.WorkspaceId != suppressedId)
+        .Where(n => !IsWorkspaceJobRunning(n.WorkspaceId))
+        .ToList();
 }
 
 @if (visible.Count > 0)
@@ -35,7 +38,7 @@
                     {
                         <div class="btn-group dropup position-relative">
                             <button class="btn btn-danger btn-sm"
-                                    disabled="@IsJobRunning"
+                                    disabled="@IsWorkspaceJobRunning(n.WorkspaceId)"
                                     @onclick="() => _ = RunUpdateAsync(n.WorkspaceId)">
                                 Update
                             </button>
@@ -43,7 +46,7 @@
                                     class="btn btn-danger btn-sm dropdown-toggle dropdown-toggle-split"
                                     aria-label="Toggle Update menu"
                                     aria-expanded="@(_openUpdateMenus.Contains(n.WorkspaceId) ? "true" : "false")"
-                                    disabled="@IsJobRunning"
+                                    disabled="@IsWorkspaceJobRunning(n.WorkspaceId)"
                                     @onclick="() => ToggleUpdateMenu(n.WorkspaceId)"
                                     @onclick:stopPropagation>
                                 <span class="visually-hidden">Toggle Dropdown</span>
@@ -54,7 +57,7 @@
                                 <ul class="dropdown-menu show shadow branch-menu-list bottom-100 mb-1" role="menu">
                                     <li>
                                         <button class="dropdown-item" type="button" role="menuitem"
-                                                disabled="@IsJobRunning"
+                                                disabled="@IsWorkspaceJobRunning(n.WorkspaceId)"
                                                 @onclick="() => { CloseUpdateMenu(n.WorkspaceId); _ = RunUpdateAsync(n.WorkspaceId); }">
                                             Update
                                         </button>
@@ -62,7 +65,7 @@
                                     <li><hr class="dropdown-divider branch-menu-divider" /></li>
                                     <li>
                                         <button class="dropdown-item" type="button" role="menuitem"
-                                                disabled="@IsJobRunning"
+                                                disabled="@IsWorkspaceJobRunning(n.WorkspaceId)"
                                                 @onclick="() => { CloseUpdateMenu(n.WorkspaceId); _ = RunUpdateAndPushAsync(n.WorkspaceId); }">
                                             Update &amp; Push
                                         </button>
@@ -74,7 +77,7 @@
                     @if (n.HasIncomingCommits)
                     {
                         <button class="btn btn-danger btn-sm"
-                                disabled="@IsJobRunning"
+                                disabled="@IsWorkspaceJobRunning(n.WorkspaceId)"
                                 @onclick="() => _ = RunPullAsync(n.WorkspaceId)">
                             Pull
                         </button>
@@ -82,7 +85,7 @@
                     else if (n.IsPushRecommended)
                     {
                         <button class="btn btn-warning btn-sm"
-                                disabled="@IsJobRunning"
+                                disabled="@IsWorkspaceJobRunning(n.WorkspaceId)"
                                 @onclick="() => _ = RunPushAsync(n.WorkspaceId)">
                             Push
                         </button>
@@ -98,8 +101,8 @@
     private bool _disposed;
     private readonly HashSet<int> _openUpdateMenus = new();
 
-    private string CurrentPageJobKey => new Uri(NavigationManager.Uri).AbsolutePath.ToLowerInvariant();
-    private bool IsJobRunning => JobService.IsRunning(CurrentPageJobKey);
+    private static string WorkspaceJobKey(int workspaceId) => $"/workspaces/{workspaceId}";
+    private bool IsWorkspaceJobRunning(int workspaceId) => JobService.IsRunning(WorkspaceJobKey(workspaceId));
 
     private static int GetSuppressedWorkspaceId(string lowerPath)
     {
@@ -195,8 +198,9 @@
 
     private Task RunUpdateAsync(int workspaceId)
     {
-        if (IsJobRunning) return Task.CompletedTask;
-        JobService.StartJob(CurrentPageJobKey, "Updating dependencies...", async (job, ct) =>
+        if (IsWorkspaceJobRunning(workspaceId)) return Task.CompletedTask;
+        PendingActionsService.Dismiss(workspaceId);
+        JobService.StartJob(WorkspaceJobKey(workspaceId), "Updating dependencies...", async (job, ct) =>
         {
             try
             {
@@ -225,8 +229,9 @@
 
     private Task RunUpdateAndPushAsync(int workspaceId)
     {
-        if (IsJobRunning) return Task.CompletedTask;
-        JobService.StartJob(CurrentPageJobKey, "Updating dependencies...", async (job, ct) =>
+        if (IsWorkspaceJobRunning(workspaceId)) return Task.CompletedTask;
+        PendingActionsService.Dismiss(workspaceId);
+        JobService.StartJob(WorkspaceJobKey(workspaceId), "Updating dependencies...", async (job, ct) =>
         {
             List<WorkspaceRepositoryLink> freshLinks;
             try
@@ -274,8 +279,9 @@
 
     private Task RunPushAsync(int workspaceId)
     {
-        if (IsJobRunning) return Task.CompletedTask;
-        JobService.StartJob(CurrentPageJobKey, "Preparing push...", async (job, ct) =>
+        if (IsWorkspaceJobRunning(workspaceId)) return Task.CompletedTask;
+        PendingActionsService.Dismiss(workspaceId);
+        JobService.StartJob(WorkspaceJobKey(workspaceId), "Preparing push...", async (job, ct) =>
         {
             try
             {
@@ -348,9 +354,10 @@
 
     private Task RunPullAsync(int workspaceId)
     {
-        if (IsJobRunning) return Task.CompletedTask;
+        if (IsWorkspaceJobRunning(workspaceId)) return Task.CompletedTask;
+        PendingActionsService.Dismiss(workspaceId);
         var apiBaseUrl = NavigationManager.BaseUri.TrimEnd('/');
-        JobService.StartJob(CurrentPageJobKey, "Synchronizing commits...", async (job, ct) =>
+        JobService.StartJob(WorkspaceJobKey(workspaceId), "Synchronizing commits...", async (job, ct) =>
         {
             try
             {

--- a/src/GrayMoon.App/Components/Shared/WorkspaceActionNotificationPanel.razor
+++ b/src/GrayMoon.App/Components/Shared/WorkspaceActionNotificationPanel.razor
@@ -22,7 +22,7 @@
         {
             <div class="workspace-action-card">
                 <div class="workspace-action-card__header">
-                    <span class="workspace-action-card__title">@n.WorkspaceName</span>
+                    <a class="workspace-action-card__title" href="/workspaces/@n.WorkspaceId">@n.WorkspaceName</a>
                     <button class="btn-close btn-close-white"
                             style="font-size: 0.7rem; flex-shrink: 0;"
                             aria-label="Dismiss"

--- a/src/GrayMoon.App/Components/Shared/WorkspaceActionNotificationPanel.razor
+++ b/src/GrayMoon.App/Components/Shared/WorkspaceActionNotificationPanel.razor
@@ -33,7 +33,7 @@
                 <div class="workspace-action-card__actions">
                     @if (n.HasUnmatchedDependencies)
                     {
-                        <div class="btn-group position-relative">
+                        <div class="btn-group dropup position-relative">
                             <button class="btn btn-danger btn-sm"
                                     disabled="@IsJobRunning"
                                     @onclick="() => _ = RunUpdateAsync(n.WorkspaceId)">
@@ -51,7 +51,7 @@
                             @if (_openUpdateMenus.Contains(n.WorkspaceId))
                             {
                                 <div class="branch-menu-backdrop" @onclick="() => CloseUpdateMenu(n.WorkspaceId)"></div>
-                                <ul class="dropdown-menu show shadow branch-menu-list" role="menu">
+                                <ul class="dropdown-menu show shadow branch-menu-list bottom-100 mb-1" role="menu">
                                     <li>
                                         <button class="dropdown-item" type="button" role="menuitem"
                                                 disabled="@IsJobRunning"

--- a/src/GrayMoon.App/Components/Shared/WorkspaceActionNotificationPanel.razor.css
+++ b/src/GrayMoon.App/Components/Shared/WorkspaceActionNotificationPanel.razor.css
@@ -37,6 +37,12 @@
     white-space: nowrap;
     flex: 1;
     margin-right: 0.5rem;
+    text-decoration: none;
+}
+
+.workspace-action-card__title:hover {
+    color: #ffffff;
+    text-decoration: underline;
 }
 
 .workspace-action-card__desc {

--- a/src/GrayMoon.App/Components/Shared/WorkspaceActionNotificationPanel.razor.css
+++ b/src/GrayMoon.App/Components/Shared/WorkspaceActionNotificationPanel.razor.css
@@ -1,0 +1,65 @@
+.workspace-action-panel {
+    position: fixed;
+    bottom: 1.25rem;
+    right: 1.25rem;
+    z-index: 9990;
+    display: flex;
+    flex-direction: column;
+    gap: 0.625rem;
+    width: 320px;
+    max-width: calc(100vw - 2.5rem);
+    pointer-events: none;
+}
+
+.workspace-action-card {
+    background-color: var(--bg-card, #252526);
+    border: 1px solid var(--border-color, #3e3e42);
+    border-radius: 0.375rem;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.45);
+    padding: 0.75rem 0.875rem;
+    pointer-events: all;
+    animation: notif-slide-in 0.28s ease-out both;
+}
+
+.workspace-action-card__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 0.3rem;
+}
+
+.workspace-action-card__title {
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: var(--text-primary, #cccccc);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    flex: 1;
+    margin-right: 0.5rem;
+}
+
+.workspace-action-card__desc {
+    font-size: 0.8125rem;
+    color: var(--text-muted, #858585);
+    margin: 0 0 0.625rem;
+    line-height: 1.35;
+}
+
+.workspace-action-card__actions {
+    display: flex;
+    gap: 0.4rem;
+    flex-wrap: wrap;
+    align-items: center;
+}
+
+@keyframes notif-slide-in {
+    from {
+        opacity: 0;
+        transform: translateX(1.5rem);
+    }
+    to {
+        opacity: 1;
+        transform: translateX(0);
+    }
+}

--- a/src/GrayMoon.App/Program.cs
+++ b/src/GrayMoon.App/Program.cs
@@ -84,6 +84,7 @@ try
     builder.Services.AddScoped<WorkspacePushService>();
     builder.Services.AddScoped<WorkspacePushHandler>();
     builder.Services.AddScoped<WorkspaceDependencyService>();
+    builder.Services.AddScoped<WorkspacePendingActionsService>();
     builder.Services.AddScoped<WorkspaceBranchHandler>();
     builder.Services.AddScoped<NewFeatureOrchestrator>();
     builder.Services.AddScoped<IBackgroundJobService, BackgroundJobService>();

--- a/src/GrayMoon.App/Services/WorkspacePendingActionsService.cs
+++ b/src/GrayMoon.App/Services/WorkspacePendingActionsService.cs
@@ -1,0 +1,55 @@
+using GrayMoon.App.Models;
+
+namespace GrayMoon.App.Services;
+
+public sealed record WorkspaceNotification(
+    int WorkspaceId,
+    string WorkspaceName,
+    bool HasUnmatchedDependencies,
+    bool IsPushRecommended,
+    bool HasIncomingCommits);
+
+public sealed class WorkspacePendingActionsService
+{
+    private readonly List<WorkspaceNotification> _notifications = new();
+
+    public IReadOnlyList<WorkspaceNotification> Notifications => _notifications;
+
+    public event Action? Changed;
+
+    public void OnWorkspaceSynced(WorkspaceNotification? notification, int workspaceId)
+    {
+        _notifications.RemoveAll(n => n.WorkspaceId == workspaceId);
+        if (notification != null)
+        {
+            if (_notifications.Count >= 2)
+                _notifications.RemoveAt(0);
+            _notifications.Add(notification);
+        }
+        Changed?.Invoke();
+    }
+
+    public void Dismiss(int workspaceId)
+    {
+        _notifications.RemoveAll(n => n.WorkspaceId == workspaceId);
+        Changed?.Invoke();
+    }
+
+    public static WorkspaceNotification? ComputeNotification(
+        int workspaceId,
+        string workspaceName,
+        IReadOnlyList<WorkspaceRepositoryLink> links)
+    {
+        bool hasUnmatched = links.Any(wr => !wr.IsOnTag && (wr.UnmatchedDeps ?? 0) > 0);
+        bool isPushRecommended = links.Any(wr => !wr.IsOnTag && ((wr.OutgoingCommits ?? 0) > 0 || wr.BranchHasUpstream == false));
+        bool hasIncoming = links.Any(wr =>
+            !wr.IsOnTag
+            && (wr.IncomingCommits ?? 0) > 0
+            && !string.IsNullOrWhiteSpace(wr.BranchName)
+            && !string.IsNullOrWhiteSpace(wr.DefaultBranchName)
+            && string.Equals(wr.BranchName, wr.DefaultBranchName, StringComparison.Ordinal));
+        if (!hasUnmatched && !isPushRecommended && !hasIncoming)
+            return null;
+        return new WorkspaceNotification(workspaceId, workspaceName, hasUnmatched, isPushRecommended, hasIncoming);
+    }
+}


### PR DESCRIPTION
## Summary

- Add a floating notification panel in the main layout that surfaces pending workspace actions (unmatched dependencies, outgoing commits to push, incoming commits on the default branch) from any page in the app
- Wire each card's Update, Update & Push, Push, and Pull actions to the same background-job handlers used on the workspace repositories page, with per-workspace dismiss and automatic refresh via the workspace sync hub
- Hide notifications for the workspace you are already viewing on its repositories page, cap visible cards at two, hide cards while a workspace job is running, and link the workspace title to its repositories view with drop-up Update menus
- Register `WorkspacePendingActionsService` to track pending state and dismissed workspaces
- Document the notification behavior in README and expand CLAUDE.md with agent command registration, migrations, toast, and REST API notes

## Test plan

- [ ] With pending dependency mismatches, outgoing commits, or default-branch incoming commits, confirm notification cards appear on Projects, Actions, and Connectors pages
- [ ] On a workspace's repositories page, confirm that workspace's notification is suppressed while other workspaces still show cards
- [ ] Run Update, Update & Push, Push, and Pull from a card and confirm the loading overlay and background job behave like the repositories grid
- [ ] Dismiss a card and confirm it stays hidden until the next sync brings pending actions back
- [ ] With three or more workspaces needing attention, confirm only the two most recent cards are shown
- [ ] Click the workspace title and confirm navigation to `/workspaces/{id}`; open the Update split menu and confirm it opens upward