### PR TITLE
Add Last Run column to workspace actions grid

### DIFF
--- a/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor
@@ -187,6 +187,7 @@
                                     <th class="col-repo">Repository</th>
                                     <th class="col-branch">Branch</th>
                                     <th class="col-workflow">Workflow</th>
+                                    <th class="col-last-run">Last Run</th>
                                     <th class="col-action-status">Status</th>
                                     <th class="col-actions">Actions</th>
                                 </tr>
@@ -195,7 +196,7 @@
                                 @if (isLoading)
                                 {
                                     <tr>
-                                        <td colspan="5" class="text-center text-muted py-4">
+                                        <td colspan="6" class="text-center text-muted py-4">
                                             Loading workspace...
                                         </td>
                                     </tr>
@@ -203,7 +204,7 @@
                                 else if (rows.Count == 0)
                                 {
                                     <tr>
-                                        <td colspan="5" class="text-center text-muted py-4">
+                                        <td colspan="6" class="text-center text-muted py-4">
                                             No repositories in this workspace. Add repositories to see actions.
                                         </td>
                                     </tr>
@@ -211,7 +212,7 @@
                                 else if (NoVisibleWorkflowRows)
                                 {
                                     <tr>
-                                        <td colspan="5" class="text-center text-muted py-4">
+                                        <td colspan="6" class="text-center text-muted py-4">
                                             @(HasSearchFilter ? "No workflows match your search." : "No workflows match the current filters.")
                                         </td>
                                     </tr>
@@ -294,6 +295,17 @@
                                                     else
                                                     {
                                                         <span class="text-muted">-</span>
+                                                    }
+                                                </td>
+                                                <td class="col-last-run text-muted">
+                                                    @if (line.Action?.UpdatedAt != null)
+                                                    {
+                                                        var lastRunTooltip = line.Action.UpdatedAt.Value.LocalDateTime.ToString("yyyy-MM-dd HH:mm:ss");
+                                                        <span title="@lastRunTooltip">@FormatLastRun(line.Action.UpdatedAt)</span>
+                                                    }
+                                                    else
+                                                    {
+                                                        <span>&middot;</span>
                                                     }
                                                 </td>
                                                 <td class="col-action-status text-center">
@@ -380,7 +392,7 @@
                                             @if (showGhaTerminal)
                                             {
                                                 <tr class="@($"{stripeClass} actions-gha-feed-row actions-data-row actions-row-running actions-row-running-terminal{(repoEndOnGhaRow ? " actions-row-repo-end" : "")}")">
-                                                    <td colspan="5" class="p-0 border-0">
+                                                    <td colspan="6" class="p-0 border-0">
                                                         <GhaWorkflowLiveTerminal @key="@($"{row.Repo.RepositoryId}-{(line.Action?.WorkflowId ?? 0)}-{(line.Action?.RunId ?? 0)}")"
                                                                                  ConnectorName="@row.Repo.ConnectorName"
                                                                                  Owner="@(row.Repo.OrgName ?? "")"

--- a/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor.cs
@@ -1458,6 +1458,17 @@ public sealed partial class WorkspaceActions : IDisposable
     internal static string GroupStripeClass(int groupIndex) =>
         (groupIndex % 2 == 0) ? "actions-group-even" : "actions-group-odd";
 
+    internal static string FormatLastRun(DateTimeOffset? updatedAt)
+    {
+        if (updatedAt == null) return string.Empty;
+        var elapsed = DateTimeOffset.UtcNow - updatedAt.Value;
+        if (elapsed.TotalSeconds < 60) return "just now";
+        if (elapsed.TotalMinutes < 60) return $"{(int)elapsed.TotalMinutes} min ago";
+        if (elapsed.TotalHours < 24) return $"{(int)elapsed.TotalHours} hr ago";
+        if (elapsed.TotalDays < 7) return $"{(int)elapsed.TotalDays} days ago";
+        return updatedAt.Value.LocalDateTime.ToString("MMM d, h:mm tt");
+    }
+
     public void Dispose()
     {
         _cts.Cancel();

--- a/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor.css
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor.css
@@ -240,28 +240,32 @@
 }
 
 .col-repo {
-    width: 26%;
+    width: 22%;
 }
 
 .col-branch {
-    width: 16%;
+    width: 14%;
 }
 
 .col-workflow {
-    width: 22%;
+    width: 20%;
 }
 
 .col-event {
     width: 18%;
 }
 
+.col-last-run {
+    width: 14%;
+}
+
 .col-action-status {
-    width: 18%;
+    width: 14%;
 }
 
 /* Last column: actions (match Workspaces.razor) */
 .col-actions {
-    width: 18%;
+    width: 16%;
 }
 
 .actions-table tbody tr.actions-group-even {


### PR DESCRIPTION
## Summary

- Add a Last Run column to the workspace actions table showing when each GitHub Action last updated
- Display relative time (e.g. "just now", "5 min ago", "2 days ago") with a full local datetime tooltip on hover
- Rebalance column widths and update empty-state colspans to fit the new column

## Test plan

- [ ] Open a workspace with configured actions and confirm Last Run shows relative times for actions with `UpdatedAt`
- [ ] Hover a Last Run cell and verify the tooltip shows `yyyy-MM-dd HH:mm:ss` local time
- [ ] Confirm actions without a last run show a muted placeholder dot
- [ ] Check empty, loading, and expanded terminal rows still align across all six columns