### PR TITLE
Override Bootstrap inline code color with goldenrod

### DIFF
--- a/src/GrayMoon.App/wwwroot/app.css
+++ b/src/GrayMoon.App/wwwroot/app.css
@@ -86,6 +86,11 @@ a:hover, .btn-link:hover {
     text-decoration: underline;
 }
 
+/* Override Bootstrap code color (#d63384) */
+code {
+    color: goldenrod;
+}
+
 /* Workspaces breadcrumb (same gray as repositories count) */
 a.workspaces-breadcrumb-link,
 a.workspaces-breadcrumb-link:hover,


### PR DESCRIPTION
## Summary

- Add a global `code` color override in `app.css` so inline code uses goldenrod instead of Bootstrap's default pink (`#d63384`)
- Keeps Bootstrap vendored CSS unchanged; the override loads after Bootstrap and applies app-wide

## Test plan

- [ ] Open a page with `<code>` elements (e.g. dependency modals, version config) and confirm text renders goldenrod
- [ ] Confirm `code` inside links still inherits link color where Bootstrap applies `a > code { color: inherit }`
- [ ] Spot-check modals with component-specific `code` styles (e.g. default branch warning) still use their local colors