### PR TITLE
Replace upstream rev-parse with for-each-ref to silence fatal stderr

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,10 @@ Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManage
 
 ## What's new
 
+### No more red "fatal" noise in the terminal during New Feature runs
+
+The upstream tracking probe used by commit-count and fetch operations now uses `git for-each-ref --format=%(upstream:short)` instead of `git rev-parse @{u}`. The old command wrote `fatal: no upstream configured for branch '<name>'` to stderr every time GrayMoon checked a branch that had not yet been pushed - which always happens during a New Feature orchestrator run (branches are created locally before the first push). Because GrayMoon streams stderr to the terminal overlay in real time, that `fatal:` line appeared as red terminal output even though nothing was wrong. The new command exits 0 with empty output when no upstream is set, so no message is produced and the terminal stays clean.
+
 ### Undo Push Commits
 
 When a branch has outgoing commits that have not yet been merged, GrayMoon can now reset them back to `origin` without leaving the app.

--- a/src/GrayMoon.Agent/Services/GitService.cs
+++ b/src/GrayMoon.Agent/Services/GitService.cs
@@ -300,7 +300,7 @@ public sealed class GitService(IOptions<AgentOptions> options, ILogger<GitServic
         // Resolve the upstream ref (e.g. origin/main) and use that as the fetch target for the
         // current branch rather than the branch name itself. This avoids fetching non-upstreamed
         // local branches and ensures we are always fetching the configured remote tracking ref.
-        var upstreamRef = skipUpstreamCheck ? null : await GetUpstreamRefAsync(repoPath, ct);
+        var upstreamRef = skipUpstreamCheck ? null : await GetUpstreamRefAsync(repoPath, branchName, ct);
         logger.LogDebug("Git minimal fetch upstream ref for {RepoPath}: {UpstreamRef}", repoPath, upstreamRef ?? "<none>");
 
         if (!string.IsNullOrWhiteSpace(upstreamRef))
@@ -383,7 +383,7 @@ public sealed class GitService(IOptions<AgentOptions> options, ILogger<GitServic
 
         // Resolve upstream ref (e.g. origin/main) once for this branch. When there is no upstream
         // configured we fall back to comparing against the default branch only.
-        var upstreamRef = skipUpstreamCheck ? null : await GetUpstreamRefAsync(repoPath, ct);
+        var upstreamRef = skipUpstreamCheck ? null : await GetUpstreamRefAsync(repoPath, branchName, ct);
         if (string.IsNullOrWhiteSpace(upstreamRef))
         {
             var defaultBranch = defaultBranchOriginRef ?? await GetDefaultBranchAsync(repoPath, ct);
@@ -1112,14 +1112,15 @@ public sealed class GitService(IOptions<AgentOptions> options, ILogger<GitServic
     }
 
     /// <summary>
-    /// Returns the configured upstream ref for the current HEAD (e.g. "origin/main") by using
-    /// `git rev-parse --abbrev-ref --symbolic-full-name @{u}`. Returns null when no upstream is configured.
+    /// Returns the configured upstream tracking ref for <paramref name="branchName"/> (e.g. "origin/main").
+    /// Uses <c>git for-each-ref --format=%(upstream:short)</c>, which exits 0 with empty output when no
+    /// upstream is set -- no fatal stderr, unlike the <c>@{u}</c> syntax.
     /// </summary>
-    private async Task<string?> GetUpstreamRefAsync(string repoPath, CancellationToken ct)
+    private async Task<string?> GetUpstreamRefAsync(string repoPath, string branchName, CancellationToken ct)
     {
         var (exitCode, stdout, _) = await RunProcessAsync(
             "git",
-            "rev-parse --abbrev-ref --symbolic-full-name @{u}",
+            $"for-each-ref --format=%(upstream:short) refs/heads/{branchName}",
             repoPath,
             ct);
 

--- a/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor
@@ -305,7 +305,7 @@
                                                     }
                                                     else
                                                     {
-                                                        <span>&middot;</span>
+                                                        <span class="text-muted">never</span>
                                                     }
                                                 </td>
                                                 <td class="col-action-status text-center">


### PR DESCRIPTION
## Summary

- Switch upstream tracking detection in the Agent from `git rev-parse @{u}` to `git for-each-ref --format=%(upstream:short)` so branches without a remote upstream no longer emit red `fatal:` lines to the job terminal during New Feature runs
- Pass the explicit branch name into upstream lookup for commit-count and fetch operations instead of relying on HEAD
- Show "never" instead of a muted dot in the workspace actions Last Run column when an action has no recorded run
- Document the upstream probe change and its effect on terminal output in the README

## Test plan

- [ ] Run New Feature on a repo whose branch has no upstream yet and confirm the terminal overlay stays clean (no `fatal: no upstream configured` lines)
- [ ] Verify commit counts and fetch still work correctly once an upstream is configured
- [ ] Open workspace actions and confirm Last Run shows relative times, "never" when unset, and tooltip on hover for actions with a last run