### PR TITLE
Add default-branch warnings to notification actions and tighten layout spacing

### DIFF
--- a/src/GrayMoon.App/Components/Layout/MainLayout.razor.css
+++ b/src/GrayMoon.App/Components/Layout/MainLayout.razor.css
@@ -279,12 +279,12 @@ article.content {
     }
 
     .top-row, article {
-        padding-left: 1.1rem !important;
-        padding-right: 1.1rem !important;
+        padding-left: 0.55rem !important;
+        padding-right: 0.55rem !important;
     }
 
     article.content {
-        padding-top: 2rem !important;
+        padding-top: 1rem !important;
     }
 
 }

--- a/src/GrayMoon.App/Components/Modals/DefaultBranchWarningModal.razor
+++ b/src/GrayMoon.App/Components/Modals/DefaultBranchWarningModal.razor
@@ -7,9 +7,9 @@
          @ref="_modalElement">
         <div class="modal-dialog modal-dialog-scrollable default-branch-warning-modal">
             <div class="modal-content">
-                <div class="modal-header">
+                <div class="modal-header bg-danger text-white">
                     <h5 class="modal-title">Default Branch Warning</h5>
-                    <button type="button" class="btn-close" aria-label="Close" @onclick="OnCancel"></button>
+                    <button type="button" class="btn-close btn-close-white" aria-label="Close" @onclick="OnCancel"></button>
                 </div>
                 <div class="modal-body">
                     <p class="mb-2 small">

--- a/src/GrayMoon.App/Components/Shared/WorkspaceActionNotificationPanel.razor
+++ b/src/GrayMoon.App/Components/Shared/WorkspaceActionNotificationPanel.razor
@@ -106,7 +106,7 @@
                                     <li>
                                         <button class="dropdown-item" type="button" role="menuitem"
                                                 disabled="@IsWorkspaceJobRunning(n.WorkspaceId)"
-                                                @onclick="() => { ClosePushUpdatedMenu(n.WorkspaceId); _ = RunUpdateAsync(n.WorkspaceId); }">
+                                                @onclick="() => { ClosePushUpdatedMenu(n.WorkspaceId); _ = RunUpdateAsync(n); }">
                                             Update Only
                                         </button>
                                     </li>
@@ -122,7 +122,7 @@
                                     <li>
                                         <button class="dropdown-item" type="button" role="menuitem"
                                                 disabled="@IsWorkspaceJobRunning(n.WorkspaceId)"
-                                                @onclick="() => { ClosePushUpdatedMenu(n.WorkspaceId); _ = RunPushAsync(n.WorkspaceId); }">
+                                                @onclick="() => { ClosePushUpdatedMenu(n.WorkspaceId); _ = RunPushAsync(n); }">
                                             Push Only
                                         </button>
                                     </li>
@@ -137,7 +137,7 @@
                             <div class="btn-group dropup position-relative">
                                 <button class="btn btn-danger btn-sm"
                                         disabled="@IsWorkspaceJobRunning(n.WorkspaceId)"
-                                        @onclick="() => _ = RunUpdateAsync(n.WorkspaceId)">
+                                        @onclick="() => _ = RunUpdateAsync(n)">
                                     Update
                                 </button>
                                 <button type="button"
@@ -156,7 +156,7 @@
                                         <li>
                                             <button class="dropdown-item" type="button" role="menuitem"
                                                     disabled="@IsWorkspaceJobRunning(n.WorkspaceId)"
-                                                    @onclick="() => { CloseUpdateMenu(n.WorkspaceId); _ = RunUpdateAsync(n.WorkspaceId); }">
+                                                    @onclick="() => { CloseUpdateMenu(n.WorkspaceId); _ = RunUpdateAsync(n); }">
                                                 Update
                                             </button>
                                         </li>
@@ -184,7 +184,7 @@
                         {
                             <button class="btn btn-warning btn-sm"
                                     disabled="@IsWorkspaceJobRunning(n.WorkspaceId)"
-                                    @onclick="() => _ = RunPushAsync(n.WorkspaceId)">
+                                    @onclick="() => _ = RunPushAsync(n)">
                                 Push
                             </button>
                         }
@@ -195,13 +195,29 @@
     </div>
 }
 
