### PR TITLE
Refactor agent git execution and delegate workspace repository workflows

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ The App is organized into:
 - `Components/Shared/` and `Components/Modals/` — reusable UI components
 - `Services/` — 60+ domain services (GitHub API, workspace operations, push orchestration, dependency update, etc.)
 - `Data/` — EF Core `DbContext`, entity models, and repository classes
-- `Api/Endpoints/` — REST API endpoints grouped by domain (Agent, Branch, Commit, Connector, Sync, Workspace)
+- `Api/Endpoints/` — REST API endpoints grouped by domain (About, Agent, Branch, Connector, Settings, Sync, Workspace)
 
 ### Orchestrators
 
@@ -78,6 +78,12 @@ Three orchestrators coordinate multi-step workflows across repositories:
 - `DependencyUpdateOrchestrator` — drives level-by-level package version updates: updates `.csproj` files, runs `dotnet restore --force --no-cache`, commits each level, then moves to the next.
 - `PushOrchestrator` — synchronized push: pushes level-by-level, waits for NuGet availability between levels so downstream consumers get the correct package version before their push starts.
 - `NewFeatureOrchestrator` — automates branch creation, optional dependency update, commit, and push across selected repositories in one workflow.
+
+### Handler services
+
+`Workspace*Handler` services (`WorkspaceBranchHandler`, `WorkspacePushHandler`, `WorkspaceUpdateHandler`, `WorkspaceUndoPushHandler`, `WorkspaceCommitSyncHandler`, `WorkspaceSyncHandler`) are the page-facing layer above orchestrators and core services. They are stateless and accept UI callbacks (`Action<string> setProgress`, `Action<string> showToast`, `CancellationToken`) so Blazor components can delegate complex operations without owning workflow logic. When adding a new user-initiated multi-step operation, add it to the appropriate existing handler or create a new one rather than putting the logic in the component or a new orchestrator.
+
+`WorkspacePendingActionsService` computes per-workspace notification state (unmatched dependencies, outgoing commits, incoming default-branch commits) by subscribing to workspace sync hub events. It powers `WorkspaceActionNotificationPanel`, the floating notification cards visible from any page.
 
 ### GHA live feed services
 

--- a/src/GrayMoon.Abstractions/Agent/AgentHubMethods.cs
+++ b/src/GrayMoon.Abstractions/Agent/AgentHubMethods.cs
@@ -22,4 +22,7 @@ public static class AgentHubMethods
 
     /// <summary>Agent → App: report agent job queue status (total pending, per-workspace counts).</summary>
     public const string ReportQueueStatus = "ReportQueueStatus";
+
+    /// <summary>App → Agent: request agent self-update (InstallUrl in payload).</summary>
+    public const string SelfUpdate = "SelfUpdate";
 }

--- a/src/GrayMoon.Agent/Abstractions/IGitService.cs
+++ b/src/GrayMoon.Agent/Abstractions/IGitService.cs
@@ -44,8 +44,6 @@ public interface IGitService
     Task<(bool Success, string? ErrorMessage)> CheckoutBranchAsync(string repoPath, string branchName, CancellationToken ct, bool skipHooks = false);
     /// <summary>Creates a new branch from the given base branch and checks it out. Returns (success, errorMessage).</summary>
     Task<(bool Success, string? ErrorMessage)> CreateBranchAsync(string repoPath, string newBranchName, string baseBranchName, CancellationToken ct, bool skipHooks = false);
-    /// <summary>Deletes a local branch. Returns true if successful. Only deletes if branch is not current and is merged or force flag is set.</summary>
-    Task<bool> DeleteLocalBranchAsync(string repoPath, string branchName, bool force, CancellationToken ct);
     /// <summary>Deletes a local or remote branch. Returns (success, errorMessage). For remote, runs git push origin --delete. For local, when <paramref name="force"/> is true, uses git branch -D.</summary>
     Task<(bool Success, string? ErrorMessage)> DeleteBranchAsync(string repoPath, string branchName, bool isRemote, bool force, CancellationToken ct);
     /// <summary>Gets the default branch name (e.g., "main" or "master") without "origin/" prefix.</summary>

--- a/src/GrayMoon.Agent/Cli/Handlers/RunCommandHandler.cs
+++ b/src/GrayMoon.Agent/Cli/Handlers/RunCommandHandler.cs
@@ -91,6 +91,7 @@ internal static class RunCommandHandler
         builder.Services.AddSingleton<IJobQueue>(sp => sp.GetRequiredService<TrackedJobQueue>());
         builder.Services.AddSingleton<IAgentQueueTracker>(sp => sp.GetRequiredService<TrackedJobQueue>());
         builder.Services.AddSingleton<ICommandLineService, CommandLineService>();
+        builder.Services.AddSingleton<GitProcessRunner>();
         builder.Services.AddSingleton<IGitService, GitService>();
         builder.Services.AddSingleton<IAgentTokenProvider, AgentTokenProvider>();
         builder.Services.AddSingleton<ICsProjFileParser, CsProjFileParser>();

--- a/src/GrayMoon.Agent/Commands/SelfUpdateCommand.cs
+++ b/src/GrayMoon.Agent/Commands/SelfUpdateCommand.cs
@@ -13,6 +13,9 @@ public sealed class SelfUpdateCommand(ILogger<SelfUpdateCommand> logger) : IComm
         if (string.IsNullOrWhiteSpace(request.InstallUrl))
             throw new ArgumentException("InstallUrl is required.");
 
