### PR TITLE
Refresh pull request status before sync-to-default checks

### DIFF
--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
@@ -865,7 +865,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
         {
             if (blocked.Count == 0)
                 ToastService.Show("No repositories to sync.");
-            return Task.CompletedTask;
+            return;
         }
 
         _syncToDefaultCheckResults = checkResults.Where(r => safeRepoIds.Contains(r.RepoId)).ToList();
@@ -936,8 +936,6 @@ public sealed partial class WorkspaceRepositories : IDisposable
                     throw;
                 }
             });
-
-        return Task.CompletedTask;
     }
 
     /// <summary>

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
@@ -820,12 +820,24 @@ public sealed partial class WorkspaceRepositories : IDisposable
         await CheckBranchesAndConfirmSyncToDefaultLevel(nonDefaultRepoIds);
     }
 
-    private Task CheckBranchesAndConfirmSyncToDefaultLevel(List<int> repositoryIds)
+    private async Task CheckBranchesAndConfirmSyncToDefaultLevel(List<int> repositoryIds)
     {
         if (workspace == null || repositoryIds == null || repositoryIds.Count == 0 || IsJobRunning)
-            return Task.CompletedTask;
+            return;
 
         _syncToDefaultCheckResults = null;
+
+        try
+        {
+            await WorkspacePageService.WorkspacePullRequestService.RefreshPullRequestsAsync(WorkspaceId, repositoryIds, force: true);
+            await ReloadWorkspaceDataFromFreshScopeAsync();
+            ApplySyncStateFromWorkspace();
+            await InvokeAsync(StateHasChanged);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogDebug(ex, "PR refresh before sync-to-default check failed for workspace {WorkspaceId}", WorkspaceId);
+        }
 
         // Synchronous pre-check using persisted state (no agent call needed)
         var checkResults = repositoryIds
@@ -2734,6 +2746,21 @@ public sealed partial class WorkspaceRepositories : IDisposable
             var wr = workspaceRepositories.FirstOrDefault(w => w.RepositoryId == repositoryId);
             var defaultAhead = wr?.DefaultBranchAheadCommits ?? 0;
             var hasUpstream = wr?.BranchHasUpstream == true;
+
+            if (defaultAhead > 0)
+            {
+                try
+                {
+                    await WorkspacePageService.WorkspacePullRequestService.RefreshPullRequestsAsync(WorkspaceId, new[] { repositoryId }, force: true);
+                    await ReloadWorkspaceDataFromFreshScopeAsync();
+                    ApplySyncStateFromWorkspace();
+                    await InvokeAsync(StateHasChanged);
+                }
+                catch (Exception ex)
+                {
+                    Logger.LogDebug(ex, "PR refresh before sync-to-default check failed for RepositoryId={RepositoryId}", repositoryId);
+                }
+            }
 
             if (defaultAhead > 0 && !IsPrMergedForRepo(repositoryId))
             {


### PR DESCRIPTION
## Summary

- Refresh open pull request data from GitHub before prompting or evaluating sync-to-default flows so branch/PR state reflects the latest remote status
- Apply the refresh in both the bulk sync-to-default confirmation path and the per-repository path when the default branch is ahead
- Reload workspace data and reapply sync state after refresh; log refresh failures at debug level without blocking the user flow

## Test plan

- [ ] On a workspace repo with an open PR and default-branch drift, start sync-to-default and confirm PR/branch indicators match GitHub before the confirmation dialog
- [ ] Repeat for a single-repo sync when default is ahead and verify PR status updates before the check proceeds
- [ ] Confirm sync-to-default still proceeds if the PR refresh call fails (e.g. transient API error)