### PR TITLE
Add one-click agent self-update from the header badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,15 @@ Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManage
 
 ## What's new
 
+### One-click agent update from the badge
+
+When the agent version does not match the app, the header badge shows a red **update** label. Clicking it now triggers a self-update directly - no need to visit the Agent page and copy a command.
+
+- **How it works:** clicking the badge sends a `SelfUpdate` command to the running agent over SignalR. The agent launches the install script in a fully detached process (`cmd.exe /c start /b powershell.exe -NoProfile -NonInteractive -Command "irm .../api/agent/install | iex"`), which stops the old service, downloads the new binary, and restarts the service.
+- **Badge changes to blue "updating"** immediately after the command is dispatched and stays there while the service restarts.
+- **Returns to green "online"** automatically once the new agent connects and its version matches.
+- **On failure:** if the command cannot be dispatched (agent not connected, process failed to start), a toast shows **Agent update failed.** and the app navigates to the Agent page where you can run the command manually.
+
 ### No more red "fatal" noise in the terminal during New Feature runs
 
 The upstream tracking probe used by commit-count and fetch operations now uses `git for-each-ref --format=%(upstream:short)` instead of `git rev-parse @{u}`. The old command wrote `fatal: no upstream configured for branch '<name>'` to stderr every time GrayMoon checked a branch that had not yet been pushed - which always happens during a New Feature orchestrator run (branches are created locally before the first push). Because GrayMoon streams stderr to the terminal overlay in real time, that `fatal:` line appeared as red terminal output even though nothing was wrong. The new command exits 0 with empty output when no upstream is set, so no message is produced and the terminal stays clean.

--- a/src/GrayMoon.Agent/Cli/Handlers/RunCommandHandler.cs
+++ b/src/GrayMoon.Agent/Cli/Handlers/RunCommandHandler.cs
@@ -126,6 +126,7 @@ internal static class RunCommandHandler
         builder.Services.AddSingleton<ICommandHandler<ValidatePathRequest, ValidatePathResponse>, ValidatePathCommand>();
         builder.Services.AddSingleton<ICommandHandler<DotnetRestoreRequest, DotnetRestoreResponse>, DotnetRestoreCommand>();
         builder.Services.AddSingleton<ICommandHandler<UndoPushRequest, UndoPushResponse>, UndoPushCommand>();
+        builder.Services.AddSingleton<ICommandHandler<SelfUpdateRequest, SelfUpdateResponse>, SelfUpdateCommand>();
         builder.Services.AddSingleton<CheckoutHookSyncCommand>();
         builder.Services.AddSingleton<CommitHookSyncCommand>();
         builder.Services.AddSingleton<MergeHookSyncCommand>();

--- a/src/GrayMoon.Agent/Commands/SelfUpdateCommand.cs
+++ b/src/GrayMoon.Agent/Commands/SelfUpdateCommand.cs
@@ -1,0 +1,30 @@
+using System.Diagnostics;
+using GrayMoon.Agent.Abstractions;
+using GrayMoon.Agent.Jobs.Requests;
+using GrayMoon.Agent.Jobs.Response;
+using Microsoft.Extensions.Logging;
+
+namespace GrayMoon.Agent.Commands;
+
+public sealed class SelfUpdateCommand(ILogger<SelfUpdateCommand> logger) : ICommandHandler<SelfUpdateRequest, SelfUpdateResponse>
+{
+    public Task<SelfUpdateResponse> ExecuteAsync(SelfUpdateRequest request, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(request.InstallUrl))
+            throw new ArgumentException("InstallUrl is required.");
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = "powershell.exe",
+            Arguments = $"-NoProfile -NonInteractive -Command \"irm '{request.InstallUrl}' | iex\"",
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+
+        _ = Process.Start(psi)
+            ?? throw new InvalidOperationException("Failed to start PowerShell process.");
+
+        logger.LogInformation("Started self-update from {InstallUrl}", request.InstallUrl);
+        return Task.FromResult(new SelfUpdateResponse());
+    }
+}