+<DefaultBranchWarningModal
+    IsVisible="_defaultBranchWarning.IsVisible"
+    Message="_defaultBranchWarning.Message"
+    RepoItems="_defaultBranchWarning.RepoItems"
+    OnProceed="OnDefaultBranchWarningProceedAsync"
+    OnCancel="CloseDefaultBranchWarningModal" />
+
 @code {
+    private sealed record DefaultBranchWarningModalState
+    {
+        public bool IsVisible { get; init; }
+        public string Message { get; init; } = "";
+        public IReadOnlyList<(string RepoName, string DefaultBranchName)> RepoItems { get; init; } = Array.Empty<(string, string)>();
+        public Func<Task>? PendingAction { get; init; }
+    }
+
     private HubConnection? _hubConnection;
     private bool _disposed;
     private readonly HashSet<int> _openUpdateMenus = new();
     private readonly HashSet<int> _openPushUpdatedMenus = new();
     private (int WorkspaceId, int RepoId)? _hoveredDepBadge;
     private CancellationTokenSource? _tooltipHideCts;
+    private DefaultBranchWarningModalState _defaultBranchWarning = new();
 
     private static string WorkspaceJobKey(int workspaceId) => $"/workspaces/{workspaceId}";
 
@@ -259,6 +275,32 @@
     }
 
     private void ClosePushUpdatedMenu(int workspaceId) => _openPushUpdatedMenus.Remove(workspaceId);
+
+    private void ShowDefaultBranchWarning(string message, IReadOnlyList<(string RepoName, string DefaultBranchName)> repoItems, Func<Task> onProceed)
+    {
+        _defaultBranchWarning = _defaultBranchWarning with
+        {
+            IsVisible = true,
+            Message = message,
+            RepoItems = repoItems,
+            PendingAction = onProceed,
+        };
+        StateHasChanged();
+    }
+
+    private void CloseDefaultBranchWarningModal()
+    {
+        _defaultBranchWarning = _defaultBranchWarning with { IsVisible = false, PendingAction = null };
+        StateHasChanged();
+    }
+
+    private async Task OnDefaultBranchWarningProceedAsync()
+    {
+        var action = _defaultBranchWarning.PendingAction;
+        CloseDefaultBranchWarningModal();
+        if (action != null)
+            await action();
+    }
 
     private static string GetDescription(WorkspaceNotification n)
     {
@@ -350,9 +392,29 @@
         _ = _hubConnection?.DisposeAsync().AsTask();
     }
 
