### PR TITLE
Show Push Updated in workspace repositories header when dependencies are unmatched

### DIFF
--- a/src/GrayMoon.App/Components/Shared/WorkspaceRepositoriesHeader.razor
+++ b/src/GrayMoon.App/Components/Shared/WorkspaceRepositoriesHeader.razor
@@ -102,7 +102,7 @@
                 </ul>
             }
         </div>
-        @if (HasUnmatchedDependencies && IsPushRecommended && !HasIncomingCommits)
+        @if (HasUnmatchedDependencies && !HasIncomingCommits)
         {
             <div class="btn-group position-relative">
                 <button class="btn btn-warning"


### PR DESCRIPTION
## Summary

- Align workspace repositories header actions with the notification panel: show Push Updated whenever there are unmatched dependencies and no incoming commits, without also requiring push to be recommended

## Test plan

- [ ] Open a workspace with unmatched dependencies but no outgoing commits and confirm Push Updated appears in the repositories header
- [ ] Confirm Push Updated is hidden when there are incoming commits on the default branch
- [ ] Confirm Push Updated still appears when both dependency updates and push are recommended