### PR TITLE
Refresh dependency state on commit and enable push/pull from notifications

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ When you complete a task, write a single sentence summarizing what was done. Kee
 # Build the solution
 dotnet build GrayMoon.sln
 
-# Run tests (xUnit)
+# Run tests (xUnit) - only GrayMoon.Common is covered; no integration tests exist
 dotnet test src/GrayMoon.Common.Tests/GrayMoon.Common.Tests.csproj
 
 # Run a single test class
@@ -107,7 +107,7 @@ Connector tokens are AES-256-GCM encrypted at rest via `AesGcmTokenProtector` (b
 
 Schema is owned by EF Core but applied via `EnsureCreated()`. Core tables: `Connectors`, `Repositories`, `Workspaces`, `WorkspaceRepositories` (join with live state), `WorkspaceRepositoryPullRequest` (1:1 with link), `WorkspaceProject`, `ProjectDependency`, `WorkspaceFile`, `WorkspaceFileVersionConfig`, `RepositoryBranch`, `Settings`.
 
-After `EnsureCreated()`, startup calls `Migrations.RunAllAsync(dbContext)` (`src/GrayMoon.App/Migrations.cs`). Each migration is an idempotent `ALTER TABLE` guarded by `pragma_table_info()`. Add new columns there - no EF Core migration assembly is used.
+After `EnsureCreated()`, startup calls `Migrations.RunAllAsync(dbContext)` (`src/GrayMoon.App/Migrations.cs`). Each migration is an idempotent `ALTER TABLE` guarded by `pragma_table_info()`. To add a new column: add a `public static async Task MigrateXxxAsync(AppDbContext dbContext)` method to `Migrations.cs` (check `pragma_table_info('TableName') WHERE name='ColumnName'` before executing the `ALTER TABLE`), then call it at the end of `RunAllAsync`. No EF Core migration assembly is used.
 
 ### Background job system
 

--- a/src/GrayMoon.Agent/Commands/CommitHookSyncCommand.cs
+++ b/src/GrayMoon.Agent/Commands/CommitHookSyncCommand.cs
@@ -7,10 +7,10 @@ using Microsoft.Extensions.Logging;
 namespace GrayMoon.Agent.Commands;
 
 /// <summary>
-/// Handles post-commit and post-update hooks: re-runs GitVersion and gets commit counts.
+/// Handles post-commit and post-update hooks: re-runs GitVersion, gets commit counts, and re-scans .csproj references.
 /// No git fetch - uses the existing remote tracking refs from the last checkout/sync.
 /// </summary>
-public sealed class CommitHookSyncCommand(IGitService git, IAgentTokenProvider tokenProvider, IHubConnectionProvider hubProvider, ILogger<CommitHookSyncCommand> logger)
+public sealed class CommitHookSyncCommand(IGitService git, ICsProjFileService csProjFileService, IAgentTokenProvider tokenProvider, IHubConnectionProvider hubProvider, ILogger<CommitHookSyncCommand> logger)
 {
     public async Task ExecuteAsync(INotifyJob payload, CancellationToken cancellationToken = default)
     {
@@ -23,6 +23,7 @@ public sealed class CommitHookSyncCommand(IGitService git, IAgentTokenProvider t
         var (versionResult, _) = await git.GetVersionAsync(payload.RepositoryPath, cancellationToken);
         var version = versionResult?.InformationalVersion ?? "-";
         var branch = versionResult?.BranchName ?? versionResult?.EscapedBranchName ?? "-";
+        var findProjectsTask = csProjFileService.FindAsync(payload.RepositoryPath, cancellationToken);
 
         var currentTag = await git.GetCheckedOutTagAsync(payload.RepositoryPath, cancellationToken);
         if (currentTag != null)
@@ -58,6 +59,27 @@ public sealed class CommitHookSyncCommand(IGitService git, IAgentTokenProvider t
             }
         }
 
+        var projects = await findProjectsTask;
+        var syncProjects = projects?
+            .Where(p => !string.IsNullOrWhiteSpace(p.Name))
+            .Select(p => new RepositorySyncProjectNotification
+            {
+                Name = p.Name.Trim(),
+                ProjectType = (int)p.ProjectType,
+                ProjectPath = p.ProjectPath ?? "",
+                TargetFramework = p.TargetFramework ?? "",
+                PackageId = p.PackageId,
+                PackageReferences = p.PackageReferences
+                    .Where(pr => !string.IsNullOrWhiteSpace(pr.Name))
+                    .Select(pr => new RepositorySyncPackageReferenceNotification
+                    {
+                        Name = pr.Name.Trim(),
+                        Version = pr.Version ?? ""
+                    })
+                    .ToList()
+            })
+            .ToList();
+
         var connection = hubProvider.Connection;
         if (connection?.State == HubConnectionState.Connected)
         {
@@ -73,6 +95,7 @@ public sealed class CommitHookSyncCommand(IGitService git, IAgentTokenProvider t
                 HasUpstream = hasUpstream,
                 DefaultBranchBehind = defaultBehind,
                 DefaultBranchAhead = defaultAhead,
+                Projects = syncProjects,
                 ErrorMessage = null
             };
             await connection.InvokeAsync(AgentHubMethods.SyncCommand, notification, cancellationToken);

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.css
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.css
@@ -442,6 +442,7 @@
 
 ::deep .repositories-table .dependency-badge-tooltip-line code {
     color: goldenrod;
+    font-size: 0.85rem;
 }
 
 ::deep .repositories-table .dependency-badge-tooltip-line:last-of-type {
@@ -450,7 +451,16 @@
 
 ::deep .repositories-table .dependency-badge-tooltip-versions {
     color: #aaa;
-    font-size: 0.72rem;
+    font-size: 0.85rem;
+}
+
+::deep .repositories-table .dependency-badge-tooltip-arrow {
+    color: rgba(255, 255, 255, 0.45);
+    font-size: 0.95rem;
+}
+
+::deep .repositories-table .dependency-badge-tooltip-new-version {
+    color: goldenrod;
 }
 
 ::deep .repositories-table .dependency-badge-tooltip-footer {

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.css
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.css
@@ -440,6 +440,10 @@
     margin-bottom: 0.15rem;
 }
 
+::deep .repositories-table .dependency-badge-tooltip-line code {
+    color: goldenrod;
+}
+
 ::deep .repositories-table .dependency-badge-tooltip-line:last-of-type {
     margin-bottom: 0;
 }

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositoriesRow.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositoriesRow.razor
@@ -158,7 +158,7 @@
                                     @foreach (var line in MismatchedDependencyLines)
                                     {
                                         <div class="dependency-badge-tooltip-line">
-                                            <code>@line.PackageId</code> <span class="dependency-badge-tooltip-versions">@line.CurrentVersion → @line.NewVersion</span>
+                                            <code>@line.PackageId</code> <span class="dependency-badge-tooltip-versions">@line.CurrentVersion <span class="dependency-badge-tooltip-arrow">→</span> <span class="dependency-badge-tooltip-new-version">@line.NewVersion</span></span>
                                         </div>
                                     }
                                     <div class="dependency-badge-tooltip-footer">@(depBadgeOnTag ? "Repository is on a tag; checkout a branch first." : "Click to update this repository only.")</div>

--- a/src/GrayMoon.App/Components/Shared/WorkspaceActionNotificationPanel.razor
+++ b/src/GrayMoon.App/Components/Shared/WorkspaceActionNotificationPanel.razor
@@ -60,7 +60,10 @@
                                                   Outgoing="repo.OutgoingCommits"
                                                   Incoming="repo.IncomingCommits"
                                                   BranchHasUpstream="@(repo.NewBranchNoPush ? false : null)"
-                                                  Disabled="true" />
+                                                  BranchName="repo.BranchName"
+                                                  Disabled="@IsWorkspaceJobRunning(n.WorkspaceId)"
+                                                  OnPushClick="() => OnPushBadgeClickAsync(n, repo)"
+                                                  OnPullClick="() => OnPullBadgeClickAsync(n, repo)" />
                                 }
                             </div>
                         }
@@ -243,6 +246,12 @@
                OnProceed="OnUndoPushProceedAsync"
                OnCancel="CloseUndoPushModal" />
 
+<PushWithDependenciesModal IsVisible="_pushWithDependenciesModal.IsVisible"
+                           Info="_pushWithDependenciesModal.Info"
+                           RepoName="_pushWithDependenciesModal.RepoName"
+                           OnProceed="OnPushWithDependenciesProceedAsync"
+                           OnCancel="ClosePushWithDependenciesModal" />
+
 @code {
     private sealed record DefaultBranchWarningModalState
     {
@@ -269,6 +278,18 @@
     }
 
     private UndoPushModalState _undoPushModal = new();
+
+    private sealed record PushWithDependenciesModalState
+    {
+        public bool IsVisible { get; init; }
+        public PushDependencyInfoForRepo? Info { get; init; }
+        public int WorkspaceId { get; init; }
+        public int RepoId { get; init; }
+        public string? BranchName { get; init; }
+        public string? RepoName { get; init; }
+    }
+
+    private PushWithDependenciesModalState _pushWithDependenciesModal = new();
 
     private static string WorkspaceJobKey(int workspaceId) => $"/workspaces/{workspaceId}";
 
@@ -771,6 +792,181 @@
             ToastService.Show,
             onAppSideComplete: () => { },
             ct);
+    }
+
+    private Task OnPullBadgeClickAsync(WorkspaceNotification n, NotificationRepo repo)
+    {
+        var workspaceId = n.WorkspaceId;
+        if (IsWorkspaceJobRunning(workspaceId)) return Task.CompletedTask;
+        return RunPullSingleRepoAsync(workspaceId, repo.RepositoryId);
+    }
+
+    private Task OnPushBadgeClickAsync(WorkspaceNotification n, NotificationRepo repo)
+    {
+        var workspaceId = n.WorkspaceId;
+        if (IsWorkspaceJobRunning(workspaceId)) return Task.CompletedTask;
+
+        if (!string.IsNullOrWhiteSpace(repo.DefaultBranchName)
+            && string.Equals(repo.BranchName, repo.DefaultBranchName, StringComparison.Ordinal))
+        {
+            ShowDefaultBranchWarning(
+                $"Pushing repository '{repo.RepositoryName}' will commit directly to the default (protected) branch.",
+                new[] { (repo.RepositoryName, repo.DefaultBranchName!) },
+                () => PushBadgeClickCoreAsync(n, repo));
+            return Task.CompletedTask;
+        }
+
+        return PushBadgeClickCoreAsync(n, repo);
+    }
+
+    private async Task PushBadgeClickCoreAsync(WorkspaceNotification n, NotificationRepo repo)
+    {
+        var workspaceId = n.WorkspaceId;
+        if (IsWorkspaceJobRunning(workspaceId)) return;
+
+        try
+        {
+            await using var scope = ServiceScopeFactory.CreateAsyncScope();
+            var depService = scope.ServiceProvider.GetRequiredService<WorkspaceDependencyService>();
+            var repoIdsThatNeedPush = n.Repos
+                .Where(r => r.OutgoingCommits > 0 || r.NewBranchNoPush)
+                .Select(r => r.RepositoryId)
+                .ToHashSet();
+            var depInfo = await depService.GetPushDependencyInfoForRepoAsync(
+                workspaceId,
+                repo.RepositoryId,
+                CancellationToken.None);
+
+            if (depInfo == null || !WorkspaceDependencyService.ShouldShowSynchronizedPushModal(depInfo, repoIdsThatNeedPush))
+            {
+                await StartPushSingleRepoJobAsync(workspaceId, repo.RepositoryId, repo.BranchName);
+                return;
+            }
+
+            _pushWithDependenciesModal = _pushWithDependenciesModal with
+            {
+                IsVisible = true,
+                Info = depInfo,
+                WorkspaceId = workspaceId,
+                RepoId = repo.RepositoryId,
+                BranchName = repo.BranchName,
+                RepoName = repo.RepositoryName,
+            };
+            await InvokeAsync(StateHasChanged);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Notification panel push badge click failed for repository {RepositoryId}", repo.RepositoryId);
+            ToastService.ShowError("Could not load dependency info. Try again.");
+        }
+    }
+
+    private void ClosePushWithDependenciesModal()
+    {
+        _pushWithDependenciesModal = _pushWithDependenciesModal with { IsVisible = false, Info = null };
+        StateHasChanged();
+    }
+
+    private Task OnPushWithDependenciesProceedAsync(bool synchronizedPush)
+    {
+        if (_pushWithDependenciesModal.Info == null) return Task.CompletedTask;
+
+        var workspaceId = _pushWithDependenciesModal.WorkspaceId;
+        var repoId = _pushWithDependenciesModal.RepoId;
+        var repoIds = _pushWithDependenciesModal.Info.DependencyRepoIds.Concat(new[] { repoId }).ToHashSet();
+        var requiredPackageIds = _pushWithDependenciesModal.Info.PayloadForRepo.RequiredPackages
+            .Select(r => r.PackageId?.Trim())
+            .Where(id => !string.IsNullOrEmpty(id))
+            .Cast<string>()
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        ClosePushWithDependenciesModal();
+
+        if (IsWorkspaceJobRunning(workspaceId)) return Task.CompletedTask;
+        PendingActionsService.Dismiss(workspaceId);
+        JobService.StartJob(WorkspaceJobKey(workspaceId), "Preparing push...", async (job, ct) =>
+        {
+            try
+            {
+                await using var scope = ServiceScopeFactory.CreateAsyncScope();
+                var pushHandler = scope.ServiceProvider.GetRequiredService<WorkspacePushHandler>();
+                await pushHandler.RunPushWithDependenciesAsync(
+                    workspaceId,
+                    repoIds,
+                    synchronizedPush,
+                    requiredPackageIds,
+                    job.ReportProgress,
+                    ToastService.Show,
+                    onAppSideComplete: () => { },
+                    ct);
+            }
+            catch (OperationCanceledException) { throw; }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "Notification panel push with dependencies failed for workspace {WorkspaceId}", workspaceId);
+                if (!_disposed) _ = InvokeAsync(() => ToastService.ShowError("Push failed."));
+                throw;
+            }
+        });
+        return Task.CompletedTask;
+    }
+
+    private Task StartPushSingleRepoJobAsync(int workspaceId, int repositoryId, string? branchName)
+    {
+        if (IsWorkspaceJobRunning(workspaceId)) return Task.CompletedTask;
+        PendingActionsService.Dismiss(workspaceId);
+        JobService.StartJob(WorkspaceJobKey(workspaceId), "Setting upstream...", async (job, ct) =>
+        {
+            try
+            {
+                await using var scope = ServiceScopeFactory.CreateAsyncScope();
+                var pushHandler = scope.ServiceProvider.GetRequiredService<WorkspacePushHandler>();
+                var (success, pushError) = await pushHandler.PushSingleRepositoryWithUpstreamAsync(
+                    workspaceId,
+                    repositoryId,
+                    branchName,
+                    job.ReportProgress,
+                    ct);
+                if (!success && !_disposed)
+                    _ = InvokeAsync(() => ToastService.ShowError(pushError ?? "Push failed."));
+            }
+            catch (OperationCanceledException) { throw; }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "Notification panel single-repo push failed for repository {RepositoryId}", repositoryId);
+                if (!_disposed) _ = InvokeAsync(() => ToastService.ShowError("Push failed."));
+                throw;
+            }
+        });
+        return Task.CompletedTask;
+    }
+
+    private Task RunPullSingleRepoAsync(int workspaceId, int repositoryId)
+    {
+        if (IsWorkspaceJobRunning(workspaceId)) return Task.CompletedTask;
+        PendingActionsService.Dismiss(workspaceId);
+        JobService.StartJob(WorkspaceJobKey(workspaceId), "Synchronizing commits...", async (job, ct) =>
+        {
+            try
+            {
+                await using var scope = ServiceScopeFactory.CreateAsyncScope();
+                var commitSyncHandler = scope.ServiceProvider.GetRequiredService<WorkspaceCommitSyncHandler>();
+                await commitSyncHandler.CommitSyncAsync(
+                    workspaceId,
+                    repositoryId,
+                    ct,
+                    msg => { job.ReportProgress(msg); return Task.CompletedTask; },
+                    (_, _) => { },
+                    _ => { });
+            }
+            catch (OperationCanceledException) { throw; }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "Notification panel pull failed for repository {RepositoryId}", repositoryId);
+                if (!_disposed) _ = InvokeAsync(() => ToastService.ShowError("Pull failed."));
+                throw;
+            }
+        });
+        return Task.CompletedTask;
     }
 
     private Task RunPullAsync(int workspaceId)

