### PR TITLE
Refresh workspace repositories when background job completes

### DIFF
--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
@@ -79,6 +79,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
     private string searchTerm = string.Empty;
 
     private bool _disposed;
+    private bool _wasJobRunning;
     private string PageJobKey => new Uri(NavigationManager.Uri).AbsolutePath.ToLowerInvariant();
     private bool IsJobRunning => JobService.IsRunning(PageJobKey);
 
@@ -98,6 +99,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
     {
         AgentQueueStateService.OnQueueStateChanged(OnQueueStateChanged);
         JobService.Changed += OnJobServiceChanged;
+        _wasJobRunning = IsJobRunning;
         await LoadWorkspaceAsync();
         ApplySyncStateFromWorkspace();
     }
@@ -179,7 +181,19 @@ public sealed partial class WorkspaceRepositories : IDisposable
         _fetchRepositoriesCts?.Dispose();
     }
 
-    private void OnJobServiceChanged() => SafeInvoke(() => { });
+    private void OnJobServiceChanged()
+    {
+        if (_disposed) return;
+        _ = InvokeAsync(() =>
+        {
+            if (_disposed) return;
+            var isRunning = IsJobRunning;
+            if (_wasJobRunning && !isRunning)
+                _ = InvokeAsync(RefreshFromSync);
+            _wasJobRunning = isRunning;
+            StateHasChanged();
+        });
+    }
 
     private void SafeInvoke(Action callback)
     {


### PR DESCRIPTION
## Summary

- Track background job running state on the workspace repositories page and detect when a job finishes
- Call `RefreshFromSync` after a job transitions from running to idle so the grid reflects post-workflow changes (e.g. after new feature)
- Invoke job-service updates on the Blazor sync context with disposal guards and `StateHasChanged`

## Test plan

- [ ] Run a background job from workspace repositories (e.g. new feature) and confirm the grid refreshes automatically when the job completes
- [ ] Navigate away and back during a job; confirm no errors and refresh still occurs on completion
- [ ] Verify the page still updates correctly while a job is running (spinner/overlay state)