--- a/src/GrayMoon.Agent/Commands/SelfUpdateCommand.cs
+++ b/src/GrayMoon.Agent/Commands/SelfUpdateCommand.cs
@@ -15,8 +15,8 @@ public sealed class SelfUpdateCommand(ILogger<SelfUpdateCommand> logger) : IComm
 
         var psi = new ProcessStartInfo
         {
-            FileName = "powershell.exe",
-            Arguments = $"-NoProfile -NonInteractive -Command \"irm '{request.InstallUrl}' | iex\"",
+            FileName = "cmd.exe",
+            Arguments = $"/c start \"\" /b powershell.exe -NoProfile -NonInteractive -Command \"irm '{request.InstallUrl}' | iex\"",
             UseShellExecute = false,
             CreateNoWindow = true,
         };

--- a/src/GrayMoon.Agent/Hosted/SignalRConnectionHostedService.cs
+++ b/src/GrayMoon.Agent/Hosted/SignalRConnectionHostedService.cs
@@ -70,8 +70,27 @@ public sealed class SignalRConnectionHostedService(
         {
             logger.LogDebug("RequestCommand {RequestId} received: {Command}", requestId, command);
             logger.LogTrace("RequestCommand {RequestId} request content: {Args}", requestId, args.HasValue ? args.Value.GetRawText() : "null");
-            var envelope = commandJobFactory.CreateCommandJob(requestId, command, args);
-            await jobQueue.EnqueueAsync(envelope, cancellationToken);
+            try
+            {
+                var envelope = commandJobFactory.CreateCommandJob(requestId, command, args);
+                await jobQueue.EnqueueAsync(envelope, cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Failed to enqueue command {Command} (RequestId={RequestId})", command, requestId);
+                if (_connection?.State == HubConnectionState.Connected)
+                {
+                    try
+                    {
+                        var errorResponse = new AgentCommandResponse(false, null, ex.Message);
+                        await _connection.InvokeAsync(AgentHubMethods.ResponseCommand, requestId, errorResponse, cancellationToken);
+                    }
+                    catch (Exception sendEx)
+                    {
+                        logger.LogWarning(sendEx, "Failed to send error response for {RequestId}", requestId);
+                    }
+                }
+            }
         });
 
         _connection.Reconnecting += error =>

--- a/src/GrayMoon.Agent/Jobs/Requests/SelfUpdateRequest.cs
+++ b/src/GrayMoon.Agent/Jobs/Requests/SelfUpdateRequest.cs
@@ -1,0 +1,9 @@
+using System.Text.Json.Serialization;
+
+namespace GrayMoon.Agent.Jobs.Requests;
+
+public sealed class SelfUpdateRequest
+{
+    [JsonPropertyName("installUrl")]
+    public string? InstallUrl { get; set; }
+}

--- a/src/GrayMoon.Agent/Jobs/Response/SelfUpdateResponse.cs
+++ b/src/GrayMoon.Agent/Jobs/Response/SelfUpdateResponse.cs
@@ -1,0 +1,5 @@
+namespace GrayMoon.Agent.Jobs.Response;
+
+public sealed class SelfUpdateResponse
+{
+}

--- a/src/GrayMoon.Agent/Services/CommandDispatcher.cs
+++ b/src/GrayMoon.Agent/Services/CommandDispatcher.cs
@@ -31,7 +31,8 @@ public sealed class CommandDispatcher(
     ICommandHandler<GetFileContentsRequest, GetFileContentsResponse> getFileContentsCommand,
     ICommandHandler<ValidatePathRequest, ValidatePathResponse> validatePathCommand,
     ICommandHandler<DotnetRestoreRequest, DotnetRestoreResponse> dotnetRestoreCommand,
-    ICommandHandler<UndoPushRequest, UndoPushResponse> undoPushCommand) : ICommandDispatcher
+    ICommandHandler<UndoPushRequest, UndoPushResponse> undoPushCommand,
+    ICommandHandler<SelfUpdateRequest, SelfUpdateResponse> selfUpdateCommand) : ICommandDispatcher
 {
     private readonly IReadOnlyDictionary<string, Func<object, CancellationToken, Task<object?>>> _executors = new Dictionary<string, Func<object, CancellationToken, Task<object?>>>(StringComparer.Ordinal)
     {
@@ -62,6 +63,7 @@ public sealed class CommandDispatcher(
         ["ValidatePath"] = async (req, ct) => await validatePathCommand.ExecuteAsync((ValidatePathRequest)req, ct),
         ["DotnetRestore"] = async (req, ct) => await dotnetRestoreCommand.ExecuteAsync((DotnetRestoreRequest)req, ct),
         ["UndoPush"] = async (req, ct) => await undoPushCommand.ExecuteAsync((UndoPushRequest)req, ct),
+        ["SelfUpdate"] = async (req, ct) => await selfUpdateCommand.ExecuteAsync((SelfUpdateRequest)req, ct),
     };
 
     public Task<object?> ExecuteAsync(string commandName, object request, CancellationToken cancellationToken = default)

--- a/src/GrayMoon.Agent/Services/CommandJobFactory.cs
+++ b/src/GrayMoon.Agent/Services/CommandJobFactory.cs
@@ -22,6 +22,8 @@ public sealed class CommandJobFactory
         {
             if (command == "GetHostInfo")
                 return new GetHostInfoRequest();
+            if (command == "SelfUpdate")
+                return new SelfUpdateRequest();
             throw new ArgumentException($"Args required for {command}");
         }
 
@@ -83,6 +85,8 @@ public sealed class CommandJobFactory
                 ?? throw new ArgumentException("Invalid DotnetRestore args"),
             "UndoPush" => JsonSerializer.Deserialize<UndoPushRequest>(json, options)
                 ?? throw new ArgumentException("Invalid UndoPush args"),
+            "SelfUpdate" => JsonSerializer.Deserialize<SelfUpdateRequest>(json, options)
+                ?? throw new ArgumentException("Invalid SelfUpdate args"),
             _ => throw new NotSupportedException($"Unknown command: {command}")
         };
     }