--- a/src/GrayMoon.App/wwwroot/app.css
+++ b/src/GrayMoon.App/wwwroot/app.css
@@ -420,6 +420,19 @@ h1:focus {
     color: var(--text-primary) !important;
 }
 
+/* Dependency badge tooltip: restore per-element colors.
+   Uses 4 class selectors to beat the (0,3,3) specificity of the rule above. */
+.table .dependency-badge-tooltip-wrap .dependency-badge-tooltip .dependency-badge-tooltip-line code {
+    color: goldenrod !important;
+}
+.table .dependency-badge-tooltip-wrap .dependency-badge-tooltip .dependency-badge-tooltip-versions .dependency-badge-tooltip-arrow {
+    color: rgba(255, 255, 255, 0.45) !important;
+    font-size: 0.95rem;
+}
+.table .dependency-badge-tooltip-wrap .dependency-badge-tooltip .dependency-badge-tooltip-versions .dependency-badge-tooltip-new-version {
+    color: goldenrod !important;
+}
+
 /* Last row of every grid: no bottom border */
 .table tbody tr:last-child td,
 .table tbody tr:last-child th {


### PR DESCRIPTION
## Summary

- Re-scan `.csproj` references during post-commit hook sync so workspace dependency state updates immediately after a commit
- Enable push and pull from workspace notification badges, including synchronized push with dependencies, default-branch warnings, and background job orchestration
- Highlight package IDs and target versions in dependency badge tooltips with goldenrod styling and clearer version arrow formatting
- Document migration column workflow and test coverage notes in `CLAUDE.md`

## Test plan

- [ ] Commit in a workspace repo and confirm dependency/package reference data refreshes without a manual sync
- [ ] From a notification card, push a single repo and verify upstream setup and push complete
- [ ] Push a repo with downstream dependencies and confirm the synchronized push modal appears and both paths work
- [ ] Pull from a notification badge and confirm commit sync runs successfully
- [ ] Hover dependency badges on the repositories grid and confirm package names and new versions render in goldenrod
- [ ] Confirm notification push/pull actions are disabled while a workspace background job is running