-    private Task RunUpdateAsync(int workspaceId)
+    private Task RunUpdateAsync(WorkspaceNotification n)
     {
+        var workspaceId = n.WorkspaceId;
         if (IsWorkspaceJobRunning(workspaceId)) return Task.CompletedTask;
+        var defaultBranchRepos = n.Repos
+            .Where(r => r.UnmatchedDeps > 0
+                && !string.IsNullOrWhiteSpace(r.DefaultBranchName)
+                && string.Equals(r.BranchName, r.DefaultBranchName, StringComparison.Ordinal))
+            .Select(r => (r.RepositoryName, r.DefaultBranchName!))
+            .ToList();
+        if (defaultBranchRepos.Count > 0)
+        {
+            ShowDefaultBranchWarning(
+                $"Update on workspace '{n.WorkspaceName}' will commit dependency changes directly to the default (protected) branch.",
+                defaultBranchRepos,
+                () => StartUpdateJobAsync(workspaceId));
+            return Task.CompletedTask;
+        }
+        return StartUpdateJobAsync(workspaceId);
+    }
+
+    private Task StartUpdateJobAsync(int workspaceId)
+    {
         PendingActionsService.Dismiss(workspaceId);
         JobService.StartJob(WorkspaceJobKey(workspaceId), "Updating dependencies...", async (job, ct) =>
         {
@@ -384,11 +446,31 @@
     private Task RunUpdateAndPushAsync(WorkspaceNotification notification)
     {
         var workspaceId = notification.WorkspaceId;
+        if (IsWorkspaceJobRunning(workspaceId)) return Task.CompletedTask;
+        var defaultBranchRepos = notification.Repos
+            .Where(r => r.UnmatchedDeps > 0
+                && !string.IsNullOrWhiteSpace(r.DefaultBranchName)
+                && string.Equals(r.BranchName, r.DefaultBranchName, StringComparison.Ordinal))
+            .Select(r => (r.RepositoryName, r.DefaultBranchName!))
+            .ToList();
+        if (defaultBranchRepos.Count > 0)
+        {
+            ShowDefaultBranchWarning(
+                $"Update on workspace '{notification.WorkspaceName}' will commit dependency changes directly to the default (protected) branch.",
+                defaultBranchRepos,
+                () => StartUpdateAndPushJobAsync(notification));
+            return Task.CompletedTask;
+        }
+        return StartUpdateAndPushJobAsync(notification);
+    }
+
+    private Task StartUpdateAndPushJobAsync(WorkspaceNotification notification)
+    {
+        var workspaceId = notification.WorkspaceId;
         var updatedRepoIds = notification.Repos
             .Where(r => r.UnmatchedDeps > 0)
             .Select(r => r.RepositoryId)
             .ToHashSet();
-        if (IsWorkspaceJobRunning(workspaceId)) return Task.CompletedTask;
         PendingActionsService.Dismiss(workspaceId);
         JobService.StartJob(WorkspaceJobKey(workspaceId), "Updating dependencies...", async (job, ct) =>
         {
@@ -468,9 +550,29 @@
         return Task.CompletedTask;
     }
 
-    private Task RunPushAsync(int workspaceId)
+    private Task RunPushAsync(WorkspaceNotification n)
     {
+        var workspaceId = n.WorkspaceId;
         if (IsWorkspaceJobRunning(workspaceId)) return Task.CompletedTask;
+        var defaultBranchRepos = n.Repos
+            .Where(r => r.OutgoingCommits > 0
+                && !string.IsNullOrWhiteSpace(r.DefaultBranchName)
+                && string.Equals(r.BranchName, r.DefaultBranchName, StringComparison.Ordinal))
+            .Select(r => (r.RepositoryName, r.DefaultBranchName!))
+            .ToList();
+        if (defaultBranchRepos.Count > 0)
+        {
+            ShowDefaultBranchWarning(
+                $"Pushing workspace '{n.WorkspaceName}' will commit directly to the default (protected) branch.",
+                defaultBranchRepos,
+                () => StartPushJobAsync(workspaceId));
+            return Task.CompletedTask;
+        }
+        return StartPushJobAsync(workspaceId);
+    }
+
+    private Task StartPushJobAsync(int workspaceId)
+    {
         PendingActionsService.Dismiss(workspaceId);
         JobService.StartJob(WorkspaceJobKey(workspaceId), "Preparing push...", async (job, ct) =>
         {

--- a/src/GrayMoon.App/Services/WorkspacePendingActionsService.cs
+++ b/src/GrayMoon.App/Services/WorkspacePendingActionsService.cs
@@ -10,7 +10,9 @@ public sealed record NotificationRepo(
     int OutgoingCommits,
     int IncomingCommits,
     bool NewBranchNoPush,
-    IReadOnlyList<(string PackageId, string CurrentVersion, string NewVersion)> MismatchedDeps);
+    IReadOnlyList<(string PackageId, string CurrentVersion, string NewVersion)> MismatchedDeps,
+    string? BranchName,
+    string? DefaultBranchName);
 
 public sealed record WorkspaceNotification(
     int WorkspaceId,
@@ -83,7 +85,9 @@ public sealed class WorkspacePendingActionsService
                     wr.OutgoingCommits ?? 0,
                     wr.IncomingCommits ?? 0,
                     wr.BranchHasUpstream == false,
-                    depLines);
+                    depLines,
+                    wr.BranchName,
+                    wr.DefaultBranchName);
             })
             .ToList();
 

--- a/src/GrayMoon.App/wwwroot/css/loading-overlay.css
+++ b/src/GrayMoon.App/wwwroot/css/loading-overlay.css
@@ -97,7 +97,7 @@
   overflow-y: auto;
   /* Start at the top of the page; GrayMoon brand overlays with its own backdrop */
   /* Bottom padding lifts the last line so all visible lines have clearance from the top edge when scrolled to end */
-  padding: 0px;
+  padding: 4px 2px 0px 2px;
   scroll-padding-top: 0.35rem;
   border: none;
   border-radius: 0;


### PR DESCRIPTION
## Summary

- Warn before Update, Push Updated, and Push from the workspace action notification panel when affected repositories are on their default (protected) branch, reusing `DefaultBranchWarningModal` with repo-specific context
- Extend notification repo payload with branch and default-branch names so the panel can detect on-default operations
- Style the default-branch warning modal header as danger (red background, white close button) so the risk is visually obvious
- Reduce mobile content padding in the main layout and fine-tune loading-overlay terminal padding to use space more efficiently

## Test plan

- [ ] From a notification, trigger Update or Push on a repo checked out on its default branch and confirm the warning lists affected repos before proceeding
- [ ] Confirm Update/Push on feature branches skips the warning and runs immediately
- [ ] Verify Push Updated shows the warning when dependency-update repos are on default branch
- [ ] Cancel and proceed from the warning modal and confirm only the chosen path runs
- [ ] On a narrow viewport, confirm page content and job terminal padding look correct without clipped lines