--- a/src/GrayMoon.App/Components/Shared/AgentStatusBadge.razor
+++ b/src/GrayMoon.App/Components/Shared/AgentStatusBadge.razor
@@ -3,6 +3,7 @@
 @inject AgentQueueStateService AgentQueueStateService
 @inject IAgentBridge AgentBridge
 @inject NavigationManager NavigationManager
+@inject IToastService ToastService
 @rendermode @(new InteractiveServerRenderMode(prerender: true))
 
 @if (State == AgentConnectionState.VersionMismatch && !_isUpdating)
@@ -53,6 +54,7 @@ else
         {
             _isUpdating = false;
             StateHasChanged();
+            ToastService.ShowError("Agent update failed.");
             NavigationManager.NavigateTo("/agent");
         }
     }

--- a/src/GrayMoon.App/Components/Shared/AgentStatusBadge.razor
+++ b/src/GrayMoon.App/Components/Shared/AgentStatusBadge.razor
@@ -1,29 +1,63 @@
 @using GrayMoon.App.Services
 @inject AgentConnectionTracker AgentConnectionTracker
 @inject AgentQueueStateService AgentQueueStateService
+@inject IAgentBridge AgentBridge
+@inject NavigationManager NavigationManager
 @rendermode @(new InteractiveServerRenderMode(prerender: true))
 