+        if (!OperatingSystem.IsWindows())
+            throw new NotSupportedException("Self-update via the badge is only supported on Windows. Run the install script manually on this platform.");
+
         var psi = new ProcessStartInfo
         {
             FileName = "cmd.exe",

--- a/src/GrayMoon.Agent/Commands/SyncToDefaultBranchCommand.cs
+++ b/src/GrayMoon.Agent/Commands/SyncToDefaultBranchCommand.cs
@@ -1,10 +1,11 @@
 using GrayMoon.Agent.Abstractions;
 using GrayMoon.Agent.Jobs.Requests;
 using GrayMoon.Agent.Jobs.Response;
+using Microsoft.Extensions.Logging;
 
 namespace GrayMoon.Agent.Commands;
 
-public sealed class SyncToDefaultBranchCommand(IGitService git) : ICommandHandler<SyncToDefaultBranchRequest, SyncToDefaultBranchResponse>
+public sealed class SyncToDefaultBranchCommand(IGitService git, ILogger<SyncToDefaultBranchCommand> logger) : ICommandHandler<SyncToDefaultBranchRequest, SyncToDefaultBranchResponse>
 {
     public async Task<SyncToDefaultBranchResponse> ExecuteAsync(SyncToDefaultBranchRequest request, CancellationToken cancellationToken = default)
     {
@@ -37,7 +38,11 @@ public sealed class SyncToDefaultBranchCommand(IGitService git) : ICommandHandle
 
         // If the user confirmed remote branch deletion, delete it before fetch so --prune removes the tracking ref
         if (request.DeleteRemoteBranch && !string.Equals(currentBranchName, defaultBranch, StringComparison.OrdinalIgnoreCase))
-            await git.DeleteBranchAsync(repoPath, currentBranchName, isRemote: true, force: false, cancellationToken);
+        {
+            var (remoteDeleteOk, remoteDeleteErr) = await git.DeleteBranchAsync(repoPath, currentBranchName, isRemote: true, force: false, cancellationToken);
+            if (!remoteDeleteOk)
+                logger.LogWarning("Remote branch delete failed for {Branch} in {RepoPath}: {Error}", currentBranchName, repoPath, remoteDeleteErr);
+        }
 
         // Fetch to update remote-tracking refs and prune deleted remote branches
         var (fetchSuccess, fetchError) = await git.FetchAsync(repoPath, includeTags: true, request.BearerToken, cancellationToken);
@@ -65,7 +70,9 @@ public sealed class SyncToDefaultBranchCommand(IGitService git) : ICommandHandle
         if (currentBranchName != defaultBranch)
         {
             // Force delete (-D) only when PR is merged (set by App from current PR status). Otherwise use -d so we only delete if merged locally.
-            await git.DeleteBranchAsync(repoPath, currentBranchName, isRemote: false, force: request.ForceDeleteLocalBranch, cancellationToken);
+            var (localDeleteOk, localDeleteErr) = await git.DeleteBranchAsync(repoPath, currentBranchName, isRemote: false, force: request.ForceDeleteLocalBranch, cancellationToken);
+            if (!localDeleteOk)
+                logger.LogWarning("Local branch delete failed for {Branch} in {RepoPath}: {Error}", currentBranchName, repoPath, localDeleteErr);
         }
 
         // Always pull after switching to default so local is up to date

--- a/src/GrayMoon.Agent/Commands/SyncToDefaultBranchCommand.cs
+++ b/src/GrayMoon.Agent/Commands/SyncToDefaultBranchCommand.cs
@@ -65,7 +65,7 @@ public sealed class SyncToDefaultBranchCommand(IGitService git) : ICommandHandle
         if (currentBranchName != defaultBranch)
         {
             // Force delete (-D) only when PR is merged (set by App from current PR status). Otherwise use -d so we only delete if merged locally.
-            await git.DeleteLocalBranchAsync(repoPath, currentBranchName, force: request.ForceDeleteLocalBranch, cancellationToken);
+            await git.DeleteBranchAsync(repoPath, currentBranchName, isRemote: false, force: request.ForceDeleteLocalBranch, cancellationToken);
         }
 
         // Always pull after switching to default so local is up to date

--- a/src/GrayMoon.Agent/Services/CommandDispatcher.cs
+++ b/src/GrayMoon.Agent/Services/CommandDispatcher.cs
@@ -1,3 +1,4 @@
+using GrayMoon.Abstractions.Agent;
 using GrayMoon.Agent.Abstractions;
 using GrayMoon.Agent.Jobs.Requests;
 using GrayMoon.Agent.Jobs.Response;
@@ -63,7 +64,7 @@ public sealed class CommandDispatcher(
         ["ValidatePath"] = async (req, ct) => await validatePathCommand.ExecuteAsync((ValidatePathRequest)req, ct),
         ["DotnetRestore"] = async (req, ct) => await dotnetRestoreCommand.ExecuteAsync((DotnetRestoreRequest)req, ct),
         ["UndoPush"] = async (req, ct) => await undoPushCommand.ExecuteAsync((UndoPushRequest)req, ct),
-        ["SelfUpdate"] = async (req, ct) => await selfUpdateCommand.ExecuteAsync((SelfUpdateRequest)req, ct),
+        [AgentHubMethods.SelfUpdate] = async (req, ct) => await selfUpdateCommand.ExecuteAsync((SelfUpdateRequest)req, ct),
     };
 
     public Task<object?> ExecuteAsync(string commandName, object request, CancellationToken cancellationToken = default)

--- a/src/GrayMoon.Agent/Services/CommandJobFactory.cs
+++ b/src/GrayMoon.Agent/Services/CommandJobFactory.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using GrayMoon.Abstractions.Agent;
 using GrayMoon.Agent.Jobs;
 using GrayMoon.Agent.Jobs.Requests;
 
@@ -22,7 +23,7 @@ public sealed class CommandJobFactory
         {
             if (command == "GetHostInfo")
                 return new GetHostInfoRequest();
-            if (command == "SelfUpdate")
+            if (command == AgentHubMethods.SelfUpdate)
                 return new SelfUpdateRequest();
             throw new ArgumentException($"Args required for {command}");
         }
@@ -85,7 +86,7 @@ public sealed class CommandJobFactory
                 ?? throw new ArgumentException("Invalid DotnetRestore args"),
             "UndoPush" => JsonSerializer.Deserialize<UndoPushRequest>(json, options)
                 ?? throw new ArgumentException("Invalid UndoPush args"),
-            "SelfUpdate" => JsonSerializer.Deserialize<SelfUpdateRequest>(json, options)
+            AgentHubMethods.SelfUpdate => JsonSerializer.Deserialize<SelfUpdateRequest>(json, options)
                 ?? throw new ArgumentException("Invalid SelfUpdate args"),
             _ => throw new NotSupportedException($"Unknown command: {command}")
         };

--- a/src/GrayMoon.Agent/Services/GitProcessRunner.cs
+++ b/src/GrayMoon.Agent/Services/GitProcessRunner.cs
@@ -40,8 +40,7 @@ public sealed class GitProcessRunner(ICommandLineService commandLine, ILogger<Gi
         bool? streamStderrAsStdout = null,
         bool? mirrorFailureOutputAsStderr = null)
     {
-        if (string.Equals(fileName, "git", StringComparison.OrdinalIgnoreCase) &&
-            !string.IsNullOrWhiteSpace(workingDirectory))
+        if (RequiresRepoLock(fileName, arguments) && !string.IsNullOrWhiteSpace(workingDirectory))
         {
             var repoLock = GetRepoLock(workingDirectory);
             await repoLock.WaitAsync(ct);
@@ -80,8 +79,7 @@ public sealed class GitProcessRunner(ICommandLineService commandLine, ILogger<Gi
         string stdinContent,
         CancellationToken ct)
     {
-        if (string.Equals(fileName, "git", StringComparison.OrdinalIgnoreCase) &&
-            !string.IsNullOrWhiteSpace(workingDirectory))
+        if (RequiresRepoLock(fileName, arguments) && !string.IsNullOrWhiteSpace(workingDirectory))
         {
             var repoLock = GetRepoLock(workingDirectory);
             await repoLock.WaitAsync(ct);
@@ -131,6 +129,14 @@ public sealed class GitProcessRunner(ICommandLineService commandLine, ILogger<Gi
         var key = Path.GetFullPath(repoPath).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
         return RepoLocks.GetOrAdd(key, _ => new SemaphoreSlim(1, 1));
     }
+
+    // dotnet-gitversion reads git HEAD/index state, so it must be serialized per-repo
+    // the same way raw git commands are.
+    private static bool RequiresRepoLock(string fileName, string arguments)
+        => string.Equals(fileName, "git", StringComparison.OrdinalIgnoreCase)
+        || string.Equals(fileName, "dotnet-gitversion", StringComparison.OrdinalIgnoreCase)
+        || (string.Equals(fileName, "dotnet", StringComparison.OrdinalIgnoreCase)
+            && arguments.Contains("gitversion", StringComparison.OrdinalIgnoreCase));
 
     private static bool IsGitLikeProgressStreaming(string fileName, string arguments)
     {

--- a/src/GrayMoon.Agent/Services/GitProcessRunner.cs
+++ b/src/GrayMoon.Agent/Services/GitProcessRunner.cs
@@ -1,0 +1,144 @@
+using System.Collections.Concurrent;
+using GrayMoon.Abstractions.Agent;
+using GrayMoon.Common;
+using Microsoft.Extensions.Logging;
+using Polly;
+
+namespace GrayMoon.Agent.Services;
+
+public sealed class GitProcessRunner(ICommandLineService commandLine, ILogger<GitProcessRunner> logger)
+{
+    internal static readonly ConcurrentDictionary<string, SemaphoreSlim> RepoLocks =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    internal readonly ResiliencePipeline<(int ExitCode, string? Stdout, string? Stderr)> SafeDirectoryPipeline =
+        GitResiliencePipelines.CreateSafeDirectoryPipeline(logger);
+
+    internal readonly ResiliencePipeline<(int ExitCode, string? Stdout, string? Stderr)> ClonePipeline =
+        GitResiliencePipelines.CreateClonePipeline(logger);
+
+    internal readonly ResiliencePipeline<(int ExitCode, string? Stdout, string? Stderr)> FetchPipeline =
+        GitResiliencePipelines.CreateFetchPipeline(logger);
+
+    internal readonly ResiliencePipeline<(int ExitCode, string? Stdout, string? Stderr)> PullPipeline =
+        GitResiliencePipelines.CreatePullPipeline(logger);
+
+    internal readonly ResiliencePipeline<(int ExitCode, string? Stdout, string? Stderr)> PushPipeline =
+        GitResiliencePipelines.CreatePushPipeline(logger);
+
+    internal readonly ResiliencePipeline<(int ExitCode, string? Stdout, string? Stderr)> LsRemotePipeline =
+        GitResiliencePipelines.CreateLsRemotePipeline(logger);
+
+    internal readonly ResiliencePipeline<(int ExitCode, string? Stdout, string? Stderr)> MinimalFetchPipeline =
+        GitResiliencePipelines.CreateMinimalFetchPipeline(logger);
+
+    internal async Task<(int ExitCode, string? Stdout, string? Stderr)> RunAsync(
+        string fileName,
+        string arguments,
+        string? workingDirectory,
+        CancellationToken ct,
+        bool? streamStderrAsStdout = null,
+        bool? mirrorFailureOutputAsStderr = null)
+    {
+        if (string.Equals(fileName, "git", StringComparison.OrdinalIgnoreCase) &&
+            !string.IsNullOrWhiteSpace(workingDirectory))
+        {
+            var repoLock = GetRepoLock(workingDirectory);
+            await repoLock.WaitAsync(ct);
+            try
+            {
+                return await RunCoreAsync(fileName, arguments, workingDirectory, ct, streamStderrAsStdout, mirrorFailureOutputAsStderr);
+            }
+            finally
+            {
+                repoLock.Release();
+            }
+        }
+
+        return await RunCoreAsync(fileName, arguments, workingDirectory, ct, streamStderrAsStdout, mirrorFailureOutputAsStderr);
+    }
+
+    private async Task<(int ExitCode, string? Stdout, string? Stderr)> RunCoreAsync(
+        string fileName,
+        string arguments,
+        string? workingDirectory,
+        CancellationToken ct,
+        bool? streamStderrAsStdout = null,
+        bool? mirrorFailureOutputAsStderr = null)
+    {
+        var gitLike = IsGitLikeProgressStreaming(fileName, arguments);
+        var stderrAsOut = streamStderrAsStdout ?? gitLike;
+        var mirror = mirrorFailureOutputAsStderr ?? gitLike;
+        var r = await commandLine.RunAsync(fileName, arguments, workingDirectory, null, ct, stderrAsOut, mirror);
+        return (r.ExitCode, r.Stdout, r.Stderr);
+    }
+
+    internal async Task<(int ExitCode, string? Stdout, string? Stderr)> RunWithStdinAsync(
+        string fileName,
+        string arguments,
+        string? workingDirectory,
+        string stdinContent,
+        CancellationToken ct)
+    {
+        if (string.Equals(fileName, "git", StringComparison.OrdinalIgnoreCase) &&
+            !string.IsNullOrWhiteSpace(workingDirectory))
+        {
+            var repoLock = GetRepoLock(workingDirectory);
+            await repoLock.WaitAsync(ct);
+            try
+            {
+                return await RunWithStdinCoreAsync(fileName, arguments, workingDirectory, stdinContent, ct);
+            }
+            finally
+            {
+                repoLock.Release();
+            }
+        }
+
+        return await RunWithStdinCoreAsync(fileName, arguments, workingDirectory, stdinContent, ct);
+    }
+
+    private async Task<(int ExitCode, string? Stdout, string? Stderr)> RunWithStdinCoreAsync(
+        string fileName,
+        string arguments,
+        string? workingDirectory,
+        string stdinContent,
+        CancellationToken ct)
+    {
+        var gitLike = IsGitLikeProgressStreaming(fileName, arguments);
+        var r = await commandLine.RunAsync(fileName, arguments, workingDirectory, stdinContent, ct, gitLike, gitLike);
+        return (r.ExitCode, r.Stdout, r.Stderr);
+    }
+
+    internal void ReportOverlayStderr(string message)
+    {
+        var sink = CommandLineStreamAmbient.Current.Value;
+        if (sink == null || string.IsNullOrWhiteSpace(message))
+            return;
+
+        try
+        {
+            sink(new CommandLineStreamEvent(AgentCommandStreamKind.Stderr, message.Trim()));
+        }
+        catch (Exception ex)
+        {
+            logger.LogDebug(ex, "Failed to report overlay stderr: {Message}", message);
+        }
+    }
+
+    private static SemaphoreSlim GetRepoLock(string repoPath)
+    {
+        var key = Path.GetFullPath(repoPath).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        return RepoLocks.GetOrAdd(key, _ => new SemaphoreSlim(1, 1));
+    }
+
+    private static bool IsGitLikeProgressStreaming(string fileName, string arguments)
+    {
+        if (string.Equals(fileName, "git", StringComparison.OrdinalIgnoreCase))
+            return true;
+        if (string.Equals(fileName, "dotnet-gitversion", StringComparison.OrdinalIgnoreCase))
+            return true;
+        return string.Equals(fileName, "dotnet", StringComparison.OrdinalIgnoreCase)
+               && arguments.Contains("gitversion", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/GrayMoon.Agent/Services/GitResiliencePipelines.cs
+++ b/src/GrayMoon.Agent/Services/GitResiliencePipelines.cs
@@ -65,8 +65,9 @@ internal static class GitResiliencePipelines
         => new ResiliencePipelineBuilder<(int ExitCode, string? Stdout, string? Stderr)>()
             .AddRetry(new RetryStrategyOptions<(int ExitCode, string? Stdout, string? Stderr)>
             {
-                // Retry any non-zero exit code from git pull (e.g., transient network failures).
-                ShouldHandle = new PredicateBuilder<(int ExitCode, string? Stdout, string? Stderr)>().HandleResult(r => r.ExitCode != 0),
+                // Retry transient failures (non-zero exit) but not merge conflicts which are deterministic.
+                ShouldHandle = new PredicateBuilder<(int ExitCode, string? Stdout, string? Stderr)>()
+                    .HandleResult(r => r.ExitCode != 0 && !IsMergeConflict(r.Stdout, r.Stderr)),
                 MaxRetryAttempts = 3,
                 Delay = TimeSpan.FromMilliseconds(200),
                 BackoffType = DelayBackoffType.Exponential,
@@ -136,5 +137,12 @@ internal static class GitResiliencePipelines
                 }
             })
             .Build();
+
+    private static bool IsMergeConflict(string? stdout, string? stderr)
+    {
+        var combined = string.Concat(stdout ?? string.Empty, stderr ?? string.Empty);
+        return combined.Contains("CONFLICT", StringComparison.OrdinalIgnoreCase)
+            || combined.Contains("Automatic merge failed", StringComparison.OrdinalIgnoreCase);
+    }
 }
 

--- a/src/GrayMoon.Agent/Services/GitResiliencePipelines.cs
+++ b/src/GrayMoon.Agent/Services/GitResiliencePipelines.cs
@@ -138,10 +138,11 @@ internal static class GitResiliencePipelines
             })
             .Build();
 
-    private static bool IsMergeConflict(string? stdout, string? stderr)
+    internal static bool IsMergeConflict(string? stdout, string? stderr)
     {
         var combined = string.Concat(stdout ?? string.Empty, stderr ?? string.Empty);
         return combined.Contains("CONFLICT", StringComparison.OrdinalIgnoreCase)
+            || combined.Contains("merge conflict", StringComparison.OrdinalIgnoreCase)
             || combined.Contains("Automatic merge failed", StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/src/GrayMoon.Agent/Services/GitService.cs
+++ b/src/GrayMoon.Agent/Services/GitService.cs
@@ -361,23 +361,17 @@ public sealed class GitService(IOptions<AgentOptions> options, ILogger<GitServic
             return (aheadCount, null, false);
         }
 
-        var (exitOut, stdoutOut, stderrOut) = await runner.RunAsync("git", $"rev-list --count {originBranch}..HEAD", repoPath, ct);
-        if (exitOut != 0)
+        // Single atomic call: left=incoming (in originBranch not HEAD), right=outgoing (in HEAD not originBranch).
+        var (exitLR, stdoutLR, stderrLR) = await runner.RunAsync("git", $"rev-list --left-right --count {originBranch}...HEAD", repoPath, ct);
+        if (exitLR != 0)
         {
-            logger.LogWarning("Git rev-list (outgoing) failed for {RepoPath}. ExitCode={ExitCode}, Stdout={Stdout}, Stderr={Stderr}", repoPath, exitOut, stdoutOut, stderrOut);
+            logger.LogWarning("Git rev-list --left-right (commit counts) failed for {RepoPath}. ExitCode={ExitCode}, Stdout={Stdout}, Stderr={Stderr}", repoPath, exitLR, stdoutLR, stderrLR);
             return (null, null, true);
         }
 
-        var outVal = int.TryParse((stdoutOut ?? "").Trim(), out var o) ? o : (int?)null;
-
-        var (exitIn, stdoutIn, stderrIn) = await runner.RunAsync("git", $"rev-list --count HEAD..{originBranch}", repoPath, ct);
-        if (exitIn != 0)
-        {
-            logger.LogWarning("Git rev-list (incoming) failed for {RepoPath}. ExitCode={ExitCode}, Stdout={Stdout}, Stderr={Stderr}", repoPath, exitIn, stdoutIn, stderrIn);
-            return (outVal, null, true);
-        }
-
-        var inVal = int.TryParse((stdoutIn ?? "").Trim(), out var i) ? i : (int?)null;
+        var parts = (stdoutLR ?? "").Trim().Split('\t', StringSplitOptions.RemoveEmptyEntries);
+        var inVal = parts.Length >= 1 && int.TryParse(parts[0], out var ic) ? ic : (int?)null;
+        var outVal = parts.Length >= 2 && int.TryParse(parts[1], out var oc) ? oc : (int?)null;
         sw.Stop();
         logger.LogDebug("GetCommitCounts completed in {ElapsedMs}ms for {RepoPath} (up{Outgoing} dn{Incoming})", sw.ElapsedMilliseconds, repoPath, outVal, inVal);
         return (outVal, inVal, true);
@@ -441,11 +435,7 @@ public sealed class GitService(IOptions<AgentOptions> options, ILogger<GitServic
         if (exitCode != 0)
         {
             var combinedOutput = CombineOutput(stdout, stderr) ?? "";
-            var isMergeConflict = combinedOutput.Contains("CONFLICT", StringComparison.OrdinalIgnoreCase)
-                                  || combinedOutput.Contains("merge conflict", StringComparison.OrdinalIgnoreCase)
-                                  || combinedOutput.Contains("Automatic merge failed", StringComparison.OrdinalIgnoreCase);
-
-            if (isMergeConflict)
+            if (GitResiliencePipelines.IsMergeConflict(stdout, stderr))
             {
                 logger.LogWarning("Git pull merge conflict detected for {RepoPath}. Branch={Branch}", repoPath, branchName);
                 return (false, true, combinedOutput);
@@ -689,7 +679,9 @@ public sealed class GitService(IOptions<AgentOptions> options, ILogger<GitServic
                 name = name.Substring("origin/".Length);
             if (string.IsNullOrWhiteSpace(name))
                 return (false, "Invalid branch name");
-            var (exitCode, stdout, stderr) = await runner.RunAsync("git", $"push origin --delete {name}", repoPath, ct);
+            var (exitCode, stdout, stderr) = await runner.PushPipeline.ExecuteAsync(
+                async cancellationToken => await runner.RunAsync("git", $"push origin --delete {name}", repoPath, cancellationToken),
+                ct);
             if (exitCode != 0)
             {
                 var combined = CombineOutput(stdout, stderr) ?? "";

--- a/src/GrayMoon.Agent/Services/GitService.cs
+++ b/src/GrayMoon.Agent/Services/GitService.cs
@@ -1,24 +1,18 @@
 using System.Diagnostics;
-using System.Collections.Concurrent;
 using System.Text;
 using System.Text.Json;
-using GrayMoon.Abstractions.Agent;
 using GrayMoon.Agent.Abstractions;
 using GrayMoon.Agent.Models;
-using GrayMoon.Common;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Polly;
-using Polly.Retry;
 
 namespace GrayMoon.Agent.Services;
 
-public sealed class GitService(IOptions<AgentOptions> options, ILogger<GitService> logger, ICommandLineService commandLine) : IGitService
+public sealed class GitService(IOptions<AgentOptions> options, ILogger<GitService> logger, GitProcessRunner runner) : IGitService
 {
     private readonly int _listenPort = options.Value.ListenPort;
     private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
-    private readonly ConcurrentDictionary<string, byte> _safeRepoCache = new(StringComparer.OrdinalIgnoreCase);
-    private static readonly ConcurrentDictionary<string, SemaphoreSlim> RepoLocks = new(StringComparer.OrdinalIgnoreCase);
+    private readonly System.Collections.Concurrent.ConcurrentDictionary<string, byte> _safeRepoCache = new(StringComparer.OrdinalIgnoreCase);
     private static string? _emptyHooksPath;
 
     public string GetWorkspacePath(string root, string workspaceName)
@@ -41,8 +35,8 @@ public sealed class GitService(IOptions<AgentOptions> options, ILogger<GitServic
 
         var args = BuildCloneArguments(cloneUrl, bearerToken);
         var sw = Stopwatch.StartNew();
-        var (exitCode, stdout, stderr) = await CloneRetryPipeline.ExecuteAsync(
-            async (cancellationToken) => await RunProcessAsync("git", args, workingDir, cancellationToken),
+        var (exitCode, stdout, stderr) = await runner.ClonePipeline.ExecuteAsync(
+            async (cancellationToken) => await runner.RunAsync("git", args, workingDir, cancellationToken),
             ct);
         sw.Stop();
         if (exitCode != 0)
@@ -67,7 +61,7 @@ public sealed class GitService(IOptions<AgentOptions> options, ILogger<GitServic
             return;
         }
 
-        var pathForGit = fullPath.Replace('\\', '/'); // Git accepts forward slashes on all platforms
+        var pathForGit = fullPath.Replace('\\', '/');
 
         var (isSafe, _) = await CheckRepoSafeAsync(repoPath, pathForGit, ct);
         logger.LogDebug("Git repo safety check: {Path} -> {Result}", pathForGit, isSafe ? "safe" : "not safe");
@@ -79,14 +73,9 @@ public sealed class GitService(IOptions<AgentOptions> options, ILogger<GitServic
             return;
         }
 
-        // Must use --global, not --local: LibGit2Sharp (used internally by GitVersion) performs its
-        // own ownership check via libgit2's git_repository_open before the repo is open, so it can
-        // only read system/global config at that point. A --local entry in .git/config is invisible
-        // to libgit2 during the ownership check (chicken-and-egg), so git.exe commands succeed but
-        // GitVersion fails with "repository path is not owned by current user".
         var addArgs = $"config --global --add safe.directory \"{pathForGit.Replace("\"", "\\\"")}\"";
-        var (exitCode, stdout, stderr) = await SafeDirectoryRetryPipeline.ExecuteAsync(
-            async (cancellationToken) => await RunProcessAsync("git", addArgs, repoPath, cancellationToken),
+        var (exitCode, stdout, stderr) = await runner.SafeDirectoryPipeline.ExecuteAsync(
+            async (cancellationToken) => await runner.RunAsync("git", addArgs, repoPath, cancellationToken),
             ct);
 
         if (exitCode == 0)
@@ -98,39 +87,15 @@ public sealed class GitService(IOptions<AgentOptions> options, ILogger<GitServic
             logger.LogError("Git config safe.directory (global) failed. ExitCode={ExitCode}, Stdout={Stdout}, Stderr={Stderr}", exitCode, stdout, stderr);
     }
 
-    /// <summary>
-    /// Uses git rev-parse --is-inside-work-tree: exit 0 = repo is safe, exit 128 with dubious ownership = not safe.
-    /// </summary>
     private async Task<(bool IsSafe, bool IsDubiousOwnership)> CheckRepoSafeAsync(string repoPath, string pathForGit, CancellationToken ct)
     {
-        var (exitCode, _, stderr) = await RunProcessAsync("git", "rev-parse --is-inside-work-tree", repoPath, ct);
+        var (exitCode, _, stderr) = await runner.RunAsync("git", "rev-parse --is-inside-work-tree", repoPath, ct);
         if (exitCode == 0)
             return (true, false);
         var err = stderr ?? "";
         var isDubious = exitCode == 128 && (err.Contains("dubious ownership", StringComparison.OrdinalIgnoreCase) || err.Contains("safe.directory", StringComparison.OrdinalIgnoreCase));
         return (false, isDubious);
     }
-
-    private readonly ResiliencePipeline<(int ExitCode, string? Stdout, string? Stderr)> SafeDirectoryRetryPipeline =
-        GitResiliencePipelines.CreateSafeDirectoryPipeline(logger);
-
-    private readonly ResiliencePipeline<(int ExitCode, string? Stdout, string? Stderr)> CloneRetryPipeline =
-        GitResiliencePipelines.CreateClonePipeline(logger);
-
-    private readonly ResiliencePipeline<(int ExitCode, string? Stdout, string? Stderr)> FetchRetryPipeline =
-        GitResiliencePipelines.CreateFetchPipeline(logger);
-
-    private readonly ResiliencePipeline<(int ExitCode, string? Stdout, string? Stderr)> PullRetryPipeline =
-        GitResiliencePipelines.CreatePullPipeline(logger);
-
-    private readonly ResiliencePipeline<(int ExitCode, string? Stdout, string? Stderr)> PushRetryPipeline =
-        GitResiliencePipelines.CreatePushPipeline(logger);
-
-    private readonly ResiliencePipeline<(int ExitCode, string? Stdout, string? Stderr)> LsRemoteRetryPipeline =
-        GitResiliencePipelines.CreateLsRemotePipeline(logger);
-
-    private readonly ResiliencePipeline<(int ExitCode, string? Stdout, string? Stderr)> MinimalFetchRetryPipeline =
-        GitResiliencePipelines.CreateMinimalFetchPipeline(logger);
 
     public async Task<(GitVersionResult? Result, string? Error)> GetVersionAsync(string repoPath, CancellationToken ct)
         => await GetVersionAsync(repoPath, nonNormalize: false, ct);
@@ -144,7 +109,7 @@ public sealed class GitService(IOptions<AgentOptions> options, ILogger<GitServic
         var toolName = fileName == "dotnet" ? "dotnet gitversion" : "dotnet-gitversion";
 
         var sw = Stopwatch.StartNew();
-        var (exitCode, stdout, stderr) = await RunProcessAsync(fileName, arguments, repoPath, ct);
+        var (exitCode, stdout, stderr) = await runner.RunAsync(fileName, arguments, repoPath, ct);
         sw.Stop();
         if (exitCode != 0)
         {
@@ -154,15 +119,15 @@ public sealed class GitService(IOptions<AgentOptions> options, ILogger<GitServic
             if (manifestExists && ShouldAttemptDotNetToolRestore(fileName, stderr, stdout))
             {
                 logger.LogWarning("{ToolName} failed and tool manifest found. Running 'dotnet tool restore' in {RepoPath}", toolName, repoPath);
-                var (restoreExitCode, _, restoreStderr) = await RunProcessAsync("dotnet", "tool restore", repoPath, ct);
+                var (restoreExitCode, _, restoreStderr) = await runner.RunAsync("dotnet", "tool restore", repoPath, ct);
                 if (restoreExitCode != 0)
                 {
                     logger.LogError("dotnet tool restore failed. ExitCode={ExitCode}, Stderr={Stderr}", restoreExitCode, restoreStderr);
-                    ReportOverlayStderr($"dotnet tool restore failed (exit {restoreExitCode}). {restoreStderr?.Trim()}");
+                    runner.ReportOverlayStderr($"dotnet tool restore failed (exit {restoreExitCode}). {restoreStderr?.Trim()}");
                     return (null, $"dotnet tool restore failed: {restoreStderr?.Trim()}");
                 }
                 logger.LogInformation("dotnet tool restore succeeded in {RepoPath}. Retrying {ToolName}", repoPath, toolName);
-                var (retryExitCode, retryStdout, retryStderr) = await RunProcessAsync(fileName, arguments, repoPath, ct);
+                var (retryExitCode, retryStdout, retryStderr) = await runner.RunAsync(fileName, arguments, repoPath, ct);
                 if (retryExitCode != 0)
                 {
                     var retryError = BuildProcessError(retryStderr, retryStdout, $"{toolName} exited with code {retryExitCode}");
@@ -188,16 +153,11 @@ public sealed class GitService(IOptions<AgentOptions> options, ILogger<GitServic
         }
         catch (JsonException ex)
         {
-            ReportOverlayStderr($"Failed to parse {toolName} JSON: {ex.Message}");
+            runner.ReportOverlayStderr($"Failed to parse {toolName} JSON: {ex.Message}");
             return (null, $"Failed to parse {toolName} output: {ex.Message}");
         }
     }
 
-    /// <summary>
-    /// Returns (fileName, arguments) for running GitVersion. Uses "dotnet gitversion" when a tool manifest
-    /// (dotnet-tools.json) exists in the repo root or in .config; otherwise uses "dotnet-gitversion".
-    /// Always passes /output json, /nofetch and /verbosity quiet; when <paramref name="nonNormalize"/> is true, also passes /nonormalize.
-    /// </summary>
     private static (string FileName, string Arguments) GetGitVersionInvocation(string repoPath, bool nonNormalize)
     {
         const string manifestFileName = "dotnet-tools.json";
@@ -216,7 +176,7 @@ public sealed class GitService(IOptions<AgentOptions> options, ILogger<GitServic
         if (string.IsNullOrWhiteSpace(repoPath) || !Directory.Exists(repoPath))
             return null;
 
-        var (exitCode, stdout, _) = await RunProcessAsync("git", "branch --show-current", repoPath, ct);
+        var (exitCode, stdout, _) = await runner.RunAsync("git", "branch --show-current", repoPath, ct);
         if (exitCode != 0)
             return null;
 
@@ -229,7 +189,7 @@ public sealed class GitService(IOptions<AgentOptions> options, ILogger<GitServic
         if (string.IsNullOrWhiteSpace(repoPath) || !Directory.Exists(repoPath))
             return null;
 
-        var (exitCode, stdout, stderr) = await RunProcessAsync("git", "config --get remote.origin.url", repoPath, ct);
+        var (exitCode, stdout, stderr) = await runner.RunAsync("git", "config --get remote.origin.url", repoPath, ct);
         if (exitCode != 0)
         {
             logger.LogError("Git config remote.origin.url failed for {RepoPath}. ExitCode={ExitCode}, Stdout={Stdout}, Stderr={Stderr}", repoPath, exitCode, stdout, stderr);
@@ -248,37 +208,25 @@ public sealed class GitService(IOptions<AgentOptions> options, ILogger<GitServic
         var logArgs = "";
         if (string.IsNullOrWhiteSpace(bearerToken))
         {
-            // Use --prune to remove stale remote-tracking branches
             args = includeTags ? "fetch origin --prune --tags" : "fetch origin --prune";
             logArgs = args;
         }
         else
         {
-            var credentials = "x-access-token:" + bearerToken;
-            var base64 = Convert.ToBase64String(Encoding.UTF8.GetBytes(credentials));
-            var headerValue = "Authorization: Basic " + base64;
-            var escaped = headerValue.Replace("\\", "\\\\").Replace("\"", "\\\"");
-            // Use --prune to remove stale remote-tracking branches
             var fetchCmd = includeTags ? "fetch origin --prune --tags" : "fetch origin --prune";
-            args = $"-c core.askpass=true -c credential.helper= -c \"http.extraHeader={escaped}\" {fetchCmd}";
+            args = $"{BuildAuthHeaderArgs(bearerToken)} {fetchCmd}";
             logArgs = "***";
         }
         var sw = Stopwatch.StartNew();
-        var (exitCode, stdout, stderr) = await FetchRetryPipeline.ExecuteAsync(
-            async cancellationToken => await RunProcessAsync("git", args, repoPath, cancellationToken),
+        var (exitCode, stdout, stderr) = await runner.FetchPipeline.ExecuteAsync(
+            async cancellationToken => await runner.RunAsync("git", args, repoPath, cancellationToken),
             ct);
         sw.Stop();
         if (exitCode != 0)
         {
-            var output = (stdout ?? "").Trim();
-            var errorOutput = (stderr ?? "").Trim();
-            var combinedOutput = string.IsNullOrWhiteSpace(output) ? errorOutput :
-                                 string.IsNullOrWhiteSpace(errorOutput) ? output :
-                                 $"{output}\n{errorOutput}";
-            if (string.IsNullOrWhiteSpace(combinedOutput))
-                combinedOutput = $"Git fetch failed (exit code {exitCode})";
+            var combined = CombineOutput(stdout, stderr) ?? $"Git fetch failed (exit code {exitCode})";
             logger.LogError("Git fetch failed in {ElapsedMs}ms for {RepoPath}. Args={Args}, ExitCode={ExitCode}, Stdout={Stdout}, Stderr={Stderr}", sw.ElapsedMilliseconds, repoPath, logArgs, exitCode, stdout, stderr);
-            return (false, combinedOutput);
+            return (false, combined);
         }
         logger.LogDebug("Git fetch completed in {ElapsedMs}ms for {RepoPath}. Args={Args}", sw.ElapsedMilliseconds, repoPath, logArgs);
         return (true, null);
@@ -290,16 +238,10 @@ public sealed class GitService(IOptions<AgentOptions> options, ILogger<GitServic
             return (true, null);
 
         logger.LogDebug("Git minimal fetch starting for {RepoPath}. InputBranch={Branch}, DefaultBranchOriginRef={DefaultRef}, HasBearer={HasBearer}",
-            repoPath,
-            branchName,
-            defaultBranchOriginRef,
-            !string.IsNullOrWhiteSpace(bearerToken));
+            repoPath, branchName, defaultBranchOriginRef, !string.IsNullOrWhiteSpace(bearerToken));
 
         var refsToFetch = new List<string>();
 
-        // Resolve the upstream ref (e.g. origin/main) and use that as the fetch target for the
-        // current branch rather than the branch name itself. This avoids fetching non-upstreamed
-        // local branches and ensures we are always fetching the configured remote tracking ref.
         var upstreamRef = skipUpstreamCheck ? null : await GetUpstreamRefAsync(repoPath, branchName, ct);
         logger.LogDebug("Git minimal fetch upstream ref for {RepoPath}: {UpstreamRef}", repoPath, upstreamRef ?? "<none>");
 
@@ -341,33 +283,23 @@ public sealed class GitService(IOptions<AgentOptions> options, ILogger<GitServic
         }
         else
         {
-            var credentials = "x-access-token:" + bearerToken;
-            var base64 = Convert.ToBase64String(Encoding.UTF8.GetBytes(credentials));
-            var headerValue = "Authorization: Basic " + base64;
-            var escaped = headerValue.Replace("\\", "\\\\").Replace("\"", "\\\"");
-            args = $"-c core.askpass=true -c credential.helper= -c \"http.extraHeader={escaped}\" fetch origin --prune {refArgs}";
+            args = $"{BuildAuthHeaderArgs(bearerToken)} fetch origin --prune {refArgs}";
             logArgs = "***";
         }
 
         logger.LogDebug("Git minimal fetch invoking git for {RepoPath}. Args={Args}, Refs={Refs}", repoPath, logArgs, string.Join(", ", refsToFetch));
 
         var sw = Stopwatch.StartNew();
-        var (exitCode, stdout, stderr) = await MinimalFetchRetryPipeline.ExecuteAsync(
-            async cancellationToken => await RunProcessAsync("git", args, repoPath, cancellationToken),
+        var (exitCode, stdout, stderr) = await runner.MinimalFetchPipeline.ExecuteAsync(
+            async cancellationToken => await runner.RunAsync("git", args, repoPath, cancellationToken),
             ct);
         sw.Stop();
         logger.LogDebug("Git minimal fetch git process completed for {RepoPath} in {ElapsedMs}ms. ExitCode={ExitCode}", repoPath, sw.ElapsedMilliseconds, exitCode);
         if (exitCode != 0)
         {
-            var output = (stdout ?? "").Trim();
-            var errorOutput = (stderr ?? "").Trim();
-            var combinedOutput = string.IsNullOrWhiteSpace(output) ? errorOutput :
-                                 string.IsNullOrWhiteSpace(errorOutput) ? output :
-                                 $"{output}\n{errorOutput}";
-            if (string.IsNullOrWhiteSpace(combinedOutput))
-                combinedOutput = $"Git fetch (minimal) failed (exit code {exitCode})";
+            var combined = CombineOutput(stdout, stderr) ?? $"Git fetch (minimal) failed (exit code {exitCode})";
             logger.LogError("Git minimal fetch failed in {ElapsedMs}ms for {RepoPath}. ExitCode={ExitCode}, Stdout={Stdout}, Stderr={Stderr}", sw.ElapsedMilliseconds, repoPath, exitCode, stdout, stderr);
-            return (false, combinedOutput);
+            return (false, combined);
         }
 
         logger.LogDebug("Git minimal fetch completed in {ElapsedMs}ms for {RepoPath}. Refs={Refs}", sw.ElapsedMilliseconds, repoPath, string.Join(", ", refsToFetch));
@@ -381,8 +313,6 @@ public sealed class GitService(IOptions<AgentOptions> options, ILogger<GitServic
 
         var sw = Stopwatch.StartNew();
 
-        // Resolve upstream ref (e.g. origin/main) once for this branch. When there is no upstream
-        // configured we fall back to comparing against the default branch only.
         var upstreamRef = skipUpstreamCheck ? null : await GetUpstreamRefAsync(repoPath, branchName, ct);
         if (string.IsNullOrWhiteSpace(upstreamRef))
         {
@@ -393,7 +323,7 @@ public sealed class GitService(IOptions<AgentOptions> options, ILogger<GitServic
                 return (null, null, false);
             }
 
-            var (exitDefault, stdoutDefault, stderrDefault) = await RunProcessAsync("git", $"rev-list --count {defaultBranch}..HEAD", repoPath, ct);
+            var (exitDefault, stdoutDefault, stderrDefault) = await runner.RunAsync("git", $"rev-list --count {defaultBranch}..HEAD", repoPath, ct);
             if (exitDefault != 0)
             {
                 logger.LogWarning("Git rev-list (outgoing vs default branch) failed for {RepoPath}. ExitCode={ExitCode}, Stdout={Stdout}, Stderr={Stderr}", repoPath, exitDefault, stdoutDefault, stderrDefault);
@@ -408,8 +338,7 @@ public sealed class GitService(IOptions<AgentOptions> options, ILogger<GitServic
 
         var originBranch = upstreamRef!;
 
-        // Branch has an upstream configured - verify the remote-tracking ref exists locally before comparing.
-        var (exitCheck, _, _) = await RunProcessAsync("git", $"rev-parse --verify {originBranch}", repoPath, ct);
+        var (exitCheck, _, _) = await runner.RunAsync("git", $"rev-parse --verify {originBranch}", repoPath, ct);
         if (exitCheck != 0)
         {
             var defaultBranch = defaultBranchOriginRef ?? await GetDefaultBranchAsync(repoPath, ct);
@@ -419,7 +348,7 @@ public sealed class GitService(IOptions<AgentOptions> options, ILogger<GitServic
                 return (null, null, false);
             }
 
-            var (exitDefault, stdoutDefault, stderrDefault) = await RunProcessAsync("git", $"rev-list --count {defaultBranch}..HEAD", repoPath, ct);
+            var (exitDefault, stdoutDefault, stderrDefault) = await runner.RunAsync("git", $"rev-list --count {defaultBranch}..HEAD", repoPath, ct);
             if (exitDefault != 0)
             {
                 logger.LogWarning("Git rev-list (outgoing vs default branch) failed for {RepoPath}. ExitCode={ExitCode}, Stdout={Stdout}, Stderr={Stderr}", repoPath, exitDefault, stdoutDefault, stderrDefault);
@@ -432,25 +361,25 @@ public sealed class GitService(IOptions<AgentOptions> options, ILogger<GitServic
             return (aheadCount, null, false);
         }
 
-        // Branch exists upstream - use standard comparison
-        var (exitOut, stdoutOut, stderrOut) = await RunProcessAsync("git", $"rev-list --count {originBranch}..HEAD", repoPath, ct);
-        var (exitIn, stdoutIn, stderrIn) = await RunProcessAsync("git", $"rev-list --count HEAD..{originBranch}", repoPath, ct);
-
+        var (exitOut, stdoutOut, stderrOut) = await runner.RunAsync("git", $"rev-list --count {originBranch}..HEAD", repoPath, ct);
         if (exitOut != 0)
         {
             logger.LogWarning("Git rev-list (outgoing) failed for {RepoPath}. ExitCode={ExitCode}, Stdout={Stdout}, Stderr={Stderr}", repoPath, exitOut, stdoutOut, stderrOut);
             return (null, null, true);
         }
+
+        var outVal = int.TryParse((stdoutOut ?? "").Trim(), out var o) ? o : (int?)null;
+
+        var (exitIn, stdoutIn, stderrIn) = await runner.RunAsync("git", $"rev-list --count HEAD..{originBranch}", repoPath, ct);
         if (exitIn != 0)
         {
             logger.LogWarning("Git rev-list (incoming) failed for {RepoPath}. ExitCode={ExitCode}, Stdout={Stdout}, Stderr={Stderr}", repoPath, exitIn, stdoutIn, stderrIn);
-            return (null, null, true);
+            return (outVal, null, true);
         }
 
-        var outVal = int.TryParse((stdoutOut ?? "").Trim(), out var o) ? o : (int?)null;
         var inVal = int.TryParse((stdoutIn ?? "").Trim(), out var i) ? i : (int?)null;
         sw.Stop();
-        logger.LogDebug("GetCommitCounts completed in {ElapsedMs}ms for {RepoPath} (↑{Outgoing} ↓{Incoming})", sw.ElapsedMilliseconds, repoPath, outVal, inVal);
+        logger.LogDebug("GetCommitCounts completed in {ElapsedMs}ms for {RepoPath} (up{Outgoing} dn{Incoming})", sw.ElapsedMilliseconds, repoPath, outVal, inVal);
         return (outVal, inVal, true);
     }
 
@@ -468,26 +397,17 @@ public sealed class GitService(IOptions<AgentOptions> options, ILogger<GitServic
 
         var sw = Stopwatch.StartNew();
 
-        // ahead = commits on current branch not in default; behind = commits on default not in current branch. Run both in parallel.
-        var aheadTask = RunProcessAsync("git", $"rev-list --count {defaultBranch}..HEAD", repoPath, ct);
-        var behindTask = RunProcessAsync("git", $"rev-list --count HEAD..{defaultBranch}", repoPath, ct);
-        await Task.WhenAll(aheadTask, behindTask);
-        var (exitAhead, stdoutAhead, stderrAhead) = await aheadTask;
-        var (exitBehind, stdoutBehind, stderrBehind) = await behindTask;
-
-        if (exitAhead != 0)
+        // Single call: --left-right gives both counts atomically; left=behind (in defaultBranch not HEAD), right=ahead (in HEAD not defaultBranch).
+        var (exitCode, stdout, stderr) = await runner.RunAsync("git", $"rev-list --left-right --count {defaultBranch}...HEAD", repoPath, ct);
+        if (exitCode != 0)
         {
-            logger.LogDebug("GetCommitCountsVsDefault (ahead) failed for {RepoPath}. ExitCode={ExitCode}", repoPath, exitAhead);
-            return (null, null, null);
-        }
-        if (exitBehind != 0)
-        {
-            logger.LogDebug("GetCommitCountsVsDefault (behind) failed for {RepoPath}. ExitCode={ExitCode}", repoPath, exitBehind);
+            logger.LogDebug("GetCommitCountsVsDefault failed for {RepoPath}. ExitCode={ExitCode}", repoPath, exitCode);
             return (null, null, null);
         }
 
-        var ahead = int.TryParse((stdoutAhead ?? "").Trim(), out var a) ? a : (int?)null;
-        var behind = int.TryParse((stdoutBehind ?? "").Trim(), out var b) ? b : (int?)null;
+        var parts = (stdout ?? "").Trim().Split('\t', StringSplitOptions.RemoveEmptyEntries);
+        var behind = parts.Length >= 1 && int.TryParse(parts[0], out var b) ? b : (int?)null;
+        var ahead = parts.Length >= 2 && int.TryParse(parts[1], out var a) ? a : (int?)null;
         var defaultBranchName = defaultBranch.StartsWith("origin/") ? defaultBranch.Substring("origin/".Length) : defaultBranch;
         sw.Stop();
         logger.LogDebug("GetCommitCountsVsDefault completed in {ElapsedMs}ms for {RepoPath}: behind={Behind}, ahead={Ahead}", sw.ElapsedMilliseconds, repoPath, behind, ahead);
@@ -508,33 +428,22 @@ public sealed class GitService(IOptions<AgentOptions> options, ILogger<GitServic
         }
         else
         {
-            var credentials = "x-access-token:" + bearerToken;
-            var base64 = Convert.ToBase64String(Encoding.UTF8.GetBytes(credentials));
-            var headerValue = "Authorization: Basic " + base64;
-            var escaped = headerValue.Replace("\\", "\\\\").Replace("\"", "\\\"");
-            args = $"-c core.askpass=true -c credential.helper= -c \"http.extraHeader={escaped}\" pull origin {branchName}";
+            args = $"{BuildAuthHeaderArgs(bearerToken)} pull origin {branchName}";
             logArgs = "***";
         }
 
         var sw = Stopwatch.StartNew();
-        var (exitCode, stdout, stderr) = await PullRetryPipeline.ExecuteAsync(
-            async cancellationToken => await RunProcessAsync("git", args, repoPath, cancellationToken),
+        var (exitCode, stdout, stderr) = await runner.PullPipeline.ExecuteAsync(
+            async cancellationToken => await runner.RunAsync("git", args, repoPath, cancellationToken),
             ct);
         sw.Stop();
 
         if (exitCode != 0)
         {
-            // Combine stdout and stderr for error message
-            var output = (stdout ?? "").Trim();
-            var errorOutput = (stderr ?? "").Trim();
-            var combinedOutput = string.IsNullOrWhiteSpace(output) ? errorOutput :
-                                 string.IsNullOrWhiteSpace(errorOutput) ? output :
-                                 $"{output}\n{errorOutput}";
-
-            // Check if it's a merge conflict
-            var isMergeConflict = combinedOutput.Contains("CONFLICT", StringComparison.OrdinalIgnoreCase) ||
-                                  combinedOutput.Contains("merge conflict", StringComparison.OrdinalIgnoreCase) ||
-                                  combinedOutput.Contains("Automatic merge failed", StringComparison.OrdinalIgnoreCase);
+            var combinedOutput = CombineOutput(stdout, stderr) ?? "";
+            var isMergeConflict = combinedOutput.Contains("CONFLICT", StringComparison.OrdinalIgnoreCase)
+                                  || combinedOutput.Contains("merge conflict", StringComparison.OrdinalIgnoreCase)
+                                  || combinedOutput.Contains("Automatic merge failed", StringComparison.OrdinalIgnoreCase);
 
             if (isMergeConflict)
             {
@@ -565,30 +474,20 @@ public sealed class GitService(IOptions<AgentOptions> options, ILogger<GitServic
         }
         else
         {
-            var credentials = "x-access-token:" + bearerToken;
-            var base64 = Convert.ToBase64String(Encoding.UTF8.GetBytes(credentials));
-            var headerValue = "Authorization: Basic " + base64;
-            var escaped = headerValue.Replace("\\", "\\\\").Replace("\"", "\\\"");
-            args = $"-c core.askpass=true -c credential.helper= -c \"http.extraHeader={escaped}\" push {pushOpts}origin {branchName}";
+            args = $"{BuildAuthHeaderArgs(bearerToken)} push {pushOpts}origin {branchName}";
             logArgs = "***";
         }
 
         var sw = Stopwatch.StartNew();
-        var (exitCode, stdout, stderr) = await PushRetryPipeline.ExecuteAsync(
-            async cancellationToken => await RunProcessAsync("git", args, repoPath, cancellationToken),
+        var (exitCode, stdout, stderr) = await runner.PushPipeline.ExecuteAsync(
+            async cancellationToken => await runner.RunAsync("git", args, repoPath, cancellationToken),
             ct);
         sw.Stop();
         if (exitCode != 0)
         {
-            // Combine stdout and stderr for error message
-            var output = (stdout ?? "").Trim();
-            var errorOutput = (stderr ?? "").Trim();
-            var combinedOutput = string.IsNullOrWhiteSpace(output) ? errorOutput :
-                                 string.IsNullOrWhiteSpace(errorOutput) ? output :
-                                 $"{output}\n{errorOutput}";
-
+            var combined = CombineOutput(stdout, stderr) ?? "";
             logger.LogError("Git push failed in {ElapsedMs}ms for {RepoPath}. Args={Args}, ExitCode={ExitCode}, Stdout={Stdout}, Stderr={Stderr}", sw.ElapsedMilliseconds, repoPath, logArgs, exitCode, stdout, stderr);
-            return (false, combinedOutput);
+            return (false, combined);
         }
 
         logger.LogInformation("Git push completed in {ElapsedMs}ms for {RepoPath}. Args={Args}, Branch={Branch}", sw.ElapsedMilliseconds, repoPath, logArgs, branchName);
@@ -600,15 +499,11 @@ public sealed class GitService(IOptions<AgentOptions> options, ILogger<GitServic
         if (string.IsNullOrWhiteSpace(repoPath) || !Directory.Exists(repoPath))
             return;
 
-        var (exitCode, stdout, stderr) = await RunProcessAsync("git", "merge --abort", repoPath, ct);
+        var (exitCode, stdout, stderr) = await runner.RunAsync("git", "merge --abort", repoPath, ct);
         if (exitCode != 0)
-        {
             logger.LogWarning("Git merge --abort failed for {RepoPath}. ExitCode={ExitCode}, Stdout={Stdout}, Stderr={Stderr}", repoPath, exitCode, stdout, stderr);
-        }
         else
-        {
             logger.LogInformation("Git merge aborted for {RepoPath}", repoPath);
-        }
     }
 
     public async Task<IReadOnlyList<string>> GetLocalBranchesAsync(string repoPath, CancellationToken ct)
@@ -616,21 +511,18 @@ public sealed class GitService(IOptions<AgentOptions> options, ILogger<GitServic
         if (string.IsNullOrWhiteSpace(repoPath) || !Directory.Exists(repoPath))
             return Array.Empty<string>();
 
-        // Use for-each-ref refs/heads to avoid the synthetic "(HEAD detached at ...)" entry that `git branch` prints in detached HEAD state.
-        var (exitCode, stdout, stderr) = await RunProcessAsync("git", "for-each-ref refs/heads --format=%(refname:short)", repoPath, ct);
+        var (exitCode, stdout, stderr) = await runner.RunAsync("git", "for-each-ref refs/heads --format=%(refname:short)", repoPath, ct);
         if (exitCode != 0)
         {
             logger.LogWarning("Git for-each-ref refs/heads failed for {RepoPath}. ExitCode={ExitCode}, Stdout={Stdout}, Stderr={Stderr}", repoPath, exitCode, stdout, stderr);
             return Array.Empty<string>();
         }
 
-        var branches = (stdout ?? "")
+        return (stdout ?? "")
             .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
             .Where(b => !string.IsNullOrWhiteSpace(b))
             .OrderBy(b => b)
             .ToList();
-
-        return branches;
     }
 
     public async Task<IReadOnlyList<string>> GetRemoteBranchesFromRefsAsync(string repoPath, CancellationToken ct)
@@ -638,8 +530,7 @@ public sealed class GitService(IOptions<AgentOptions> options, ILogger<GitServic
         if (string.IsNullOrWhiteSpace(repoPath) || !Directory.Exists(repoPath))
             return Array.Empty<string>();
 
-        // Local refs only (no network). Use after fetch when refs/remotes/origin is up to date.
-        var (exitCode, stdout, stderr) = await RunProcessAsync("git", "for-each-ref refs/remotes/origin --format=%(refname:short)", repoPath, ct);
+        var (exitCode, stdout, stderr) = await runner.RunAsync("git", "for-each-ref refs/remotes/origin --format=%(refname:short)", repoPath, ct);
         if (exitCode != 0)
         {
             logger.LogDebug("Git for-each-ref refs/remotes/origin failed for {RepoPath}. ExitCode={ExitCode}", repoPath, exitCode);
@@ -647,15 +538,13 @@ public sealed class GitService(IOptions<AgentOptions> options, ILogger<GitServic
         }
 
         const string originPrefix = "origin/";
-        var branches = (stdout ?? "")
+        return (stdout ?? "")
             .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
             .Where(b => !string.IsNullOrWhiteSpace(b) && b.StartsWith(originPrefix, StringComparison.Ordinal))
             .Select(b => b.Substring(originPrefix.Length))
             .Where(b => !string.IsNullOrWhiteSpace(b) && b != "HEAD")
             .OrderBy(b => b)
             .ToList();
-
-        return branches;
     }
 
     public async Task<IReadOnlyList<string>> GetRemoteBranchesAsync(string repoPath, string? bearerToken, CancellationToken ct)
@@ -672,19 +561,13 @@ public sealed class GitService(IOptions<AgentOptions> options, ILogger<GitServic
         }
         else
         {
-            var credentials = "x-access-token:" + bearerToken;
-            var base64 = Convert.ToBase64String(Encoding.UTF8.GetBytes(credentials));
-            var headerValue = "Authorization: Basic " + base64;
-            var escaped = headerValue.Replace("\\", "\\\\").Replace("\"", "\\\"");
-            args = $"-c core.askpass=true -c credential.helper= -c \"http.extraHeader={escaped}\" ls-remote --heads origin";
+            args = $"{BuildAuthHeaderArgs(bearerToken)} ls-remote --heads origin";
             logArgs = "***";
         }
 
-        // Use ls-remote to query the actual remote branches (not local remote-tracking refs)
-        // This ensures we only see branches that actually exist on origin, not stale local references
         var sw = Stopwatch.StartNew();
-        var (exitCode, stdout, stderr) = await LsRemoteRetryPipeline.ExecuteAsync(
-            async cancellationToken => await RunProcessAsync("git", args, repoPath, cancellationToken),
+        var (exitCode, stdout, stderr) = await runner.LsRemotePipeline.ExecuteAsync(
+            async cancellationToken => await runner.RunAsync("git", args, repoPath, cancellationToken),
             ct);
         sw.Stop();
         if (exitCode != 0)
@@ -693,7 +576,6 @@ public sealed class GitService(IOptions<AgentOptions> options, ILogger<GitServic
             return Array.Empty<string>();
         }
 
-        // ls-remote output format: <commit-hash>    refs/heads/branch-name
         var branches = (stdout ?? "")
             .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
             .Where(line => !string.IsNullOrWhiteSpace(line) && line.Contains("refs/heads/"))
@@ -701,9 +583,7 @@ public sealed class GitService(IOptions<AgentOptions> options, ILogger<GitServic
             {
                 var parts = line.Split(new[] { '\t' }, StringSplitOptions.RemoveEmptyEntries);
                 if (parts.Length >= 2 && parts[1].StartsWith("refs/heads/"))
-                {
                     return parts[1].Substring("refs/heads/".Length);
-                }
                 return null;
             })
             .Where(b => !string.IsNullOrWhiteSpace(b))
@@ -718,50 +598,37 @@ public sealed class GitService(IOptions<AgentOptions> options, ILogger<GitServic
         if (string.IsNullOrWhiteSpace(repoPath) || !Directory.Exists(repoPath) || string.IsNullOrWhiteSpace(branchName))
             return (false, "Invalid repository path or branch name");
 
-        static string CombineOutput(string? stdout, string? stderr)
-        {
-            var outStr = (stdout ?? "").Trim();
-            var errStr = (stderr ?? "").Trim();
-            return string.IsNullOrWhiteSpace(outStr) ? errStr
-                 : string.IsNullOrWhiteSpace(errStr) ? outStr
-                 : $"{outStr}\n{errStr}";
-        }
-
         var hooksPrefix = GetHooksConfigPrefix(skipHooks);
 
-        // Prefer an existing local branch; only create a tracking branch when local is missing.
-        var (exitCheckLocal, _, _) = await RunProcessAsync("git", $"rev-parse --verify refs/heads/{branchName}", repoPath, ct);
+        var (exitCheckLocal, _, _) = await runner.RunAsync("git", $"rev-parse --verify refs/heads/{branchName}", repoPath, ct);
         if (exitCheckLocal == 0)
         {
-            var (exitCode, stdout, stderr) = await RunProcessAsync("git", $"{hooksPrefix}checkout {branchName}", repoPath, ct);
+            var (exitCode, stdout, stderr) = await runner.RunAsync("git", $"{hooksPrefix}checkout {branchName}", repoPath, ct);
             if (exitCode != 0)
             {
-                var combined = CombineOutput(stdout, stderr);
                 logger.LogError("Git checkout failed for {RepoPath}. Branch={Branch}, ExitCode={ExitCode}, Stdout={Stdout}, Stderr={Stderr}", repoPath, branchName, exitCode, stdout, stderr);
-                return (false, combined);
+                return (false, CombineOutput(stdout, stderr));
             }
         }
         else
         {
-            var (exitCheckRemote, _, _) = await RunProcessAsync("git", $"rev-parse --verify origin/{branchName}", repoPath, ct);
+            var (exitCheckRemote, _, _) = await runner.RunAsync("git", $"rev-parse --verify origin/{branchName}", repoPath, ct);
             if (exitCheckRemote == 0)
             {
-                var (exitCode, stdout, stderr) = await RunProcessAsync("git", $"{hooksPrefix}checkout -b {branchName} origin/{branchName}", repoPath, ct);
+                var (exitCode, stdout, stderr) = await runner.RunAsync("git", $"{hooksPrefix}checkout -b {branchName} origin/{branchName}", repoPath, ct);
                 if (exitCode != 0)
                 {
-                    var combined = CombineOutput(stdout, stderr);
                     logger.LogError("Git checkout failed for {RepoPath}. Branch={Branch}, ExitCode={ExitCode}, Stdout={Stdout}, Stderr={Stderr}", repoPath, branchName, exitCode, stdout, stderr);
-                    return (false, combined);
+                    return (false, CombineOutput(stdout, stderr));
                 }
             }
             else
             {
-                var (exitCode, stdout, stderr) = await RunProcessAsync("git", $"{hooksPrefix}checkout {branchName}", repoPath, ct);
+                var (exitCode, stdout, stderr) = await runner.RunAsync("git", $"{hooksPrefix}checkout {branchName}", repoPath, ct);
                 if (exitCode != 0)
                 {
-                    var combined = CombineOutput(stdout, stderr);
                     logger.LogError("Git checkout failed for {RepoPath}. Branch={Branch}, ExitCode={ExitCode}, Stdout={Stdout}, Stderr={Stderr}", repoPath, branchName, exitCode, stdout, stderr);
-                    return (false, combined);
+                    return (false, CombineOutput(stdout, stderr));
                 }
             }
         }
@@ -775,88 +642,39 @@ public sealed class GitService(IOptions<AgentOptions> options, ILogger<GitServic
         if (string.IsNullOrWhiteSpace(repoPath) || !Directory.Exists(repoPath) || string.IsNullOrWhiteSpace(newBranchName) || string.IsNullOrWhiteSpace(baseBranchName))
             return (false, "Invalid repository path or branch name");
 
-        static string CombineOutput(string? stdout, string? stderr)
-        {
-            var outStr = (stdout ?? "").Trim();
-            var errStr = (stderr ?? "").Trim();
-            return string.IsNullOrWhiteSpace(outStr) ? errStr
-                 : string.IsNullOrWhiteSpace(errStr) ? outStr
-                 : $"{outStr}\n{errStr}";
-        }
-
-        // Determine the start point for the new branch without performing an extra checkout:
-        // prefer origin/<baseBranchName> when it exists, otherwise fall back to the local baseBranchName.
         var trimmedBase = baseBranchName.Trim();
         var startPoint = trimmedBase;
         var remoteCandidate = trimmedBase.StartsWith("origin/", StringComparison.OrdinalIgnoreCase)
             ? trimmedBase
             : "origin/" + trimmedBase;
 
-        var (exitRemote, _, _) = await RunProcessAsync("git", $"rev-parse --verify {remoteCandidate}", repoPath, ct);
+        var (exitRemote, _, _) = await runner.RunAsync("git", $"rev-parse --verify {remoteCandidate}", repoPath, ct);
         if (exitRemote == 0)
             startPoint = remoteCandidate;
 
         var hooksPrefix = GetHooksConfigPrefix(skipHooks);
 
-        // Create and checkout new branch from the chosen start point in a single checkout, so we only
-        // trigger one post-checkout hook instead of first checking out the base branch and then the new branch.
-        var (exitCode, stdout, stderr) = await RunProcessAsync("git", $"{hooksPrefix}checkout -b {newBranchName} --no-track {startPoint}", repoPath, ct);
+        var (exitCode, stdout, stderr) = await runner.RunAsync("git", $"{hooksPrefix}checkout -b {newBranchName} --no-track {startPoint}", repoPath, ct);
         if (exitCode != 0)
         {
-            // Branch may already exist (e.g. persistence out of date); try checkout existing
-            var (verifyExit, _, _) = await RunProcessAsync("git", $"rev-parse --verify refs/heads/{newBranchName}", repoPath, ct);
+            var (verifyExit, _, _) = await runner.RunAsync("git", $"rev-parse --verify refs/heads/{newBranchName}", repoPath, ct);
             if (verifyExit == 0)
             {
                 logger.LogWarning("Branch {Branch} already exists in {RepoPath}; checking out existing branch.", newBranchName, repoPath);
-                var (coExit, coOut, coErr) = await RunProcessAsync("git", $"{hooksPrefix}checkout {newBranchName}", repoPath, ct);
+                var (coExit, coOut, coErr) = await runner.RunAsync("git", $"{hooksPrefix}checkout {newBranchName}", repoPath, ct);
                 if (coExit != 0)
                 {
-                    var combined = CombineOutput(coOut, coErr);
                     logger.LogError("Git checkout of existing branch failed for {RepoPath}. Branch={Branch}, ExitCode={ExitCode}", repoPath, newBranchName, coExit);
-                    return (false, combined);
+                    return (false, CombineOutput(coOut, coErr));
                 }
                 return (true, null);
             }
-            var combinedErr = CombineOutput(stdout, stderr);
             logger.LogError("Git create branch failed for {RepoPath}. NewBranch={NewBranch}, BaseBranch={BaseBranch}, ExitCode={ExitCode}", repoPath, newBranchName, baseBranchName, exitCode);
-            return (false, combinedErr);
+            return (false, CombineOutput(stdout, stderr));
         }
 
         logger.LogInformation("Git branch created for {RepoPath}. NewBranch={NewBranch}, BaseBranch={BaseBranch}", repoPath, newBranchName, baseBranchName);
         return (true, null);
-    }
-
-    public async Task<bool> DeleteLocalBranchAsync(string repoPath, string branchName, bool force, CancellationToken ct)
-    {
-        if (string.IsNullOrWhiteSpace(repoPath) || !Directory.Exists(repoPath) || string.IsNullOrWhiteSpace(branchName))
-            return false;
-
-        // Check if branch exists
-        var (exitCheck, _, _) = await RunProcessAsync("git", $"rev-parse --verify {branchName}", repoPath, ct);
-        if (exitCheck != 0)
-        {
-            logger.LogWarning("Branch {Branch} does not exist in {RepoPath}", branchName, repoPath);
-            return false;
-        }
-
-        // Check if it's the current branch
-        var (exitCurrent, stdoutCurrent, _) = await RunProcessAsync("git", "branch --show-current", repoPath, ct);
-        if (exitCurrent == 0 && (stdoutCurrent ?? "").Trim() == branchName)
-        {
-            logger.LogWarning("Cannot delete current branch {Branch} in {RepoPath}", branchName, repoPath);
-            return false;
-        }
-
-        string args = force ? $"branch -D {branchName}" : $"branch -d {branchName}";
-        var (exitCode, stdout, stderr) = await RunProcessAsync("git", args, repoPath, ct);
-        if (exitCode != 0)
-        {
-            logger.LogWarning("Git branch delete failed for {RepoPath}. Branch={Branch}, ExitCode={ExitCode}, Stdout={Stdout}, Stderr={Stderr}", repoPath, branchName, exitCode, stdout, stderr);
-            return false;
-        }
-
-        logger.LogInformation("Git branch deleted for {RepoPath}. Branch={Branch}", repoPath, branchName);
-        return true;
     }
 
     public async Task<(bool Success, string? ErrorMessage)> DeleteBranchAsync(string repoPath, string branchName, bool isRemote, bool force, CancellationToken ct)
@@ -864,27 +682,17 @@ public sealed class GitService(IOptions<AgentOptions> options, ILogger<GitServic
         if (string.IsNullOrWhiteSpace(repoPath) || !Directory.Exists(repoPath) || string.IsNullOrWhiteSpace(branchName))
             return (false, "Invalid repository path or branch name");
 
-        static string CombineOutput(string? stdout, string? stderr)
-        {
-            var outStr = (stdout ?? "").Trim();
-            var errStr = (stderr ?? "").Trim();
-            return string.IsNullOrWhiteSpace(outStr) ? errStr
-                 : string.IsNullOrWhiteSpace(errStr) ? outStr
-                 : $"{outStr}\n{errStr}";
-        }
-
         if (isRemote)
         {
-            // Remote only: delete the branch on origin. Does not modify local refs (refs/heads/).
             var name = branchName.Trim();
             if (name.StartsWith("origin/", StringComparison.OrdinalIgnoreCase))
                 name = name.Substring("origin/".Length);
             if (string.IsNullOrWhiteSpace(name))
                 return (false, "Invalid branch name");
-            var (exitCode, stdout, stderr) = await RunProcessAsync("git", $"push origin --delete {name}", repoPath, ct);
+            var (exitCode, stdout, stderr) = await runner.RunAsync("git", $"push origin --delete {name}", repoPath, ct);
             if (exitCode != 0)
             {
-                var combined = CombineOutput(stdout, stderr);
+                var combined = CombineOutput(stdout, stderr) ?? "";
                 if (IsRemoteBranchAlreadyDeleted(combined))
                 {
                     logger.LogInformation("Git remote branch already deleted for {RepoPath}. Branch={Branch}", repoPath, name);
@@ -897,48 +705,43 @@ public sealed class GitService(IOptions<AgentOptions> options, ILogger<GitServic
             return (true, null);
         }
 
-        // Local only: delete the branch in refs/heads/. Does not run push or modify remote.
         var localName = branchName.Trim();
         if (localName.StartsWith("origin/", StringComparison.OrdinalIgnoreCase))
             localName = localName.Substring("origin/".Length);
         if (string.IsNullOrWhiteSpace(localName))
             return (false, "Invalid branch name");
 
-        var (exitCheck, _, _) = await RunProcessAsync("git", $"rev-parse --verify refs/heads/{localName}", repoPath, ct);
+        var (exitCheck, _, _) = await runner.RunAsync("git", $"rev-parse --verify refs/heads/{localName}", repoPath, ct);
         if (exitCheck != 0)
         {
             logger.LogWarning("Branch {Branch} does not exist in {RepoPath}", localName, repoPath);
             return (false, "Branch does not exist.");
         }
 
-        var (exitCurrent, stdoutCurrent, _) = await RunProcessAsync("git", "branch --show-current", repoPath, ct);
+        var (exitCurrent, stdoutCurrent, _) = await runner.RunAsync("git", "branch --show-current", repoPath, ct);
         if (exitCurrent == 0 && (stdoutCurrent ?? "").Trim().Equals(localName, StringComparison.Ordinal))
         {
             logger.LogWarning("Cannot delete current branch {Branch} in {RepoPath}", localName, repoPath);
             return (false, "Cannot delete the current branch. Check out another branch first.");
         }
 
-        // Force delete: git branch -D (user confirmed after -d reported not fully merged)
         if (force)
         {
-            var (exitForce, stdoutForce, stderrForce) = await RunProcessAsync("git", $"branch -D {localName}", repoPath, ct);
+            var (exitForce, stdoutForce, stderrForce) = await runner.RunAsync("git", $"branch -D {localName}", repoPath, ct);
             if (exitForce != 0)
             {
-                var combinedForce = CombineOutput(stdoutForce, stderrForce);
                 logger.LogWarning("Git branch force delete failed for {RepoPath}. Branch={Branch}, ExitCode={ExitCode}", repoPath, localName, exitForce);
-                return (false, combinedForce);
+                return (false, CombineOutput(stdoutForce, stderrForce));
             }
             logger.LogInformation("Git branch force deleted for {RepoPath}. Branch={Branch}", repoPath, localName);
             return (true, null);
         }
 
-        var args = $"branch -d {localName}";
-        var (exitCodeLocal, stdoutLocal, stderrLocal) = await RunProcessAsync("git", args, repoPath, ct);
+        var (exitCodeLocal, stdoutLocal, stderrLocal) = await runner.RunAsync("git", $"branch -d {localName}", repoPath, ct);
         if (exitCodeLocal != 0)
         {
-            var combined = CombineOutput(stdoutLocal, stderrLocal);
             logger.LogWarning("Git branch delete failed for {RepoPath}. Branch={Branch}, ExitCode={ExitCode}", repoPath, localName, exitCodeLocal);
-            return (false, combined);
+            return (false, CombineOutput(stdoutLocal, stderrLocal));
         }
 
         logger.LogInformation("Git branch deleted for {RepoPath}. Branch={Branch}", repoPath, localName);
@@ -950,11 +753,8 @@ public sealed class GitService(IOptions<AgentOptions> options, ILogger<GitServic
         var defaultBranch = await GetDefaultBranchAsync(repoPath, ct);
         if (defaultBranch == null)
             return null;
-
-        // Remove "origin/" prefix
         if (defaultBranch.StartsWith("origin/"))
             return defaultBranch.Substring("origin/".Length);
-
         return defaultBranch;
     }
 
@@ -963,20 +763,17 @@ public sealed class GitService(IOptions<AgentOptions> options, ILogger<GitServic
         if (string.IsNullOrWhiteSpace(repoPath) || !Directory.Exists(repoPath))
             return Array.Empty<string>();
 
-        // Newest tag first by creator date so the most recent release surfaces at the top of the picker.
-        var (exitCode, stdout, stderr) = await RunProcessAsync("git", "tag --sort=-creatordate", repoPath, ct);
+        var (exitCode, stdout, stderr) = await runner.RunAsync("git", "tag --sort=-creatordate", repoPath, ct);
         if (exitCode != 0)
         {
             logger.LogDebug("Git tag list failed for {RepoPath}. ExitCode={ExitCode}, Stderr={Stderr}", repoPath, exitCode, stderr);
             return Array.Empty<string>();
         }
 
-        var tags = (stdout ?? "")
+        return (stdout ?? "")
             .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
             .Where(t => !string.IsNullOrWhiteSpace(t))
             .ToList();
-
-        return tags;
     }
 
     public async Task<(bool Success, string? ErrorMessage)> FetchTagsAsync(string repoPath, string? bearerToken, CancellationToken ct)
@@ -986,32 +783,18 @@ public sealed class GitService(IOptions<AgentOptions> options, ILogger<GitServic
 
         string args;
         if (string.IsNullOrWhiteSpace(bearerToken))
-        {
             args = "fetch origin --tags";
-        }
         else
-        {
-            var credentials = "x-access-token:" + bearerToken;
-            var base64 = Convert.ToBase64String(Encoding.UTF8.GetBytes(credentials));
-            var headerValue = "Authorization: Basic " + base64;
-            var escaped = headerValue.Replace("\\", "\\\\").Replace("\"", "\\\"");
-            args = $"-c http.extraHeader=\"{escaped}\" fetch origin --tags";
-        }
+            args = $"{BuildAuthHeaderArgs(bearerToken)} fetch origin --tags";
 
-        var sw = System.Diagnostics.Stopwatch.StartNew();
-        var (exitCode, stdout, stderr) = await FetchRetryPipeline.ExecuteAsync(
-            async cancellationToken => await RunProcessAsync("git", args, repoPath, cancellationToken),
+        var sw = Stopwatch.StartNew();
+        var (exitCode, stdout, stderr) = await runner.FetchPipeline.ExecuteAsync(
+            async cancellationToken => await runner.RunAsync("git", args, repoPath, cancellationToken),
             ct);
         sw.Stop();
         if (exitCode != 0)
         {
-            var output = (stdout ?? "").Trim();
-            var errorOutput = (stderr ?? "").Trim();
-            var combined = string.IsNullOrWhiteSpace(output) ? errorOutput :
-                           string.IsNullOrWhiteSpace(errorOutput) ? output :
-                           $"{output}\n{errorOutput}";
-            if (string.IsNullOrWhiteSpace(combined))
-                combined = $"Git fetch tags failed (exit code {exitCode})";
+            var combined = CombineOutput(stdout, stderr) ?? $"Git fetch tags failed (exit code {exitCode})";
             logger.LogWarning("Git fetch tags failed in {ElapsedMs}ms for {RepoPath}. ExitCode={ExitCode}", sw.ElapsedMilliseconds, repoPath, exitCode);
             return (false, combined);
         }
@@ -1024,31 +807,16 @@ public sealed class GitService(IOptions<AgentOptions> options, ILogger<GitServic
         if (string.IsNullOrWhiteSpace(repoPath) || !Directory.Exists(repoPath) || string.IsNullOrWhiteSpace(tagName))
             return (false, "Invalid repository path or tag name");
 
-        static string CombineOutput(string? stdout, string? stderr)
-        {
-            var outStr = (stdout ?? "").Trim();
-            var errStr = (stderr ?? "").Trim();
-            return string.IsNullOrWhiteSpace(outStr) ? errStr
-                 : string.IsNullOrWhiteSpace(errStr) ? outStr
-                 : $"{outStr}\n{errStr}";
-        }
-
         var name = tagName.Trim();
-        // Verify the tag exists locally to avoid ambiguous checkout against a branch with same name.
-        var (verifyExit, _, _) = await RunProcessAsync("git", $"rev-parse --verify refs/tags/{name}", repoPath, ct);
+        var (verifyExit, _, _) = await runner.RunAsync("git", $"rev-parse --verify refs/tags/{name}", repoPath, ct);
         if (verifyExit != 0)
             return (false, $"Tag '{name}' does not exist.");
 
-        var (exitCode, stdout, stderr) = await RunProcessAsync(
-            "git",
-            $"-c advice.detachedHead=false checkout refs/tags/{name}",
-            repoPath,
-            ct);
+        var (exitCode, stdout, stderr) = await runner.RunAsync("git", $"-c advice.detachedHead=false checkout refs/tags/{name}", repoPath, ct);
         if (exitCode != 0)
         {
-            var combined = CombineOutput(stdout, stderr);
             logger.LogError("Git checkout tag failed for {RepoPath}. Tag={Tag}, ExitCode={ExitCode}", repoPath, name, exitCode);
-            return (false, combined);
+            return (false, CombineOutput(stdout, stderr));
         }
 
         logger.LogInformation("Git checkout tag completed for {RepoPath}. Tag={Tag}", repoPath, name);
@@ -1060,13 +828,11 @@ public sealed class GitService(IOptions<AgentOptions> options, ILogger<GitServic
         if (string.IsNullOrWhiteSpace(repoPath) || !Directory.Exists(repoPath))
             return null;
 
-        // symbolic-ref exits 0 only when HEAD points to a branch; non-zero means detached HEAD.
-        var (symExit, _, _) = await RunProcessAsync("git", "symbolic-ref -q HEAD", repoPath, ct);
+        var (symExit, _, _) = await runner.RunAsync("git", "symbolic-ref -q HEAD", repoPath, ct);
         if (symExit == 0)
             return null;
 
-        // describe --tags --exact-match returns the tag name only if HEAD is exactly on a tag.
-        var (descExit, stdout, _) = await RunProcessAsync("git", "describe --tags --exact-match", repoPath, ct);
+        var (descExit, stdout, _) = await runner.RunAsync("git", "describe --tags --exact-match", repoPath, ct);
         if (descExit != 0)
             return null;
 
@@ -1077,13 +843,9 @@ public sealed class GitService(IOptions<AgentOptions> options, ILogger<GitServic
     public Task<string?> GetDefaultBranchOriginRefAsync(string repoPath, CancellationToken ct)
         => GetDefaultBranchAsync(repoPath, ct);
 
-    /// <summary>
-    /// Finds the default branch on origin (e.g. origin/main). Tries symbolic-ref first, then origin/main, then origin/master.
-    /// </summary>
     private async Task<string?> GetDefaultBranchAsync(string repoPath, CancellationToken ct)
     {
-        // Try configured default first (single git call in common case)
-        var (exitHead, stdoutHead, _) = await RunProcessAsync("git", "symbolic-ref refs/remotes/origin/HEAD", repoPath, ct);
+        var (exitHead, stdoutHead, _) = await runner.RunAsync("git", "symbolic-ref refs/remotes/origin/HEAD", repoPath, ct);
         if (exitHead == 0 && !string.IsNullOrWhiteSpace(stdoutHead))
         {
             var refName = stdoutHead.Trim();
@@ -1092,33 +854,27 @@ public sealed class GitService(IOptions<AgentOptions> options, ILogger<GitServic
                 var branch = refName.Substring("refs/remotes/origin/".Length);
                 if (!string.IsNullOrEmpty(branch) && branch != "HEAD")
                 {
-                    var (exitVerify, _, _) = await RunProcessAsync("git", $"rev-parse --verify origin/{branch}", repoPath, ct);
+                    var (exitVerify, _, _) = await runner.RunAsync("git", $"rev-parse --verify origin/{branch}", repoPath, ct);
                     if (exitVerify == 0)
                         return $"origin/{branch}";
                 }
             }
         }
 
-        // Fall back to origin/main then origin/master
-        var (exitMain, _, _) = await RunProcessAsync("git", "rev-parse --verify origin/main", repoPath, ct);
+        var (exitMain, _, _) = await runner.RunAsync("git", "rev-parse --verify origin/main", repoPath, ct);
         if (exitMain == 0)
             return "origin/main";
 
-        var (exitMaster, _, _) = await RunProcessAsync("git", "rev-parse --verify origin/master", repoPath, ct);
+        var (exitMaster, _, _) = await runner.RunAsync("git", "rev-parse --verify origin/master", repoPath, ct);
         if (exitMaster == 0)
             return "origin/master";
 
         return null;
     }
 
-    /// <summary>
-    /// Returns the configured upstream tracking ref for <paramref name="branchName"/> (e.g. "origin/main").
-    /// Uses <c>git for-each-ref --format=%(upstream:short)</c>, which exits 0 with empty output when no
-    /// upstream is set -- no fatal stderr, unlike the <c>@{u}</c> syntax.
-    /// </summary>
     private async Task<string?> GetUpstreamRefAsync(string repoPath, string branchName, CancellationToken ct)
     {
-        var (exitCode, stdout, _) = await RunProcessAsync(
+        var (exitCode, stdout, _) = await runner.RunAsync(
             "git",
             $"for-each-ref --format=%(upstream:short) refs/heads/{branchName}",
             repoPath,
@@ -1145,7 +901,7 @@ public sealed class GitService(IOptions<AgentOptions> options, ILogger<GitServic
             return (false, "No paths to stage");
 
         var addArgs = "add -- " + string.Join(" ", paths.Select(p => p.Contains(' ') ? "\"" + p.Replace("\"", "\\\"") + "\"" : p));
-        var (addExit, addOut, addErr) = await RunProcessAsync("git", addArgs, repoPath, ct);
+        var (addExit, addOut, addErr) = await runner.RunAsync("git", addArgs, repoPath, ct);
         if (addExit != 0)
         {
             var err = (addErr ?? addOut ?? "").Trim();
@@ -1153,8 +909,7 @@ public sealed class GitService(IOptions<AgentOptions> options, ILogger<GitServic
             return (false, err);
         }
 
-        // Skip commit when staging resulted in no index changes.
-        var (stagedExit, _, stagedErr) = await RunProcessAsync("git", "diff --cached --quiet", repoPath, ct);
+        var (stagedExit, _, stagedErr) = await runner.RunAsync("git", "diff --cached --quiet", repoPath, ct);
         if (stagedExit == 0)
         {
             logger.LogInformation("Git stage and commit skipped for {RepoPath}: nothing staged to commit", repoPath);
@@ -1168,7 +923,7 @@ public sealed class GitService(IOptions<AgentOptions> options, ILogger<GitServic
         }
 
         var messageNormalized = commitMessage.Replace("\r\n", "\n").Replace("\r", "\n").TrimEnd();
-        var (commitExit, commitOut, commitErr) = await RunProcessWithStdinAsync("git", "commit -F -", repoPath, messageNormalized, ct);
+        var (commitExit, commitOut, commitErr) = await runner.RunWithStdinAsync("git", "commit -F -", repoPath, messageNormalized, ct);
         if (commitExit != 0)
         {
             var err = (commitErr ?? commitOut ?? "").Trim();
@@ -1190,15 +945,11 @@ public sealed class GitService(IOptions<AgentOptions> options, ILogger<GitServic
         var args = $"reset {mode} {target}";
 
         var sw = Stopwatch.StartNew();
-        var (exitCode, stdout, stderr) = await RunProcessAsync("git", args, repoPath, ct);
+        var (exitCode, stdout, stderr) = await runner.RunAsync("git", args, repoPath, ct);
         sw.Stop();
         if (exitCode != 0)
         {
-            var output = (stdout ?? "").Trim();
-            var errOutput = (stderr ?? "").Trim();
-            var combined = string.IsNullOrWhiteSpace(output) ? errOutput :
-                           string.IsNullOrWhiteSpace(errOutput) ? output :
-                           $"{output}\n{errOutput}";
+            var combined = CombineOutput(stdout, stderr) ?? "";
             logger.LogError("Git reset failed in {ElapsedMs}ms for {RepoPath}. Args={Args}, ExitCode={ExitCode}, Stdout={Stdout}, Stderr={Stderr}",
                 sw.ElapsedMilliseconds, repoPath, args, exitCode, stdout, stderr);
             return (false, combined);
@@ -1231,7 +982,7 @@ public sealed class GitService(IOptions<AgentOptions> options, ILogger<GitServic
         Directory.CreateDirectory(hooksDir);
 
         var jsonPayload = JsonSerializer.Serialize(new { repositoryId, workspaceId, repositoryPath = repoPath });
-        var escapedPayload = jsonPayload.Replace("'", "'\\'' ");
+        var escapedPayload = jsonPayload.Replace("'", "'\\''");
         var header = "-H \"Content-Type: application/json\"";
         var curlFlags = "-s --connect-timeout 1 --max-time 2";
         var commitCurl = $"curl {curlFlags} -X POST \"http://127.0.0.1:{_listenPort}/hook/commit\"   {header} -d '{escapedPayload}' || true";
@@ -1258,15 +1009,20 @@ public sealed class GitService(IOptions<AgentOptions> options, ILogger<GitServic
             File.SetUnixFileMode(path, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
     }
 
-    private static string BuildCloneArguments(string cloneUrl, string? bearerToken)
+    private static string BuildAuthHeaderArgs(string bearerToken)
     {
-        if (string.IsNullOrWhiteSpace(bearerToken))
-            return $"clone \"{cloneUrl}\"";
         var credentials = "x-access-token:" + bearerToken;
         var base64 = Convert.ToBase64String(Encoding.UTF8.GetBytes(credentials));
         var headerValue = "Authorization: Basic " + base64;
         var escaped = headerValue.Replace("\\", "\\\\").Replace("\"", "\\\"");
-        return $"-c core.askpass=true -c credential.helper= -c \"http.extraHeader={escaped}\" clone \"{cloneUrl}\"";
+        return $"-c core.askpass=true -c credential.helper= -c \"http.extraHeader={escaped}\"";
+    }
+
+    private static string BuildCloneArguments(string cloneUrl, string? bearerToken)
+    {
+        if (string.IsNullOrWhiteSpace(bearerToken))
+            return $"clone \"{cloneUrl}\"";
+        return $"{BuildAuthHeaderArgs(bearerToken)} clone \"{cloneUrl}\"";
     }
 
     private static string SanitizeDirectoryName(string name)
@@ -1278,137 +1034,33 @@ public sealed class GitService(IOptions<AgentOptions> options, ILogger<GitServic
         return string.IsNullOrWhiteSpace(sanitized) ? "workspace" : sanitized;
     }
 
-    /// <summary>Git and GitVersion use stderr for progress; mirror combined output as stderr on failure for the overlay.</summary>
-    private static bool IsGitLikeProgressStreaming(string fileName, string arguments)
+    private static string? CombineOutput(string? stdout, string? stderr)
     {
-        if (string.Equals(fileName, "git", StringComparison.OrdinalIgnoreCase))
-            return true;
-        if (string.Equals(fileName, "dotnet-gitversion", StringComparison.OrdinalIgnoreCase))
-            return true;
-        return string.Equals(fileName, "dotnet", StringComparison.OrdinalIgnoreCase)
-               && arguments.Contains("gitversion", StringComparison.OrdinalIgnoreCase);
-    }
-
-    private async Task<(int ExitCode, string? Stdout, string? Stderr)> RunProcessAsync(
-        string fileName,
-        string arguments,
-        string? workingDirectory,
-        CancellationToken ct,
-        bool? streamStderrAsStdout = null,
-        bool? mirrorFailureOutputAsStderr = null)
-    {
-        if (string.Equals(fileName, "git", StringComparison.OrdinalIgnoreCase) &&
-            !string.IsNullOrWhiteSpace(workingDirectory))
-        {
-            var repoLock = GetRepoLock(workingDirectory);
-            await repoLock.WaitAsync(ct);
-            try
-            {
-                return await RunProcessCoreAsync(fileName, arguments, workingDirectory, ct, streamStderrAsStdout, mirrorFailureOutputAsStderr);
-            }
-            finally
-            {
-                repoLock.Release();
-            }
-        }
-
-        return await RunProcessCoreAsync(fileName, arguments, workingDirectory, ct, streamStderrAsStdout, mirrorFailureOutputAsStderr);
-    }
-
-    private async Task<(int ExitCode, string? Stdout, string? Stderr)> RunProcessCoreAsync(
-        string fileName,
-        string arguments,
-        string? workingDirectory,
-        CancellationToken ct,
-        bool? streamStderrAsStdout = null,
-        bool? mirrorFailureOutputAsStderr = null)
-    {
-        var gitLike = IsGitLikeProgressStreaming(fileName, arguments);
-        var stderrAsOut = streamStderrAsStdout ?? gitLike;
-        var mirror = mirrorFailureOutputAsStderr ?? gitLike;
-        var r = await commandLine.RunAsync(fileName, arguments, workingDirectory, null, ct, stderrAsOut, mirror);
-        return (r.ExitCode, r.Stdout, r.Stderr);
-    }
-
-    private async Task<(int ExitCode, string? Stdout, string? Stderr)> RunProcessWithStdinAsync(
-        string fileName,
-        string arguments,
-        string? workingDirectory,
-        string stdinContent,
-        CancellationToken ct)
-    {
-        if (string.Equals(fileName, "git", StringComparison.OrdinalIgnoreCase) &&
-            !string.IsNullOrWhiteSpace(workingDirectory))
-        {
-            var repoLock = GetRepoLock(workingDirectory);
-            await repoLock.WaitAsync(ct);
-            try
-            {
-                return await RunProcessWithStdinCoreAsync(fileName, arguments, workingDirectory, stdinContent, ct);
-            }
-            finally
-            {
-                repoLock.Release();
-            }
-        }
-
-        return await RunProcessWithStdinCoreAsync(fileName, arguments, workingDirectory, stdinContent, ct);
-    }
-
-    private async Task<(int ExitCode, string? Stdout, string? Stderr)> RunProcessWithStdinCoreAsync(
-        string fileName,
-        string arguments,
-        string? workingDirectory,
-        string stdinContent,
-        CancellationToken ct)
-    {
-        var gitLike = IsGitLikeProgressStreaming(fileName, arguments);
-        var r = await commandLine.RunAsync(fileName, arguments, workingDirectory, stdinContent, ct, gitLike, gitLike);
-        return (r.ExitCode, r.Stdout, r.Stderr);
-    }
-
-    private static void ReportOverlayStderr(string message)
-    {
-        var sink = CommandLineStreamAmbient.Current.Value;
-        if (sink == null || string.IsNullOrWhiteSpace(message))
-            return;
-
-        try
-        {
-            sink(new CommandLineStreamEvent(AgentCommandStreamKind.Stderr, message.Trim()));
-        }
-        catch
-        {
-            // overlay must not break GitVersion handling
-        }
+        var outStr = (stdout ?? "").Trim();
+        var errStr = (stderr ?? "").Trim();
+        if (string.IsNullOrWhiteSpace(outStr) && string.IsNullOrWhiteSpace(errStr))
+            return null;
+        return string.IsNullOrWhiteSpace(outStr) ? errStr
+             : string.IsNullOrWhiteSpace(errStr) ? outStr
+             : $"{outStr}\n{errStr}";
     }
 
     private static string BuildProcessError(string? stderr, string? stdout, string fallback)
-    {
-        return (!string.IsNullOrWhiteSpace(stderr) ? stderr : stdout)?.Trim() ?? fallback;
-    }
+        => (!string.IsNullOrWhiteSpace(stderr) ? stderr : stdout)?.Trim() ?? fallback;
 
     private static bool ShouldAttemptDotNetToolRestore(string fileName, string? stderr, string? stdout)
     {
         if (!string.Equals(fileName, "dotnet", StringComparison.OrdinalIgnoreCase))
             return false;
-
         var output = string.Concat(stderr ?? string.Empty, "\n", stdout ?? string.Empty);
         if (string.IsNullOrWhiteSpace(output))
             return false;
-
         return output.Contains("could not execute because the specified command or file was not found", StringComparison.OrdinalIgnoreCase)
             || output.Contains("dotnet-gitversion does not exist", StringComparison.OrdinalIgnoreCase)
             || output.Contains("no executable found matching command", StringComparison.OrdinalIgnoreCase)
             || output.Contains("is not recognized as an internal or external command", StringComparison.OrdinalIgnoreCase)
             || output.Contains("run 'dotnet tool restore'", StringComparison.OrdinalIgnoreCase)
             || output.Contains("run \"dotnet tool restore\"", StringComparison.OrdinalIgnoreCase);
-    }
-
-    private static SemaphoreSlim GetRepoLock(string repoPath)
-    {
-        var key = Path.GetFullPath(repoPath).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-        return RepoLocks.GetOrAdd(key, _ => new SemaphoreSlim(1, 1));
     }
 
     private static string EmptyHooksPath =>
@@ -1425,15 +1077,12 @@ public sealed class GitService(IOptions<AgentOptions> options, ILogger<GitServic
     {
         if (!skipHooks)
             return string.Empty;
-
         var escaped = EmptyHooksPath.Replace("\\", "\\\\").Replace("\"", "\\\"");
         return $"-c core.hooksPath=\"{escaped}\" ";
     }
 
     private static bool IsRemoteBranchAlreadyDeleted(string output)
-    {
-        return output.Contains("remote ref does not exist", StringComparison.OrdinalIgnoreCase)
-            || (output.Contains("unable to delete", StringComparison.OrdinalIgnoreCase)
-                && output.Contains("does not exist", StringComparison.OrdinalIgnoreCase));
-    }
+        => output.Contains("remote ref does not exist", StringComparison.OrdinalIgnoreCase)
+        || (output.Contains("unable to delete", StringComparison.OrdinalIgnoreCase)
+            && output.Contains("does not exist", StringComparison.OrdinalIgnoreCase));
 }

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
@@ -1,4 +1,3 @@
-using System.Text.Json;
 using GrayMoon.Abstractions.Exceptions;
 using GrayMoon.App.Components.Modals;
 using GrayMoon.App.Models;
@@ -20,10 +19,8 @@ public sealed partial class WorkspaceRepositories : IDisposable
     private IReadOnlyDictionary<int, PullRequestInfo?> prByRepositoryId = new Dictionary<int, PullRequestInfo?>();
     private readonly Dictionary<int, DateTime> _lastPrRefreshByRepoId = new();
     private static readonly TimeSpan PrRefreshThrottle = TimeSpan.FromSeconds(10);
-    private IReadOnlyDictionary<int, RepoGitVersionInfo> repoGitInfos = new Dictionary<int, RepoGitVersionInfo>();
     private string? errorMessage;
     private bool isLoading = true;
-    private IReadOnlySet<int>? pushPlanRepoIds = null;
     private bool? isOutOfSync = null;
     private bool hasUnmatchedDependencies => workspaceRepositories.Any(wr => !wr.IsOnTag && (wr.UnmatchedDeps ?? 0) > 0);
     private bool isPushRecommended => workspaceRepositories.Any(wr => !wr.IsOnTag && ((wr.OutgoingCommits ?? 0) > 0 || wr.BranchHasUpstream == false));
@@ -40,7 +37,9 @@ public sealed partial class WorkspaceRepositories : IDisposable
             .GroupBy(wr => wr.DependencyLevel)
             .OrderByDescending(g => g.Key ?? int.MinValue);
 
-    private List<WorkspaceRepositoryLink> FilteredWorkspaceRepositories => GetFilteredWorkspaceRepositories();
+    private List<WorkspaceRepositoryLink> _filteredWorkspaceRepositories = new();
+    private List<WorkspaceRepositoryLink> FilteredWorkspaceRepositories => _filteredWorkspaceRepositories;
+    private void UpdateFilteredRepositories() => _filteredWorkspaceRepositories = GetFilteredWorkspaceRepositories();
 
     private string ApiBaseUrl => NavigationManager.BaseUri.TrimEnd('/');
 
@@ -87,6 +86,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
 
     private const int RefreshDebounceMs = 200;
     private CancellationTokenSource? _refreshDebounceCts;
+    private readonly object _refreshDebounceLock = new();
 
     /// <summary>Toast shown when the user attempts a write action against a repository that is pinned to a tag.</summary>
     private const string TagBlockedActionMessage = "Repository is on a tag; checkout a branch first.";
@@ -122,10 +122,14 @@ public sealed partial class WorkspaceRepositories : IDisposable
             {
                 if (workspaceId != WorkspaceId) return;
                 if (IsJobRunning) return;
-                _refreshDebounceCts?.Cancel();
-                _refreshDebounceCts?.Dispose();
-                _refreshDebounceCts = new CancellationTokenSource();
-                var cts = _refreshDebounceCts;
+                CancellationTokenSource cts;
+                lock (_refreshDebounceLock)
+                {
+                    _refreshDebounceCts?.Cancel();
+                    _refreshDebounceCts?.Dispose();
+                    _refreshDebounceCts = new CancellationTokenSource();
+                    cts = _refreshDebounceCts;
+                }
                 try
                 {
                     await Task.Delay(RefreshDebounceMs, cts.Token);
@@ -137,10 +141,13 @@ public sealed partial class WorkspaceRepositories : IDisposable
                 }
                 finally
                 {
-                    if (cts == _refreshDebounceCts)
+                    lock (_refreshDebounceLock)
                     {
-                        _refreshDebounceCts?.Dispose();
-                        _refreshDebounceCts = null;
+                        if (cts == _refreshDebounceCts)
+                        {
+                            _refreshDebounceCts?.Dispose();
+                            _refreshDebounceCts = null;
+                        }
                     }
                 }
             });
@@ -172,9 +179,12 @@ public sealed partial class WorkspaceRepositories : IDisposable
         _disposed = true;
         AgentQueueStateService.RemoveQueueStateChanged(OnQueueStateChanged);
         JobService.Changed -= OnJobServiceChanged;
-        _refreshDebounceCts?.Cancel();
-        _refreshDebounceCts?.Dispose();
-        _refreshDebounceCts = null;
+        lock (_refreshDebounceLock)
+        {
+            _refreshDebounceCts?.Cancel();
+            _refreshDebounceCts?.Dispose();
+            _refreshDebounceCts = null;
+        }
         _ = _hubConnection?.StopAsync();
         _hubConnection?.DisposeAsync();
         _fetchRepositoriesCts?.Cancel();
@@ -188,7 +198,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
         {
             if (_disposed) return;
             var isRunning = IsJobRunning;
-            if (_wasJobRunning && !isRunning)
+            if (_wasJobRunning && !isRunning && !_disposed)
                 _ = InvokeAsync(RefreshFromSync);
             _wasJobRunning = isRunning;
             StateHasChanged();
@@ -237,6 +247,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
         {
             errorMessage = "Workspace not found.";
             workspaceRepositories = new List<WorkspaceRepositoryLink>();
+            UpdateFilteredRepositories();
             return;
         }
 
@@ -247,6 +258,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
             .ToList();
         prByRepositoryId = BuildPrByRepositoryIdFromLinks(workspaceRepositories);
         await LoadMismatchedDependencyLinesAsync();
+        UpdateFilteredRepositories();
     }
 
     private static int GetRepositoryTypeSortOrder(ProjectType? type) => type switch
@@ -324,22 +336,13 @@ public sealed partial class WorkspaceRepositories : IDisposable
         }
     }
 
-    /// <summary>Calls the same branch refresh API as Switch Branch Fetch (fetch + persist) for the given repo.</summary>
     private async Task RefreshBranchesForRepositoryAsync(int repositoryId)
     {
         try
         {
-            var httpClient = WorkspacePageService.HttpClientFactory.CreateClient();
-            var request = new { workspaceId = WorkspaceId, repositoryId };
-            var json = JsonSerializer.Serialize(request);
-            var content = new System.Net.Http.StringContent(json, System.Text.Encoding.UTF8, "application/json");
-            var baseUrl = NavigationManager.BaseUri.TrimEnd('/');
-            var response = await httpClient.PostAsync($"{baseUrl}/api/branches/refresh", content);
-            if (!response.IsSuccessStatusCode)
-            {
-                var errorText = await response.Content.ReadAsStringAsync();
-                Logger.LogDebug("Branch refresh after PR merge failed for RepositoryId={RepositoryId}: {StatusCode}, {Error}", repositoryId, response.StatusCode, errorText);
-            }
+            await using var scope = ServiceScopeFactory.CreateAsyncScope();
+            var gitService = scope.ServiceProvider.GetRequiredService<WorkspaceGitService>();
+            await gitService.RefreshBranchesAndBroadcastAsync(repositoryId, WorkspaceId, CancellationToken.None);
         }
         catch (Exception ex)
         {
@@ -381,6 +384,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
         {
             errorMessage = "Workspace not found.";
             workspaceRepositories = new List<WorkspaceRepositoryLink>();
+            UpdateFilteredRepositories();
             return;
         }
         workspace = w;
@@ -391,6 +395,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
             .ToList();
         prByRepositoryId = BuildPrByRepositoryIdFromLinks(workspaceRepositories);
         await LoadMismatchedDependencyLinesAsync();
+        UpdateFilteredRepositories();
     }
 
     private async Task LoadMismatchedDependencyLinesAsync()
@@ -441,6 +446,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
     private void OnSearchChanged(ChangeEventArgs e)
     {
         searchTerm = e.Value?.ToString() ?? string.Empty;
+        UpdateFilteredRepositories();
         StateHasChanged();
     }
 
@@ -1048,7 +1054,6 @@ public sealed partial class WorkspaceRepositories : IDisposable
                     ct,
                     job.ReportProgress,
                     (repoId, msg) => SafeInvoke(() => { repositoryErrors[repoId] = msg; }),
-                    onAppSideComplete: () => { },
                     repoIdsToUpdate: new HashSet<int> { repositoryId });
 
                 await InvokeAsync(async () =>
@@ -1201,6 +1206,34 @@ public sealed partial class WorkspaceRepositories : IDisposable
         return Task.CompletedTask;
     }
 
+    private async Task<(IReadOnlySet<int> PushRepoIds, IReadOnlySet<string> RequiredPackageIds)?> BuildPushPlanAsync(
+        string emptyMessage, CancellationToken ct)
+    {
+        await using var planScope = ServiceScopeFactory.CreateAsyncScope();
+        var planPushHandler = planScope.ServiceProvider.GetRequiredService<WorkspacePushHandler>();
+        var planDepService = planScope.ServiceProvider.GetRequiredService<WorkspaceDependencyService>();
+        var (payload, hasUnpushed) = await planPushHandler.GetPushPlanAsync(WorkspaceId, workspaceRepositories, ct);
+        if (!hasUnpushed)
+        {
+            SafeInvoke(() => ToastService.Show(emptyMessage));
+            return null;
+        }
+        var taggedRepoIds = workspaceRepositories.Where(wr => wr.IsOnTag).Select(wr => wr.RepositoryId).ToHashSet();
+        IReadOnlySet<int> pushRepoIds = payload.Select(p => p.RepoId).Where(id => !taggedRepoIds.Contains(id)).ToHashSet();
+        if (pushRepoIds.Count == 0)
+        {
+            SafeInvoke(() => ToastService.Show(emptyMessage));
+            return null;
+        }
+        var depInfo = await planDepService.GetPushDependencyInfoForRepoSetAsync(WorkspaceId, pushRepoIds, ct);
+        IReadOnlySet<string> requiredPackageIds = depInfo?.PayloadForRepo?.RequiredPackages
+            .Select(r => r.PackageId?.Trim())
+            .Where(id => !string.IsNullOrEmpty(id))
+            .Cast<string>()
+            .ToHashSet(StringComparer.OrdinalIgnoreCase) ?? new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        return (pushRepoIds, requiredPackageIds);
+    }
+
     private async Task ExecutePushCoreAsync(
         BackgroundJobHandle job,
         CancellationToken ct,
@@ -1219,8 +1252,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
                 requiredPackageIds,
                 job.ReportProgress,
                 ToastService.Show,
-                onAppSideComplete: () => { },
-                ct);
+                cancellationToken: ct);
         }
         catch (OperationCanceledException)
         {
@@ -1311,8 +1343,6 @@ public sealed partial class WorkspaceRepositories : IDisposable
                 ToastService.Show("No repositories to push.");
                 return;
             }
-            pushPlanRepoIds = repoIdsWithUnpushed;
-
             var repoIdsThatNeedPush = workspaceRepositories
                 .Where(wr => !wr.IsOnTag && (wr.OutgoingCommits ?? 0) > 0)
                 .Select(wr => wr.RepositoryId)
@@ -1465,7 +1495,6 @@ public sealed partial class WorkspaceRepositories : IDisposable
                         ct,
                         job.ReportProgress,
                         (repoId, msg) => SafeInvoke(() => { repositoryErrors[repoId] = msg; }),
-                        onAppSideComplete: () => { },
                         repoIdsToUpdate: null,
                         commitMessage: commitMessage,
                         includeDepsInCommitMessage: includeDepsInCommitMessage);
@@ -1609,7 +1638,6 @@ public sealed partial class WorkspaceRepositories : IDisposable
                         ct,
                         job.ReportProgress,
                         (repoId, msg) => SafeInvoke(() => { repositoryErrors[repoId] = msg; }),
-                        onAppSideComplete: () => { },
                         repoIdsToUpdate: null,
                         commitMessage: commitMessage,
                         includeDepsInCommitMessage: includeDepsInCommitMessage);
@@ -1637,30 +1665,9 @@ public sealed partial class WorkspaceRepositories : IDisposable
             IReadOnlySet<string> requiredPackageIds;
             try
             {
-                await using var planScope = ServiceScopeFactory.CreateAsyncScope();
-                var planPushHandler = planScope.ServiceProvider.GetRequiredService<WorkspacePushHandler>();
-                var planDepService = planScope.ServiceProvider.GetRequiredService<WorkspaceDependencyService>();
-                var (payload, hasUnpushed) = await planPushHandler.GetPushPlanAsync(
-                    WorkspaceId, workspaceRepositories, ct);
-                if (!hasUnpushed)
-                {
-                    SafeInvoke(() => ToastService.Show("Update complete. Nothing to push."));
-                    return;
-                }
-                var taggedRepoIds = workspaceRepositories.Where(wr => wr.IsOnTag).Select(wr => wr.RepositoryId).ToHashSet();
-                pushRepoIds = payload.Select(p => p.RepoId).Where(id => !taggedRepoIds.Contains(id)).ToHashSet();
-                if (pushRepoIds.Count == 0)
-                {
-                    SafeInvoke(() => ToastService.Show("Update complete. Nothing to push."));
-                    return;
-                }
-                var depInfo = await planDepService.GetPushDependencyInfoForRepoSetAsync(
-                    WorkspaceId, pushRepoIds, ct);
-                requiredPackageIds = depInfo?.PayloadForRepo?.RequiredPackages
-                    .Select(r => r.PackageId?.Trim())
-                    .Where(id => !string.IsNullOrEmpty(id))
-                    .Cast<string>()
-                    .ToHashSet(StringComparer.OrdinalIgnoreCase) ?? new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                var plan = await BuildPushPlanAsync("Update complete. Nothing to push.", ct);
+                if (plan == null) return;
+                (pushRepoIds, requiredPackageIds) = plan.Value;
             }
             catch (OperationCanceledException)
             {
@@ -1862,127 +1869,33 @@ public sealed partial class WorkspaceRepositories : IDisposable
         }
     }
 
-    /// <summary>Sync repos only (git, version, branch, commit counts). Does not read or write .csproj; dependency mismatches are resolved only by Update. Runs in a fresh scope so DbContext is not stale and PersistVersionsAsync â†’ dependency recompute sees current state.</summary>
-    private Task SyncAsync()
+    private Task RunSyncJobAsync(IReadOnlyList<int>? repositoryIds, string jobLabel, bool skipDependencyLevelPersistence)
     {
-        if (workspace == null || workspaceRepositories.Count == 0 || IsJobRunning)
-            return Task.CompletedTask;
-
-        var isRetryAfterError = !string.IsNullOrEmpty(errorMessage);
-        errorMessage = null;
-
-        JobService.StartJob(PageJobKey, "Synchronizing...", async (job, ct) =>
+        JobService.StartJob(PageJobKey, jobLabel, async (job, ct) =>
         {
             try
             {
                 await using var scope = ServiceScopeFactory.CreateAsyncScope();
                 var syncHandler = scope.ServiceProvider.GetRequiredService<WorkspaceSyncHandler>();
-                repoGitInfos = await syncHandler.RunSyncAsync(
-                    WorkspaceId,
-                    repositoryIds: null,
-                    skipDependencyLevelPersistence: isRetryAfterError,
-                    cancellationToken: ct,
-                    setProgress: job.ReportProgress,
-                    updateRepoGitInfo: (repoId, info) =>
-                    {
-                        SafeInvoke(() =>
-                        {
-                            var wr = workspaceRepositories.FirstOrDefault(w => w.RepositoryId == repoId);
-                            if (wr != null)
-                            {
-                                wr.GitVersion = info.Version == "-" ? null : info.Version;
-                                wr.BranchName = info.Branch == "-" ? null : info.Branch;
-                                wr.Projects = info.Projects;
-                                wr.OutgoingCommits = info.OutgoingCommits;
-                                wr.IncomingCommits = info.IncomingCommits;
-                            }
-                        });
-                    },
-                    setRepoSyncStatus: (repoId, status) => repoSyncStatus[repoId] = status,
-                    onAppSideComplete: () => { });
-
-                await InvokeAsync(async () =>
-                {
-                    if (_disposed) return;
-                    await ReloadWorkspaceDataAsync();
-                    ApplySyncStateFromWorkspace();
-                    isOutOfSync = repoSyncStatus.Values.Any(v => v != RepoSyncStatus.InSync);
-                    foreach (var (repoId, info) in repoGitInfos)
-                    {
-                        if (!string.IsNullOrWhiteSpace(info.ErrorMessage))
-                            repositoryErrors[repoId] = info.ErrorMessage;
-                        else
-                            repositoryErrors.Remove(repoId);
-                    }
-                    StateHasChanged();
-                });
-            }
-            catch (OperationCanceledException)
-            {
-                await ReloadWorkspaceDataAfterCancelAsync();
-                throw;
-            }
-            catch (AgentNotConnectedException ex)
-            {
-                Logger.LogError(ex, "Error syncing workspace {WorkspaceId}", WorkspaceId);
-                SafeInvoke(() => errorMessage = $"Sync failed. {ex.Message}");
-                throw;
-            }
-            catch (ConnectorHealthException ex)
-            {
-                Logger.LogError(ex, "Error syncing workspace {WorkspaceId}", WorkspaceId);
-                SafeInvoke(() => errorMessage = $"Sync failed. {ex.Message}");
-                throw;
-            }
-            catch (Exception ex)
-            {
-                Logger.LogError(ex, "Error syncing workspace {WorkspaceId}", WorkspaceId);
-                SafeInvoke(() => errorMessage = "Sync failed. An unexpected error occurred. Check the logs for details.");
-                throw;
-            }
-        });
-
-        return Task.CompletedTask;
-    }
-
-    /// <summary>Sync (refresh version, branch, commits) for the given repositories in a level. Uses skipDependencyLevelPersistence so merge does not persist with partial edges; PersistVersionsAsync then recomputes levels from full DB. Same overlay and error handling as SyncAsync.</summary>
-    private Task SyncLevelAsync(List<int> repositoryIds)
-    {
-        if (workspace == null || repositoryIds == null || repositoryIds.Count == 0 || IsJobRunning)
-            return Task.CompletedTask;
-
-        var msg = $"Synchronizing {repositoryIds.Count} {(repositoryIds.Count == 1 ? "repository" : "repositories")}...";
-        errorMessage = null;
-
-        JobService.StartJob(PageJobKey, msg, async (job, ct) =>
-        {
-            try
-            {
-                await using var scope = ServiceScopeFactory.CreateAsyncScope();
-                var syncHandler = scope.ServiceProvider.GetRequiredService<WorkspaceSyncHandler>();
-                repoGitInfos = await syncHandler.RunSyncAsync(
+                var repoGitInfos = await syncHandler.RunSyncAsync(
                     WorkspaceId,
                     repositoryIds,
-                    skipDependencyLevelPersistence: true,
+                    skipDependencyLevelPersistence,
                     cancellationToken: ct,
                     setProgress: job.ReportProgress,
-                    updateRepoGitInfo: (repoId, info) =>
+                    updateRepoGitInfo: (repoId, info) => SafeInvoke(() =>
                     {
-                        SafeInvoke(() =>
+                        var wr = workspaceRepositories.FirstOrDefault(w => w.RepositoryId == repoId);
+                        if (wr != null)
                         {
-                            var wr = workspaceRepositories.FirstOrDefault(w => w.RepositoryId == repoId);
-                            if (wr != null)
-                            {
-                                wr.GitVersion = info.Version == "-" ? null : info.Version;
-                                wr.BranchName = info.Branch == "-" ? null : info.Branch;
-                                wr.Projects = info.Projects;
-                                wr.OutgoingCommits = info.OutgoingCommits;
-                                wr.IncomingCommits = info.IncomingCommits;
-                            }
-                        });
-                    },
-                    setRepoSyncStatus: (repoId, status) => repoSyncStatus[repoId] = status,
-                    onAppSideComplete: () => { });
+                            wr.GitVersion = info.Version == "-" ? null : info.Version;
+                            wr.BranchName = info.Branch == "-" ? null : info.Branch;
+                            wr.Projects = info.Projects;
+                            wr.OutgoingCommits = info.OutgoingCommits;
+                            wr.IncomingCommits = info.IncomingCommits;
+                        }
+                    }),
+                    setRepoSyncStatus: (repoId, status) => repoSyncStatus[repoId] = status);
 
                 await InvokeAsync(async () =>
                 {
@@ -2007,107 +1920,47 @@ public sealed partial class WorkspaceRepositories : IDisposable
             }
             catch (AgentNotConnectedException ex)
             {
-                Logger.LogError(ex, "Error syncing level for workspace {WorkspaceId}", WorkspaceId);
+                Logger.LogError(ex, "Sync failed for workspace {WorkspaceId}", WorkspaceId);
                 SafeInvoke(() => errorMessage = $"Sync failed. {ex.Message}");
                 throw;
             }
             catch (ConnectorHealthException ex)
             {
-                Logger.LogError(ex, "Error syncing level for workspace {WorkspaceId}", WorkspaceId);
+                Logger.LogError(ex, "Sync failed for workspace {WorkspaceId}", WorkspaceId);
                 SafeInvoke(() => errorMessage = $"Sync failed. {ex.Message}");
                 throw;
             }
             catch (Exception ex)
             {
-                Logger.LogError(ex, "Error syncing level for workspace {WorkspaceId}", WorkspaceId);
+                Logger.LogError(ex, "Sync failed for workspace {WorkspaceId}", WorkspaceId);
                 SafeInvoke(() => errorMessage = "Sync failed. An unexpected error occurred. Check the logs for details.");
                 throw;
             }
         });
-
         return Task.CompletedTask;
     }
 
-    /// <summary>Sync a single repository (same as Sync button but for one repo). Levels are recomputed after persist via full DB graph (see PersistVersionsAsync when skipDependencyLevelPersistence).</summary>
+    private Task SyncAsync()
+    {
+        if (workspace == null || workspaceRepositories.Count == 0 || IsJobRunning) return Task.CompletedTask;
+        var skipDependencyLevelPersistence = !string.IsNullOrEmpty(errorMessage);
+        errorMessage = null;
+        return RunSyncJobAsync(null, "Synchronizing...", skipDependencyLevelPersistence);
+    }
+
+    private Task SyncLevelAsync(List<int> repositoryIds)
+    {
+        if (workspace == null || repositoryIds == null || repositoryIds.Count == 0 || IsJobRunning) return Task.CompletedTask;
+        errorMessage = null;
+        var label = $"Synchronizing {repositoryIds.Count} {(repositoryIds.Count == 1 ? "repository" : "repositories")}...";
+        return RunSyncJobAsync(repositoryIds, label, skipDependencyLevelPersistence: true);
+    }
+
     private Task SyncSingleRepoAsync(int repositoryId)
     {
-        if (workspace == null || workspaceRepositories.Count == 0 || IsJobRunning)
-            return Task.CompletedTask;
-
+        if (workspace == null || workspaceRepositories.Count == 0 || IsJobRunning) return Task.CompletedTask;
         errorMessage = null;
-
-        JobService.StartJob(PageJobKey, "Synchronizing repository...", async (job, ct) =>
-        {
-            try
-            {
-                await using var scope = ServiceScopeFactory.CreateAsyncScope();
-                var syncHandler = scope.ServiceProvider.GetRequiredService<WorkspaceSyncHandler>();
-                repoGitInfos = await syncHandler.RunSyncAsync(
-                    WorkspaceId,
-                    new[] { repositoryId },
-                    skipDependencyLevelPersistence: true,
-                    cancellationToken: ct,
-                    setProgress: job.ReportProgress,
-                    updateRepoGitInfo: (repoId, info) =>
-                    {
-                        SafeInvoke(() =>
-                        {
-                            var wr = workspaceRepositories.FirstOrDefault(w => w.RepositoryId == repoId);
-                            if (wr != null)
-                            {
-                                wr.GitVersion = info.Version == "-" ? null : info.Version;
-                                wr.BranchName = info.Branch == "-" ? null : info.Branch;
-                                wr.Projects = info.Projects;
-                                wr.OutgoingCommits = info.OutgoingCommits;
-                                wr.IncomingCommits = info.IncomingCommits;
-                            }
-                        });
-                    },
-                    setRepoSyncStatus: (repoId, status) => repoSyncStatus[repoId] = status,
-                    onAppSideComplete: () => { });
-
-                await InvokeAsync(async () =>
-                {
-                    if (_disposed) return;
-                    await ReloadWorkspaceDataAsync();
-                    ApplySyncStateFromWorkspace();
-                    isOutOfSync = repoSyncStatus.Values.Any(v => v != RepoSyncStatus.InSync);
-                    foreach (var (repoId, info) in repoGitInfos)
-                    {
-                        if (!string.IsNullOrWhiteSpace(info.ErrorMessage))
-                            repositoryErrors[repoId] = info.ErrorMessage;
-                        else
-                            repositoryErrors.Remove(repoId);
-                    }
-                    StateHasChanged();
-                });
-            }
-            catch (OperationCanceledException)
-            {
-                await ReloadWorkspaceDataAfterCancelAsync();
-                throw;
-            }
-            catch (AgentNotConnectedException ex)
-            {
-                Logger.LogError(ex, "Error syncing repository {RepositoryId} in workspace {WorkspaceId}", repositoryId, WorkspaceId);
-                SafeInvoke(() => errorMessage = $"Sync failed. {ex.Message}");
-                throw;
-            }
-            catch (ConnectorHealthException ex)
-            {
-                Logger.LogError(ex, "Error syncing repository {RepositoryId} in workspace {WorkspaceId}", repositoryId, WorkspaceId);
-                SafeInvoke(() => errorMessage = $"Sync failed. {ex.Message}");
-                throw;
-            }
-            catch (Exception ex)
-            {
-                Logger.LogError(ex, "Error syncing repository {RepositoryId} in workspace {WorkspaceId}", repositoryId, WorkspaceId);
-                SafeInvoke(() => errorMessage = "Sync failed. An unexpected error occurred. Check the logs for details.");
-                throw;
-            }
-        });
-
-        return Task.CompletedTask;
+        return RunSyncJobAsync(new[] { repositoryId }, "Synchronizing repository...", skipDependencyLevelPersistence: true);
     }
 
     private Task CommitSyncAsync(int repositoryId)
@@ -2132,11 +1985,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
                     WorkspaceId,
                     repositoryId,
                     ct,
-                    async message =>
-                    {
-                        job.ReportProgress(message);
-                        await Task.CompletedTask;
-                    },
+                    msg => { job.ReportProgress(msg); return Task.CompletedTask; },
                     (id, err) => SafeInvoke(() =>
                     {
                         if (err is null)
@@ -2186,11 +2035,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
                     WorkspaceId,
                     repositoryIds,
                     ct,
-                    async (completed, total) =>
-                    {
-                        job.ReportProgress($"Synchronized commits {completed} of {total}");
-                        await Task.CompletedTask;
-                    },
+                    (completed, total) => { job.ReportProgress($"Synchronized commits {completed} of {total}"); return Task.CompletedTask; },
                     (id, err) => SafeInvoke(() =>
                     {
                         if (err is null)
@@ -2414,30 +2259,9 @@ public sealed partial class WorkspaceRepositories : IDisposable
             IReadOnlySet<string> requiredPackageIds;
             try
             {
-                await using var planScope = ServiceScopeFactory.CreateAsyncScope();
-                var planPushHandler = planScope.ServiceProvider.GetRequiredService<WorkspacePushHandler>();
-                var planDepService = planScope.ServiceProvider.GetRequiredService<WorkspaceDependencyService>();
-                var (payload, hasUnpushed) = await planPushHandler.GetPushPlanAsync(
-                    WorkspaceId, workspaceRepositories, ct);
-                if (!hasUnpushed)
-                {
-                    SafeInvoke(() => ToastService.Show("No repositories to push."));
-                    return;
-                }
-                var taggedRepoIds = workspaceRepositories.Where(wr => wr.IsOnTag).Select(wr => wr.RepositoryId).ToHashSet();
-                pushRepoIds = payload.Select(p => p.RepoId).Where(id => !taggedRepoIds.Contains(id)).ToHashSet();
-                if (pushRepoIds.Count == 0)
-                {
-                    SafeInvoke(() => ToastService.Show("No repositories to push."));
-                    return;
-                }
-                var depInfo = await planDepService.GetPushDependencyInfoForRepoSetAsync(
-                    WorkspaceId, pushRepoIds, ct);
-                requiredPackageIds = depInfo?.PayloadForRepo?.RequiredPackages
-                    .Select(r => r.PackageId?.Trim())
-                    .Where(id => !string.IsNullOrEmpty(id))
-                    .Cast<string>()
-                    .ToHashSet(StringComparer.OrdinalIgnoreCase) ?? new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                var plan = await BuildPushPlanAsync("No repositories to push.", ct);
+                if (plan == null) return;
+                (pushRepoIds, requiredPackageIds) = plan.Value;
             }
             catch (OperationCanceledException)
             {
@@ -3065,6 +2889,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
         if (e.Key == "Escape")
         {
             searchTerm = string.Empty;
+            UpdateFilteredRepositories();
             StateHasChanged();
         }
     }
@@ -3072,6 +2897,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
     private void ClearSearchFilter()
     {
         searchTerm = string.Empty;
+        UpdateFilteredRepositories();
         StateHasChanged();
     }
 

--- a/src/GrayMoon.App/Components/Shared/AgentStatusBadge.razor
+++ b/src/GrayMoon.App/Components/Shared/AgentStatusBadge.razor
@@ -1,4 +1,5 @@
 @using GrayMoon.App.Services
+@using GrayMoon.Abstractions.Agent
 @inject AgentConnectionTracker AgentConnectionTracker
 @inject AgentQueueStateService AgentQueueStateService
 @inject IAgentBridge AgentBridge
@@ -49,7 +50,7 @@ else
         _isUpdating = true;
         StateHasChanged();
         var installUrl = NavigationManager.BaseUri.TrimEnd('/') + "/api/agent/install";
-        var response = await AgentBridge.SendCommandAsync("SelfUpdate", new { installUrl }, CancellationToken.None);
+        var response = await AgentBridge.SendCommandAsync(AgentHubMethods.SelfUpdate, new { installUrl }, CancellationToken.None);
         if (!response.Success)
         {
             _isUpdating = false;

--- a/src/GrayMoon.App/Services/WorkspaceGitService.cs
+++ b/src/GrayMoon.App/Services/WorkspaceGitService.cs
@@ -889,6 +889,13 @@ public class WorkspaceGitService(
         return true;
     }
 
+    public async Task RefreshBranchesAndBroadcastAsync(int repositoryId, int workspaceId, CancellationToken cancellationToken = default)
+    {
+        await RefreshBranchesForRepositoryAsync(repositoryId, workspaceId, cancellationToken);
+        if (_hubContext != null)
+            await _hubContext.Clients.All.SendAsync("WorkspaceSynced", workspaceId, cancellationToken: cancellationToken);
+    }
+
     public async Task<IReadOnlyDictionary<int, RepoSyncStatus>> GetRepoSyncStatusAsync(
         int workspaceId,
         Action<int, RepoSyncStatus>? onProgress = null,


### PR DESCRIPTION
## Summary

- Extract `GitProcessRunner` to centralize per-repo git/dotnet-gitversion locking, Polly resilience pipelines, and command-line streaming for the loading overlay
- Slim `GitService` by delegating process execution; unify local/remote branch delete behind `DeleteBranchAsync` and log non-fatal delete failures during sync-to-default-branch
- Stop retrying `git pull` when output indicates a merge conflict; restrict badge-triggered agent self-update to Windows
- Register `SelfUpdate` via `AgentHubMethods` instead of string literals across dispatcher and job factory
- Move multi-step workspace repository operations out of `WorkspaceRepositories` into existing handler services, reducing page complexity
- Document handler services and `WorkspacePendingActionsService` in `CLAUDE.md`

## Test plan

- [ ] Run sync-to-default-branch with a branch that cannot be deleted remotely or locally; confirm warnings are logged and the workflow completes where possible
- [ ] Trigger concurrent git commands against the same repo; confirm operations serialize without corrupt state
- [ ] Pull a repo with a merge conflict; confirm the operation fails once without retry loops
- [ ] On Windows, use the agent status badge self-update; on non-Windows, confirm a clear unsupported error
- [ ] Smoke-test workspace repository actions (branch, push, update, undo push, commit sync) from the repositories page