### PR TITLE
Improve page vertical space and collapsed navbar scrollbar

### DIFF
--- a/src/GrayMoon.App/Components/Layout/MainLayout.razor.css
+++ b/src/GrayMoon.App/Components/Layout/MainLayout.razor.css
@@ -232,6 +232,15 @@ article.content {
         pointer-events: none;
     }
 
+    .page--navbar-collapsed .sidebar ::deep .nav-scrollable {
+        scrollbar-width: thin;
+        scrollbar-color: #5a5a5a var(--bg-card, #252526);
+    }
+
+    .page--navbar-collapsed .sidebar ::deep .nav-scrollable::-webkit-scrollbar {
+        width: 3px;
+    }
+
     .top-row {
         position: sticky;
         top: 0;

--- a/src/GrayMoon.App/Components/Pages/WorkspaceDependencies.razor.css
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceDependencies.razor.css
@@ -1,6 +1,7 @@
 /* Match other grid pages; fit viewport so no vertical scroll */
+/* Height = 100vh - top-row (3.5rem) - article padding-top (2rem) */
 .dependencies-page.page-container.grid-page {
-    height: calc(100vh - 8rem);
+    height: calc(100vh - 5.5rem);
     min-height: 240px;
     overflow: hidden;
 }
@@ -11,6 +12,7 @@
     max-height: none;
     position: relative;
     overflow: hidden;
+    border-radius: 0.375rem;
 }
 
 .dependencies-page .cytoscape-graph {

--- a/src/GrayMoon.App/wwwroot/app.css
+++ b/src/GrayMoon.App/wwwroot/app.css
@@ -481,7 +481,7 @@ h1:focus {
 .grid-page-body {
     flex: 1 1 auto;
     min-height: 0;
-    max-height: calc(100vh - 190px);
+    max-height: calc(100vh - 168px);
     overflow: hidden;
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
## Summary

- Increase usable content height by tightening bottom margin calculations in the main layout and workspace dependencies view
- Size the dependencies canvas to fill available viewport space below the top row and article padding
- Apply a thin scrollbar style to the collapsed sidebar navigation for a less intrusive scroll affordance

## Test plan

- [ ] Open a workspace page with a long grid and confirm more rows are visible without scrolling the outer page
- [ ] Open the Dependencies page and confirm the canvas fills the viewport without clipping or excess empty space below
- [ ] Collapse the navbar, scroll a long nav list, and confirm the thin scrollbar appears and remains usable