### PR TITLE
Fix Push Updated scope and route sync-to-default through job terminal

### DIFF
--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
@@ -2800,14 +2800,13 @@ public sealed partial class WorkspaceRepositories : IDisposable
             try
             {
                 await using var scope = ServiceScopeFactory.CreateAsyncScope();
-                var branchHandler = scope.ServiceProvider.GetRequiredService<WorkspaceBranchHandler>();
-                var (success, errMsg) = await branchHandler.SyncToDefaultSingleAsync(
+                var gitService = scope.ServiceProvider.GetRequiredService<WorkspaceGitService>();
+                var (success, errMsg) = await gitService.SyncToDefaultDirectAsync(
                     WorkspaceId,
                     repositoryId,
                     currentBranchName,
                     deleteRemoteBranch,
                     allowForceDeleteLocalBranch,
-                    ApiBaseUrl,
                     ct);
 
                 if (success)
@@ -2879,14 +2878,13 @@ public sealed partial class WorkspaceRepositories : IDisposable
                     {
                         var repoHasRemote = !resultByRepo.TryGetValue(repositoryId, out var repoCheck) || repoCheck.HasUpstream == true;
                         await using var taskScope = ServiceScopeFactory.CreateAsyncScope();
-                        var taskBranchHandler = taskScope.ServiceProvider.GetRequiredService<WorkspaceBranchHandler>();
-                        var (success, errMsg) = await taskBranchHandler.SyncToDefaultSingleAsync(
+                        var taskGitService = taskScope.ServiceProvider.GetRequiredService<WorkspaceGitService>();
+                        var (success, errMsg) = await taskGitService.SyncToDefaultDirectAsync(
                             WorkspaceId,
                             repositoryId,
                             currentBranchName,
                             deleteRemoteBranch && repoHasRemote,
                             allowForceDeleteLocalBranch,
-                            ApiBaseUrl,
                             ct);
 
                         return (repositoryId, success, errMsg);

--- a/src/GrayMoon.App/Components/Shared/WorkspaceActionNotificationPanel.razor
+++ b/src/GrayMoon.App/Components/Shared/WorkspaceActionNotificationPanel.razor
@@ -37,6 +37,7 @@
                 <p class="workspace-action-card__desc">@GetDescription(n)</p>
                 @if (n.Repos.Count > 0)
                 {
+                    var showCommitBadges = n.Repos.Any(r => r.OutgoingCommits > 0 || r.IncomingCommits > 0 || r.NewBranchNoPush);
                     <div class="notif-repo-list">
                         @foreach (var repo in n.Repos)
                         {
@@ -51,12 +52,15 @@
                                         @repo.UnmatchedDeps of @repo.TotalDeps
                                     </span>
                                 }
-                                <CommitsBadge @key="@($"cmt-{repo.RepositoryId}")"
-                                              RepositoryId="repo.RepositoryId"
-                                              Outgoing="repo.OutgoingCommits"
-                                              Incoming="repo.IncomingCommits"
-                                              BranchHasUpstream="@(repo.NewBranchNoPush ? false : null)"
-                                              Disabled="true" />
+                                @if (showCommitBadges)
+                                {
+                                    <CommitsBadge @key="@($"cmt-{repo.RepositoryId}")"
+                                                  RepositoryId="repo.RepositoryId"
+                                                  Outgoing="repo.OutgoingCommits"
+                                                  Incoming="repo.IncomingCommits"
+                                                  BranchHasUpstream="@(repo.NewBranchNoPush ? false : null)"
+                                                  Disabled="true" />
+                                }
                             </div>
                         }
                     </div>
@@ -78,7 +82,7 @@
                     </div>
                 }
                 <div class="workspace-action-card__actions">
-                    @if (n.HasUnmatchedDependencies && n.IsPushRecommended && !n.HasIncomingCommits)
+                    @if (n.HasUnmatchedDependencies && !n.HasIncomingCommits)
                     {
                         <div class="btn-group dropup position-relative">
                             <button class="btn btn-warning btn-sm"

--- a/src/GrayMoon.App/Components/Shared/WorkspaceActionNotificationPanel.razor
+++ b/src/GrayMoon.App/Components/Shared/WorkspaceActionNotificationPanel.razor
@@ -51,15 +51,12 @@
                                         @repo.UnmatchedDeps of @repo.TotalDeps
                                     </span>
                                 }
-                                @if (repo.OutgoingCommits > 0 || repo.NewBranchNoPush)
-                                {
-                                    <CommitsBadge @key="@($"cmt-{repo.RepositoryId}")"
-                                                  RepositoryId="repo.RepositoryId"
-                                                  Outgoing="repo.OutgoingCommits"
-                                                  Incoming="repo.IncomingCommits"
-                                                  BranchHasUpstream="@(repo.NewBranchNoPush ? false : null)"
-                                                  Disabled="true" />
-                                }
+                                <CommitsBadge @key="@($"cmt-{repo.RepositoryId}")"
+                                              RepositoryId="repo.RepositoryId"
+                                              Outgoing="repo.OutgoingCommits"
+                                              Incoming="repo.IncomingCommits"
+                                              BranchHasUpstream="@(repo.NewBranchNoPush ? false : null)"
+                                              Disabled="true" />
                             </div>
                         }
                     </div>
@@ -86,7 +83,7 @@
                         <div class="btn-group dropup position-relative">
                             <button class="btn btn-warning btn-sm"
                                     disabled="@IsWorkspaceJobRunning(n.WorkspaceId)"
-                                    @onclick="() => _ = RunUpdateAndPushAsync(n.WorkspaceId)">
+                                    @onclick="() => _ = RunUpdateAndPushAsync(n)">
                                 Push Updated
                             </button>
                             <button type="button"
@@ -163,7 +160,7 @@
                                         <li>
                                             <button class="dropdown-item" type="button" role="menuitem"
                                                     disabled="@IsWorkspaceJobRunning(n.WorkspaceId)"
-                                                    @onclick="() => { CloseUpdateMenu(n.WorkspaceId); _ = RunUpdateAndPushAsync(n.WorkspaceId); }">
+                                                    @onclick="() => { CloseUpdateMenu(n.WorkspaceId); _ = RunUpdateAndPushAsync(n); }">
                                                 Update &amp; Push
                                             </button>
                                         </li>
@@ -380,8 +377,13 @@
         return Task.CompletedTask;
     }
 
-    private Task RunUpdateAndPushAsync(int workspaceId)
+    private Task RunUpdateAndPushAsync(WorkspaceNotification notification)
     {
+        var workspaceId = notification.WorkspaceId;
+        var updatedRepoIds = notification.Repos
+            .Where(r => r.UnmatchedDeps > 0)
+            .Select(r => r.RepositoryId)
+            .ToHashSet();
         if (IsWorkspaceJobRunning(workspaceId)) return Task.CompletedTask;
         PendingActionsService.Dismiss(workspaceId);
         JobService.StartJob(WorkspaceJobKey(workspaceId), "Updating dependencies...", async (job, ct) =>
@@ -417,7 +419,7 @@
             job.ReportProgress("Preparing push...");
             try
             {
-                await ExecutePushAsync(workspaceId, freshLinks, job, ct);
+                await ExecutePushAsync(workspaceId, freshLinks, job, ct, updatedRepoIds);
             }
             catch (OperationCanceledException) { throw; }
             catch (Exception ex)
@@ -492,13 +494,14 @@
         int workspaceId,
         List<WorkspaceRepositoryLink> links,
         BackgroundJobHandle job,
-        CancellationToken ct)
+        CancellationToken ct,
+        IReadOnlySet<int>? forceIncludeRepoIds = null)
     {
         await using var scope = ServiceScopeFactory.CreateAsyncScope();
         var pushHandler = scope.ServiceProvider.GetRequiredService<WorkspacePushHandler>();
         var depService = scope.ServiceProvider.GetRequiredService<WorkspaceDependencyService>();
 
-        var (payload, hasUnpushed) = await pushHandler.GetPushPlanAsync(workspaceId, links, ct);
+        var (payload, hasUnpushed) = await pushHandler.GetPushPlanAsync(workspaceId, links, ct, forceIncludeRepoIds);
         if (!hasUnpushed)
         {
             if (!_disposed) _ = InvokeAsync(() => ToastService.Show("Nothing to push."));
@@ -517,6 +520,8 @@
             .Where(wr => !wr.IsOnTag && (wr.OutgoingCommits ?? 0) > 0)
             .Select(wr => wr.RepositoryId)
             .ToHashSet();
+        if (forceIncludeRepoIds != null)
+            repoIdsThatNeedPush.UnionWith(forceIncludeRepoIds);
         var depInfo = await depService.GetPushDependencyInfoForRepoSetAsync(workspaceId, pushRepoIds, ct);
         bool synchronizedPush = WorkspaceDependencyService.ShouldShowSynchronizedPushModal(depInfo, repoIdsThatNeedPush);
 

--- a/src/GrayMoon.App/Services/WorkspaceGitService.cs
+++ b/src/GrayMoon.App/Services/WorkspaceGitService.cs
@@ -754,6 +754,87 @@ public class WorkspaceGitService(
         return (true, null);
     }
 
+    /// <summary>Syncs a single repository to its default branch by calling the agent directly, so CommandOutput flows to TerminalSinkContext when called inside a background job.</summary>
+    public async Task<(bool Success, string? ErrorMessage)> SyncToDefaultDirectAsync(
+        int workspaceId,
+        int repositoryId,
+        string currentBranchName,
+        bool deleteRemoteBranch,
+        bool allowForceDeleteLocalBranch,
+        CancellationToken cancellationToken)
+    {
+        var workspace = await _workspaceRepository.GetByIdAsync(workspaceId);
+        if (workspace == null)
+            return (false, "Workspace not found.");
+
+        var repo = await _repositoryRepository.GetByIdAsync(repositoryId, cancellationToken);
+        if (repo == null)
+            return (false, "Repository not found.");
+
+        var wr = await _dbContext.WorkspaceRepositories
+            .FirstOrDefaultAsync(x => x.WorkspaceId == workspaceId && x.RepositoryId == repositoryId, cancellationToken);
+        if (wr == null)
+            return (false, "Repository is not in the given workspace.");
+
+        if (_connectorHealthService != null)
+            await _connectorHealthService.EnsureConnectorHealthyForRepositoryAsync(repo.RepositoryId, cancellationToken);
+
+        await _workspacePullRequestService.RefreshPullRequestsAsync(workspaceId, [repositoryId], force: true, cancellationToken);
+
+        var wrWithPr = await _dbContext.WorkspaceRepositories
+            .AsNoTracking()
+            .Include(x => x.PullRequest)
+            .FirstOrDefaultAsync(x => x.WorkspaceId == workspaceId && x.RepositoryId == repositoryId, cancellationToken);
+        var prInfo = wrWithPr?.PullRequest?.PullRequestNumber.HasValue == true
+            ? wrWithPr.PullRequest.ToPullRequestInfo()
+            : null;
+        var forceDeleteLocalBranch = allowForceDeleteLocalBranch && (prInfo?.IsMerged == true || prInfo?.IsClosed == true);
+
+        var workspaceRoot = await _workspaceService.GetRootPathForWorkspaceAsync(workspace, cancellationToken);
+        var args = new
+        {
+            workspaceName = workspace.Name,
+            repositoryName = repo.RepositoryName,
+            currentBranchName,
+            bearerToken = ConnectorHelpers.UnprotectToken(repo.Connector?.UserToken),
+            workspaceRoot,
+            forceDeleteLocalBranch,
+            deleteRemoteBranch
+        };
+
+        var response = await _agentBridge.SendCommandAsync("SyncToDefaultBranch", args, cancellationToken);
+        var syncResponse = AgentResponseJson.DeserializeAgentResponse<SyncToDefaultBranchResponse>(response.Data);
+        var commandSuccess = syncResponse?.Success ?? response.Success;
+        var errorMessage = syncResponse?.ErrorMessage ?? response.Error ?? "Failed to sync to default branch";
+
+        if (!commandSuccess)
+            return (false, errorMessage);
+
+        if (syncResponse?.LocalBranches != null)
+        {
+            var localBranches = syncResponse.LocalBranches.Where(b => !string.IsNullOrWhiteSpace(b)).ToList();
+            var remoteBranches = syncResponse.RemoteBranches?.Where(b => !string.IsNullOrWhiteSpace(b)).ToList() ?? new List<string>();
+            var tags = syncResponse.Tags?.Where(t => !string.IsNullOrWhiteSpace(t)).ToList() ?? new List<string>();
+            await PersistBranchesAsync(wr.WorkspaceRepositoryId, localBranches, remoteBranches, syncResponse.DefaultBranch, tags, syncResponse.CurrentTag, cancellationToken);
+        }
+        else
+        {
+            var toRemove = await _dbContext.RepositoryBranches
+                .Where(rb => rb.WorkspaceRepositoryId == wr.WorkspaceRepositoryId && !rb.IsRemote && rb.BranchName == currentBranchName)
+                .ToListAsync(cancellationToken);
+            if (toRemove.Count > 0)
+            {
+                _dbContext.RepositoryBranches.RemoveRange(toRemove);
+                await _dbContext.SaveChangesAsync(cancellationToken);
+            }
+        }
+
+        if (_hubContext != null)
+            await _hubContext.Clients.All.SendAsync("WorkspaceSynced", workspaceId, cancellationToken);
+
+        return (true, null);
+    }
+
     /// <summary>Refreshes branches for a single repository by calling the agent directly. Routes CommandOutput to TerminalSinkContext when called within a background job.</summary>
     public async Task<bool> RefreshBranchesForRepositoryAsync(int repositoryId, int workspaceId, CancellationToken cancellationToken = default)
     {

--- a/src/GrayMoon.App/Services/WorkspacePushHandler.cs
+++ b/src/GrayMoon.App/Services/WorkspacePushHandler.cs
@@ -14,13 +14,16 @@ public sealed class WorkspacePushHandler(
     public async Task<(IReadOnlyList<PushRepoPayload> Payload, bool HasUnpushed)> GetPushPlanAsync(
         int workspaceId,
         IReadOnlyList<WorkspaceRepositoryLink> workspaceRepositories,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        IReadOnlySet<int>? forceIncludeRepoIds = null)
     {
         var (payload, _) = await workspacePushService.GetPushPlanAsync(workspaceId, cancellationToken);
         var repoIdsWithUnpushed = workspaceRepositories
             .Where(wr => !wr.IsOnTag && ((wr.OutgoingCommits ?? 0) > 0 || wr.BranchHasUpstream == false))
             .Select(wr => wr.RepositoryId)
             .ToHashSet();
+        if (forceIncludeRepoIds != null)
+            repoIdsWithUnpushed.UnionWith(forceIncludeRepoIds);
         var toPush = payload.Where(p => repoIdsWithUnpushed.Contains(p.RepoId)).ToList();
         return (toPush, toPush.Count > 0);
     }

--- a/src/GrayMoon.App/wwwroot/css/loading-overlay.css
+++ b/src/GrayMoon.App/wwwroot/css/loading-overlay.css
@@ -95,8 +95,8 @@
   min-height: 0;
   overflow-x: hidden;
   overflow-y: auto;
-  /* Start at the top of the page; GrayMoon brand overlays with its own backdrop */
-  padding: 0.75rem 0.65rem 0.65rem;
+  /* Top padding clears the brand bar (--loading-overlay-top-bar-height, default 3.5rem) so text is not clipped */
+  padding: var(--loading-overlay-top-bar-height, 3.5rem) 0.65rem 0.65rem;
   scroll-padding-top: 0.35rem;
   border: none;
   border-radius: 0;

--- a/src/GrayMoon.App/wwwroot/css/loading-overlay.css
+++ b/src/GrayMoon.App/wwwroot/css/loading-overlay.css
@@ -95,8 +95,9 @@
   min-height: 0;
   overflow-x: hidden;
   overflow-y: auto;
-  /* Top padding clears the brand bar (--loading-overlay-top-bar-height, default 3.5rem) so text is not clipped */
-  padding: var(--loading-overlay-top-bar-height, 3.5rem) 0.65rem 0.65rem;
+  /* Start at the top of the page; GrayMoon brand overlays with its own backdrop */
+  /* Bottom padding lifts the last line so all visible lines have clearance from the top edge when scrolled to end */
+  padding: 0px;
   scroll-padding-top: 0.35rem;
   border: none;
   border-radius: 0;


### PR DESCRIPTION
## Summary

- Fix Push Updated so repositories with dependency updates are always included in the push plan, even when commit badges alone would not mark them as unpushed
- Broaden notification actions: show Push Updated whenever dependencies are unmatched (not only when push is also recommended) and display commit badges when any listed repo has incoming or outgoing commits
- Add `SyncToDefaultDirectAsync` on `WorkspaceGitService` and use it from workspace repositories sync-to-default jobs so agent output streams into the background job terminal instead of going through the branch handler HTTP path
- Adjust loading-overlay terminal padding so the last line stays visible when scrolled to the end

## Test plan

- [ ] From a notification with unmatched dependencies but no outgoing commits, run Push Updated and confirm updated repos are pushed
- [ ] Confirm Push Updated still works when both dependency updates and unpushed commits are present
- [ ] Run sync-to-default on a single repo from the workspace grid and verify git output appears in the job terminal overlay
- [ ] Scroll a long terminal log to the bottom and confirm the last line is not clipped against the pane edge