-<a href="/agent" class="@BadgeClassFull" 
-   title="@TitleText" 
-   style="cursor: pointer; display: inline-flex; align-items: center; vertical-align: middle; @BadgeStyle">
-    @StateLabel
-</a>
+@if (State == AgentConnectionState.VersionMismatch && !_isUpdating)
+{
+    <a class="@BadgeClassFull"
+       title="@TitleText"
+       style="cursor: pointer; display: inline-flex; align-items: center; vertical-align: middle; @BadgeStyle"
+       @onclick="StartUpdateAsync">
+        update
+    </a>
+}
+else
+{
+    <a href="/agent" class="@BadgeClassFull"
+       title="@TitleText"
+       style="cursor: pointer; display: inline-flex; align-items: center; vertical-align: middle; @BadgeStyle">
+        @StateLabel
+    </a>
+}
 
 @implements IDisposable
 
 @code {
     private AgentConnectionState State => AgentConnectionTracker.State;
     private string? AgentSemVer => AgentConnectionTracker.AgentSemVer;
+    private bool _isUpdating;
 
     protected override void OnInitialized()
     {
-        AgentConnectionTracker.OnStateChanged((state) => { _ = InvokeAsync(StateHasChanged); });
+        AgentConnectionTracker.OnStateChanged(state =>
+        {
+            if (state == AgentConnectionState.Online)
+                _isUpdating = false;
+            _ = InvokeAsync(StateHasChanged);
+        });
         AgentQueueStateService.OnQueueStateChanged(OnQueueStateChanged);
     }
 
     private void OnQueueStateChanged(object? sender, EventArgs e) => _ = InvokeAsync(StateHasChanged);
 
-    private string BadgeClass => State switch
+    private async Task StartUpdateAsync()
+    {
+        _isUpdating = true;
+        StateHasChanged();
+        var installUrl = NavigationManager.BaseUri.TrimEnd('/') + "/api/agent/install";
+        var response = await AgentBridge.SendCommandAsync("SelfUpdate", new { installUrl }, CancellationToken.None);
+        if (!response.Success)
+        {
+            _isUpdating = false;
+            StateHasChanged();
+            NavigationManager.NavigateTo("/agent");
+        }
+    }
+
+    private string BadgeClass => _isUpdating ? "bg-primary" : State switch
     {
         AgentConnectionState.Online => "bg-success",
         AgentConnectionState.Offline => "bg-danger",
@@ -32,17 +66,19 @@
         _ => "bg-secondary"
     };
 
-    private string BadgeStyle => State switch
-    {
-        AgentConnectionState.Online => "background-color: #198754 !important;",
-        AgentConnectionState.Offline => "background-color: #dc3545 !important; color: #fff !important;",
-        AgentConnectionState.VersionMismatch => "background-color: #dc3545 !important; color: #fff !important;",
-        _ => ""
-    };
+    private string BadgeStyle => _isUpdating
+        ? "background-color: #0d6efd !important; color: #fff !important;"
+        : State switch
+        {
+            AgentConnectionState.Online => "background-color: #198754 !important;",
+            AgentConnectionState.Offline => "background-color: #dc3545 !important; color: #fff !important;",
+            AgentConnectionState.VersionMismatch => "background-color: #dc3545 !important; color: #fff !important;",
+            _ => ""
+        };
 
     private string BadgeClassFull => $"badge {BadgeClass} text-decoration-none ms-2";
 
-    private string StateLabel => State switch
+    private string StateLabel => _isUpdating ? "updating" : State switch
     {
         AgentConnectionState.Online => AgentQueueStateService.GetTotalPendingCount() > 0 ? "running" : "online",
         AgentConnectionState.Offline => "offline",
@@ -51,7 +87,7 @@
         _ => "offline"
     };
 
-    private string TitleText => State switch
+    private string TitleText => _isUpdating ? "Updating agent..." : State switch
     {
         AgentConnectionState.VersionMismatch => $"Agent version mismatch. Agent version: {AgentSemVer ?? "unknown"}. Click to update.",
         AgentConnectionState.Online => AgentQueueStateService.GetTotalPendingCount() > 0 ? "Agent is running tasks" : "Agent connection status: online",


### PR DESCRIPTION
## Summary

- Add a `SelfUpdate` agent command that launches the install script in a detached process so the running service can replace itself
- Wire the header badge: when the agent version mismatches, clicking **update** dispatches the command, shows a blue **updating** state, and returns to green **online** once the new agent connects
- Return command enqueue failures to the app over SignalR so the UI can toast **Agent update failed.** and fall back to the Agent page for manual install
- Document the one-click update flow in the README

## Test plan

- [ ] With an outdated agent connected, confirm the badge shows red **update** and clicking it triggers self-update without visiting the Agent page
- [ ] Confirm the badge switches to blue **updating** during restart and back to green **online** when versions match
- [ ] Simulate dispatch failure (agent disconnected or process start error) and verify the error toast plus navigation to `/agent`
- [ ] Confirm normal badge behavior is unchanged when online, offline, or not in version-mismatch state