### PR TITLE
Add file version tracking, custom repo dependencies, and combined dependency ordering

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,15 +97,29 @@ Three orchestrators coordinate multi-step workflows across repositories:
 
 ### Dependency levels
 
-Workspace repositories are topologically sorted into dependency levels (Kahn's algorithm). Level 1 = no dependencies; higher levels depend on lower ones. This drives: grid grouping, push ordering (synchronized push waits for NuGet availability level-by-level), and the dependency update flow.
+Workspace repositories are topologically sorted into dependency levels (Kahn's algorithm). Level 1 = no dependencies; higher levels depend on lower ones. This drives: grid grouping, push ordering (synchronized push waits for NuGet availability level-by-level), and the dependency update flow. Dependency edges come from three sources, all merged before the sort runs: (1) csproj `<PackageReference>` entries, (2) file-config token names (`{repositoryname}` in `WorkspaceFileVersionConfig` patterns), and (3) user-declared `WorkspaceRepositoryCustomDependencies` edges.
 
 ### Token encryption
 
 Connector tokens are AES-256-GCM encrypted at rest via `AesGcmTokenProtector` (backed by ASP.NET Core Data Protection). Keys live in `/app/db/DataProtection-Keys/`. All git remote operations pass the token at runtime via `-c http.extraHeader="Authorization: Basic ..."` — tokens are never written to disk by the Agent.
 
+### File versioning
+
+`WorkspaceFiles` (`/workspaces/{id}/files`) lets users pin arbitrary files from workspace repos. Each file can have a `WorkspaceFileVersionConfig` with a multi-line version pattern (`KEY={repositoryname}` per line) that maps file content tokens to workspace repo names.
+
+- **`WorkspaceFileVersionService`** - two main operations: `UpdateAllVersionsAsync` (calls `UpdateFileVersions` agent command to do in-place token substitution) and `CheckAndPersistFileVersionStatusAsync` (calls `CheckFileVersions` agent command, persists results to `WorkspaceFileLineStatuses`, updates `OutOfDateFileRepos`/`TotalFileConfigRepos` counters on `WorkspaceRepositories`). Concurrent callers for the same workspace coalesce onto one in-flight check unless `forceFresh: true`.
+- **`WorkspaceFileLineStatuses`** - one row per out-of-date token per file. Stores `TokenName`, `CurrentValue`, `ExpectedValue`. Cleared and rebuilt on every check.
+- **`WorkspaceFile.IsMissingOnDisk`** - nullable bool set by `CheckFileVersions` when the file path no longer exists. Missing files are excluded from badge computation and version update.
+- Agent commands `CheckFileVersions` and `UpdateFileVersions` live in `src/GrayMoon.Agent/Commands/`.
+- File-config token names also contribute dependency edges to the topological sort (alongside csproj project deps). `ImplicitReferencedRepoIdsBySource` separates `FromProject` vs `FromFile` for badge tooltip clarity.
+
+### Custom dependencies
+
+`WorkspaceRepositoryCustomDependencies` lets users declare explicit ordering edges between workspace repos. These user-declared edges are merged with csproj-derived and file-config-derived edges before Kahn's algorithm runs. Managed via `WorkspaceRepositoryCustomDependencyRepository` and the `CustomDependenciesModal`.
+
 ### Database schema
 
-Schema is owned by EF Core but applied via `EnsureCreated()`. Core tables: `Connectors`, `Repositories`, `Workspaces`, `WorkspaceRepositories` (join with live state), `WorkspaceRepositoryPullRequest` (1:1 with link), `WorkspaceProject`, `ProjectDependency`, `WorkspaceFile`, `WorkspaceFileVersionConfig`, `RepositoryBranch`, `Settings`.
+Schema is owned by EF Core but applied via `EnsureCreated()`. Core tables: `Connectors`, `Repositories`, `Workspaces`, `WorkspaceRepositories` (join with live state), `WorkspaceRepositoryPullRequest` (1:1 with link), `WorkspaceRepositoryActions` (CI status per link), `WorkspaceProject`, `ProjectDependency`, `WorkspaceFile`, `WorkspaceFileVersionConfig`, `WorkspaceFileLineStatuses`, `WorkspaceRepositoryCustomDependencies`, `RepositoryBranch`, `Settings`.
 
 After `EnsureCreated()`, startup calls `Migrations.RunAllAsync(dbContext)` (`src/GrayMoon.App/Migrations.cs`). Each migration is an idempotent `ALTER TABLE` guarded by `pragma_table_info()`. To add a new column: add a `public static async Task MigrateXxxAsync(AppDbContext dbContext)` method to `Migrations.cs` (check `pragma_table_info('TableName') WHERE name='ColumnName'` before executing the `ALTER TABLE`), then call it at the end of `RunAllAsync`. No EF Core migration assembly is used.
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,19 @@ Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManage
 
 ## What's new
 
+### File version config validation
+
+The version configuration dialog now validates pattern lines against the actual file on disk and highlights any that cannot be matched.
+
+- **On dialog open:** as soon as the dialog appears, GrayMoon calls the agent to scan the file and checks which configured pattern lines exist. Results appear within a second.
+- **While editing:** after 2 seconds of inactivity in the textarea, the check reruns automatically so you get immediate feedback without any button click.
+- **Red badges for missing lines:** token names whose pattern line is not found in the file appear as red badges below the textarea under "Not found in file:". Tokens that ARE found (even with a wrong version) are not flagged here.
+- **"Checking file..." indicator:** a small muted label appears while the agent call is in flight so you know validation is running.
+
+### Missing file lines no longer counted as out of date
+
+When a configured version pattern line does not exist in the file (for example a `PackageReference` was removed from a `.csproj` or a variable was dropped from a `.env`), GrayMoon previously counted it as out of date and showed it in the dependency tooltip as `-> expected-version` with nothing on the left. Those absent lines are now silently ignored: they do not contribute to the "X of Y" out-of-date badge count and produce no row in the file dependency tooltip. Only lines that actually exist in the file but carry a different version from the expected one are reported as out of date.
+
 ### One-click agent update from the badge
 
 When the agent version does not match the app, the header badge shows a red **update** label. Clicking it now triggers a self-update directly - no need to visit the Agent page and copy a command.

--- a/src/GrayMoon.Abstractions/Agent/AgentHubMethods.cs
+++ b/src/GrayMoon.Abstractions/Agent/AgentHubMethods.cs
@@ -25,4 +25,7 @@ public static class AgentHubMethods
 
     /// <summary>App → Agent: request agent self-update (InstallUrl in payload).</summary>
     public const string SelfUpdate = "SelfUpdate";
+
+    /// <summary>App → Agent: check configured version files and return per-line staleness (read-only, no file writes).</summary>
+    public const string CheckFileVersions = "CheckFileVersions";
 }

--- a/src/GrayMoon.Agent/Cli/Handlers/RunCommandHandler.cs
+++ b/src/GrayMoon.Agent/Cli/Handlers/RunCommandHandler.cs
@@ -123,6 +123,7 @@ internal static class RunCommandHandler
         builder.Services.AddSingleton<ICommandHandler<PushRepositoryRequest, PushRepositoryResponse>, PushRepositoryCommand>();
         builder.Services.AddSingleton<ICommandHandler<SearchFilesRequest, SearchFilesResponse>, SearchFilesCommand>();
         builder.Services.AddSingleton<ICommandHandler<UpdateFileVersionsRequest, UpdateFileVersionsResponse>, UpdateFileVersionsCommand>();
+        builder.Services.AddSingleton<ICommandHandler<CheckFileVersionsRequest, CheckFileVersionsResponse>, CheckFileVersionsCommand>();
         builder.Services.AddSingleton<ICommandHandler<GetFileContentsRequest, GetFileContentsResponse>, GetFileContentsCommand>();
         builder.Services.AddSingleton<ICommandHandler<ValidatePathRequest, ValidatePathResponse>, ValidatePathCommand>();
         builder.Services.AddSingleton<ICommandHandler<DotnetRestoreRequest, DotnetRestoreResponse>, DotnetRestoreCommand>();

--- a/src/GrayMoon.Agent/Commands/CheckFileVersionsCommand.cs
+++ b/src/GrayMoon.Agent/Commands/CheckFileVersionsCommand.cs
@@ -32,6 +32,12 @@ public sealed class CheckFileVersionsCommand(IGitService git) : ICommandHandler<
             var fullFilePath = Path.Combine(repoPath, filePath.Replace('/', Path.DirectorySeparatorChar));
             var fileName = Path.GetFileName(fullFilePath);
 
+            var patternEntries = ParsePatternLines(pattern);
+            if (patternEntries.Count == 0)
+                continue;
+
+            var expectedTokenCount = patternEntries.Count(e => expectedVersions.ContainsKey(e.RepoName));
+
             if (!File.Exists(fullFilePath))
             {
                 results.Add(new CheckFileVersionsResult
@@ -40,18 +46,16 @@ public sealed class CheckFileVersionsCommand(IGitService git) : ICommandHandler<
                     FilePath = filePath,
                     FileName = fileName,
                     TotalMatchedLines = 0,
-                    OutOfDateLines = []
+                    ExpectedTokenCount = expectedTokenCount,
+                    OutOfDateLines = BuildMissingTokenLines(patternEntries, expectedVersions, matchedTokens: null)
                 });
                 continue;
             }
 
-            var patternEntries = ParsePatternLines(pattern);
-            if (patternEntries.Count == 0)
-                continue;
-
             var fileLines = await File.ReadAllLinesAsync(fullFilePath, cancellationToken);
             var totalMatchedLines = 0;
             var outOfDateLines = new List<CheckFileVersionsOutOfDateLine>();
+            var matchedTokens = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
             foreach (var line in fileLines)
             {
@@ -67,6 +71,7 @@ public sealed class CheckFileVersionsCommand(IGitService git) : ICommandHandler<
                     var valueEnd = suffix.Length > 0 ? trimmedLine.Length - suffix.Length : trimmedLine.Length;
                     var currentValue = trimmedLine[prefix.Length..valueEnd];
                     totalMatchedLines++;
+                    matchedTokens.Add(repoName);
 
                     if (expectedVersions.TryGetValue(repoName, out var expectedValue) && currentValue != expectedValue)
                     {
@@ -81,17 +86,48 @@ public sealed class CheckFileVersionsCommand(IGitService git) : ICommandHandler<
                 }
             }
 
+            foreach (var missing in BuildMissingTokenLines(patternEntries, expectedVersions, matchedTokens))
+            {
+                if (!outOfDateLines.Any(o => string.Equals(o.TokenName, missing.TokenName, StringComparison.OrdinalIgnoreCase)))
+                    outOfDateLines.Add(missing);
+            }
+
             results.Add(new CheckFileVersionsResult
             {
                 RepositoryName = repositoryName,
                 FilePath = filePath,
                 FileName = fileName,
                 TotalMatchedLines = totalMatchedLines,
+                ExpectedTokenCount = expectedTokenCount,
                 OutOfDateLines = outOfDateLines
             });
         }
 
         return new CheckFileVersionsResponse { Files = results };
+    }
+
+    private static List<CheckFileVersionsOutOfDateLine> BuildMissingTokenLines(
+        IReadOnlyList<(string Prefix, string RepoName, string Suffix)> patternEntries,
+        IReadOnlyDictionary<string, string> expectedVersions,
+        IReadOnlySet<string>? matchedTokens)
+    {
+        var missing = new List<CheckFileVersionsOutOfDateLine>();
+        foreach (var (_, repoName, _) in patternEntries)
+        {
+            if (!expectedVersions.TryGetValue(repoName, out var expectedValue))
+                continue;
+            if (matchedTokens != null && matchedTokens.Contains(repoName))
+                continue;
+
+            missing.Add(new CheckFileVersionsOutOfDateLine
+            {
+                TokenName = repoName,
+                CurrentValue = "",
+                ExpectedValue = expectedValue
+            });
+        }
+
+        return missing;
     }
 
     private static List<(string Prefix, string RepoName, string Suffix)> ParsePatternLines(string pattern)

--- a/src/GrayMoon.Agent/Commands/CheckFileVersionsCommand.cs
+++ b/src/GrayMoon.Agent/Commands/CheckFileVersionsCommand.cs
@@ -1,10 +1,11 @@
 using GrayMoon.Agent.Abstractions;
 using GrayMoon.Agent.Jobs.Requests;
 using GrayMoon.Agent.Jobs.Response;
+using Microsoft.Extensions.Logging;
 
 namespace GrayMoon.Agent.Commands;
 
-public sealed class CheckFileVersionsCommand(IGitService git) : ICommandHandler<CheckFileVersionsRequest, CheckFileVersionsResponse>
+public sealed class CheckFileVersionsCommand(IGitService git, ILogger<CheckFileVersionsCommand> logger) : ICommandHandler<CheckFileVersionsRequest, CheckFileVersionsResponse>
 {
     public async Task<CheckFileVersionsResponse> ExecuteAsync(CheckFileVersionsRequest request, CancellationToken cancellationToken = default)
     {
@@ -74,14 +75,21 @@ public sealed class CheckFileVersionsCommand(IGitService git) : ICommandHandler<
                     totalMatchedLines++;
                     matchedTokens.Add(repoName);
 
-                    if (expectedVersions.TryGetValue(repoName, out var expectedValue) && currentValue != expectedValue)
+                    if (expectedVersions.TryGetValue(repoName, out var expectedValue))
                     {
-                        outOfDateLines.Add(new CheckFileVersionsOutOfDateLine
+                        var match = currentValue == expectedValue;
+                        logger.LogInformation(
+                            "CheckFileVersions {FilePath} token {Token}: current={Current} expected={Expected} match={Match}",
+                            filePath, repoName, currentValue, expectedValue, match);
+                        if (!match)
                         {
-                            TokenName = repoName,
-                            CurrentValue = currentValue,
-                            ExpectedValue = expectedValue
-                        });
+                            outOfDateLines.Add(new CheckFileVersionsOutOfDateLine
+                            {
+                                TokenName = repoName,
+                                CurrentValue = currentValue,
+                                ExpectedValue = expectedValue
+                            });
+                        }
                     }
                     break;
                 }
@@ -90,7 +98,12 @@ public sealed class CheckFileVersionsCommand(IGitService git) : ICommandHandler<
             foreach (var missing in BuildMissingTokenLines(patternEntries, expectedVersions, matchedTokens))
             {
                 if (!outOfDateLines.Any(o => string.Equals(o.TokenName, missing.TokenName, StringComparison.OrdinalIgnoreCase)))
+                {
+                    logger.LogInformation(
+                        "CheckFileVersions {FilePath} token {Token}: NOT FOUND in file (expected={Expected})",
+                        filePath, missing.TokenName, missing.ExpectedValue);
                     outOfDateLines.Add(missing);
+                }
             }
 
             results.Add(new CheckFileVersionsResult

--- a/src/GrayMoon.Agent/Commands/CheckFileVersionsCommand.cs
+++ b/src/GrayMoon.Agent/Commands/CheckFileVersionsCommand.cs
@@ -1,0 +1,125 @@
+using GrayMoon.Agent.Abstractions;
+using GrayMoon.Agent.Jobs.Requests;
+using GrayMoon.Agent.Jobs.Response;
+
+namespace GrayMoon.Agent.Commands;
+
+public sealed class CheckFileVersionsCommand(IGitService git) : ICommandHandler<CheckFileVersionsRequest, CheckFileVersionsResponse>
+{
+    public async Task<CheckFileVersionsResponse> ExecuteAsync(CheckFileVersionsRequest request, CancellationToken cancellationToken = default)
+    {
+        var workspaceName = request.WorkspaceName ?? throw new ArgumentException("workspaceName required");
+        var items = request.Files;
+        if (items == null || items.Count == 0)
+            return new CheckFileVersionsResponse { Files = [] };
+
+        var workspacePath = git.GetWorkspacePath(request.WorkspaceRoot!, workspaceName);
+        var results = new List<CheckFileVersionsResult>();
+
+        foreach (var item in items)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var repositoryName = item.RepositoryName;
+            var filePath = item.FilePath;
+            var pattern = item.Pattern;
+            var expectedVersions = item.ExpectedVersions ?? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+            if (string.IsNullOrWhiteSpace(repositoryName) || string.IsNullOrWhiteSpace(filePath) || string.IsNullOrWhiteSpace(pattern))
+                continue;
+
+            var repoPath = Path.Combine(workspacePath, repositoryName);
+            var fullFilePath = Path.Combine(repoPath, filePath.Replace('/', Path.DirectorySeparatorChar));
+            var fileName = Path.GetFileName(fullFilePath);
+
+            if (!File.Exists(fullFilePath))
+            {
+                results.Add(new CheckFileVersionsResult
+                {
+                    RepositoryName = repositoryName,
+                    FilePath = filePath,
+                    FileName = fileName,
+                    TotalMatchedLines = 0,
+                    OutOfDateLines = []
+                });
+                continue;
+            }
+
+            var patternEntries = ParsePatternLines(pattern);
+            if (patternEntries.Count == 0)
+                continue;
+
+            var fileLines = await File.ReadAllLinesAsync(fullFilePath, cancellationToken);
+            var totalMatchedLines = 0;
+            var outOfDateLines = new List<CheckFileVersionsOutOfDateLine>();
+
+            foreach (var line in fileLines)
+            {
+                var (_, contentStart) = GetLeadingWhitespace(line);
+                var trimmedLine = contentStart >= line.Length ? "" : line[contentStart..];
+
+                foreach (var (prefix, repoName, suffix) in patternEntries)
+                {
+                    if (!trimmedLine.StartsWith(prefix, StringComparison.Ordinal)) continue;
+                    if (suffix.Length > 0 && (trimmedLine.Length < prefix.Length + suffix.Length || !trimmedLine.EndsWith(suffix, StringComparison.Ordinal)))
+                        continue;
+
+                    var valueEnd = suffix.Length > 0 ? trimmedLine.Length - suffix.Length : trimmedLine.Length;
+                    var currentValue = trimmedLine[prefix.Length..valueEnd];
+                    totalMatchedLines++;
+
+                    if (expectedVersions.TryGetValue(repoName, out var expectedValue) && currentValue != expectedValue)
+                    {
+                        outOfDateLines.Add(new CheckFileVersionsOutOfDateLine
+                        {
+                            TokenName = repoName,
+                            CurrentValue = currentValue,
+                            ExpectedValue = expectedValue
+                        });
+                    }
+                    break;
+                }
+            }
+
+            results.Add(new CheckFileVersionsResult
+            {
+                RepositoryName = repositoryName,
+                FilePath = filePath,
+                FileName = fileName,
+                TotalMatchedLines = totalMatchedLines,
+                OutOfDateLines = outOfDateLines
+            });
+        }
+
+        return new CheckFileVersionsResponse { Files = results };
+    }
+
+    private static List<(string Prefix, string RepoName, string Suffix)> ParsePatternLines(string pattern)
+    {
+        var result = new List<(string, string, string)>();
+        foreach (var raw in pattern.Split('\n'))
+        {
+            var line = raw.Trim().TrimEnd('\r');
+            if (string.IsNullOrEmpty(line)) continue;
+
+            var start = line.IndexOf('{');
+            var end = line.IndexOf('}', start >= 0 ? start : 0);
+            if (start < 1 || end <= start) continue;
+
+            var prefix = line[..start];
+            var repoName = line[(start + 1)..end];
+            var suffix = end + 1 < line.Length ? line[(end + 1)..] : "";
+            if (string.IsNullOrEmpty(prefix) || string.IsNullOrEmpty(repoName)) continue;
+
+            result.Add((prefix, repoName, suffix));
+        }
+        return result;
+    }
+
+    private static (string LeadingWhitespace, int ContentStart) GetLeadingWhitespace(string line)
+    {
+        var i = 0;
+        while (i < line.Length && char.IsWhiteSpace(line[i])) i++;
+        return (line[..i], i);
+    }
+}

--- a/src/GrayMoon.Agent/Commands/CheckFileVersionsCommand.cs
+++ b/src/GrayMoon.Agent/Commands/CheckFileVersionsCommand.cs
@@ -47,7 +47,8 @@ public sealed class CheckFileVersionsCommand(IGitService git) : ICommandHandler<
                     FileName = fileName,
                     TotalMatchedLines = 0,
                     ExpectedTokenCount = expectedTokenCount,
-                    OutOfDateLines = BuildMissingTokenLines(patternEntries, expectedVersions, matchedTokens: null)
+                    FileMissing = true,
+                    OutOfDateLines = []
                 });
                 continue;
             }

--- a/src/GrayMoon.Agent/Commands/CheckFileVersionsCommand.cs
+++ b/src/GrayMoon.Agent/Commands/CheckFileVersionsCommand.cs
@@ -95,15 +95,17 @@ public sealed class CheckFileVersionsCommand(IGitService git, ILogger<CheckFileV
                 }
             }
 
-            foreach (var missing in BuildMissingTokenLines(patternEntries, expectedVersions, matchedTokens))
+            var notMatchedTokens = patternEntries
+                .Select(e => e.RepoName)
+                .Where(r => !matchedTokens.Contains(r))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            foreach (var token in notMatchedTokens)
             {
-                if (!outOfDateLines.Any(o => string.Equals(o.TokenName, missing.TokenName, StringComparison.OrdinalIgnoreCase)))
-                {
-                    logger.LogInformation(
-                        "CheckFileVersions {FilePath} token {Token}: NOT FOUND in file (expected={Expected})",
-                        filePath, missing.TokenName, missing.ExpectedValue);
-                    outOfDateLines.Add(missing);
-                }
+                logger.LogInformation(
+                    "CheckFileVersions {FilePath} token {Token}: NOT FOUND in file (not counted as out-of-date)",
+                    filePath, token);
             }
 
             results.Add(new CheckFileVersionsResult
@@ -113,35 +115,12 @@ public sealed class CheckFileVersionsCommand(IGitService git, ILogger<CheckFileV
                 FileName = fileName,
                 TotalMatchedLines = totalMatchedLines,
                 ExpectedTokenCount = expectedTokenCount,
-                OutOfDateLines = outOfDateLines
+                OutOfDateLines = outOfDateLines,
+                NotMatchedTokens = notMatchedTokens
             });
         }
 
         return new CheckFileVersionsResponse { Files = results };
-    }
-
-    private static List<CheckFileVersionsOutOfDateLine> BuildMissingTokenLines(
-        IReadOnlyList<(string Prefix, string RepoName, string Suffix)> patternEntries,
-        IReadOnlyDictionary<string, string> expectedVersions,
-        IReadOnlySet<string>? matchedTokens)
-    {
-        var missing = new List<CheckFileVersionsOutOfDateLine>();
-        foreach (var (_, repoName, _) in patternEntries)
-        {
-            if (!expectedVersions.TryGetValue(repoName, out var expectedValue))
-                continue;
-            if (matchedTokens != null && matchedTokens.Contains(repoName))
-                continue;
-
-            missing.Add(new CheckFileVersionsOutOfDateLine
-            {
-                TokenName = repoName,
-                CurrentValue = "",
-                ExpectedValue = expectedValue
-            });
-        }
-
-        return missing;
     }
 
     private static List<(string Prefix, string RepoName, string Suffix)> ParsePatternLines(string pattern)

--- a/src/GrayMoon.Agent/Commands/CommitHookSyncCommand.cs
+++ b/src/GrayMoon.Agent/Commands/CommitHookSyncCommand.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using GrayMoon.Abstractions.Agent;
 using GrayMoon.Abstractions.Notifications;
 using GrayMoon.Agent.Abstractions;
@@ -98,9 +99,14 @@ public sealed class CommitHookSyncCommand(IGitService git, ICsProjFileService cs
                 Projects = syncProjects,
                 ErrorMessage = null
             };
+            var syncSw = Stopwatch.StartNew();
+            logger.LogDebug(
+                "CommitHookSync invoking SyncCommand: workspace={WorkspaceId}, repo={RepoId}",
+                payload.WorkspaceId, payload.RepositoryId);
             await connection.InvokeAsync(AgentHubMethods.SyncCommand, notification, cancellationToken);
-            logger.LogInformation("CommitHookSync sent: workspace={WorkspaceId}, repo={RepoId}, version={Version}, branch={Branch}, ↑{Outgoing} ↓{Incoming}, hasUpstream={HasUpstream}",
-                payload.WorkspaceId, payload.RepositoryId, version, branch, outgoing, incoming, hasUpstream);
+            logger.LogInformation(
+                "CommitHookSync SyncCommand returned in {ElapsedMs}ms: workspace={WorkspaceId}, repo={RepoId}, version={Version}, branch={Branch}, ↑{Outgoing} ↓{Incoming}, hasUpstream={HasUpstream}",
+                syncSw.ElapsedMilliseconds, payload.WorkspaceId, payload.RepositoryId, version, branch, outgoing, incoming, hasUpstream);
         }
         else
         {

--- a/src/GrayMoon.Agent/Jobs/Requests/CheckFileVersionsRequest.cs
+++ b/src/GrayMoon.Agent/Jobs/Requests/CheckFileVersionsRequest.cs
@@ -1,0 +1,17 @@
+using System.Text.Json.Serialization;
+
+namespace GrayMoon.Agent.Jobs.Requests;
+
+public sealed class CheckFileVersionsRequest : WorkspaceCommandRequest
+{
+    [JsonPropertyName("workspaceName")] public string? WorkspaceName { get; set; }
+    [JsonPropertyName("files")] public List<CheckFileVersionsItem>? Files { get; set; }
+}
+
+public sealed class CheckFileVersionsItem
+{
+    [JsonPropertyName("repositoryName")] public string? RepositoryName { get; set; }
+    [JsonPropertyName("filePath")] public string? FilePath { get; set; }
+    [JsonPropertyName("pattern")] public string? Pattern { get; set; }
+    [JsonPropertyName("expectedVersions")] public Dictionary<string, string>? ExpectedVersions { get; set; }
+}

--- a/src/GrayMoon.Agent/Jobs/Response/CheckFileVersionsResponse.cs
+++ b/src/GrayMoon.Agent/Jobs/Response/CheckFileVersionsResponse.cs
@@ -14,6 +14,7 @@ public sealed class CheckFileVersionsResult
     [JsonPropertyName("fileName")] public string? FileName { get; set; }
     [JsonPropertyName("totalMatchedLines")] public int TotalMatchedLines { get; set; }
     [JsonPropertyName("expectedTokenCount")] public int ExpectedTokenCount { get; set; }
+    [JsonPropertyName("fileMissing")] public bool FileMissing { get; set; }
     [JsonPropertyName("outOfDateLines")] public List<CheckFileVersionsOutOfDateLine>? OutOfDateLines { get; set; }
 }
 

--- a/src/GrayMoon.Agent/Jobs/Response/CheckFileVersionsResponse.cs
+++ b/src/GrayMoon.Agent/Jobs/Response/CheckFileVersionsResponse.cs
@@ -13,6 +13,7 @@ public sealed class CheckFileVersionsResult
     [JsonPropertyName("filePath")] public string? FilePath { get; set; }
     [JsonPropertyName("fileName")] public string? FileName { get; set; }
     [JsonPropertyName("totalMatchedLines")] public int TotalMatchedLines { get; set; }
+    [JsonPropertyName("expectedTokenCount")] public int ExpectedTokenCount { get; set; }
     [JsonPropertyName("outOfDateLines")] public List<CheckFileVersionsOutOfDateLine>? OutOfDateLines { get; set; }
 }
 

--- a/src/GrayMoon.Agent/Jobs/Response/CheckFileVersionsResponse.cs
+++ b/src/GrayMoon.Agent/Jobs/Response/CheckFileVersionsResponse.cs
@@ -1,0 +1,24 @@
+using System.Text.Json.Serialization;
+
+namespace GrayMoon.Agent.Jobs.Response;
+
+public sealed class CheckFileVersionsResponse
+{
+    [JsonPropertyName("files")] public List<CheckFileVersionsResult>? Files { get; set; }
+}
+
+public sealed class CheckFileVersionsResult
+{
+    [JsonPropertyName("repositoryName")] public string? RepositoryName { get; set; }
+    [JsonPropertyName("filePath")] public string? FilePath { get; set; }
+    [JsonPropertyName("fileName")] public string? FileName { get; set; }
+    [JsonPropertyName("totalMatchedLines")] public int TotalMatchedLines { get; set; }
+    [JsonPropertyName("outOfDateLines")] public List<CheckFileVersionsOutOfDateLine>? OutOfDateLines { get; set; }
+}
+
+public sealed class CheckFileVersionsOutOfDateLine
+{
+    [JsonPropertyName("tokenName")] public string? TokenName { get; set; }
+    [JsonPropertyName("currentValue")] public string? CurrentValue { get; set; }
+    [JsonPropertyName("expectedValue")] public string? ExpectedValue { get; set; }
+}

--- a/src/GrayMoon.Agent/Jobs/Response/CheckFileVersionsResponse.cs
+++ b/src/GrayMoon.Agent/Jobs/Response/CheckFileVersionsResponse.cs
@@ -16,6 +16,7 @@ public sealed class CheckFileVersionsResult
     [JsonPropertyName("expectedTokenCount")] public int ExpectedTokenCount { get; set; }
     [JsonPropertyName("fileMissing")] public bool FileMissing { get; set; }
     [JsonPropertyName("outOfDateLines")] public List<CheckFileVersionsOutOfDateLine>? OutOfDateLines { get; set; }
+    [JsonPropertyName("notMatchedTokens")] public List<string> NotMatchedTokens { get; set; } = [];
 }
 
 public sealed class CheckFileVersionsOutOfDateLine

--- a/src/GrayMoon.Agent/Services/CommandDispatcher.cs
+++ b/src/GrayMoon.Agent/Services/CommandDispatcher.cs
@@ -33,7 +33,8 @@ public sealed class CommandDispatcher(
     ICommandHandler<ValidatePathRequest, ValidatePathResponse> validatePathCommand,
     ICommandHandler<DotnetRestoreRequest, DotnetRestoreResponse> dotnetRestoreCommand,
     ICommandHandler<UndoPushRequest, UndoPushResponse> undoPushCommand,
-    ICommandHandler<SelfUpdateRequest, SelfUpdateResponse> selfUpdateCommand) : ICommandDispatcher
+    ICommandHandler<SelfUpdateRequest, SelfUpdateResponse> selfUpdateCommand,
+    ICommandHandler<CheckFileVersionsRequest, CheckFileVersionsResponse> checkFileVersionsCommand) : ICommandDispatcher
 {
     private readonly IReadOnlyDictionary<string, Func<object, CancellationToken, Task<object?>>> _executors = new Dictionary<string, Func<object, CancellationToken, Task<object?>>>(StringComparer.Ordinal)
     {
@@ -65,6 +66,7 @@ public sealed class CommandDispatcher(
         ["DotnetRestore"] = async (req, ct) => await dotnetRestoreCommand.ExecuteAsync((DotnetRestoreRequest)req, ct),
         ["UndoPush"] = async (req, ct) => await undoPushCommand.ExecuteAsync((UndoPushRequest)req, ct),
         [AgentHubMethods.SelfUpdate] = async (req, ct) => await selfUpdateCommand.ExecuteAsync((SelfUpdateRequest)req, ct),
+        [AgentHubMethods.CheckFileVersions] = async (req, ct) => await checkFileVersionsCommand.ExecuteAsync((CheckFileVersionsRequest)req, ct),
     };
 
     public Task<object?> ExecuteAsync(string commandName, object request, CancellationToken cancellationToken = default)

--- a/src/GrayMoon.Agent/Services/CommandJobFactory.cs
+++ b/src/GrayMoon.Agent/Services/CommandJobFactory.cs
@@ -88,6 +88,8 @@ public sealed class CommandJobFactory
                 ?? throw new ArgumentException("Invalid UndoPush args"),
             AgentHubMethods.SelfUpdate => JsonSerializer.Deserialize<SelfUpdateRequest>(json, options)
                 ?? throw new ArgumentException("Invalid SelfUpdate args"),
+            AgentHubMethods.CheckFileVersions => JsonSerializer.Deserialize<CheckFileVersionsRequest>(json, options)
+                ?? throw new ArgumentException("Invalid CheckFileVersions args"),
             _ => throw new NotSupportedException($"Unknown command: {command}")
         };
     }

--- a/src/GrayMoon.App/Api/Endpoints/WorkspaceEndpoints.cs
+++ b/src/GrayMoon.App/Api/Endpoints/WorkspaceEndpoints.cs
@@ -35,7 +35,8 @@ public static class WorkspaceEndpoints
             RepositoryId = f.RepositoryId,
             RepositoryName = f.Repository?.RepositoryName,
             FileName = f.FileName,
-            FilePath = f.FilePath
+            FilePath = f.FilePath,
+            IsMissingOnDisk = f.IsMissingOnDisk == true
         }).ToList();
         return TypedResults.Ok(dtos);
     }
@@ -111,6 +112,7 @@ public sealed class WorkspaceFileDto
     public string? RepositoryName { get; set; }
     public string FileName { get; set; } = string.Empty;
     public string FilePath { get; set; } = string.Empty;
+    public bool IsMissingOnDisk { get; set; }
 }
 
 public sealed class AddWorkspaceFileRequest

--- a/src/GrayMoon.App/Components/App.razor
+++ b/src/GrayMoon.App/Components/App.razor
@@ -23,6 +23,7 @@
     <script src="js/cytoscape-dagre.js"></script>
     <script src="js/cytoscape-graph.js"></script>
     <script src="js/resizable-columns.js"></script>
+    <script src="js/dependency-badge-tooltip.js"></script>
     <script src="js/matrixOverlay.js"></script>
     <script src="js/loadingOverlayTerminal.js"></script>
     <script src="js/versionPatternEditor.js"></script>

--- a/src/GrayMoon.App/Components/Modals/CustomDependenciesModal.razor
+++ b/src/GrayMoon.App/Components/Modals/CustomDependenciesModal.razor
@@ -65,13 +65,22 @@
                                                        @onchange="(ChangeEventArgs e) => _ = ToggleRepository(repository.RepositoryId, (bool)e.Value!, isLocked)" />
                                             </td>
                                             <td>
-                                                <span class="repo-name-cell" title="@repository.RepositoryName">
-                                                    @repository.RepositoryName
+                                                <div class="repo-name-row">
+                                                    <span class="repo-name-cell" title="@repository.RepositoryName">@repository.RepositoryName</span>
                                                     @if (isLocked)
                                                     {
-                                                        <span class="text-muted small ms-1">(from project or file)</span>
+                                                        <span class="repo-source-badges">
+                                                            @if (LockedFromProjectRepoIds.Contains(repository.RepositoryId))
+                                                            {
+                                                                <span class="badge custom-deps-source-badge bg-secondary" title="Referenced from .csproj">project</span>
+                                                            }
+                                                            @if (LockedFromFileRepoIds.Contains(repository.RepositoryId))
+                                                            {
+                                                                <span class="badge custom-deps-source-badge bg-secondary" title="Referenced from version file">file</span>
+                                                            }
+                                                        </span>
                                                     }
-                                                </span>
+                                                </div>
                                             </td>
                                         </tr>
                                     }
@@ -107,6 +116,8 @@
     [Parameter] public int DependentRepositoryId { get; set; }
     [Parameter] public IReadOnlyList<CustomDependencyRepoEntry> Repositories { get; set; } = Array.Empty<CustomDependencyRepoEntry>();
     [Parameter] public IReadOnlySet<int> LockedReferencedRepoIds { get; set; } = new HashSet<int>();
+    [Parameter] public IReadOnlySet<int> LockedFromProjectRepoIds { get; set; } = new HashSet<int>();
+    [Parameter] public IReadOnlySet<int> LockedFromFileRepoIds { get; set; } = new HashSet<int>();
     [Parameter] public HashSet<int> SelectedCustomRepoIds { get; set; } = new();
     [Parameter] public bool IsSaving { get; set; }
     [Parameter] public string? ErrorMessage { get; set; }

--- a/src/GrayMoon.App/Components/Modals/CustomDependenciesModal.razor
+++ b/src/GrayMoon.App/Components/Modals/CustomDependenciesModal.razor
@@ -8,9 +8,15 @@
          @onkeydown="HandleKeyDown">
         <div class="modal-dialog modal-lg custom-deps-modal-dialog">
             <div class="modal-content">
-                <div class="modal-header">
-                    <h5 class="modal-title">Custom dependencies@(string.IsNullOrEmpty(DependentRepoName) ? "" : $" - {DependentRepoName}")</h5>
-                    <button type="button" class="btn-close" aria-label="Close" @onclick="OnCancel"></button>
+                <div class="modal-header custom-deps-modal-header">
+                    <h5 class="modal-title custom-deps-modal-title">
+                        Custom dependencies
+                        @if (!string.IsNullOrEmpty(DependentRepoName))
+                        {
+                            <span class="custom-deps-modal-repo-name text-muted fw-normal fs-6" title="@DependentRepoName">@DependentRepoName</span>
+                        }
+                    </h5>
+                    <button type="button" class="btn-close flex-shrink-0" aria-label="Close" @onclick="OnCancel"></button>
                 </div>
                 <div class="modal-body custom-deps-modal-body">
                     <div class="form-label mb-2">Repositories <span class="text-muted ms-1">@GetSelectableCount() available</span></div>

--- a/src/GrayMoon.App/Components/Modals/CustomDependenciesModal.razor
+++ b/src/GrayMoon.App/Components/Modals/CustomDependenciesModal.razor
@@ -11,72 +11,76 @@
                     <h5 class="modal-title">Custom dependencies@(string.IsNullOrEmpty(DependentRepoName) ? "" : $" - {DependentRepoName}")</h5>
                     <button type="button" class="btn-close" aria-label="Close" @onclick="OnCancel"></button>
                 </div>
-                <div class="modal-body">
-                    <div class="mb-3 custom-deps-modal-body-content">
-                        <div class="form-label mb-2">Repositories</div>
-                        <div class="d-flex align-items-center mb-3">
-                            <FilterSearchInput @bind-Value="repositorySearch"
-                                               @ref="filterSearchInput"
-                                               WrapperAdditionalClass="flex-grow-1 min-width-0"
-                                               Placeholder="Search repositories…"
-                                               OnKeyDown="HandleKeyDown" />
-                        </div>
-                        <div class="repository-list border rounded">
-                            <table class="table table-sm mb-0 repository-grid workspaces-table resizable-columns custom-deps-grid">
-                                <thead class="table-dark">
+                <div class="modal-body custom-deps-modal-body">
+                    <div class="form-label mb-2">Repositories <span class="text-muted ms-1">@GetSelectableCount() available</span></div>
+                    <div class="d-flex align-items-center custom-deps-search-row">
+                        <FilterSearchInput @bind-Value="repositorySearch"
+                                           @ref="filterSearchInput"
+                                           WrapperAdditionalClass="flex-grow-1 min-width-0"
+                                           Placeholder="Search repositories…"
+                                           OnKeyDown="HandleKeyDown" />
+                    </div>
+                    <div class="custom-deps-grid-container">
+                        <table class="table table-sm mb-0 custom-deps-grid">
+                            <thead class="table-dark">
+                                <tr>
+                                    <th class="col-select">
+                                        <input class="form-check-input workspace-repo-checkbox"
+                                               type="checkbox"
+                                               checked="@AreAllToggleableFilteredSelected()"
+                                               @onchange="(ChangeEventArgs e) => _ = ToggleAllFiltered((bool)e.Value!)" />
+                                    </th>
+                                    <th>Repository</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @{
+                                    var filtered = GetFilteredRepositories();
+                                }
+                                @if (Repositories.Count == 0)
+                                {
                                     <tr>
-                                        <th class="col-select no-resize" data-width="26">
-                                            <input class="form-check-input workspace-repo-checkbox"
-                                                   type="checkbox"
-                                                   checked="@AreAllToggleableFilteredSelected()"
-                                                   @onchange="(ChangeEventArgs e) => _ = ToggleAllFiltered((bool)e.Value!)" />
-                                        </th>
-                                        <th>Repository</th>
+                                        <td colspan="2" class="text-muted p-2">No repositories in this workspace.</td>
                                     </tr>
-                                </thead>
-                                <tbody>
-                                    @{
-                                        var filtered = GetFilteredRepositories();
-                                    }
-                                    @if (filtered.Count == 0)
+                                }
+                                else if (filtered.Count == 0)
+                                {
+                                    <tr>
+                                        <td colspan="2" class="text-muted p-2">No repositories match your search.</td>
+                                    </tr>
+                                }
+                                else
+                                {
+                                    @foreach (var repository in filtered)
                                     {
+                                        var isLocked = LockedReferencedRepoIds.Contains(repository.RepositoryId);
+                                        var isChecked = isLocked || SelectedCustomRepoIds.Contains(repository.RepositoryId);
                                         <tr>
-                                            <td colspan="2" class="text-muted p-2">No repositories match your search.</td>
+                                            <td class="col-select">
+                                                <input class="form-check-input workspace-repo-checkbox"
+                                                       type="checkbox"
+                                                       checked="@isChecked"
+                                                       disabled="@isLocked"
+                                                       @onchange="(ChangeEventArgs e) => _ = ToggleRepository(repository.RepositoryId, (bool)e.Value!, isLocked)" />
+                                            </td>
+                                            <td>
+                                                <span class="repo-name-cell" title="@repository.RepositoryName">
+                                                    @repository.RepositoryName
+                                                    @if (isLocked)
+                                                    {
+                                                        <span class="text-muted small ms-1">(from project or file)</span>
+                                                    }
+                                                </span>
+                                            </td>
                                         </tr>
                                     }
-                                    else
-                                    {
-                                        @foreach (var repository in filtered)
-                                        {
-                                            var isLocked = LockedReferencedRepoIds.Contains(repository.RepositoryId);
-                                            var isChecked = isLocked || SelectedCustomRepoIds.Contains(repository.RepositoryId);
-                                            <tr>
-                                                <td class="col-select">
-                                                    <input class="form-check-input workspace-repo-checkbox"
-                                                           type="checkbox"
-                                                           checked="@isChecked"
-                                                           disabled="@isLocked"
-                                                           @onchange="(ChangeEventArgs e) => _ = ToggleRepository(repository.RepositoryId, (bool)e.Value!, isLocked)" />
-                                                </td>
-                                                <td>
-                                                    <span class="repo-name-cell" title="@repository.RepositoryName">
-                                                        @repository.RepositoryName
-                                                        @if (isLocked)
-                                                        {
-                                                            <span class="text-muted small ms-1">(from project or file)</span>
-                                                        }
-                                                    </span>
-                                                </td>
-                                            </tr>
-                                        }
-                                    }
-                                </tbody>
-                            </table>
-                        </div>
+                                }
+                            </tbody>
+                        </table>
                     </div>
                     @if (ErrorMessage != null)
                     {
-                        <div class="alert alert-danger mb-0">@ErrorMessage</div>
+                        <div class="alert alert-danger mt-3 mb-0">@ErrorMessage</div>
                     }
                 </div>
                 <div class="modal-footer">
@@ -143,6 +147,9 @@
         else if (e.Key == "Enter" && !IsSaving)
             await OnSave.InvokeAsync();
     }
+
+    private int GetSelectableCount()
+        => Repositories.Count(r => r.RepositoryId != DependentRepositoryId);
 
     private List<CustomDependencyRepoEntry> GetFilteredRepositories()
     {

--- a/src/GrayMoon.App/Components/Modals/CustomDependenciesModal.razor
+++ b/src/GrayMoon.App/Components/Modals/CustomDependenciesModal.razor
@@ -1,4 +1,5 @@
 @using GrayMoon.App.Components.Shared
+@using GrayMoon.App.Services
 @using Microsoft.AspNetCore.Components.Web
 
 @if (IsVisible)
@@ -158,7 +159,7 @@
             return source.OrderBy(r => r.RepositoryName, StringComparer.OrdinalIgnoreCase).ToList();
 
         return source
-            .Where(r => r.RepositoryName.Contains(repositorySearch.Trim(), StringComparison.OrdinalIgnoreCase))
+            .Where(r => WorkspaceRepositoryNameSearchMatcher.Matches(r.RepositoryName, repositorySearch))
             .OrderBy(r => r.RepositoryName, StringComparer.OrdinalIgnoreCase)
             .ToList();
     }

--- a/src/GrayMoon.App/Components/Modals/CustomDependenciesModal.razor
+++ b/src/GrayMoon.App/Components/Modals/CustomDependenciesModal.razor
@@ -1,0 +1,195 @@
+@using GrayMoon.App.Components.Shared
+@using Microsoft.AspNetCore.Components.Web
+
+@if (IsVisible)
+{
+    <div class="modal show d-block custom-deps-modal-container" tabindex="-1" style="background-color: rgba(0,0,0,0.5); z-index: 1075;"
+         @onkeydown="HandleKeyDown">
+        <div class="modal-dialog modal-lg custom-deps-modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Custom dependencies@(string.IsNullOrEmpty(DependentRepoName) ? "" : $" - {DependentRepoName}")</h5>
+                    <button type="button" class="btn-close" aria-label="Close" @onclick="OnCancel"></button>
+                </div>
+                <div class="modal-body">
+                    <div class="mb-3 custom-deps-modal-body-content">
+                        <div class="form-label mb-2">Repositories</div>
+                        <div class="d-flex align-items-center mb-3">
+                            <FilterSearchInput @bind-Value="repositorySearch"
+                                               @ref="filterSearchInput"
+                                               WrapperAdditionalClass="flex-grow-1 min-width-0"
+                                               Placeholder="Search repositories…"
+                                               OnKeyDown="HandleKeyDown" />
+                        </div>
+                        <div class="repository-list border rounded">
+                            <table class="table table-sm mb-0 repository-grid workspaces-table resizable-columns custom-deps-grid">
+                                <thead class="table-dark">
+                                    <tr>
+                                        <th class="col-select no-resize" data-width="26">
+                                            <input class="form-check-input workspace-repo-checkbox"
+                                                   type="checkbox"
+                                                   checked="@AreAllToggleableFilteredSelected()"
+                                                   @onchange="(ChangeEventArgs e) => _ = ToggleAllFiltered((bool)e.Value!)" />
+                                        </th>
+                                        <th>Repository</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    @{
+                                        var filtered = GetFilteredRepositories();
+                                    }
+                                    @if (filtered.Count == 0)
+                                    {
+                                        <tr>
+                                            <td colspan="2" class="text-muted p-2">No repositories match your search.</td>
+                                        </tr>
+                                    }
+                                    else
+                                    {
+                                        @foreach (var repository in filtered)
+                                        {
+                                            var isLocked = LockedReferencedRepoIds.Contains(repository.RepositoryId);
+                                            var isChecked = isLocked || SelectedCustomRepoIds.Contains(repository.RepositoryId);
+                                            <tr>
+                                                <td class="col-select">
+                                                    <input class="form-check-input workspace-repo-checkbox"
+                                                           type="checkbox"
+                                                           checked="@isChecked"
+                                                           disabled="@isLocked"
+                                                           @onchange="(ChangeEventArgs e) => _ = ToggleRepository(repository.RepositoryId, (bool)e.Value!, isLocked)" />
+                                                </td>
+                                                <td>
+                                                    <span class="repo-name-cell" title="@repository.RepositoryName">
+                                                        @repository.RepositoryName
+                                                        @if (isLocked)
+                                                        {
+                                                            <span class="text-muted small ms-1">(from project or file)</span>
+                                                        }
+                                                    </span>
+                                                </td>
+                                            </tr>
+                                        }
+                                    }
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                    @if (ErrorMessage != null)
+                    {
+                        <div class="alert alert-danger mb-0">@ErrorMessage</div>
+                    }
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" @onclick="OnCancel">Cancel</button>
+                    <button type="button" class="btn btn-primary" @onclick="OnSave" disabled="@IsSaving">
+                        @if (IsSaving)
+                        {
+                            <span class="spinner-border spinner-border-sm me-2"></span>
+                        }
+                        Save
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+}
+
+@code {
+    private FilterSearchInput? filterSearchInput;
+
+    [Parameter] public bool IsVisible { get; set; }
+    [Parameter] public string? DependentRepoName { get; set; }
+    [Parameter] public int DependentRepositoryId { get; set; }
+    [Parameter] public IReadOnlyList<CustomDependencyRepoEntry> Repositories { get; set; } = Array.Empty<CustomDependencyRepoEntry>();
+    [Parameter] public IReadOnlySet<int> LockedReferencedRepoIds { get; set; } = new HashSet<int>();
+    [Parameter] public HashSet<int> SelectedCustomRepoIds { get; set; } = new();
+    [Parameter] public bool IsSaving { get; set; }
+    [Parameter] public string? ErrorMessage { get; set; }
+    [Parameter] public EventCallback OnSave { get; set; }
+    [Parameter] public EventCallback OnCancel { get; set; }
+
+    private string repositorySearch = string.Empty;
+    private bool _wasVisible;
+    private bool _needsFocus;
+
+    protected override void OnParametersSet()
+    {
+        if (IsVisible && !_wasVisible)
+        {
+            _wasVisible = true;
+            _needsFocus = true;
+            repositorySearch = string.Empty;
+        }
+        else if (!IsVisible)
+        {
+            _wasVisible = false;
+        }
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (_needsFocus)
+        {
+            _needsFocus = false;
+            if (filterSearchInput != null)
+                await filterSearchInput.FocusAsync();
+        }
+    }
+
+    private async Task HandleKeyDown(KeyboardEventArgs e)
+    {
+        if (e.Key == "Escape")
+            await OnCancel.InvokeAsync();
+        else if (e.Key == "Enter" && !IsSaving)
+            await OnSave.InvokeAsync();
+    }
+
+    private List<CustomDependencyRepoEntry> GetFilteredRepositories()
+    {
+        var source = Repositories.Where(r => r.RepositoryId != DependentRepositoryId);
+        if (string.IsNullOrWhiteSpace(repositorySearch))
+            return source.OrderBy(r => r.RepositoryName, StringComparer.OrdinalIgnoreCase).ToList();
+
+        return source
+            .Where(r => r.RepositoryName.Contains(repositorySearch.Trim(), StringComparison.OrdinalIgnoreCase))
+            .OrderBy(r => r.RepositoryName, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    private IEnumerable<CustomDependencyRepoEntry> GetToggleableFiltered()
+        => GetFilteredRepositories().Where(r => !LockedReferencedRepoIds.Contains(r.RepositoryId));
+
+    private bool AreAllToggleableFilteredSelected()
+    {
+        var toggleable = GetToggleableFiltered().ToList();
+        return toggleable.Count > 0 && toggleable.All(r => SelectedCustomRepoIds.Contains(r.RepositoryId));
+    }
+
+    private async Task ToggleRepository(int repositoryId, bool isSelected, bool isLocked)
+    {
+        if (isLocked)
+            return;
+
+        if (isSelected)
+            SelectedCustomRepoIds.Add(repositoryId);
+        else
+            SelectedCustomRepoIds.Remove(repositoryId);
+
+        await InvokeAsync(StateHasChanged);
+    }
+
+    private async Task ToggleAllFiltered(bool isSelected)
+    {
+        foreach (var repository in GetToggleableFiltered())
+        {
+            if (isSelected)
+                SelectedCustomRepoIds.Add(repository.RepositoryId);
+            else
+                SelectedCustomRepoIds.Remove(repository.RepositoryId);
+        }
+
+        await InvokeAsync(StateHasChanged);
+    }
+
+    public sealed record CustomDependencyRepoEntry(int RepositoryId, string RepositoryName);
+}

--- a/src/GrayMoon.App/Components/Modals/CustomDependenciesModal.razor.css
+++ b/src/GrayMoon.App/Components/Modals/CustomDependenciesModal.razor.css
@@ -27,31 +27,10 @@
     border: 1px solid #5a5a5a;
     border-radius: 6px;
     max-height: min(50vh, 420px);
-    overflow-y: auto;
-    overflow-x: hidden;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
     background-color: #252526;
-}
-
-.custom-deps-grid-container::-webkit-scrollbar {
-    width: 8px;
-}
-
-.custom-deps-grid-container::-webkit-scrollbar-track {
-    background: #252526;
-}
-
-.custom-deps-grid-container::-webkit-scrollbar-thumb {
-    background: #5a5a5a;
-    border-radius: 4px;
-}
-
-.custom-deps-grid-container::-webkit-scrollbar-thumb:hover {
-    background: #6a6a6a;
-}
-
-.custom-deps-grid-container {
-    scrollbar-width: thin;
-    scrollbar-color: #5a5a5a #252526;
 }
 
 .custom-deps-grid {
@@ -60,6 +39,53 @@
     border-collapse: collapse;
     table-layout: fixed;
     background-color: #252526;
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    min-height: 0;
+}
+
+.custom-deps-grid thead {
+    display: table;
+    width: 100%;
+    table-layout: fixed;
+    flex-shrink: 0;
+}
+
+.custom-deps-grid tbody {
+    display: block;
+    overflow-y: auto;
+    overflow-x: hidden;
+    flex: 1 1 auto;
+    min-height: 0;
+}
+
+.custom-deps-grid tbody tr {
+    display: table;
+    width: 100%;
+    table-layout: fixed;
+}
+
+.custom-deps-grid tbody::-webkit-scrollbar {
+    width: 8px;
+}
+
+.custom-deps-grid tbody::-webkit-scrollbar-track {
+    background: #252526;
+}
+
+.custom-deps-grid tbody::-webkit-scrollbar-thumb {
+    background: #5a5a5a;
+    border-radius: 4px;
+}
+
+.custom-deps-grid tbody::-webkit-scrollbar-thumb:hover {
+    background: #6a6a6a;
+}
+
+.custom-deps-grid tbody {
+    scrollbar-width: thin;
+    scrollbar-color: #5a5a5a #252526;
 }
 
 .custom-deps-grid th,
@@ -70,9 +96,6 @@
 }
 
 .custom-deps-grid thead th {
-    position: sticky;
-    top: 0;
-    z-index: 1;
     background-color: #2d2d30;
     color: #f1f1f1;
 }

--- a/src/GrayMoon.App/Components/Modals/CustomDependenciesModal.razor.css
+++ b/src/GrayMoon.App/Components/Modals/CustomDependenciesModal.razor.css
@@ -4,6 +4,29 @@
     justify-content: center;
 }
 
+.custom-deps-modal-header {
+    min-width: 0;
+    gap: 0.75rem;
+}
+
+.custom-deps-modal-title {
+    display: flex;
+    align-items: baseline;
+    flex-wrap: nowrap;
+    gap: 0.35rem;
+    min-width: 0;
+    flex: 1 1 auto;
+    margin-bottom: 0;
+    overflow: hidden;
+}
+
+.custom-deps-modal-repo-name {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
 ::deep .custom-deps-modal-dialog {
     width: 50vw;
     max-width: 640px;

--- a/src/GrayMoon.App/Components/Modals/CustomDependenciesModal.razor.css
+++ b/src/GrayMoon.App/Components/Modals/CustomDependenciesModal.razor.css
@@ -84,8 +84,8 @@
 }
 
 .custom-deps-grid tbody {
-    scrollbar-width: thin;
-    scrollbar-color: #5a5a5a #252526;
+    scrollbar-width: auto;
+    scrollbar-color: #5a5a5a var(--bg-card, #252526);
 }
 
 .custom-deps-grid th,

--- a/src/GrayMoon.App/Components/Modals/CustomDependenciesModal.razor.css
+++ b/src/GrayMoon.App/Components/Modals/CustomDependenciesModal.razor.css
@@ -7,77 +7,91 @@
 ::deep .custom-deps-modal-dialog {
     width: 50vw;
     max-width: 640px;
-    max-height: 80vh;
-    margin: 0;
+    margin: 1rem auto;
 }
 
 ::deep .custom-deps-modal-dialog .modal-content {
-    max-height: 80vh;
-    display: flex;
-    flex-direction: column;
+    max-height: calc(100vh - 2rem);
 }
 
-::deep .custom-deps-modal-dialog .modal-body {
-    flex: 1 1 0;
-    min-height: 0;
-    overflow: hidden;
-    display: flex;
-    flex-direction: column;
+.custom-deps-modal-body {
+    display: block;
+    overflow: visible;
 }
 
-.custom-deps-modal-body-content {
-    flex: 1 1 0;
-    min-height: 0;
-    display: flex;
-    flex-direction: column;
+.custom-deps-search-row {
+    margin-bottom: 0.75rem;
 }
 
-.custom-deps-modal-body-content .repository-list {
-    flex: 1 1 0;
-    min-height: 0;
-    min-height: 240px;
-    max-height: 50vh;
-    overflow: hidden;
+.custom-deps-grid-container {
+    border: 1px solid #5a5a5a;
+    border-radius: 6px;
+    max-height: min(50vh, 420px);
+    overflow-y: auto;
+    overflow-x: hidden;
+    background-color: #252526;
+}
+
+.custom-deps-grid-container::-webkit-scrollbar {
+    width: 8px;
+}
+
+.custom-deps-grid-container::-webkit-scrollbar-track {
+    background: #252526;
+}
+
+.custom-deps-grid-container::-webkit-scrollbar-thumb {
+    background: #5a5a5a;
+    border-radius: 4px;
+}
+
+.custom-deps-grid-container::-webkit-scrollbar-thumb:hover {
+    background: #6a6a6a;
+}
+
+.custom-deps-grid-container {
+    scrollbar-width: thin;
+    scrollbar-color: #5a5a5a #252526;
+}
+
+.custom-deps-grid {
+    width: 100%;
+    margin-bottom: 0;
+    border-collapse: collapse;
+    table-layout: fixed;
+    background-color: #252526;
+}
+
+.custom-deps-grid th,
+.custom-deps-grid td {
+    border-color: #3c3c3c;
+    vertical-align: middle;
+    padding: 0.35rem 0.5rem;
+}
+
+.custom-deps-grid thead th {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    background-color: #2d2d30;
+    color: #f1f1f1;
+}
+
+.custom-deps-grid td {
+    background-color: #252526;
+    color: #d4d4d4;
+}
+
+.custom-deps-grid th.col-select,
+.custom-deps-grid td.col-select {
+    width: 40px;
+    padding-left: 12px;
+    text-align: center;
 }
 
 .custom-deps-grid th:nth-child(2),
 .custom-deps-grid td:nth-child(2) {
     width: auto;
-    flex: 1 1 auto;
-}
-
-.custom-deps-grid {
-    border: none;
-    border-collapse: collapse;
-    background-color: #252526;
-}
-
-.custom-deps-grid thead {
-    position: sticky;
-    top: 0;
-    z-index: 1;
-    flex-shrink: 0;
-}
-
-.custom-deps-grid tbody {
-    display: block;
-    flex: 1 1 0;
-    min-height: 0;
-    overflow-y: auto;
-    overflow-x: hidden;
-}
-
-.custom-deps-grid thead tr,
-.custom-deps-grid tbody tr {
-    display: flex;
-    width: 100%;
-}
-
-.custom-deps-grid th,
-.custom-deps-grid td {
-    flex: 1 0 auto;
-    min-width: 0;
-    overflow: hidden;
 }
 
 .custom-deps-grid .workspace-repo-checkbox {
@@ -88,4 +102,11 @@
 .custom-deps-grid .workspace-repo-checkbox:checked {
     background-color: var(--accent-blue) !important;
     border-color: var(--accent-blue) !important;
+}
+
+.custom-deps-grid .repo-name-cell {
+    display: block;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }

--- a/src/GrayMoon.App/Components/Modals/CustomDependenciesModal.razor.css
+++ b/src/GrayMoon.App/Components/Modals/CustomDependenciesModal.razor.css
@@ -127,9 +127,30 @@
     border-color: var(--accent-blue) !important;
 }
 
+.custom-deps-grid .repo-name-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    min-width: 0;
+}
+
 .custom-deps-grid .repo-name-cell {
     display: block;
+    flex: 1 1 auto;
+    min-width: 0;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+}
+
+.custom-deps-grid .repo-source-badges {
+    display: flex;
+    flex-shrink: 0;
+    gap: 0.25rem;
+    margin-left: auto;
+}
+
+.custom-deps-grid .custom-deps-source-badge {
+    font-size: 0.65em;
 }

--- a/src/GrayMoon.App/Components/Modals/CustomDependenciesModal.razor.css
+++ b/src/GrayMoon.App/Components/Modals/CustomDependenciesModal.razor.css
@@ -1,0 +1,91 @@
+.custom-deps-modal-container {
+    display: flex !important;
+    align-items: center;
+    justify-content: center;
+}
+
+::deep .custom-deps-modal-dialog {
+    width: 50vw;
+    max-width: 640px;
+    max-height: 80vh;
+    margin: 0;
+}
+
+::deep .custom-deps-modal-dialog .modal-content {
+    max-height: 80vh;
+    display: flex;
+    flex-direction: column;
+}
+
+::deep .custom-deps-modal-dialog .modal-body {
+    flex: 1 1 0;
+    min-height: 0;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+}
+
+.custom-deps-modal-body-content {
+    flex: 1 1 0;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+}
+
+.custom-deps-modal-body-content .repository-list {
+    flex: 1 1 0;
+    min-height: 0;
+    min-height: 240px;
+    max-height: 50vh;
+    overflow: hidden;
+}
+
+.custom-deps-grid th:nth-child(2),
+.custom-deps-grid td:nth-child(2) {
+    width: auto;
+    flex: 1 1 auto;
+}
+
+.custom-deps-grid {
+    border: none;
+    border-collapse: collapse;
+    background-color: #252526;
+}
+
+.custom-deps-grid thead {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    flex-shrink: 0;
+}
+
+.custom-deps-grid tbody {
+    display: block;
+    flex: 1 1 0;
+    min-height: 0;
+    overflow-y: auto;
+    overflow-x: hidden;
+}
+
+.custom-deps-grid thead tr,
+.custom-deps-grid tbody tr {
+    display: flex;
+    width: 100%;
+}
+
+.custom-deps-grid th,
+.custom-deps-grid td {
+    flex: 1 0 auto;
+    min-width: 0;
+    overflow: hidden;
+}
+
+.custom-deps-grid .workspace-repo-checkbox {
+    background-color: var(--bg-input) !important;
+    border-color: var(--border-light) !important;
+}
+
+.custom-deps-grid .workspace-repo-checkbox:checked {
+    background-color: var(--accent-blue) !important;
+    border-color: var(--accent-blue) !important;
+}

--- a/src/GrayMoon.App/Components/Modals/VersionConfigModal.razor
+++ b/src/GrayMoon.App/Components/Modals/VersionConfigModal.razor
@@ -3,6 +3,7 @@
 @using GrayMoon.App.Services
 @using GrayMoon.App.Api.Endpoints
 @inject IJSRuntime JS
+@inject WorkspaceFileVersionService VersionService
 
 @if (IsVisible)
 {
@@ -68,6 +69,21 @@
                             </div>
                         }
 
+                        @if (_fileValidating)
+                        {
+                            <div class="small text-muted mt-1">Checking file...</div>
+                        }
+                        else if (_notFoundInFileTokens.Count > 0)
+                        {
+                            <div class="mt-2 small">
+                                <span class="text-danger">Not found in file:</span>
+                                @foreach (var t in _notFoundInFileTokens)
+                                {
+                                    <span class="badge bg-danger ms-1">@t</span>
+                                }
+                            </div>
+                        }
+
                     </div>
                 </div>
                 <div class="modal-footer">
@@ -89,6 +105,7 @@
 
 @code {
     [Parameter] public bool IsVisible { get; set; }
+    [Parameter] public int WorkspaceId { get; set; }
     [Parameter] public WorkspaceFileDto? File { get; set; }
     [Parameter] public List<WorkspaceRepoItem> WorkspaceRepos { get; set; } = new();
     [Parameter] public string? CurrentPattern { get; set; }
@@ -101,6 +118,10 @@
     private bool _wasVisible;
     private ElementReference textareaRef;
     private ElementReference _suggestionsRef;
+
+    private IReadOnlyList<string> _notFoundInFileTokens = [];
+    private bool _fileValidating;
+    private CancellationTokenSource? _validateCts;
 
     // Autocomplete state
     private bool showSuggestions;
@@ -120,6 +141,9 @@
             patternText = CurrentPattern ?? "";
             showSuggestions = false;
             _justOpened = true;
+            _notFoundInFileTokens = [];
+            _fileValidating = false;
+            CancelValidateCts();
             Validate();
         }
         _wasVisible = IsVisible;
@@ -133,6 +157,7 @@
             try { await JS.InvokeVoidAsync("versionPatternEditor.initAutocomplete", textareaRef); } catch { /* ignore */ }
             try { await textareaRef.FocusAsync(); } catch { /* ignore */ }
             try { await JS.InvokeVoidAsync("versionPatternEditor.autoResize", textareaRef); } catch { /* ignore */ }
+            _ = InvokeAsync(() => ValidateAgainstFileAsync(CancellationToken.None));
         }
         if (IsVisible)
         {
@@ -156,6 +181,7 @@
         Validate();
         await JS.InvokeVoidAsync("versionPatternEditor.autoResize", textareaRef);
         await UpdateSuggestionsAsync();
+        ScheduleFileValidation();
     }
 
     private async Task UpdateSuggestionsAsync()
@@ -243,6 +269,9 @@
         invalidTokens.Clear();
         validTokenCount = 0;
         showSuggestions = false;
+        CancelValidateCts();
+        _notFoundInFileTokens = [];
+        _fileValidating = false;
     }
 
     private async Task SaveAsync()
@@ -254,6 +283,45 @@
     {
         // Escape is handled per-context in OnTextareaKeyDown; this catches modal-level escape
         if (!showSuggestions && e.Key == "Escape") await OnCancel.InvokeAsync();
+    }
+
+    private void CancelValidateCts()
+    {
+        _validateCts?.Cancel();
+        _validateCts?.Dispose();
+        _validateCts = null;
+    }
+
+    private void ScheduleFileValidation()
+    {
+        CancelValidateCts();
+        var cts = new CancellationTokenSource();
+        _validateCts = cts;
+        _ = InvokeAsync(async () =>
+        {
+            try
+            {
+                await Task.Delay(2000, cts.Token);
+                await ValidateAgainstFileAsync(cts.Token);
+            }
+            catch (OperationCanceledException) { }
+        });
+    }
+
+    private async Task ValidateAgainstFileAsync(CancellationToken cancellationToken)
+    {
+        if (File == null || string.IsNullOrWhiteSpace(patternText)) return;
+        _fileValidating = true;
+        StateHasChanged();
+        try
+        {
+            _notFoundInFileTokens = await VersionService.ValidatePatternAgainstFileAsync(
+                WorkspaceId, File.RepositoryName, File.FilePath, patternText, cancellationToken);
+        }
+        catch (OperationCanceledException) { return; }
+        catch { _notFoundInFileTokens = []; }
+        _fileValidating = false;
+        StateHasChanged();
     }
 
     private sealed class AtContext

--- a/src/GrayMoon.App/Components/Pages/WorkspaceFiles.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceFiles.razor
@@ -157,6 +157,7 @@
                 OnCancel="CloseAddFilesModal" />
 
 <VersionConfigModal IsVisible="@showVersionConfigModal"
+                    WorkspaceId="WorkspaceId"
                     File="@configuringFile"
                     WorkspaceRepos="@workspaceRepos"
                     CurrentPattern="@currentConfigPattern"

--- a/src/GrayMoon.App/Components/Pages/WorkspaceFiles.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceFiles.razor
@@ -12,6 +12,7 @@
 @inject WorkspaceFileRepository WorkspaceFileRepository
 @inject WorkspaceFileVersionConfigRepository VersionConfigRepository
 @inject WorkspaceFileVersionService FileVersionService
+@inject IServiceScopeFactory ServiceScopeFactory
 @inject WorkspaceService WorkspaceService
 @inject IToastService ToastService
 @inject ILogger<WorkspaceFiles> Logger
@@ -111,7 +112,13 @@
                                     @foreach (var f in FilteredFiles)
                                     {
                                         <tr>
-                                            <td class="col-filename"><strong>@f.FileName</strong></td>
+                                            <td class="col-filename">
+                                                <strong>@f.FileName</strong>
+                                                @if (f.IsMissingOnDisk)
+                                                {
+                                                    <span class="badge bg-secondary ms-2" title="File not found on disk; excluded from dependency and badge counts until restored.">Missing on disk</span>
+                                                }
+                                            </td>
                                             <td class="col-filepath text-muted">@f.FilePath</td>
                                             <td class="col-repo">@(f.RepositoryName ?? "-")</td>
                                             <td class="col-actions">
@@ -254,7 +261,8 @@
                 RepositoryId = f.RepositoryId,
                 RepositoryName = f.Repository?.RepositoryName,
                 FileName = f.FileName,
-                FilePath = f.FilePath
+                FilePath = f.FilePath,
+                IsMissingOnDisk = f.IsMissingOnDisk == true
             }).ToList();
             var configs = await VersionConfigRepository.GetByWorkspaceIdAsync(WorkspaceId);
             fileVersionConfigs = configs.ToDictionary(c => c.FileId, c => c.VersionPattern);
@@ -333,12 +341,23 @@
                 fileVersionConfigs[configuringFile.FileId] = normalized;
             }
             CloseVersionConfigModal();
+            await RefreshFileDependencyStateAsync();
         }
         catch (Exception ex)
         {
             Logger.LogError(ex, "Error saving version config for FileId={FileId}", configuringFile.FileId);
             errorMessage = "Failed to save version configuration.";
         }
+    }
+
+    private async Task RefreshFileDependencyStateAsync()
+    {
+        await using var scope = ServiceScopeFactory.CreateAsyncScope();
+        var fileVersionService = scope.ServiceProvider.GetRequiredService<WorkspaceFileVersionService>();
+        var projectRepo = scope.ServiceProvider.GetRequiredService<WorkspaceProjectRepository>();
+        await fileVersionService.CheckAndPersistFileVersionStatusAsync(WorkspaceId, forceFresh: true);
+        await projectRepo.RecomputeAndPersistRepositoryDependencyStatsAsync(WorkspaceId);
+        await LoadAsync();
     }
 
     private async Task UpdateVersionsAsync()
@@ -353,6 +372,13 @@
         try
         {
             var (updated, failed, error, _) = await FileVersionService.UpdateAllVersionsAsync(WorkspaceId, selectedRepositoryIds: null, cancellationToken: _updateCts.Token);
+            if (error == null)
+            {
+                updateMessage = "Checking file versions...";
+                StateHasChanged();
+                await FileVersionService.CheckAndPersistFileVersionStatusAsync(WorkspaceId, _updateCts.Token, forceFresh: true);
+                await LoadAsync();
+            }
             if (error != null)
                 errorMessage = error;
             else if (failed > 0)
@@ -382,6 +408,7 @@
             errorMessage = null;
             await WorkspaceFileRepository.RemoveAsync(f.FileId);
             files.Remove(f);
+            await RefreshFileDependencyStateAsync();
         }
         catch (Exception ex)
         {

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor
@@ -156,6 +156,8 @@
                                                                   RepoSyncStatus="@GetRepoSyncStatus(wr.RepositoryId)"
                                                                   MismatchedDependencyLines="@GetMismatchedDependencyLines(wr.RepositoryId)"
                                                                   AllDependencyLines="@GetAllDependencyLines(wr.RepositoryId)"
+                                                                  FileLineStatuses="@GetFileLineStatus(wr.RepositoryId)"
+                                                                  TotalMatchedFileLines="@GetTotalMatchedFileLines(wr.RepositoryId)"
                                                                   IsVersionClicked="@(wr.GitVersion != null && clickedVersions.Contains(wr.GitVersion))"
                                                                   IsDependencyBadgeClicked="@clickedDependencyBadges.Contains(wr.RepositoryId)"
                                                                   RepositoryError="@GetRepositoryError(wr.RepositoryId)"

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor
@@ -156,6 +156,7 @@
                                                                   RepoSyncStatus="@GetRepoSyncStatus(wr.RepositoryId)"
                                                                   MismatchedDependencyLines="@GetMismatchedDependencyLines(wr.RepositoryId)"
                                                                   AllDependencyLines="@GetAllDependencyLines(wr.RepositoryId)"
+                                                                  CustomDependencyLines="@GetCustomDependencyLines(wr.RepositoryId)"
                                                                   FileLineStatuses="@GetFileLineStatus(wr.RepositoryId)"
                                                                   AllFileVersionLines="@GetAllFileVersionLines(wr.RepositoryId)"
                                                                   IsVersionClicked="@(wr.GitVersion != null && clickedVersions.Contains(wr.GitVersion))"
@@ -168,6 +169,7 @@
                                                                   OnVersionMouseLeave="() => OnVersionMouseLeave(wr.GitVersion)"
                                                                   OnBranchClick="() => ShowSwitchBranchModal(wr.RepositoryId, wr.BranchName, wr.Repository?.CloneUrl)"
                                                                   OnDependencyBadgeClick="() => OnDependencyBadgeClick(wr.RepositoryId, wr.UnmatchedDeps ?? 0)"
+                                                                  OnCustomDependenciesClick="() => ShowCustomDependenciesModalAsync(wr.RepositoryId)"
                                                                   OnFileDependencyBadgeClick="() => OnFileDependencyBadgeClick(wr.RepositoryId)"
                                                                   OnDependencyBadgeKeydown="(e) => HandleDependencyBadgeKeydown(e, wr.RepositoryId, wr.UnmatchedDeps ?? 0)"
                                                                   OnDependencyBadgeMouseLeave="() => OnDependencyBadgeMouseLeave(wr.RepositoryId)"
@@ -251,6 +253,17 @@
                           RepoName="@_updateSingleRepoModal.RepoName"
                           OnProceed="@OnUpdateSingleRepositoryDependenciesProceedAsync"
                           OnCancel="@CloseUpdateSingleRepositoryDependenciesModal" />
+
+<CustomDependenciesModal IsVisible="@_customDependenciesModal.IsVisible"
+                         DependentRepoName="@_customDependenciesModal.DependentRepoName"
+                         DependentRepositoryId="@_customDependenciesModal.DependentRepositoryId"
+                         Repositories="@_customDependenciesModal.Repositories"
+                         LockedReferencedRepoIds="@_customDependenciesModal.LockedReferencedRepoIds"
+                         SelectedCustomRepoIds="@_customDependenciesModal.SelectedCustomRepoIds"
+                         IsSaving="@_customDependenciesModal.IsSaving"
+                         ErrorMessage="@_customDependenciesModal.ErrorMessage"
+                         OnSave="@SaveCustomDependenciesAsync"
+                         OnCancel="@CloseCustomDependenciesModal" />
 
 <PushWithDependenciesModal IsVisible="@_pushWithDependenciesModal.IsVisible"
           Info="@_pushWithDependenciesModal.Info"

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor
@@ -260,6 +260,8 @@
                          DependentRepositoryId="@_customDependenciesModal.DependentRepositoryId"
                          Repositories="@_customDependenciesModal.Repositories"
                          LockedReferencedRepoIds="@_customDependenciesModal.LockedReferencedRepoIds"
+                         LockedFromProjectRepoIds="@_customDependenciesModal.LockedFromProjectRepoIds"
+                         LockedFromFileRepoIds="@_customDependenciesModal.LockedFromFileRepoIds"
                          SelectedCustomRepoIds="@_customDependenciesModal.SelectedCustomRepoIds"
                          IsSaving="@_customDependenciesModal.IsSaving"
                          ErrorMessage="@_customDependenciesModal.ErrorMessage"

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor
@@ -157,6 +157,7 @@
                                                                   MismatchedDependencyLines="@GetMismatchedDependencyLines(wr.RepositoryId)"
                                                                   AllDependencyLines="@GetAllDependencyLines(wr.RepositoryId)"
                                                                   CustomDependencyLines="@GetCustomDependencyLines(wr.RepositoryId)"
+                                                                  MismatchedFileVersionLines="@GetMismatchedFileVersionLines(wr.RepositoryId)"
                                                                   FileLineStatuses="@GetFileLineStatus(wr.RepositoryId)"
                                                                   AllFileVersionLines="@GetAllFileVersionLines(wr.RepositoryId)"
                                                                   IsVersionClicked="@(wr.GitVersion != null && clickedVersions.Contains(wr.GitVersion))"

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor
@@ -168,6 +168,7 @@
                                                                   OnVersionMouseLeave="() => OnVersionMouseLeave(wr.GitVersion)"
                                                                   OnBranchClick="() => ShowSwitchBranchModal(wr.RepositoryId, wr.BranchName, wr.Repository?.CloneUrl)"
                                                                   OnDependencyBadgeClick="() => OnDependencyBadgeClick(wr.RepositoryId, wr.UnmatchedDeps ?? 0)"
+                                                                  OnFileDependencyBadgeClick="() => OnFileDependencyBadgeClick(wr.RepositoryId)"
                                                                   OnDependencyBadgeKeydown="(e) => HandleDependencyBadgeKeydown(e, wr.RepositoryId, wr.UnmatchedDeps ?? 0)"
                                                                   OnDependencyBadgeMouseLeave="() => OnDependencyBadgeMouseLeave(wr.RepositoryId)"
                                                                   OnPushBadgeClick="() => OnPushBadgeClickAsync(wr.RepositoryId, wr.BranchName)"

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor
@@ -158,7 +158,6 @@
                                                                   AllDependencyLines="@GetAllDependencyLines(wr.RepositoryId)"
                                                                   FileLineStatuses="@GetFileLineStatus(wr.RepositoryId)"
                                                                   AllFileVersionLines="@GetAllFileVersionLines(wr.RepositoryId)"
-                                                                  TotalMatchedFileLines="@GetTotalMatchedFileLines(wr.RepositoryId)"
                                                                   IsVersionClicked="@(wr.GitVersion != null && clickedVersions.Contains(wr.GitVersion))"
                                                                   IsDependencyBadgeClicked="@clickedDependencyBadges.Contains(wr.RepositoryId)"
                                                                   RepositoryError="@GetRepositoryError(wr.RepositoryId)"

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor
@@ -157,6 +157,7 @@
                                                                   MismatchedDependencyLines="@GetMismatchedDependencyLines(wr.RepositoryId)"
                                                                   AllDependencyLines="@GetAllDependencyLines(wr.RepositoryId)"
                                                                   FileLineStatuses="@GetFileLineStatus(wr.RepositoryId)"
+                                                                  AllFileVersionLines="@GetAllFileVersionLines(wr.RepositoryId)"
                                                                   TotalMatchedFileLines="@GetTotalMatchedFileLines(wr.RepositoryId)"
                                                                   IsVersionClicked="@(wr.GitVersion != null && clickedVersions.Contains(wr.GitVersion))"
                                                                   IsDependencyBadgeClicked="@clickedDependencyBadges.Contains(wr.RepositoryId)"

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
@@ -487,6 +487,9 @@ public sealed partial class WorkspaceRepositories : IDisposable
     private IReadOnlyList<WorkspaceFileLineStatus> GetFileLineStatus(int repositoryId) =>
         _fileLineStatusByRepo.TryGetValue(repositoryId, out var lines) ? lines : Array.Empty<WorkspaceFileLineStatus>();
 
+    private bool HasOutOfDateFiles(int repositoryId) =>
+        GetFileLineStatus(repositoryId).Any(s => s.OutOfDateLines > 0);
+
     private IReadOnlyList<(string FileName, string TokenName, string Version)> GetAllFileVersionLines(int repositoryId) =>
         _allFileVersionLinesByRepo.TryGetValue(repositoryId, out var lines) ? lines : Array.Empty<(string, string, string)>();
 
@@ -1610,6 +1613,64 @@ public sealed partial class WorkspaceRepositories : IDisposable
         return Task.CompletedTask;
     }
 
+    private Task UpdateSingleRepositoryFileVersionsAsync(int repositoryId)
+    {
+        if (workspace == null || IsJobRunning)
+            return Task.CompletedTask;
+        if (IsRepoOnTag(repositoryId))
+        {
+            ToastService.Show(TagBlockedActionMessage);
+            return Task.CompletedTask;
+        }
+
+        errorMessage = null;
+
+        JobService.StartJob(PageJobKey, "Updating file versions...", async (job, ct) =>
+        {
+            try
+            {
+                await using var scope = ServiceScopeFactory.CreateAsyncScope();
+                var fileVersionService = scope.ServiceProvider.GetRequiredService<WorkspaceFileVersionService>();
+                var repoIds = new HashSet<int> { repositoryId };
+                var (updated, failed, error, _) = await fileVersionService.UpdateAllVersionsAsync(
+                    WorkspaceId, selectedRepositoryIds: repoIds, cancellationToken: ct);
+
+                if (error != null)
+                {
+                    SafeInvoke(() => errorMessage = error);
+                    return;
+                }
+
+                job.ReportProgress("Checking file versions...");
+                await fileVersionService.CheckAndPersistFileVersionStatusAsync(WorkspaceId, ct);
+
+                await InvokeAsync(async () =>
+                {
+                    if (_disposed) return;
+                    await RefreshFromSync();
+                    if (failed > 0)
+                        errorMessage = $"Updated {updated} line(s). {failed} file(s) could not be updated - check logs.";
+                    else if (updated > 0)
+                        ToastService.Show($"Updated {updated} line(s) in configured files.");
+                    else
+                        ToastService.Show("File versions are already up to date.");
+                });
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "Error updating file versions for repository {RepositoryId} in workspace {WorkspaceId}", repositoryId, WorkspaceId);
+                SafeInvoke(() => errorMessage = "Failed to update file versions. Please try again.");
+                throw;
+            }
+        });
+
+        return Task.CompletedTask;
+    }
+
     private async Task OnUpdateAndPushClickAsync()
     {
         if (workspace == null || workspaceRepositories.Count == 0 || IsJobRunning)
@@ -1758,8 +1819,12 @@ public sealed partial class WorkspaceRepositories : IDisposable
 
     private async Task HandleDependencyBadgeKeydown(KeyboardEventArgs e, int repositoryId, int unmatchedDeps)
     {
-        if ((e.Key == "Enter" || e.Key == " ") && !IsJobRunning)
+        if ((e.Key != "Enter" && e.Key != " ") || IsJobRunning)
+            return;
+        if (unmatchedDeps > 0)
             await ShowConfirmUpdateDependenciesAsync(repositoryId, unmatchedDeps);
+        else if (HasOutOfDateFiles(repositoryId))
+            OnFileDependencyBadgeClick(repositoryId);
     }
 
     /// <summary>Update dependencies for a single repository only (refresh projects, sync deps, no commit). Same as Update but scoped to one repo.</summary>
@@ -2920,6 +2985,13 @@ public sealed partial class WorkspaceRepositories : IDisposable
     {
         clickedDependencyBadges.Add(repositoryId);
         _ = ShowConfirmUpdateDependenciesAsync(repositoryId, unmatchedDeps);
+        StateHasChanged();
+    }
+
+    private void OnFileDependencyBadgeClick(int repositoryId)
+    {
+        clickedDependencyBadges.Add(repositoryId);
+        _ = UpdateSingleRepositoryFileVersionsAsync(repositoryId);
         StateHasChanged();
     }
 

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
@@ -61,6 +61,8 @@ public sealed partial class WorkspaceRepositories : IDisposable
 
     /// <summary>All workspace-internal package dependencies of each repository (PackageId + version as written in the .csproj). Used to populate the dependency-badge tooltip for repositories whose dependencies are up to date.</summary>
     private IReadOnlyDictionary<int, IReadOnlyList<(string PackageId, string Version)>> _allDependencyLinesByRepo = new Dictionary<int, IReadOnlyList<(string, string)>>();
+    /// <summary>Per-repo (FileName, TokenName, Version) triples derived from version-file configs and current GitVersions. Drives the OK badge file-dependency tooltip.</summary>
+    private IReadOnlyDictionary<int, IReadOnlyList<(string FileName, string TokenName, string Version)>> _allFileVersionLinesByRepo = new Dictionary<int, IReadOnlyList<(string, string, string)>>();
     private Dictionary<int, string> repositoryErrors = new(); // repositoryId -> error message
     private HashSet<string> clickedVersions = new(); // Track clicked versions to hide hover until mouse leaves
     private HashSet<int> clickedDependencyBadges = new(); // Track clicked dependency badges to hide tooltip immediately
@@ -90,6 +92,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
     private const int RefreshDebounceMs = 200;
     private CancellationTokenSource? _refreshDebounceCts;
     private readonly object _refreshDebounceLock = new();
+    private readonly SemaphoreSlim _loadMismatchedDepsLock = new(1, 1);
 
     /// <summary>Toast shown when the user attempts a write action against a repository that is pinned to a tag.</summary>
     private const string TagBlockedActionMessage = "Repository is on a tag; checkout a branch first.";
@@ -192,6 +195,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
         _hubConnection?.DisposeAsync();
         _fetchRepositoriesCts?.Cancel();
         _fetchRepositoriesCts?.Dispose();
+        _loadMismatchedDepsLock.Dispose();
     }
 
     private void OnJobServiceChanged()
@@ -403,66 +407,88 @@ public sealed partial class WorkspaceRepositories : IDisposable
 
     private async Task LoadMismatchedDependencyLinesAsync()
     {
-        if (!workspaceRepositories.Any(wr => (wr.UnmatchedDeps ?? 0) > 0))
+        await _loadMismatchedDepsLock.WaitAsync();
+        try
         {
-            _mismatchedDependencyLinesByRepo = new Dictionary<int, IReadOnlyList<(string, string, string)>>();
-        }
-        else
-        {
+            // Fresh scope: circuit-scoped DbContext may be busy (e.g. CheckFileVersions during sync/update).
+            await using var scope = ServiceScopeFactory.CreateAsyncScope();
+            var projectRepo = scope.ServiceProvider.GetRequiredService<WorkspaceProjectRepository>();
+            var fileVersionService = scope.ServiceProvider.GetRequiredService<WorkspaceFileVersionService>();
+
+            if (!workspaceRepositories.Any(wr => (wr.UnmatchedDeps ?? 0) > 0))
+            {
+                _mismatchedDependencyLinesByRepo = new Dictionary<int, IReadOnlyList<(string, string, string)>>();
+            }
+            else
+            {
+                try
+                {
+                    // Use raw sync payloads so tag-pinned repos still get mismatch lines for hover/copy in the badge tooltip.
+                    // GetUpdatePlanAsync excludes tag-pinned repos on purpose so Update does not target them.
+                    var payloads = await projectRepo.GetSyncDependenciesPayloadAsync(WorkspaceId);
+                    var dict = new Dictionary<int, IReadOnlyList<(string PackageId, string CurrentVersion, string NewVersion)>>();
+                    foreach (var p in payloads.Where(p => p.ProjectUpdates.Count > 0))
+                    {
+                        var lines = p.ProjectUpdates
+                            .SelectMany(pu => pu.PackageUpdates)
+                            .GroupBy(x => (x.PackageId.Trim(), x.CurrentVersion.Trim(), x.NewVersion.Trim()))
+                            .Select(g => (g.Key.Item1, g.Key.Item2, g.Key.Item3))
+                            .ToList();
+                        dict[p.RepoId] = lines;
+                    }
+                    _mismatchedDependencyLinesByRepo = dict;
+                }
+                catch (Exception ex)
+                {
+                    Logger.LogDebug(ex, "Could not load mismatched dependency lines for workspace {WorkspaceId}", WorkspaceId);
+                    _mismatchedDependencyLinesByRepo = new Dictionary<int, IReadOnlyList<(string, string, string)>>();
+                }
+            }
+
             try
             {
-                // Use raw sync payloads so tag-pinned repos still get mismatch lines for hover/copy in the badge tooltip.
-                // GetUpdatePlanAsync excludes tag-pinned repos on purpose so Update does not target them.
-                var payloads = await WorkspacePageService.WorkspaceProjectRepository
-                    .GetSyncDependenciesPayloadAsync(WorkspaceId);
-                var dict = new Dictionary<int, IReadOnlyList<(string PackageId, string CurrentVersion, string NewVersion)>>();
-                foreach (var p in payloads.Where(p => p.ProjectUpdates.Count > 0))
-                {
-                    var lines = p.ProjectUpdates
-                        .SelectMany(pu => pu.PackageUpdates)
-                        .GroupBy(x => (x.PackageId.Trim(), x.CurrentVersion.Trim(), x.NewVersion.Trim()))
-                        .Select(g => (g.Key.Item1, g.Key.Item2, g.Key.Item3))
-                        .ToList();
-                    dict[p.RepoId] = lines;
-                }
-                _mismatchedDependencyLinesByRepo = dict;
+                _allDependencyLinesByRepo = await projectRepo.GetPackageDependencyLinesByRepoAsync(WorkspaceId);
             }
             catch (Exception ex)
             {
-                Logger.LogDebug(ex, "Could not load mismatched dependency lines for workspace {WorkspaceId}", WorkspaceId);
-                _mismatchedDependencyLinesByRepo = new Dictionary<int, IReadOnlyList<(string, string, string)>>();
+                Logger.LogDebug(ex, "Could not load dependency listing for workspace {WorkspaceId}", WorkspaceId);
+                _allDependencyLinesByRepo = new Dictionary<int, IReadOnlyList<(string, string)>>();
+            }
+
+            try
+            {
+                _fileLineStatusByRepo = await fileVersionService.GetFileLineStatusByWorkspaceAsync(WorkspaceId);
+            }
+            catch (Exception ex)
+            {
+                Logger.LogDebug(ex, "Could not load file line status for workspace {WorkspaceId}", WorkspaceId);
+                _fileLineStatusByRepo = new Dictionary<int, IReadOnlyList<WorkspaceFileLineStatus>>();
+            }
+
+            try
+            {
+                var repoVersionMap = workspaceRepositories
+                    .Where(r => r.Repository?.RepositoryName != null && !string.IsNullOrEmpty(r.GitVersion))
+                    .ToDictionary(r => r.Repository!.RepositoryName!, r => r.GitVersion!, StringComparer.OrdinalIgnoreCase);
+                _allFileVersionLinesByRepo = await fileVersionService.GetAllFileVersionLinesByRepoAsync(WorkspaceId, repoVersionMap);
+            }
+            catch (Exception ex)
+            {
+                Logger.LogDebug(ex, "Could not load file version lines for workspace {WorkspaceId}", WorkspaceId);
+                _allFileVersionLinesByRepo = new Dictionary<int, IReadOnlyList<(string, string, string)>>();
             }
         }
-
-        try
+        finally
         {
-            _allDependencyLinesByRepo = await WorkspacePageService.WorkspaceProjectRepository
-                .GetPackageDependencyLinesByRepoAsync(WorkspaceId);
-        }
-        catch (Exception ex)
-        {
-            Logger.LogDebug(ex, "Could not load dependency listing for workspace {WorkspaceId}", WorkspaceId);
-            _allDependencyLinesByRepo = new Dictionary<int, IReadOnlyList<(string, string)>>();
-        }
-
-        await LoadFileLineStatusAsync();
-    }
-
-    private async Task LoadFileLineStatusAsync()
-    {
-        try
-        {
-            _fileLineStatusByRepo = await FileVersionService.GetFileLineStatusByWorkspaceAsync(WorkspaceId);
-        }
-        catch (Exception ex)
-        {
-            Logger.LogDebug(ex, "Could not load file line status for workspace {WorkspaceId}", WorkspaceId);
-            _fileLineStatusByRepo = new Dictionary<int, IReadOnlyList<WorkspaceFileLineStatus>>();
+            _loadMismatchedDepsLock.Release();
         }
     }
 
     private IReadOnlyList<WorkspaceFileLineStatus> GetFileLineStatus(int repositoryId) =>
         _fileLineStatusByRepo.TryGetValue(repositoryId, out var lines) ? lines : Array.Empty<WorkspaceFileLineStatus>();
+
+    private IReadOnlyList<(string FileName, string TokenName, string Version)> GetAllFileVersionLines(int repositoryId) =>
+        _allFileVersionLinesByRepo.TryGetValue(repositoryId, out var lines) ? lines : Array.Empty<(string, string, string)>();
 
     private int GetTotalMatchedFileLines(int repositoryId) =>
         workspaceRepositories.FirstOrDefault(wr => wr.RepositoryId == repositoryId)?.TotalFileLines ?? 0;

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
@@ -1040,6 +1040,11 @@ public sealed partial class WorkspaceRepositories : IDisposable
             var (payload, _) = await workspaceGitService.GetUpdatePlanAsync(WorkspaceId, new HashSet<int> { repositoryId });
             if (payload == null || payload.Count == 0)
             {
+                if (HasOutOfDateFiles(repositoryId))
+                {
+                    OnFileDependencyBadgeClick(repositoryId);
+                    return;
+                }
                 ToastService.Show("No dependency updates for this repository.");
                 return;
             }
@@ -1051,8 +1056,12 @@ public sealed partial class WorkspaceRepositories : IDisposable
                 && !string.IsNullOrWhiteSpace(repo.DefaultBranchName)
                 && string.Equals(repo.BranchName, repo.DefaultBranchName, StringComparison.Ordinal))
             {
+                var hasFiles = HasOutOfDateFiles(repositoryId);
+                var warningMsg = hasFiles
+                    ? "The following repository is on its default branch. Updating dependencies and file versions will commit changes directly to the default (protected) branch."
+                    : "The following repository is on its default branch. Updating dependencies will commit changes directly to the default (protected) branch.";
                 ShowDefaultBranchWarning(
-                    "The following repository is on its default branch. Updating dependencies will commit changes directly to the default (protected) branch.",
+                    warningMsg,
                     new[] { (repoName ?? $"repo {repositoryId}", repo.DefaultBranchName!) },
                     () => OpenUpdateSingleRepoModalAsync(repoPayload, repositoryId, repoName));
                 return;

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
@@ -3156,7 +3156,10 @@ public sealed partial class WorkspaceRepositories : IDisposable
             var workspaceData = await workspaceRepo.GetByIdAsync(WorkspaceId);
             var allLinks = workspaceData?.Repositories ?? workspaceRepositories;
 
-            var lockedIds = await projectRepo.GetImplicitReferencedRepoIdsAsync(WorkspaceId, repositoryId);
+            var implicitBySource = await projectRepo.GetImplicitReferencedRepoIdsBySourceAsync(WorkspaceId, repositoryId);
+            var lockedIds = new HashSet<int>(implicitBySource.FromProject);
+            lockedIds.UnionWith(implicitBySource.FromFile);
+            var circularRepoIds = await projectRepo.GetCircularCustomDependencyRepoIdsAsync(WorkspaceId, repositoryId);
             var savedCustomIds = await customDepRepo.GetCustomReferencedRepositoryIdsAsync(WorkspaceId, repositoryId);
 
             _customDependenciesModal = new CustomDependenciesModalState
@@ -3166,9 +3169,13 @@ public sealed partial class WorkspaceRepositories : IDisposable
                 DependentWorkspaceRepositoryId = link.WorkspaceRepositoryId,
                 DependentRepoName = link.Repository?.RepositoryName,
                 LockedReferencedRepoIds = lockedIds,
+                LockedFromProjectRepoIds = implicitBySource.FromProject,
+                LockedFromFileRepoIds = implicitBySource.FromFile,
+                CircularCustomDependencyRepoIds = circularRepoIds,
                 SelectedCustomRepoIds = new HashSet<int>(savedCustomIds),
                 Repositories = allLinks
                     .Where(wr => wr.Repository != null && !string.IsNullOrWhiteSpace(wr.Repository.RepositoryName))
+                    .Where(wr => !circularRepoIds.Contains(wr.RepositoryId))
                     .Select(wr => new CustomDependenciesModal.CustomDependencyRepoEntry(
                         wr.RepositoryId,
                         wr.Repository!.RepositoryName!))
@@ -3199,8 +3206,9 @@ public sealed partial class WorkspaceRepositories : IDisposable
 
         var dependentRepoId = _customDependenciesModal.DependentRepositoryId;
         var locked = _customDependenciesModal.LockedReferencedRepoIds;
+        var circular = _customDependenciesModal.CircularCustomDependencyRepoIds;
         var selected = _customDependenciesModal.SelectedCustomRepoIds
-            .Where(id => !locked.Contains(id) && id != dependentRepoId)
+            .Where(id => !locked.Contains(id) && !circular.Contains(id) && id != dependentRepoId)
             .ToHashSet();
 
         _customDependenciesModal.IsSaving = true;
@@ -3287,6 +3295,9 @@ public sealed partial class WorkspaceRepositories : IDisposable
         public int DependentWorkspaceRepositoryId { get; set; }
         public string? DependentRepoName { get; set; }
         public IReadOnlySet<int> LockedReferencedRepoIds { get; set; } = new HashSet<int>();
+        public IReadOnlySet<int> LockedFromProjectRepoIds { get; set; } = new HashSet<int>();
+        public IReadOnlySet<int> LockedFromFileRepoIds { get; set; } = new HashSet<int>();
+        public IReadOnlySet<int> CircularCustomDependencyRepoIds { get; set; } = new HashSet<int>();
         public HashSet<int> SelectedCustomRepoIds { get; set; } = new();
         public IReadOnlyList<CustomDependenciesModal.CustomDependencyRepoEntry> Repositories { get; set; } = Array.Empty<CustomDependenciesModal.CustomDependencyRepoEntry>();
         public bool IsSaving { get; set; }

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
@@ -3139,6 +3139,10 @@ public sealed partial class WorkspaceRepositories : IDisposable
             await using var scope = ServiceScopeFactory.CreateAsyncScope();
             var projectRepo = scope.ServiceProvider.GetRequiredService<WorkspaceProjectRepository>();
             var customDepRepo = scope.ServiceProvider.GetRequiredService<WorkspaceRepositoryCustomDependencyRepository>();
+            var workspaceRepo = scope.ServiceProvider.GetRequiredService<WorkspaceRepository>();
+
+            var workspaceData = await workspaceRepo.GetByIdAsync(WorkspaceId);
+            var allLinks = workspaceData?.Repositories ?? workspaceRepositories;
 
             var lockedIds = await projectRepo.GetImplicitReferencedRepoIdsAsync(WorkspaceId, repositoryId);
             var savedCustomIds = await customDepRepo.GetCustomReferencedRepositoryIdsAsync(WorkspaceId, repositoryId);
@@ -3151,11 +3155,12 @@ public sealed partial class WorkspaceRepositories : IDisposable
                 DependentRepoName = link.Repository?.RepositoryName,
                 LockedReferencedRepoIds = lockedIds,
                 SelectedCustomRepoIds = new HashSet<int>(savedCustomIds),
-                Repositories = workspaceRepositories
-                    .Where(wr => wr.Repository?.RepositoryName != null)
+                Repositories = allLinks
+                    .Where(wr => wr.Repository != null && !string.IsNullOrWhiteSpace(wr.Repository.RepositoryName))
                     .Select(wr => new CustomDependenciesModal.CustomDependencyRepoEntry(
                         wr.RepositoryId,
                         wr.Repository!.RepositoryName!))
+                    .OrderBy(r => r.RepositoryName, StringComparer.OrdinalIgnoreCase)
                     .ToList(),
                 ErrorMessage = null,
                 IsSaving = false

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
@@ -4,6 +4,7 @@ using GrayMoon.App.Models;
 using GrayMoon.App.Repositories;
 using GrayMoon.App.Services;
 using Microsoft.AspNetCore.Components;
+
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.SignalR.Client;
 using Microsoft.JSInterop;
@@ -22,7 +23,8 @@ public sealed partial class WorkspaceRepositories : IDisposable
     private string? errorMessage;
     private bool isLoading = true;
     private bool? isOutOfSync = null;
-    private bool hasUnmatchedDependencies => workspaceRepositories.Any(wr => !wr.IsOnTag && (wr.UnmatchedDeps ?? 0) > 0);
+    private bool hasUnmatchedDependencies => workspaceRepositories.Any(wr => !wr.IsOnTag &&
+        ((wr.UnmatchedDeps ?? 0) > 0 || (wr.OutOfDateFileLines ?? 0) > 0));
     private bool isPushRecommended => workspaceRepositories.Any(wr => !wr.IsOnTag && ((wr.OutgoingCommits ?? 0) > 0 || wr.BranchHasUpstream == false));
     private bool hasTaggedRepos => workspaceRepositories.Any(wr => wr.IsOnTag);
     /// <summary>When true, any repository on its default branch has incoming commits; header shows red Pull button and executes only Pull (commit sync) for those repos. Repos pinned to a tag are excluded.</summary>
@@ -55,6 +57,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
         : $"Fetched {_repositoriesModal.FetchedRepositoryCount} {(_repositoriesModal.FetchedRepositoryCount == 1 ? "repository" : "repositories")}";
     private Dictionary<int, RepoSyncStatus> repoSyncStatus = new();
     private IReadOnlyDictionary<int, IReadOnlyList<(string PackageId, string CurrentVersion, string NewVersion)>> _mismatchedDependencyLinesByRepo = new Dictionary<int, IReadOnlyList<(string, string, string)>>();
+    private IReadOnlyDictionary<int, IReadOnlyList<WorkspaceFileLineStatus>> _fileLineStatusByRepo = new Dictionary<int, IReadOnlyList<WorkspaceFileLineStatus>>();
 
     /// <summary>All workspace-internal package dependencies of each repository (PackageId + version as written in the .csproj). Used to populate the dependency-badge tooltip for repositories whose dependencies are up to date.</summary>
     private IReadOnlyDictionary<int, IReadOnlyList<(string PackageId, string Version)>> _allDependencyLinesByRepo = new Dictionary<int, IReadOnlyList<(string, string)>>();
@@ -441,7 +444,28 @@ public sealed partial class WorkspaceRepositories : IDisposable
             Logger.LogDebug(ex, "Could not load dependency listing for workspace {WorkspaceId}", WorkspaceId);
             _allDependencyLinesByRepo = new Dictionary<int, IReadOnlyList<(string, string)>>();
         }
+
+        await LoadFileLineStatusAsync();
     }
+
+    private async Task LoadFileLineStatusAsync()
+    {
+        try
+        {
+            _fileLineStatusByRepo = await FileVersionService.GetFileLineStatusByWorkspaceAsync(WorkspaceId);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogDebug(ex, "Could not load file line status for workspace {WorkspaceId}", WorkspaceId);
+            _fileLineStatusByRepo = new Dictionary<int, IReadOnlyList<WorkspaceFileLineStatus>>();
+        }
+    }
+
+    private IReadOnlyList<WorkspaceFileLineStatus> GetFileLineStatus(int repositoryId) =>
+        _fileLineStatusByRepo.TryGetValue(repositoryId, out var lines) ? lines : Array.Empty<WorkspaceFileLineStatus>();
+
+    private int GetTotalMatchedFileLines(int repositoryId) =>
+        workspaceRepositories.FirstOrDefault(wr => wr.RepositoryId == repositoryId)?.TotalFileLines ?? 0;
 
     private void OnSearchChanged(ChangeEventArgs e)
     {

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
@@ -24,7 +24,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
     private bool isLoading = true;
     private bool? isOutOfSync = null;
     private bool hasUnmatchedDependencies => workspaceRepositories.Any(wr => !wr.IsOnTag &&
-        ((wr.UnmatchedDeps ?? 0) > 0 || (wr.OutOfDateFileLines ?? 0) > 0));
+        ((wr.UnmatchedDeps ?? 0) > 0 || (wr.OutOfDateFileLines ?? 0) > 0 || (wr.OutOfDateFileRepos ?? 0) > 0));
     private bool isPushRecommended => workspaceRepositories.Any(wr => !wr.IsOnTag && ((wr.OutgoingCommits ?? 0) > 0 || wr.BranchHasUpstream == false));
     private bool hasTaggedRepos => workspaceRepositories.Any(wr => wr.IsOnTag);
     /// <summary>When true, any repository on its default branch has incoming commits; header shows red Pull button and executes only Pull (commit sync) for those repos. Repos pinned to a tag are excluded.</summary>
@@ -487,8 +487,13 @@ public sealed partial class WorkspaceRepositories : IDisposable
     private IReadOnlyList<WorkspaceFileLineStatus> GetFileLineStatus(int repositoryId) =>
         _fileLineStatusByRepo.TryGetValue(repositoryId, out var lines) ? lines : Array.Empty<WorkspaceFileLineStatus>();
 
-    private bool HasOutOfDateFiles(int repositoryId) =>
-        GetFileLineStatus(repositoryId).Any(s => s.OutOfDateLines > 0);
+    private bool HasOutOfDateFiles(int repositoryId)
+    {
+        var link = workspaceRepositories.FirstOrDefault(wr => wr.RepositoryId == repositoryId);
+        if (link != null && ((link.OutOfDateFileRepos ?? 0) > 0 || (link.OutOfDateFileLines ?? 0) > 0))
+            return true;
+        return GetFileLineStatus(repositoryId).Any(s => s.OutOfDateLines > 0);
+    }
 
     private IReadOnlyList<(string FileName, string TokenName, string Version)> GetAllFileVersionLines(int repositoryId) =>
         _allFileVersionLinesByRepo.TryGetValue(repositoryId, out var lines) ? lines : Array.Empty<(string, string, string)>();
@@ -1642,7 +1647,10 @@ public sealed partial class WorkspaceRepositories : IDisposable
                 var fileVersionService = scope.ServiceProvider.GetRequiredService<WorkspaceFileVersionService>();
                 var repoIds = new HashSet<int> { repositoryId };
                 var (updated, failed, error, _) = await fileVersionService.UpdateAllVersionsAsync(
-                    WorkspaceId, selectedRepositoryIds: repoIds, cancellationToken: ct);
+                    WorkspaceId,
+                    selectedRepositoryIds: repoIds,
+                    filterPatternTokensToSelectedRepositories: false,
+                    cancellationToken: ct);
 
                 if (error != null)
                 {

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
@@ -3134,6 +3134,9 @@ public sealed partial class WorkspaceRepositories : IDisposable
             return;
         }
 
+        clickedDependencyBadges.Add(repositoryId);
+        StateHasChanged();
+
         try
         {
             await using var scope = ServiceScopeFactory.CreateAsyncScope();

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
@@ -490,9 +490,6 @@ public sealed partial class WorkspaceRepositories : IDisposable
     private IReadOnlyList<(string FileName, string TokenName, string Version)> GetAllFileVersionLines(int repositoryId) =>
         _allFileVersionLinesByRepo.TryGetValue(repositoryId, out var lines) ? lines : Array.Empty<(string, string, string)>();
 
-    private int GetTotalMatchedFileLines(int repositoryId) =>
-        workspaceRepositories.FirstOrDefault(wr => wr.RepositoryId == repositoryId)?.TotalFileLines ?? 0;
-
     private void OnSearchChanged(ChangeEventArgs e)
     {
         searchTerm = e.Value?.ToString() ?? string.Empty;

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
@@ -58,7 +58,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
     private Dictionary<int, RepoSyncStatus> repoSyncStatus = new();
     private IReadOnlyDictionary<int, IReadOnlyList<(string PackageId, string CurrentVersion, string NewVersion)>> _mismatchedDependencyLinesByRepo = new Dictionary<int, IReadOnlyList<(string, string, string)>>();
     private IReadOnlyDictionary<int, IReadOnlyList<WorkspaceFileLineStatus>> _fileLineStatusByRepo = new Dictionary<int, IReadOnlyList<WorkspaceFileLineStatus>>();
-    private IReadOnlyDictionary<int, IReadOnlyList<(string TokenName, string CurrentValue, string ExpectedValue)>> _mismatchedFileVersionLinesByRepo = new Dictionary<int, IReadOnlyList<(string, string, string)>>();
+    private IReadOnlyDictionary<int, IReadOnlyList<(string FileName, string TokenName, string CurrentValue, string ExpectedValue)>> _mismatchedFileVersionLinesByRepo = new Dictionary<int, IReadOnlyList<(string, string, string, string)>>();
 
     /// <summary>All workspace-internal package dependencies of each repository (PackageId + version as written in the .csproj). Used to populate the dependency-badge tooltip for repositories whose dependencies are up to date.</summary>
     private IReadOnlyDictionary<int, IReadOnlyList<(string PackageId, string Version)>> _allDependencyLinesByRepo = new Dictionary<int, IReadOnlyList<(string, string)>>();
@@ -466,7 +466,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
             catch (Exception ex)
             {
                 Logger.LogDebug(ex, "Could not load mismatched file version lines for workspace {WorkspaceId}", WorkspaceId);
-                _mismatchedFileVersionLinesByRepo = new Dictionary<int, IReadOnlyList<(string, string, string)>>();
+                _mismatchedFileVersionLinesByRepo = new Dictionary<int, IReadOnlyList<(string, string, string, string)>>();
             }
 
             try
@@ -512,8 +512,8 @@ public sealed partial class WorkspaceRepositories : IDisposable
     private bool HasOutOfDateFiles(int repositoryId) =>
         (workspaceRepositories.FirstOrDefault(wr => wr.RepositoryId == repositoryId)?.OutOfDateFileRepos ?? 0) > 0;
 
-    private IReadOnlyList<(string TokenName, string CurrentValue, string ExpectedValue)> GetMismatchedFileVersionLines(int repositoryId) =>
-        _mismatchedFileVersionLinesByRepo.TryGetValue(repositoryId, out var lines) ? lines : Array.Empty<(string, string, string)>();
+    private IReadOnlyList<(string FileName, string TokenName, string CurrentValue, string ExpectedValue)> GetMismatchedFileVersionLines(int repositoryId) =>
+        _mismatchedFileVersionLinesByRepo.TryGetValue(repositoryId, out var lines) ? lines : Array.Empty<(string, string, string, string)>();
 
     private IReadOnlyList<WorkspaceFileLineStatus> GetFileLineStatus(int repositoryId) =>
         _fileLineStatusByRepo.TryGetValue(repositoryId, out var lines) ? lines : Array.Empty<WorkspaceFileLineStatus>();

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
@@ -1602,14 +1602,24 @@ public sealed partial class WorkspaceRepositories : IDisposable
                 var (updated, failed, error, _) = await fileVersionService.UpdateAllVersionsAsync(
                     WorkspaceId, selectedRepositoryIds: null, cancellationToken: ct);
 
-                SafeInvoke(() =>
+                if (error == null)
                 {
+                    job.ReportProgress("Checking file versions...");
+                    await fileVersionService.CheckAndPersistFileVersionStatusAsync(WorkspaceId, ct, forceFresh: true);
+                }
+
+                await InvokeAsync(async () =>
+                {
+                    if (_disposed) return;
+                    if (error == null)
+                        await RefreshFromSync();
+                    StateHasChanged();
                     if (error != null)
                         errorMessage = error;
                     else if (failed > 0)
                         errorMessage = $"Updated {updated} line(s). {failed} file(s) could not be updated - check logs.";
                     else
-                        ToastService.Show("Versions updated in configured files.");
+                        ToastService.Show(updated > 0 ? "Versions updated in configured files." : "File versions are already up to date.");
                 });
             }
             catch (OperationCanceledException)
@@ -1659,12 +1669,13 @@ public sealed partial class WorkspaceRepositories : IDisposable
                 }
 
                 job.ReportProgress("Checking file versions...");
-                await fileVersionService.CheckAndPersistFileVersionStatusAsync(WorkspaceId, ct);
+                await fileVersionService.CheckAndPersistFileVersionStatusAsync(WorkspaceId, ct, forceFresh: true);
 
                 await InvokeAsync(async () =>
                 {
                     if (_disposed) return;
                     await RefreshFromSync();
+                    StateHasChanged();
                     if (failed > 0)
                         errorMessage = $"Updated {updated} line(s). {failed} file(s) could not be updated - check logs.";
                     else if (updated > 0)

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
@@ -63,6 +63,8 @@ public sealed partial class WorkspaceRepositories : IDisposable
     private IReadOnlyDictionary<int, IReadOnlyList<(string PackageId, string Version)>> _allDependencyLinesByRepo = new Dictionary<int, IReadOnlyList<(string, string)>>();
     /// <summary>Per-repo (FileName, TokenName, Version) triples derived from version-file configs and current GitVersions. Drives the OK badge file-dependency tooltip.</summary>
     private IReadOnlyDictionary<int, IReadOnlyList<(string FileName, string TokenName, string Version)>> _allFileVersionLinesByRepo = new Dictionary<int, IReadOnlyList<(string, string, string)>>();
+    /// <summary>User-declared custom dependency repo names per dependent repository (ordering only).</summary>
+    private IReadOnlyDictionary<int, IReadOnlyList<string>> _customDependencyLinesByRepo = new Dictionary<int, IReadOnlyList<string>>();
     private Dictionary<int, string> repositoryErrors = new(); // repositoryId -> error message
     private HashSet<string> clickedVersions = new(); // Track clicked versions to hide hover until mouse leaves
     private HashSet<int> clickedDependencyBadges = new(); // Track clicked dependency badges to hide tooltip immediately
@@ -75,6 +77,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
     private UpdateModalState _updateModal = new();
     private UpdateModalState _updateAndPushModal = new();
     private UpdateSingleRepoDependenciesModalState _updateSingleRepoModal = new();
+    private CustomDependenciesModalState _customDependenciesModal = new();
     private PushWithDependenciesModalState _pushWithDependenciesModal = new();
     private ConfirmModalState _confirmModal = new();
     private DefaultBranchWarningModalState _defaultBranchWarningModal = new();
@@ -476,6 +479,17 @@ public sealed partial class WorkspaceRepositories : IDisposable
             {
                 Logger.LogDebug(ex, "Could not load file version lines for workspace {WorkspaceId}", WorkspaceId);
                 _allFileVersionLinesByRepo = new Dictionary<int, IReadOnlyList<(string, string, string)>>();
+            }
+
+            try
+            {
+                var customDepRepo = scope.ServiceProvider.GetRequiredService<WorkspaceRepositoryCustomDependencyRepository>();
+                _customDependencyLinesByRepo = await customDepRepo.GetCustomDependencyNamesByRepoAsync(WorkspaceId);
+            }
+            catch (Exception ex)
+            {
+                Logger.LogDebug(ex, "Could not load custom dependency lines for workspace {WorkspaceId}", WorkspaceId);
+                _customDependencyLinesByRepo = new Dictionary<int, IReadOnlyList<string>>();
             }
         }
         finally
@@ -3104,6 +3118,100 @@ public sealed partial class WorkspaceRepositories : IDisposable
         return _allDependencyLinesByRepo.GetValueOrDefault(repositoryId) ?? Array.Empty<(string PackageId, string Version)>();
     }
 
+    private IReadOnlyList<string> GetCustomDependencyLines(int repositoryId)
+    {
+        return _customDependencyLinesByRepo.GetValueOrDefault(repositoryId) ?? Array.Empty<string>();
+    }
+
+    private async Task ShowCustomDependenciesModalAsync(int repositoryId)
+    {
+        if (workspaceRepositories.FirstOrDefault(wr => wr.RepositoryId == repositoryId) is not { } link)
+            return;
+
+        if (link.IsOnTag)
+        {
+            ToastService.Show("Repository is on a tag; checkout a branch first.");
+            return;
+        }
+
+        try
+        {
+            await using var scope = ServiceScopeFactory.CreateAsyncScope();
+            var projectRepo = scope.ServiceProvider.GetRequiredService<WorkspaceProjectRepository>();
+            var customDepRepo = scope.ServiceProvider.GetRequiredService<WorkspaceRepositoryCustomDependencyRepository>();
+
+            var lockedIds = await projectRepo.GetImplicitReferencedRepoIdsAsync(WorkspaceId, repositoryId);
+            var savedCustomIds = await customDepRepo.GetCustomReferencedRepositoryIdsAsync(WorkspaceId, repositoryId);
+
+            _customDependenciesModal = new CustomDependenciesModalState
+            {
+                IsVisible = true,
+                DependentRepositoryId = repositoryId,
+                DependentWorkspaceRepositoryId = link.WorkspaceRepositoryId,
+                DependentRepoName = link.Repository?.RepositoryName,
+                LockedReferencedRepoIds = lockedIds,
+                SelectedCustomRepoIds = new HashSet<int>(savedCustomIds),
+                Repositories = workspaceRepositories
+                    .Where(wr => wr.Repository?.RepositoryName != null)
+                    .Select(wr => new CustomDependenciesModal.CustomDependencyRepoEntry(
+                        wr.RepositoryId,
+                        wr.Repository!.RepositoryName!))
+                    .ToList(),
+                ErrorMessage = null,
+                IsSaving = false
+            };
+            StateHasChanged();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex, "Could not open custom dependencies dialog for repo {RepositoryId}", repositoryId);
+            ToastService.ShowError("Could not open custom dependencies dialog.");
+        }
+    }
+
+    private void CloseCustomDependenciesModal()
+    {
+        _customDependenciesModal = new CustomDependenciesModalState();
+        StateHasChanged();
+    }
+
+    private async Task SaveCustomDependenciesAsync()
+    {
+        if (!_customDependenciesModal.IsVisible || _customDependenciesModal.IsSaving)
+            return;
+
+        var dependentRepoId = _customDependenciesModal.DependentRepositoryId;
+        var locked = _customDependenciesModal.LockedReferencedRepoIds;
+        var selected = _customDependenciesModal.SelectedCustomRepoIds
+            .Where(id => !locked.Contains(id) && id != dependentRepoId)
+            .ToHashSet();
+
+        _customDependenciesModal.IsSaving = true;
+        _customDependenciesModal.ErrorMessage = null;
+        StateHasChanged();
+
+        try
+        {
+            await using var scope = ServiceScopeFactory.CreateAsyncScope();
+            var customDepRepo = scope.ServiceProvider.GetRequiredService<WorkspaceRepositoryCustomDependencyRepository>();
+            var gitService = scope.ServiceProvider.GetRequiredService<WorkspaceGitService>();
+
+            await customDepRepo.ReplaceCustomDependenciesForDependentAsync(WorkspaceId, dependentRepoId, selected);
+            await gitService.RecomputeAndBroadcastWorkspaceSyncedAsync(WorkspaceId);
+            await ReloadWorkspaceDataFromFreshScopeAsync();
+
+            CloseCustomDependenciesModal();
+            ToastService.Show("Custom dependencies saved.");
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex, "Failed to save custom dependencies for repo {RepositoryId}", dependentRepoId);
+            _customDependenciesModal.IsSaving = false;
+            _customDependenciesModal.ErrorMessage = "Failed to save custom dependencies. Please try again.";
+            StateHasChanged();
+        }
+    }
+
     private List<WorkspaceRepositoryLink> GetFilteredWorkspaceRepositories()
     {
         if (string.IsNullOrWhiteSpace(searchTerm))
@@ -3153,6 +3261,19 @@ public sealed partial class WorkspaceRepositories : IDisposable
         public bool IsFetching { get; set; }
         public int? FetchedRepositoryCount { get; set; }
         public bool HasConnectors { get; set; }
+    }
+
+    private sealed class CustomDependenciesModalState
+    {
+        public bool IsVisible { get; set; }
+        public int DependentRepositoryId { get; set; }
+        public int DependentWorkspaceRepositoryId { get; set; }
+        public string? DependentRepoName { get; set; }
+        public IReadOnlySet<int> LockedReferencedRepoIds { get; set; } = new HashSet<int>();
+        public HashSet<int> SelectedCustomRepoIds { get; set; } = new();
+        public IReadOnlyList<CustomDependenciesModal.CustomDependencyRepoEntry> Repositories { get; set; } = Array.Empty<CustomDependenciesModal.CustomDependencyRepoEntry>();
+        public bool IsSaving { get; set; }
+        public string? ErrorMessage { get; set; }
     }
 
     private sealed record BranchModalState

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
@@ -24,7 +24,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
     private bool isLoading = true;
     private bool? isOutOfSync = null;
     private bool hasUnmatchedDependencies => workspaceRepositories.Any(wr => !wr.IsOnTag &&
-        ((wr.UnmatchedDeps ?? 0) > 0 || (wr.OutOfDateFileLines ?? 0) > 0 || (wr.OutOfDateFileRepos ?? 0) > 0));
+        ((wr.UnmatchedDeps ?? 0) > 0 || (wr.OutOfDateFileRepos ?? 0) > 0));
     private bool isPushRecommended => workspaceRepositories.Any(wr => !wr.IsOnTag && ((wr.OutgoingCommits ?? 0) > 0 || wr.BranchHasUpstream == false));
     private bool hasTaggedRepos => workspaceRepositories.Any(wr => wr.IsOnTag);
     /// <summary>When true, any repository on its default branch has incoming commits; header shows red Pull button and executes only Pull (commit sync) for those repos. Repos pinned to a tag are excluded.</summary>
@@ -58,6 +58,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
     private Dictionary<int, RepoSyncStatus> repoSyncStatus = new();
     private IReadOnlyDictionary<int, IReadOnlyList<(string PackageId, string CurrentVersion, string NewVersion)>> _mismatchedDependencyLinesByRepo = new Dictionary<int, IReadOnlyList<(string, string, string)>>();
     private IReadOnlyDictionary<int, IReadOnlyList<WorkspaceFileLineStatus>> _fileLineStatusByRepo = new Dictionary<int, IReadOnlyList<WorkspaceFileLineStatus>>();
+    private IReadOnlyDictionary<int, IReadOnlyList<(string TokenName, string CurrentValue, string ExpectedValue)>> _mismatchedFileVersionLinesByRepo = new Dictionary<int, IReadOnlyList<(string, string, string)>>();
 
     /// <summary>All workspace-internal package dependencies of each repository (PackageId + version as written in the .csproj). Used to populate the dependency-badge tooltip for repositories whose dependencies are up to date.</summary>
     private IReadOnlyDictionary<int, IReadOnlyList<(string PackageId, string Version)>> _allDependencyLinesByRepo = new Dictionary<int, IReadOnlyList<(string, string)>>();
@@ -460,6 +461,16 @@ public sealed partial class WorkspaceRepositories : IDisposable
 
             try
             {
+                _mismatchedFileVersionLinesByRepo = await fileVersionService.GetMismatchedFileVersionLinesByRepoAsync(WorkspaceId);
+            }
+            catch (Exception ex)
+            {
+                Logger.LogDebug(ex, "Could not load mismatched file version lines for workspace {WorkspaceId}", WorkspaceId);
+                _mismatchedFileVersionLinesByRepo = new Dictionary<int, IReadOnlyList<(string, string, string)>>();
+            }
+
+            try
+            {
                 _fileLineStatusByRepo = await fileVersionService.GetFileLineStatusByWorkspaceAsync(WorkspaceId);
             }
             catch (Exception ex)
@@ -498,16 +509,14 @@ public sealed partial class WorkspaceRepositories : IDisposable
         }
     }
 
+    private bool HasOutOfDateFiles(int repositoryId) =>
+        (workspaceRepositories.FirstOrDefault(wr => wr.RepositoryId == repositoryId)?.OutOfDateFileRepos ?? 0) > 0;
+
+    private IReadOnlyList<(string TokenName, string CurrentValue, string ExpectedValue)> GetMismatchedFileVersionLines(int repositoryId) =>
+        _mismatchedFileVersionLinesByRepo.TryGetValue(repositoryId, out var lines) ? lines : Array.Empty<(string, string, string)>();
+
     private IReadOnlyList<WorkspaceFileLineStatus> GetFileLineStatus(int repositoryId) =>
         _fileLineStatusByRepo.TryGetValue(repositoryId, out var lines) ? lines : Array.Empty<WorkspaceFileLineStatus>();
-
-    private bool HasOutOfDateFiles(int repositoryId)
-    {
-        var link = workspaceRepositories.FirstOrDefault(wr => wr.RepositoryId == repositoryId);
-        if (link != null && ((link.OutOfDateFileRepos ?? 0) > 0 || (link.OutOfDateFileLines ?? 0) > 0))
-            return true;
-        return GetFileLineStatus(repositoryId).Any(s => s.OutOfDateLines > 0);
-    }
 
     private IReadOnlyList<(string FileName, string TokenName, string Version)> GetAllFileVersionLines(int repositoryId) =>
         _allFileVersionLinesByRepo.TryGetValue(repositoryId, out var lines) ? lines : Array.Empty<(string, string, string)>();

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.css
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.css
@@ -383,24 +383,12 @@
     display: inline-block;
 }
 
-/* Elevate row and wrap while tooltip is open so popup is not covered by rows below */
-::deep .grid-page-body .repositories-table tbody tr:has(.dependency-badge-tooltip-wrap:hover),
-::deep .grid-page-body .repositories-table tbody tr:has(.dependency-badge-tooltip-wrap:focus-within) {
-    position: relative;
-    z-index: 200;
-}
-
-::deep .repositories-table .dependency-badge-tooltip-wrap:hover,
-::deep .repositories-table .dependency-badge-tooltip-wrap:focus-within {
-    z-index: 201;
-}
-
 ::deep .repositories-table .dependency-badge-tooltip {
     display: block;
-    position: absolute;
-    right: 0;
-    left: auto;
-    top: 100%;
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: auto;
     /* No margin-top here: a transparent gap between badge and popup would break the :hover chain when the cursor
        crosses it. Use padding-top inside the popup instead so the popup is contiguous with the badge. */
     background: #2a2a2a;
@@ -412,7 +400,8 @@
     font-family: var(--bs-font-monospace);
     color: #f0f0f0;
     box-shadow: 0 4px 12px rgba(0,0,0,0.5);
-    z-index: 202;
+    /* Above table rows/thead; below page-scoped loading overlay (z-index 100) */
+    z-index: 50;
     pointer-events: none;
     max-height: 14rem;
     width: 30rem;
@@ -423,6 +412,29 @@
     opacity: 0;
     /* Fade out slowly with a 0.4s delay so brief cursor jitters between the badge and the popup don't close it. */
     transition: opacity 0.15s ease 0.4s;
+}
+
+/* Narrow scrollbar (same 8px track as custom dependencies dialog) */
+::deep .repositories-table .dependency-badge-tooltip {
+    scrollbar-width: thin;
+    scrollbar-color: #5a5a5a #2a2a2a;
+}
+
+::deep .repositories-table .dependency-badge-tooltip::-webkit-scrollbar {
+    width: 8px;
+}
+
+::deep .repositories-table .dependency-badge-tooltip::-webkit-scrollbar-track {
+    background: #2a2a2a;
+}
+
+::deep .repositories-table .dependency-badge-tooltip::-webkit-scrollbar-thumb {
+    background: #5a5a5a;
+    border-radius: 4px;
+}
+
+::deep .repositories-table .dependency-badge-tooltip::-webkit-scrollbar-thumb:hover {
+    background: #6a6a6a;
 }
 
 ::deep .repositories-table .dependency-badge-tooltip-wrap:hover .dependency-badge-tooltip,

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.css
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.css
@@ -472,6 +472,15 @@
     font-family: var(--bs-body-font-family);
 }
 
+::deep .repositories-table .dependency-badge-tooltip-section-header {
+    color: #aaa;
+    font-family: var(--bs-body-font-family);
+    font-size: 0.78rem;
+    margin-top: 0.45rem;
+    padding-top: 0.35rem;
+    border-top: 1px solid #444;
+}
+
 ::deep .repositories-table .dependency-badge-tooltip-copy {
     flex: 0 0 auto;
     background: transparent;

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.css
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.css
@@ -475,9 +475,17 @@
 
 ::deep .repositories-table .dependency-badge-tooltip-file {
     display: block;
-    color: #888;
+    color: #fff;
     font-size: 0.78rem;
     margin-bottom: 0.05rem;
+}
+
+::deep .repositories-table .dependency-badge-tooltip-filename {
+    color: #fff;
+}
+
+::deep .repositories-table .dependency-badge-tooltip-section-suffix {
+    color: #aaa;
 }
 
 ::deep .repositories-table .dependency-badge-tooltip-versions {

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.css
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.css
@@ -480,6 +480,21 @@
     font-family: var(--bs-body-font-family);
 }
 
+::deep .repositories-table .dependency-badge-tooltip-show-deps {
+    color: #8ab4f8;
+    font-size: 0.72rem;
+    text-decoration: none;
+}
+
+::deep .repositories-table .dependency-badge-tooltip-show-deps:hover:not(:disabled) {
+    color: #aecbfa;
+    text-decoration: underline;
+}
+
+::deep .repositories-table .dependency-badge-tooltip-show-deps:disabled {
+    color: #666;
+}
+
 ::deep .repositories-table .dependency-badge-tooltip-section-header {
     color: #aaa;
     font-family: var(--bs-body-font-family);

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.css
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.css
@@ -473,6 +473,13 @@
     margin-bottom: 0;
 }
 
+::deep .repositories-table .dependency-badge-tooltip-file {
+    display: block;
+    color: #888;
+    font-size: 0.78rem;
+    margin-bottom: 0.05rem;
+}
+
 ::deep .repositories-table .dependency-badge-tooltip-versions {
     color: #aaa;
     font-size: 0.85rem;

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.css
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.css
@@ -463,6 +463,10 @@
     color: goldenrod;
 }
 
+::deep .repositories-table .dependency-badge-tooltip-file-count {
+    color: #fff;
+}
+
 ::deep .repositories-table .dependency-badge-tooltip-footer {
     color: #888;
     font-size: 0.72rem;

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.css
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.css
@@ -383,6 +383,18 @@
     display: inline-block;
 }
 
+/* Elevate row and wrap while tooltip is open so popup is not covered by rows below */
+::deep .grid-page-body .repositories-table tbody tr:has(.dependency-badge-tooltip-wrap:hover),
+::deep .grid-page-body .repositories-table tbody tr:has(.dependency-badge-tooltip-wrap:focus-within) {
+    position: relative;
+    z-index: 200;
+}
+
+::deep .repositories-table .dependency-badge-tooltip-wrap:hover,
+::deep .repositories-table .dependency-badge-tooltip-wrap:focus-within {
+    z-index: 201;
+}
+
 ::deep .repositories-table .dependency-badge-tooltip {
     display: block;
     position: absolute;
@@ -400,7 +412,7 @@
     font-family: var(--bs-font-monospace);
     color: #f0f0f0;
     box-shadow: 0 4px 12px rgba(0,0,0,0.5);
-    z-index: 2100;
+    z-index: 202;
     pointer-events: none;
     max-height: 14rem;
     width: 30rem;
@@ -478,6 +490,24 @@
     padding-top: 0.25rem;
     border-top: 1px solid #444;
     font-family: var(--bs-body-font-family);
+}
+
+::deep .repositories-table .dependency-badge-tooltip-footer--end {
+    display: flex;
+    justify-content: flex-end;
+}
+
+::deep .repositories-table .dependency-badge-tooltip-footer--split {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 0.35rem;
+}
+
+::deep .repositories-table .dependency-badge-tooltip-footer-hint {
+    align-self: stretch;
+    text-align: left;
+    line-height: 1.35;
 }
 
 ::deep .repositories-table .dependency-badge-tooltip-show-deps {

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.css
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.css
@@ -467,6 +467,10 @@
     color: #fff;
 }
 
+::deep .repositories-table .dependency-badge-tooltip-versions--after-file {
+    margin-left: 0.35rem;
+}
+
 ::deep .repositories-table .dependency-badge-tooltip-footer {
     color: #888;
     font-size: 0.72rem;

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositoriesRow.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositoriesRow.razor
@@ -152,12 +152,25 @@
                                             @if (entry.i == 0 && AllDependencyLines.Count == 0 && CustomDependencyLines.Count == 0)
                                             {
                                                 <div class="dependency-badge-tooltip-header">
-                                                    <span class="dependency-badge-tooltip-title">@entry.fg.Key - dependencies (up to date):</span>
+                                                    <span class="dependency-badge-tooltip-title">
+                                                        <span class="dependency-badge-tooltip-filename">@entry.fg.Key</span><span class="dependency-badge-tooltip-section-suffix"> (up to date):</span>
+                                                    </span>
+                                                    <button type="button"
+                                                            class="dependency-badge-tooltip-copy"
+                                                            title="Copy list to clipboard"
+                                                            aria-label="Copy list to clipboard"
+                                                            @onclick="HandleCopyAllDependencies"
+                                                            @onclick:preventDefault
+                                                            @onclick:stopPropagation>
+                                                        <i class="bi bi-clipboard" aria-hidden="true"></i>
+                                                    </button>
                                                 </div>
                                             }
                                             else
                                             {
-                                                <div class="dependency-badge-tooltip-section-header">@entry.fg.Key - dependencies (up to date):</div>
+                                                <div class="dependency-badge-tooltip-section-header">
+                                                    <span class="dependency-badge-tooltip-filename">@entry.fg.Key</span><span class="dependency-badge-tooltip-section-suffix"> (up to date):</span>
+                                                </div>
                                             }
                                             @foreach (var line in entry.fg)
                                             {
@@ -165,25 +178,6 @@
                                                     <code>@line.TokenName</code> <span class="dependency-badge-tooltip-versions">@line.Version</span>
                                                 </div>
                                             }
-                                        }
-                                    }
-                                    else if (AllFileVersionLines.Count > 0)
-                                    {
-                                        @if (AllDependencyLines.Count > 0 || CustomDependencyLines.Count > 0)
-                                        {
-                                            <div class="dependency-badge-tooltip-section-header">File dependencies (up to date):</div>
-                                        }
-                                        else
-                                        {
-                                            <div class="dependency-badge-tooltip-header">
-                                                <span class="dependency-badge-tooltip-title">File dependencies (up to date):</span>
-                                            </div>
-                                        }
-                                        @foreach (var line in AllFileVersionLines.GroupBy(l => l.TokenName).Select(g => g.First()))
-                                        {
-                                            <div class="dependency-badge-tooltip-line">
-                                                <code>@line.TokenName</code> <span class="dependency-badge-tooltip-versions">@line.Version</span>
-                                            </div>
                                         }
                                     }
                                     @if (CustomDependencyLines.Count > 0)
@@ -196,6 +190,15 @@
                                         {
                                             <div class="dependency-badge-tooltip-header">
                                                 <span class="dependency-badge-tooltip-title">Custom dependencies:</span>
+                                                <button type="button"
+                                                        class="dependency-badge-tooltip-copy"
+                                                        title="Copy list to clipboard"
+                                                        aria-label="Copy list to clipboard"
+                                                        @onclick="HandleCopyAllDependencies"
+                                                        @onclick:preventDefault
+                                                        @onclick:stopPropagation>
+                                                    <i class="bi bi-clipboard" aria-hidden="true"></i>
+                                                </button>
                                             </div>
                                         }
                                         @foreach (var name in CustomDependencyLines)
@@ -265,6 +268,15 @@
                                         {
                                             <div class="dependency-badge-tooltip-header">
                                                 <span class="dependency-badge-tooltip-title">File dependencies requiring update:</span>
+                                                <button type="button"
+                                                        class="dependency-badge-tooltip-copy"
+                                                        title="Copy list to clipboard"
+                                                        aria-label="Copy list to clipboard"
+                                                        @onclick="HandleCopyDependencies"
+                                                        @onclick:preventDefault
+                                                        @onclick:stopPropagation>
+                                                    <i class="bi bi-clipboard" aria-hidden="true"></i>
+                                                </button>
                                             </div>
                                         }
                                         @foreach (var line in MismatchedFileVersionLines)
@@ -291,6 +303,15 @@
                                         {
                                             <div class="dependency-badge-tooltip-header">
                                                 <span class="dependency-badge-tooltip-title">Custom dependencies:</span>
+                                                <button type="button"
+                                                        class="dependency-badge-tooltip-copy"
+                                                        title="Copy list to clipboard"
+                                                        aria-label="Copy list to clipboard"
+                                                        @onclick="HandleCopyDependencies"
+                                                        @onclick:preventDefault
+                                                        @onclick:stopPropagation>
+                                                    <i class="bi bi-clipboard" aria-hidden="true"></i>
+                                                </button>
                                             </div>
                                         }
                                         @foreach (var name in CustomDependencyLines)
@@ -466,31 +487,72 @@
 
     private async Task HandleCopyDependencies()
     {
-        if (MismatchedDependencyLines.Count == 0 && MismatchedFileVersionLines.Count == 0) return;
+        if (MismatchedDependencyLines.Count == 0 && MismatchedFileVersionLines.Count == 0 && CustomDependencyLines.Count == 0) return;
         var sb = new System.Text.StringBuilder();
         var repoName = Link?.Repository?.RepositoryName;
-        if (!string.IsNullOrWhiteSpace(repoName))
-            sb.AppendLine($"{repoName} - dependencies requiring update:");
-        else
-            sb.AppendLine("Dependencies requiring update:");
-        foreach (var line in MismatchedDependencyLines)
-            sb.AppendLine($"{line.PackageId}: {line.CurrentVersion} -> {line.NewVersion}");
-        foreach (var line in MismatchedFileVersionLines)
-            sb.AppendLine($"{line.TokenName}: {line.CurrentValue} -> {line.ExpectedValue}");
+        if (MismatchedDependencyLines.Count > 0)
+        {
+            if (!string.IsNullOrWhiteSpace(repoName))
+                sb.AppendLine($"{repoName} - dependencies requiring update:");
+            else
+                sb.AppendLine("Dependencies requiring update:");
+            foreach (var line in MismatchedDependencyLines)
+                sb.AppendLine($"{line.PackageId}: {line.CurrentVersion} -> {line.NewVersion}");
+        }
+        if (MismatchedFileVersionLines.Count > 0)
+        {
+            if (sb.Length > 0)
+                sb.AppendLine();
+            sb.AppendLine("File dependencies requiring update:");
+            foreach (var line in MismatchedFileVersionLines)
+            {
+                if (!string.IsNullOrEmpty(line.FileName))
+                    sb.AppendLine($"{line.FileName} - {line.TokenName}: {line.CurrentValue} -> {line.ExpectedValue}");
+                else
+                    sb.AppendLine($"{line.TokenName}: {line.CurrentValue} -> {line.ExpectedValue}");
+            }
+        }
+        if (CustomDependencyLines.Count > 0)
+        {
+            if (sb.Length > 0)
+                sb.AppendLine();
+            sb.AppendLine("Custom dependencies:");
+            foreach (var name in CustomDependencyLines)
+                sb.AppendLine(name);
+        }
         await OnCopyDependencies.InvokeAsync(sb.ToString().TrimEnd());
     }
 
     private async Task HandleCopyAllDependencies()
     {
-        if (AllDependencyLines.Count == 0) return;
+        if (AllDependencyLines.Count == 0 && AllFileVersionLines.Count == 0 && CustomDependencyLines.Count == 0) return;
         var sb = new System.Text.StringBuilder();
         var repoName = Link?.Repository?.RepositoryName;
-        if (!string.IsNullOrWhiteSpace(repoName))
-            sb.AppendLine($"{repoName} - dependencies (up to date):");
-        else
-            sb.AppendLine("Dependencies (up to date):");
-        foreach (var line in AllDependencyLines)
-            sb.AppendLine($"{line.PackageId}: {line.Version}");
+        if (AllDependencyLines.Count > 0)
+        {
+            if (!string.IsNullOrWhiteSpace(repoName))
+                sb.AppendLine($"{repoName} - dependencies (up to date):");
+            else
+                sb.AppendLine("Dependencies (up to date):");
+            foreach (var line in AllDependencyLines)
+                sb.AppendLine($"{line.PackageId}: {line.Version}");
+        }
+        foreach (var fileGroup in AllFileVersionLines.GroupBy(l => l.FileName))
+        {
+            if (sb.Length > 0)
+                sb.AppendLine();
+            sb.AppendLine($"{fileGroup.Key} (up to date):");
+            foreach (var line in fileGroup)
+                sb.AppendLine($"{line.TokenName}: {line.Version}");
+        }
+        if (CustomDependencyLines.Count > 0)
+        {
+            if (sb.Length > 0)
+                sb.AppendLine();
+            sb.AppendLine("Custom dependencies:");
+            foreach (var name in CustomDependencyLines)
+                sb.AppendLine(name);
+        }
         await OnCopyDependencies.InvokeAsync(sb.ToString().TrimEnd());
     }
 }

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositoriesRow.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositoriesRow.razor
@@ -103,7 +103,7 @@
                             <a href="@graphUrl" class="dependency-badge-graph-link">
                                 <span class="badge build-dep-badge build-dep-badge-ok">@totalWithFiles</span>
                             </a>
-                            @if (AllDependencyLines.Count > 0 || FileLineStatuses.Count > 0)
+                            @if (AllDependencyLines.Count > 0 || AllFileVersionLines.Count > 0 || FileLineStatuses.Count > 0)
                             {
                                 <div class="dependency-badge-tooltip">
                                     @if (AllDependencyLines.Count > 0)
@@ -127,7 +127,29 @@
                                             </div>
                                         }
                                     }
-                                    @if (FileLineStatuses.Count > 0)
+                                    @if (AllFileVersionLines.Count > 0)
+                                    {
+                                        @foreach (var entry in AllFileVersionLines.GroupBy(l => l.FileName).Select((fg, i) => new { fg, i }))
+                                        {
+                                            @if (entry.i == 0 && AllDependencyLines.Count == 0)
+                                            {
+                                                <div class="dependency-badge-tooltip-header">
+                                                    <span class="dependency-badge-tooltip-title">@entry.fg.Key - dependencies (up to date):</span>
+                                                </div>
+                                            }
+                                            else
+                                            {
+                                                <div class="dependency-badge-tooltip-section-header">@entry.fg.Key - dependencies (up to date):</div>
+                                            }
+                                            @foreach (var line in entry.fg)
+                                            {
+                                                <div class="dependency-badge-tooltip-line">
+                                                    <code>@line.TokenName</code> <span class="dependency-badge-tooltip-versions">@line.Version</span>
+                                                </div>
+                                            }
+                                        }
+                                    }
+                                    else if (FileLineStatuses.Count > 0)
                                     {
                                         @if (AllDependencyLines.Count > 0)
                                         {
@@ -287,6 +309,8 @@
     [Parameter] public IReadOnlyList<(string PackageId, string Version)> AllDependencyLines { get; set; } = Array.Empty<(string, string)>();
     /// <summary>Out-of-date version-file line statuses for this repository loaded from DB (read-only, persisted at sync time).</summary>
     [Parameter] public IReadOnlyList<WorkspaceFileLineStatus> FileLineStatuses { get; set; } = Array.Empty<WorkspaceFileLineStatus>();
+    /// <summary>Per-token (FileName, TokenName, Version) entries for the OK badge tooltip. Populated when all file-tracked deps are up to date.</summary>
+    [Parameter] public IReadOnlyList<(string FileName, string TokenName, string Version)> AllFileVersionLines { get; set; } = Array.Empty<(string, string, string)>();
     /// <summary>Total count of version-file lines that matched configured patterns in this repository's files (matched lines, regardless of staleness).</summary>
     [Parameter] public int TotalMatchedFileLines { get; set; }
     [Parameter] public bool IsVersionClicked { get; set; }

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositoriesRow.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositoriesRow.razor
@@ -13,17 +13,13 @@
         : null;
     var depCount = Link.Dependencies ?? 0;
     var unmatchedDeps = Link.UnmatchedDeps ?? 0;
-    var outOfDateFileRepoCount = Link.OutOfDateFileRepos ?? 0;
-    var fileLinesNeedUpdate = FileLineStatuses.Any(s => s.OutOfDateLines > 0);
-    var fileMismatchRepos = fileLinesNeedUpdate
-        ? (outOfDateFileRepoCount > 0 ? outOfDateFileRepoCount : 1)
-        : 0;
+    var fileMismatchRepos = Link.OutOfDateFileRepos ?? 0;
     var totalWithFiles = depCount;
     var unmatchedWithFiles = unmatchedDeps + fileMismatchRepos;
-    var hasOutOfDateFiles = fileLinesNeedUpdate || outOfDateFileRepoCount > 0 || (Link.OutOfDateFileLines ?? 0) > 0;
+    var hasOutOfDateFiles = fileMismatchRepos > 0;
     var hasDependencyTooltipContent = AllDependencyLines.Count > 0
         || AllFileVersionLines.Count > 0
-        || FileLineStatuses.Count > 0
+        || MismatchedFileVersionLines.Count > 0
         || CustomDependencyLines.Count > 0;
     var depOkBadgeInactive = ActionsDisabled || Link.IsOnTag;
 
@@ -171,28 +167,28 @@
                                             }
                                         }
                                     }
-                                    else if (FileLineStatuses.Count > 0)
+                                    else if (AllFileVersionLines.Count > 0)
                                     {
                                         @if (AllDependencyLines.Count > 0 || CustomDependencyLines.Count > 0)
                                         {
-                                            <div class="dependency-badge-tooltip-section-header">Files:</div>
+                                            <div class="dependency-badge-tooltip-section-header">File dependencies (up to date):</div>
                                         }
                                         else
                                         {
                                             <div class="dependency-badge-tooltip-header">
-                                                <span class="dependency-badge-tooltip-title">Files:</span>
+                                                <span class="dependency-badge-tooltip-title">File dependencies (up to date):</span>
                                             </div>
                                         }
-                                        @foreach (var s in FileLineStatuses)
+                                        @foreach (var line in AllFileVersionLines.GroupBy(l => l.TokenName).Select(g => g.First()))
                                         {
                                             <div class="dependency-badge-tooltip-line">
-                                                <code>@s.FileName</code> <span class="dependency-badge-tooltip-versions">@s.TotalMatchedLines of @s.TotalMatchedLines current</span>
+                                                <code>@line.TokenName</code> <span class="dependency-badge-tooltip-versions">@line.Version</span>
                                             </div>
                                         }
                                     }
                                     @if (CustomDependencyLines.Count > 0)
                                     {
-                                        @if (AllDependencyLines.Count > 0 || AllFileVersionLines.Count > 0 || FileLineStatuses.Count > 0)
+                                        @if (AllDependencyLines.Count > 0 || AllFileVersionLines.Count > 0)
                                         {
                                             <div class="dependency-badge-tooltip-section-header">Custom dependencies:</div>
                                         }
@@ -235,7 +231,7 @@
                               @onkeydown="OnDependencyBadgeKeydown"
                               @onmouseleave="OnDependencyBadgeMouseLeave">
                             <span class="badge build-dep-badge @(depBadgeOnTag ? "build-dep-badge-none" : "build-dep-badge-mismatch")">@unmatchedWithFiles of @totalWithFiles</span>
-                            @if (MismatchedDependencyLines.Count > 0 || FileLineStatuses.Any(s => s.OutOfDateLines > 0) || CustomDependencyLines.Count > 0)
+                            @if (MismatchedDependencyLines.Count > 0 || MismatchedFileVersionLines.Count > 0 || CustomDependencyLines.Count > 0)
                             {
                                 <div class="dependency-badge-tooltip">
                                     @if (MismatchedDependencyLines.Count > 0)
@@ -259,37 +255,31 @@
                                             </div>
                                         }
                                     }
-                                    @if (FileLineStatuses.Count > 0)
+                                    @if (MismatchedFileVersionLines.Count > 0)
                                     {
                                         @if (MismatchedDependencyLines.Count > 0)
                                         {
-                                            <div class="dependency-badge-tooltip-section-header">Files:</div>
+                                            <div class="dependency-badge-tooltip-section-header">File dependencies requiring update:</div>
                                         }
                                         else
                                         {
                                             <div class="dependency-badge-tooltip-header">
-                                                <span class="dependency-badge-tooltip-title">Files:</span>
+                                                <span class="dependency-badge-tooltip-title">File dependencies requiring update:</span>
                                             </div>
                                         }
-                                        @foreach (var s in FileLineStatuses)
+                                        @foreach (var line in MismatchedFileVersionLines)
                                         {
                                             <div class="dependency-badge-tooltip-line">
-                                                <code>@s.FileName</code><span class="dependency-badge-tooltip-versions dependency-badge-tooltip-versions--after-file">
-                                                @if (s.OutOfDateLines == 0)
-                                                {
-                                                    @:@s.TotalMatchedLines of @s.TotalMatchedLines current
-                                                }
-                                                else
-                                                {
-                                                    <span class="dependency-badge-tooltip-file-count">@s.OutOfDateLines of @s.TotalMatchedLines</span>@: need update
-                                                }
+                                                <code>@line.TokenName</code>
+                                                <span class="dependency-badge-tooltip-versions">
+                                                    @line.CurrentValue <span class="dependency-badge-tooltip-arrow">→</span> <span class="dependency-badge-tooltip-new-version">@line.ExpectedValue</span>
                                                 </span>
                                             </div>
                                         }
                                     }
                                     @if (CustomDependencyLines.Count > 0)
                                     {
-                                        @if (MismatchedDependencyLines.Count > 0 || FileLineStatuses.Any(s => s.OutOfDateLines > 0))
+                                        @if (MismatchedDependencyLines.Count > 0 || MismatchedFileVersionLines.Count > 0)
                                         {
                                             <div class="dependency-badge-tooltip-section-header">Custom dependencies:</div>
                                         }
@@ -386,7 +376,8 @@
     /// <summary>All workspace-internal package dependencies of this repository (PackageId + version) used to populate the dependency-badge tooltip when everything is up to date.</summary>
     [Parameter] public IReadOnlyList<(string PackageId, string Version)> AllDependencyLines { get; set; } = Array.Empty<(string, string)>();
     [Parameter] public IReadOnlyList<string> CustomDependencyLines { get; set; } = Array.Empty<string>();
-    /// <summary>Out-of-date version-file line statuses for this repository loaded from DB (read-only, persisted at sync time).</summary>
+    [Parameter] public IReadOnlyList<(string TokenName, string CurrentValue, string ExpectedValue)> MismatchedFileVersionLines { get; set; } = Array.Empty<(string, string, string)>();
+    /// <summary>Legacy per-file line statuses; no longer used for badge display.</summary>
     [Parameter] public IReadOnlyList<WorkspaceFileLineStatus> FileLineStatuses { get; set; } = Array.Empty<WorkspaceFileLineStatus>();
     /// <summary>Per-token (FileName, TokenName, Version) entries for the badge and tooltip. TokenName is the repository name being tracked.</summary>
     [Parameter] public IReadOnlyList<(string FileName, string TokenName, string Version)> AllFileVersionLines { get; set; } = Array.Empty<(string, string, string)>();
@@ -443,7 +434,7 @@
             return;
         if ((Link?.UnmatchedDeps ?? 0) > 0)
             await OnDependencyBadgeClick.InvokeAsync();
-        else if ((Link?.OutOfDateFileRepos ?? 0) > 0 || (Link?.OutOfDateFileLines ?? 0) > 0)
+        else if ((Link?.OutOfDateFileRepos ?? 0) > 0)
             await OnFileDependencyBadgeClick.InvokeAsync();
     }
 
@@ -471,7 +462,7 @@
 
     private async Task HandleCopyDependencies()
     {
-        if (MismatchedDependencyLines.Count == 0) return;
+        if (MismatchedDependencyLines.Count == 0 && MismatchedFileVersionLines.Count == 0) return;
         var sb = new System.Text.StringBuilder();
         var repoName = Link?.Repository?.RepositoryName;
         if (!string.IsNullOrWhiteSpace(repoName))
@@ -480,6 +471,8 @@
             sb.AppendLine("Dependencies requiring update:");
         foreach (var line in MismatchedDependencyLines)
             sb.AppendLine($"{line.PackageId}: {line.CurrentVersion} -> {line.NewVersion}");
+        foreach (var line in MismatchedFileVersionLines)
+            sb.AppendLine($"{line.TokenName}: {line.CurrentValue} -> {line.ExpectedValue}");
         await OnCopyDependencies.InvokeAsync(sb.ToString().TrimEnd());
     }
 

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositoriesRow.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositoriesRow.razor
@@ -13,7 +13,7 @@
         : null;
     var depCount = Link.Dependencies ?? 0;
     var unmatchedDeps = Link.UnmatchedDeps ?? 0;
-    var outOfDateFiles = FileLineStatuses.Count;
+    var outOfDateFiles = FileLineStatuses.Sum(s => s.OutOfDateLines);
     var totalWithFiles = depCount + TotalMatchedFileLines;
     var unmatchedWithFiles = unmatchedDeps + outOfDateFiles;
     var graphUrl = WorkspaceUrlHelper.GetDependencyGraphUrl(WorkspaceId, repositoryId: repo.RepositoryId);
@@ -103,26 +103,48 @@
                             <a href="@graphUrl" class="dependency-badge-graph-link">
                                 <span class="badge build-dep-badge build-dep-badge-ok">@totalWithFiles</span>
                             </a>
-                            @if (AllDependencyLines.Count > 0)
+                            @if (AllDependencyLines.Count > 0 || FileLineStatuses.Count > 0)
                             {
                                 <div class="dependency-badge-tooltip">
-                                    <div class="dependency-badge-tooltip-header">
-                                        <span class="dependency-badge-tooltip-title">Dependencies:</span>
-                                        <button type="button"
-                                                class="dependency-badge-tooltip-copy"
-                                                title="Copy list to clipboard"
-                                                aria-label="Copy list to clipboard"
-                                                @onclick="HandleCopyAllDependencies"
-                                                @onclick:preventDefault
-                                                @onclick:stopPropagation>
-                                            <i class="bi bi-clipboard" aria-hidden="true"></i>
-                                        </button>
-                                    </div>
-                                    @foreach (var line in AllDependencyLines)
+                                    @if (AllDependencyLines.Count > 0)
                                     {
-                                        <div class="dependency-badge-tooltip-line">
-                                            <code>@line.PackageId</code> <span class="dependency-badge-tooltip-versions">@line.Version</span>
+                                        <div class="dependency-badge-tooltip-header">
+                                            <span class="dependency-badge-tooltip-title">Dependencies:</span>
+                                            <button type="button"
+                                                    class="dependency-badge-tooltip-copy"
+                                                    title="Copy list to clipboard"
+                                                    aria-label="Copy list to clipboard"
+                                                    @onclick="HandleCopyAllDependencies"
+                                                    @onclick:preventDefault
+                                                    @onclick:stopPropagation>
+                                                <i class="bi bi-clipboard" aria-hidden="true"></i>
+                                            </button>
                                         </div>
+                                        @foreach (var line in AllDependencyLines)
+                                        {
+                                            <div class="dependency-badge-tooltip-line">
+                                                <code>@line.PackageId</code> <span class="dependency-badge-tooltip-versions">@line.Version</span>
+                                            </div>
+                                        }
+                                    }
+                                    @if (FileLineStatuses.Count > 0)
+                                    {
+                                        @if (AllDependencyLines.Count > 0)
+                                        {
+                                            <div class="dependency-badge-tooltip-section-header">Files:</div>
+                                        }
+                                        else
+                                        {
+                                            <div class="dependency-badge-tooltip-header">
+                                                <span class="dependency-badge-tooltip-title">Files:</span>
+                                            </div>
+                                        }
+                                        @foreach (var s in FileLineStatuses)
+                                        {
+                                            <div class="dependency-badge-tooltip-line">
+                                                <code>@s.FileName</code> <span class="dependency-badge-tooltip-versions">@s.TotalMatchedLines of @s.TotalMatchedLines current</span>
+                                            </div>
+                                        }
                                     }
                                     <div class="dependency-badge-tooltip-footer">Click to view the dependency graph.</div>
                                 </div>
@@ -167,22 +189,30 @@
                                             </div>
                                         }
                                     }
-                                    @if (outOfDateFiles > 0)
+                                    @if (FileLineStatuses.Count > 0)
                                     {
                                         @if (MismatchedDependencyLines.Count > 0)
                                         {
-                                            <div class="dependency-badge-tooltip-section-header">Files requiring update:</div>
+                                            <div class="dependency-badge-tooltip-section-header">Files:</div>
                                         }
                                         else
                                         {
                                             <div class="dependency-badge-tooltip-header">
-                                                <span class="dependency-badge-tooltip-title">Files requiring update:</span>
+                                                <span class="dependency-badge-tooltip-title">Files:</span>
                                             </div>
                                         }
                                         @foreach (var s in FileLineStatuses)
                                         {
                                             <div class="dependency-badge-tooltip-line">
-                                                <code>@s.FileName</code> <span class="dependency-badge-tooltip-versions">@s.TokenName: @s.CurrentValue <span class="dependency-badge-tooltip-arrow">→</span> <span class="dependency-badge-tooltip-new-version">@s.ExpectedValue</span></span>
+                                                <code>@s.FileName</code>
+                                                @if (s.OutOfDateLines == 0)
+                                                {
+                                                    <span class="dependency-badge-tooltip-versions">@s.TotalMatchedLines of @s.TotalMatchedLines current</span>
+                                                }
+                                                else
+                                                {
+                                                    <span class="dependency-badge-tooltip-versions"><span class="dependency-badge-tooltip-new-version">@s.OutOfDateLines of @s.TotalMatchedLines</span> need update</span>
+                                                }
                                             </div>
                                         }
                                     }

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositoriesRow.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositoriesRow.razor
@@ -102,7 +102,7 @@
                 <span class="metrics-block metrics-deps">
                     @if (totalWithFiles == 0)
                     {
-                        <span class="dependency-badge-tooltip-wrap dependency-badge-link @(depOkBadgeInactive ? "dependency-badge-link--disabled dependency-badge-link--readonly" : "")">
+                        <span class="dependency-badge-link @(depOkBadgeInactive ? "dependency-badge-link--disabled dependency-badge-link--readonly" : "")">
                             <span class="badge build-dep-badge build-dep-badge-none dependency-badge-graph-link"
                                   role="button"
                                   tabindex="@(depOkBadgeInactive ? -1 : 0)"
@@ -111,21 +111,12 @@
                                   @onclick="HandleCustomDependenciesClick"
                                   @onclick:preventDefault
                                   @onkeydown="HandleCustomDependenciesKeydown">0</span>
-                            <div class="dependency-badge-tooltip">
-                                <div class="dependency-badge-tooltip-footer">
-                                    <button type="button"
-                                            class="btn btn-link btn-sm p-0 dependency-badge-tooltip-show-deps"
-                                            disabled="@depOkBadgeInactive"
-                                            @onclick="HandleShowDependenciesClick"
-                                            @onclick:preventDefault
-                                            @onclick:stopPropagation>Show dependencies</button>
-                                </div>
-                            </div>
                         </span>
                     }
                     else if (unmatchedWithFiles == 0)
                     {
-                        <span class="dependency-badge-tooltip-wrap dependency-badge-link @(depOkBadgeInactive ? "dependency-badge-link--disabled dependency-badge-link--readonly" : "")">
+                        <span class="dependency-badge-tooltip-wrap dependency-badge-link @(depOkBadgeInactive ? "dependency-badge-link--disabled dependency-badge-link--readonly" : "") @(IsDependencyBadgeClicked ? "dependency-badge-tooltip-wrap--clicked" : "")"
+                              @onmouseleave="OnDependencyBadgeMouseLeave">
                             <span class="badge build-dep-badge build-dep-badge-ok dependency-badge-graph-link"
                                   role="button"
                                   tabindex="@(depOkBadgeInactive ? -1 : 0)"
@@ -218,7 +209,7 @@
                                             </div>
                                         }
                                     }
-                                    <div class="dependency-badge-tooltip-footer">
+                                    <div class="dependency-badge-tooltip-footer dependency-badge-tooltip-footer--end">
                                         <button type="button"
                                                 class="btn btn-link btn-sm p-0 dependency-badge-tooltip-show-deps"
                                                 disabled="@depOkBadgeInactive"
@@ -315,22 +306,22 @@
                                             </div>
                                         }
                                     }
-                                    <div class="dependency-badge-tooltip-footer">
+                                    <div class="dependency-badge-tooltip-footer dependency-badge-tooltip-footer--split">
                                         @if (depBadgeOnTag)
                                         {
-                                            @("Repository is on a tag; checkout a branch first.")
+                                            <span class="dependency-badge-tooltip-footer-hint">Repository is on a tag; checkout a branch first.</span>
                                         }
                                         else if (unmatchedDeps > 0 && hasOutOfDateFiles)
                                         {
-                                            @("Click to update dependencies and file versions in this repository only.")
+                                            <span class="dependency-badge-tooltip-footer-hint">Click to update dependencies and file versions in this repository only.</span>
                                         }
                                         else if (unmatchedDeps > 0)
                                         {
-                                            @("Click to update this repository only.")
+                                            <span class="dependency-badge-tooltip-footer-hint">Click to update this repository only.</span>
                                         }
                                         else if (hasOutOfDateFiles)
                                         {
-                                            @("Click to update file versions in this repository only.")
+                                            <span class="dependency-badge-tooltip-footer-hint">Click to update file versions in this repository only.</span>
                                         }
                                         <button type="button"
                                                 class="btn btn-link btn-sm p-0 dependency-badge-tooltip-show-deps"

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositoriesRow.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositoriesRow.razor
@@ -21,7 +21,11 @@
     var totalWithFiles = depCount;
     var unmatchedWithFiles = unmatchedDeps + fileMismatchRepos;
     var hasOutOfDateFiles = fileLinesNeedUpdate || outOfDateFileRepoCount > 0 || (Link.OutOfDateFileLines ?? 0) > 0;
-    var graphUrl = WorkspaceUrlHelper.GetDependencyGraphUrl(WorkspaceId, repositoryId: repo.RepositoryId);
+    var hasDependencyTooltipContent = AllDependencyLines.Count > 0
+        || AllFileVersionLines.Count > 0
+        || FileLineStatuses.Count > 0
+        || CustomDependencyLines.Count > 0;
+    var depOkBadgeInactive = ActionsDisabled || Link.IsOnTag;
 
     <tr>
         <td class="col-repo">
@@ -98,17 +102,39 @@
                 <span class="metrics-block metrics-deps">
                     @if (totalWithFiles == 0)
                     {
-                        <a href="@graphUrl" class="dependency-badge-link" title="View dependency graph for this repository">
-                            <span class="badge build-dep-badge build-dep-badge-none">0</span>
-                        </a>
+                        <span class="dependency-badge-tooltip-wrap dependency-badge-link @(depOkBadgeInactive ? "dependency-badge-link--disabled dependency-badge-link--readonly" : "")">
+                            <span class="badge build-dep-badge build-dep-badge-none dependency-badge-graph-link"
+                                  role="button"
+                                  tabindex="@(depOkBadgeInactive ? -1 : 0)"
+                                  style="cursor: @(depOkBadgeInactive ? "default" : "pointer");"
+                                  title="@(depOkBadgeInactive ? "Repository is on a tag; checkout a branch first." : "Manage custom dependencies")"
+                                  @onclick="HandleCustomDependenciesClick"
+                                  @onclick:preventDefault
+                                  @onkeydown="HandleCustomDependenciesKeydown">0</span>
+                            <div class="dependency-badge-tooltip">
+                                <div class="dependency-badge-tooltip-footer">
+                                    <button type="button"
+                                            class="btn btn-link btn-sm p-0 dependency-badge-tooltip-show-deps"
+                                            disabled="@depOkBadgeInactive"
+                                            @onclick="HandleShowDependenciesClick"
+                                            @onclick:preventDefault
+                                            @onclick:stopPropagation>Show dependencies</button>
+                                </div>
+                            </div>
+                        </span>
                     }
                     else if (unmatchedWithFiles == 0)
                     {
-                        <span class="dependency-badge-tooltip-wrap dependency-badge-link">
-                            <a href="@graphUrl" class="dependency-badge-graph-link">
-                                <span class="badge build-dep-badge build-dep-badge-ok">@totalWithFiles</span>
-                            </a>
-                            @if (AllDependencyLines.Count > 0 || AllFileVersionLines.Count > 0 || FileLineStatuses.Count > 0)
+                        <span class="dependency-badge-tooltip-wrap dependency-badge-link @(depOkBadgeInactive ? "dependency-badge-link--disabled dependency-badge-link--readonly" : "")">
+                            <span class="badge build-dep-badge build-dep-badge-ok dependency-badge-graph-link"
+                                  role="button"
+                                  tabindex="@(depOkBadgeInactive ? -1 : 0)"
+                                  style="cursor: @(depOkBadgeInactive ? "default" : "pointer");"
+                                  title="@(depOkBadgeInactive ? "Repository is on a tag; checkout a branch first." : "Manage dependencies")"
+                                  @onclick="HandleCustomDependenciesClick"
+                                  @onclick:preventDefault
+                                  @onkeydown="HandleCustomDependenciesKeydown">@totalWithFiles</span>
+                            @if (hasDependencyTooltipContent)
                             {
                                 <div class="dependency-badge-tooltip">
                                     @if (AllDependencyLines.Count > 0)
@@ -136,7 +162,7 @@
                                     {
                                         @foreach (var entry in AllFileVersionLines.GroupBy(l => l.FileName).Select((fg, i) => new { fg, i }))
                                         {
-                                            @if (entry.i == 0 && AllDependencyLines.Count == 0)
+                                            @if (entry.i == 0 && AllDependencyLines.Count == 0 && CustomDependencyLines.Count == 0)
                                             {
                                                 <div class="dependency-badge-tooltip-header">
                                                     <span class="dependency-badge-tooltip-title">@entry.fg.Key - dependencies (up to date):</span>
@@ -156,7 +182,7 @@
                                     }
                                     else if (FileLineStatuses.Count > 0)
                                     {
-                                        @if (AllDependencyLines.Count > 0)
+                                        @if (AllDependencyLines.Count > 0 || CustomDependencyLines.Count > 0)
                                         {
                                             <div class="dependency-badge-tooltip-section-header">Files:</div>
                                         }
@@ -173,7 +199,33 @@
                                             </div>
                                         }
                                     }
-                                    <div class="dependency-badge-tooltip-footer">Click to view the dependency graph.</div>
+                                    @if (CustomDependencyLines.Count > 0)
+                                    {
+                                        @if (AllDependencyLines.Count > 0 || AllFileVersionLines.Count > 0 || FileLineStatuses.Count > 0)
+                                        {
+                                            <div class="dependency-badge-tooltip-section-header">Custom dependencies:</div>
+                                        }
+                                        else
+                                        {
+                                            <div class="dependency-badge-tooltip-header">
+                                                <span class="dependency-badge-tooltip-title">Custom dependencies:</span>
+                                            </div>
+                                        }
+                                        @foreach (var name in CustomDependencyLines)
+                                        {
+                                            <div class="dependency-badge-tooltip-line">
+                                                <code>@name</code>
+                                            </div>
+                                        }
+                                    }
+                                    <div class="dependency-badge-tooltip-footer">
+                                        <button type="button"
+                                                class="btn btn-link btn-sm p-0 dependency-badge-tooltip-show-deps"
+                                                disabled="@depOkBadgeInactive"
+                                                @onclick="HandleShowDependenciesClick"
+                                                @onclick:preventDefault
+                                                @onclick:stopPropagation>Show dependencies</button>
+                                    </div>
                                 </div>
                             }
                         </span>
@@ -192,7 +244,7 @@
                               @onkeydown="OnDependencyBadgeKeydown"
                               @onmouseleave="OnDependencyBadgeMouseLeave">
                             <span class="badge build-dep-badge @(depBadgeOnTag ? "build-dep-badge-none" : "build-dep-badge-mismatch")">@unmatchedWithFiles of @totalWithFiles</span>
-                            @if (MismatchedDependencyLines.Count > 0 || FileLineStatuses.Any(s => s.OutOfDateLines > 0))
+                            @if (MismatchedDependencyLines.Count > 0 || FileLineStatuses.Any(s => s.OutOfDateLines > 0) || CustomDependencyLines.Count > 0)
                             {
                                 <div class="dependency-badge-tooltip">
                                     @if (MismatchedDependencyLines.Count > 0)
@@ -244,6 +296,25 @@
                                             </div>
                                         }
                                     }
+                                    @if (CustomDependencyLines.Count > 0)
+                                    {
+                                        @if (MismatchedDependencyLines.Count > 0 || FileLineStatuses.Any(s => s.OutOfDateLines > 0))
+                                        {
+                                            <div class="dependency-badge-tooltip-section-header">Custom dependencies:</div>
+                                        }
+                                        else
+                                        {
+                                            <div class="dependency-badge-tooltip-header">
+                                                <span class="dependency-badge-tooltip-title">Custom dependencies:</span>
+                                            </div>
+                                        }
+                                        @foreach (var name in CustomDependencyLines)
+                                        {
+                                            <div class="dependency-badge-tooltip-line">
+                                                <code>@name</code>
+                                            </div>
+                                        }
+                                    }
                                     <div class="dependency-badge-tooltip-footer">
                                         @if (depBadgeOnTag)
                                         {
@@ -257,10 +328,16 @@
                                         {
                                             @("Click to update this repository only.")
                                         }
-                                        else
+                                        else if (hasOutOfDateFiles)
                                         {
                                             @("Click to update file versions in this repository only.")
                                         }
+                                        <button type="button"
+                                                class="btn btn-link btn-sm p-0 dependency-badge-tooltip-show-deps"
+                                                disabled="@depBadgeOnTag"
+                                                @onclick="HandleShowDependenciesClick"
+                                                @onclick:preventDefault
+                                                @onclick:stopPropagation>Show dependencies</button>
                                     </div>
                                 </div>
                             }
@@ -317,6 +394,7 @@
     [Parameter] public IReadOnlyList<(string PackageId, string CurrentVersion, string NewVersion)> MismatchedDependencyLines { get; set; } = Array.Empty<(string, string, string)>();
     /// <summary>All workspace-internal package dependencies of this repository (PackageId + version) used to populate the dependency-badge tooltip when everything is up to date.</summary>
     [Parameter] public IReadOnlyList<(string PackageId, string Version)> AllDependencyLines { get; set; } = Array.Empty<(string, string)>();
+    [Parameter] public IReadOnlyList<string> CustomDependencyLines { get; set; } = Array.Empty<string>();
     /// <summary>Out-of-date version-file line statuses for this repository loaded from DB (read-only, persisted at sync time).</summary>
     [Parameter] public IReadOnlyList<WorkspaceFileLineStatus> FileLineStatuses { get; set; } = Array.Empty<WorkspaceFileLineStatus>();
     /// <summary>Per-token (FileName, TokenName, Version) entries for the badge and tooltip. TokenName is the repository name being tracked.</summary>
@@ -333,6 +411,7 @@
     [Parameter] public EventCallback OnVersionMouseLeave { get; set; }
     [Parameter] public EventCallback OnBranchClick { get; set; }
     [Parameter] public EventCallback OnDependencyBadgeClick { get; set; }
+    [Parameter] public EventCallback OnCustomDependenciesClick { get; set; }
     [Parameter] public EventCallback OnFileDependencyBadgeClick { get; set; }
     [Parameter] public EventCallback<KeyboardEventArgs> OnDependencyBadgeKeydown { get; set; }
     [Parameter] public EventCallback OnDependencyBadgeMouseLeave { get; set; }
@@ -373,8 +452,30 @@
             return;
         if ((Link?.UnmatchedDeps ?? 0) > 0)
             await OnDependencyBadgeClick.InvokeAsync();
-        else if ((Link.OutOfDateFileRepos ?? 0) > 0 || (Link.OutOfDateFileLines ?? 0) > 0)
+        else if ((Link?.OutOfDateFileRepos ?? 0) > 0 || (Link?.OutOfDateFileLines ?? 0) > 0)
             await OnFileDependencyBadgeClick.InvokeAsync();
+    }
+
+    private async Task HandleCustomDependenciesClick()
+    {
+        if (ActionsDisabled || Link?.IsOnTag == true)
+            return;
+        await OnCustomDependenciesClick.InvokeAsync();
+    }
+
+    private async Task HandleShowDependenciesClick()
+    {
+        if (ActionsDisabled || Link?.IsOnTag == true)
+            return;
+        await OnCustomDependenciesClick.InvokeAsync();
+    }
+
+    private async Task HandleCustomDependenciesKeydown(KeyboardEventArgs e)
+    {
+        if (e.Key is "Enter" or " ")
+        {
+            await HandleCustomDependenciesClick();
+        }
     }
 
     private async Task HandleCopyDependencies()

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositoriesRow.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositoriesRow.razor
@@ -13,6 +13,9 @@
         : null;
     var depCount = Link.Dependencies ?? 0;
     var unmatchedDeps = Link.UnmatchedDeps ?? 0;
+    var outOfDateFiles = FileLineStatuses.Count;
+    var totalWithFiles = depCount + TotalMatchedFileLines;
+    var unmatchedWithFiles = unmatchedDeps + outOfDateFiles;
     var graphUrl = WorkspaceUrlHelper.GetDependencyGraphUrl(WorkspaceId, repositoryId: repo.RepositoryId);
 
     <tr>
@@ -88,17 +91,17 @@
                             OnUpgradeClick="@(() => OnUpgradeClick.InvokeAsync(Link))" />
                 </span>
                 <span class="metrics-block metrics-deps">
-                    @if (depCount == 0)
+                    @if (totalWithFiles == 0)
                     {
                         <a href="@graphUrl" class="dependency-badge-link" title="View dependency graph for this repository">
                             <span class="badge build-dep-badge build-dep-badge-none">0</span>
                         </a>
                     }
-                    else if (unmatchedDeps == 0)
+                    else if (unmatchedWithFiles == 0)
                     {
                         <span class="dependency-badge-tooltip-wrap dependency-badge-link">
                             <a href="@graphUrl" class="dependency-badge-graph-link">
-                                <span class="badge build-dep-badge build-dep-badge-ok">@depCount</span>
+                                <span class="badge build-dep-badge build-dep-badge-ok">@totalWithFiles</span>
                             </a>
                             @if (AllDependencyLines.Count > 0)
                             {
@@ -134,34 +137,69 @@
                         <span class="dependency-badge-tooltip-wrap dependency-badge-link @(depMismatchBadgeInactive ? "dependency-badge-link--disabled" : "") @(depBadgeOnTag ? "dependency-badge-link--readonly" : "") @(IsDependencyBadgeClicked ? "dependency-badge-tooltip-wrap--clicked" : "")"
                               role="button"
                               tabindex="0"
-                              style="cursor: @(depBadgeOnTag ? "default" : "pointer");"
+                              style="cursor: @(depBadgeOnTag || unmatchedDeps == 0 ? "default" : "pointer");"
                               @onclick="HandleDependencyBadgeClick"
                               @onclick:preventDefault
                               @onkeydown="OnDependencyBadgeKeydown"
                               @onmouseleave="OnDependencyBadgeMouseLeave">
-                            <span class="badge build-dep-badge @(depBadgeOnTag ? "build-dep-badge-none" : "build-dep-badge-mismatch")">@unmatchedDeps of @depCount</span>
-                            @if (MismatchedDependencyLines.Count > 0)
+                            <span class="badge build-dep-badge @(depBadgeOnTag ? "build-dep-badge-none" : "build-dep-badge-mismatch")">@unmatchedWithFiles of @totalWithFiles</span>
+                            @if (MismatchedDependencyLines.Count > 0 || outOfDateFiles > 0)
                             {
                                 <div class="dependency-badge-tooltip">
-                                    <div class="dependency-badge-tooltip-header">
-                                        <span class="dependency-badge-tooltip-title">Dependencies requiring update:</span>
-                                        <button type="button"
-                                                class="dependency-badge-tooltip-copy"
-                                                title="Copy list to clipboard"
-                                                aria-label="Copy list to clipboard"
-                                                @onclick="HandleCopyDependencies"
-                                                @onclick:preventDefault
-                                                @onclick:stopPropagation>
-                                            <i class="bi bi-clipboard" aria-hidden="true"></i>
-                                        </button>
-                                    </div>
-                                    @foreach (var line in MismatchedDependencyLines)
+                                    @if (MismatchedDependencyLines.Count > 0)
                                     {
-                                        <div class="dependency-badge-tooltip-line">
-                                            <code>@line.PackageId</code> <span class="dependency-badge-tooltip-versions">@line.CurrentVersion <span class="dependency-badge-tooltip-arrow">→</span> <span class="dependency-badge-tooltip-new-version">@line.NewVersion</span></span>
+                                        <div class="dependency-badge-tooltip-header">
+                                            <span class="dependency-badge-tooltip-title">Dependencies requiring update:</span>
+                                            <button type="button"
+                                                    class="dependency-badge-tooltip-copy"
+                                                    title="Copy list to clipboard"
+                                                    aria-label="Copy list to clipboard"
+                                                    @onclick="HandleCopyDependencies"
+                                                    @onclick:preventDefault
+                                                    @onclick:stopPropagation>
+                                                <i class="bi bi-clipboard" aria-hidden="true"></i>
+                                            </button>
                                         </div>
+                                        @foreach (var line in MismatchedDependencyLines)
+                                        {
+                                            <div class="dependency-badge-tooltip-line">
+                                                <code>@line.PackageId</code> <span class="dependency-badge-tooltip-versions">@line.CurrentVersion <span class="dependency-badge-tooltip-arrow">→</span> <span class="dependency-badge-tooltip-new-version">@line.NewVersion</span></span>
+                                            </div>
+                                        }
                                     }
-                                    <div class="dependency-badge-tooltip-footer">@(depBadgeOnTag ? "Repository is on a tag; checkout a branch first." : "Click to update this repository only.")</div>
+                                    @if (outOfDateFiles > 0)
+                                    {
+                                        @if (MismatchedDependencyLines.Count > 0)
+                                        {
+                                            <div class="dependency-badge-tooltip-section-header">Files requiring update:</div>
+                                        }
+                                        else
+                                        {
+                                            <div class="dependency-badge-tooltip-header">
+                                                <span class="dependency-badge-tooltip-title">Files requiring update:</span>
+                                            </div>
+                                        }
+                                        @foreach (var s in FileLineStatuses)
+                                        {
+                                            <div class="dependency-badge-tooltip-line">
+                                                <code>@s.FileName</code> <span class="dependency-badge-tooltip-versions">@s.TokenName: @s.CurrentValue <span class="dependency-badge-tooltip-arrow">→</span> <span class="dependency-badge-tooltip-new-version">@s.ExpectedValue</span></span>
+                                            </div>
+                                        }
+                                    }
+                                    <div class="dependency-badge-tooltip-footer">
+                                        @if (depBadgeOnTag)
+                                        {
+                                            @("Repository is on a tag; checkout a branch first.")
+                                        }
+                                        else if (unmatchedDeps > 0)
+                                        {
+                                            @("Click to update this repository only.")
+                                        }
+                                        else
+                                        {
+                                            @("Use Update to sync file versions.")
+                                        }
+                                    </div>
                                 </div>
                             }
                         </span>
@@ -217,6 +255,10 @@
     [Parameter] public IReadOnlyList<(string PackageId, string CurrentVersion, string NewVersion)> MismatchedDependencyLines { get; set; } = Array.Empty<(string, string, string)>();
     /// <summary>All workspace-internal package dependencies of this repository (PackageId + version) used to populate the dependency-badge tooltip when everything is up to date.</summary>
     [Parameter] public IReadOnlyList<(string PackageId, string Version)> AllDependencyLines { get; set; } = Array.Empty<(string, string)>();
+    /// <summary>Out-of-date version-file line statuses for this repository loaded from DB (read-only, persisted at sync time).</summary>
+    [Parameter] public IReadOnlyList<WorkspaceFileLineStatus> FileLineStatuses { get; set; } = Array.Empty<WorkspaceFileLineStatus>();
+    /// <summary>Total count of version-file lines that matched configured patterns in this repository's files (matched lines, regardless of staleness).</summary>
+    [Parameter] public int TotalMatchedFileLines { get; set; }
     [Parameter] public bool IsVersionClicked { get; set; }
     [Parameter] public bool IsDependencyBadgeClicked { get; set; }
     [Parameter] public string? RepositoryError { get; set; }
@@ -264,7 +306,8 @@
 
     private async Task HandleDependencyBadgeClick()
     {
-        if (!ActionsDisabled && Link?.IsOnTag != true) await OnDependencyBadgeClick.InvokeAsync();
+        if (!ActionsDisabled && Link?.IsOnTag != true && (Link?.UnmatchedDeps ?? 0) > 0)
+            await OnDependencyBadgeClick.InvokeAsync();
     }
 
     private async Task HandleCopyDependencies()

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositoriesRow.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositoriesRow.razor
@@ -13,15 +13,10 @@
         : null;
     var depCount = Link.Dependencies ?? 0;
     var unmatchedDeps = Link.UnmatchedDeps ?? 0;
-    var filesWithOutOfDate = FileLineStatuses.Where(s => s.OutOfDateLines > 0).Select(s => s.FileName).ToHashSet(StringComparer.OrdinalIgnoreCase);
-    var outOfDateFileRepos = AllFileVersionLines
-        .Where(l => filesWithOutOfDate.Contains(l.FileName))
-        .Select(l => l.TokenName)
-        .Distinct(StringComparer.OrdinalIgnoreCase)
-        .Count();
+    var outOfDateFileRepoCount = Link.OutOfDateFileRepos ?? 0;
     var totalWithFiles = depCount;
-    var unmatchedWithFiles = unmatchedDeps + outOfDateFileRepos;
-    var hasOutOfDateFiles = FileLineStatuses.Any(s => s.OutOfDateLines > 0);
+    var unmatchedWithFiles = unmatchedDeps + outOfDateFileRepoCount;
+    var hasOutOfDateFiles = outOfDateFileRepoCount > 0 || (Link.OutOfDateFileLines ?? 0) > 0;
     var graphUrl = WorkspaceUrlHelper.GetDependencyGraphUrl(WorkspaceId, repositoryId: repo.RepositoryId);
 
     <tr>
@@ -232,15 +227,16 @@
                                         @foreach (var s in FileLineStatuses)
                                         {
                                             <div class="dependency-badge-tooltip-line">
-                                                <code>@s.FileName</code>
+                                                <code>@s.FileName</code><span class="dependency-badge-tooltip-versions dependency-badge-tooltip-versions--after-file">
                                                 @if (s.OutOfDateLines == 0)
                                                 {
-                                                    <span class="dependency-badge-tooltip-versions"> @s.TotalMatchedLines of @s.TotalMatchedLines current</span>
+                                                    @:@s.TotalMatchedLines of @s.TotalMatchedLines current
                                                 }
                                                 else
                                                 {
-                                                    <span class="dependency-badge-tooltip-versions"> <span class="dependency-badge-tooltip-file-count">@s.OutOfDateLines of @s.TotalMatchedLines</span> need update</span>
+                                                    <span class="dependency-badge-tooltip-file-count">@s.OutOfDateLines of @s.TotalMatchedLines</span>@: need update
                                                 }
+                                                </span>
                                             </div>
                                         }
                                     }
@@ -373,7 +369,7 @@
             return;
         if ((Link?.UnmatchedDeps ?? 0) > 0)
             await OnDependencyBadgeClick.InvokeAsync();
-        else if (FileLineStatuses.Any(s => s.OutOfDateLines > 0))
+        else if ((Link.OutOfDateFileRepos ?? 0) > 0 || (Link.OutOfDateFileLines ?? 0) > 0)
             await OnFileDependencyBadgeClick.InvokeAsync();
     }
 

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositoriesRow.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositoriesRow.razor
@@ -249,6 +249,10 @@
                                         {
                                             @("Repository is on a tag; checkout a branch first.")
                                         }
+                                        else if (unmatchedDeps > 0 && hasOutOfDateFiles)
+                                        {
+                                            @("Click to update dependencies and file versions in this repository only.")
+                                        }
                                         else if (unmatchedDeps > 0)
                                         {
                                             @("Click to update this repository only.")

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositoriesRow.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositoriesRow.razor
@@ -13,10 +13,13 @@
         : null;
     var depCount = Link.Dependencies ?? 0;
     var unmatchedDeps = Link.UnmatchedDeps ?? 0;
-    var totalFileRepos = AllFileVersionLines.Select(l => l.TokenName).Distinct().Count();
     var filesWithOutOfDate = FileLineStatuses.Where(s => s.OutOfDateLines > 0).Select(s => s.FileName).ToHashSet(StringComparer.OrdinalIgnoreCase);
-    var outOfDateFileRepos = AllFileVersionLines.Where(l => filesWithOutOfDate.Contains(l.FileName)).Select(l => l.TokenName).Distinct().Count();
-    var totalWithFiles = depCount + totalFileRepos;
+    var outOfDateFileRepos = AllFileVersionLines
+        .Where(l => filesWithOutOfDate.Contains(l.FileName))
+        .Select(l => l.TokenName)
+        .Distinct(StringComparer.OrdinalIgnoreCase)
+        .Count();
+    var totalWithFiles = depCount;
     var unmatchedWithFiles = unmatchedDeps + outOfDateFileRepos;
     var graphUrl = WorkspaceUrlHelper.GetDependencyGraphUrl(WorkspaceId, repositoryId: repo.RepositoryId);
 

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositoriesRow.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositoriesRow.razor
@@ -14,9 +14,13 @@
     var depCount = Link.Dependencies ?? 0;
     var unmatchedDeps = Link.UnmatchedDeps ?? 0;
     var outOfDateFileRepoCount = Link.OutOfDateFileRepos ?? 0;
+    var fileLinesNeedUpdate = FileLineStatuses.Any(s => s.OutOfDateLines > 0);
+    var fileMismatchRepos = fileLinesNeedUpdate
+        ? (outOfDateFileRepoCount > 0 ? outOfDateFileRepoCount : 1)
+        : 0;
     var totalWithFiles = depCount;
-    var unmatchedWithFiles = unmatchedDeps + outOfDateFileRepoCount;
-    var hasOutOfDateFiles = outOfDateFileRepoCount > 0 || (Link.OutOfDateFileLines ?? 0) > 0;
+    var unmatchedWithFiles = unmatchedDeps + fileMismatchRepos;
+    var hasOutOfDateFiles = fileLinesNeedUpdate || outOfDateFileRepoCount > 0 || (Link.OutOfDateFileLines ?? 0) > 0;
     var graphUrl = WorkspaceUrlHelper.GetDependencyGraphUrl(WorkspaceId, repositoryId: repo.RepositoryId);
 
     <tr>

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositoriesRow.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositoriesRow.razor
@@ -21,6 +21,7 @@
         .Count();
     var totalWithFiles = depCount;
     var unmatchedWithFiles = unmatchedDeps + outOfDateFileRepos;
+    var hasOutOfDateFiles = FileLineStatuses.Any(s => s.OutOfDateLines > 0);
     var graphUrl = WorkspaceUrlHelper.GetDependencyGraphUrl(WorkspaceId, repositoryId: repo.RepositoryId);
 
     <tr>
@@ -186,7 +187,7 @@
                         <span class="dependency-badge-tooltip-wrap dependency-badge-link @(depMismatchBadgeInactive ? "dependency-badge-link--disabled" : "") @(depBadgeOnTag ? "dependency-badge-link--readonly" : "") @(IsDependencyBadgeClicked ? "dependency-badge-tooltip-wrap--clicked" : "")"
                               role="button"
                               tabindex="0"
-                              style="cursor: @(depBadgeOnTag || unmatchedDeps == 0 ? "default" : "pointer");"
+                              style="cursor: @(depBadgeOnTag || (unmatchedDeps == 0 && !hasOutOfDateFiles) ? "default" : "pointer");"
                               @onclick="HandleDependencyBadgeClick"
                               @onclick:preventDefault
                               @onkeydown="OnDependencyBadgeKeydown"
@@ -234,11 +235,11 @@
                                                 <code>@s.FileName</code>
                                                 @if (s.OutOfDateLines == 0)
                                                 {
-                                                    <span class="dependency-badge-tooltip-versions">@s.TotalMatchedLines of @s.TotalMatchedLines current</span>
+                                                    <span class="dependency-badge-tooltip-versions"> @s.TotalMatchedLines of @s.TotalMatchedLines current</span>
                                                 }
                                                 else
                                                 {
-                                                    <span class="dependency-badge-tooltip-versions"><span class="dependency-badge-tooltip-new-version">@s.OutOfDateLines of @s.TotalMatchedLines</span> need update</span>
+                                                    <span class="dependency-badge-tooltip-versions"> <span class="dependency-badge-tooltip-file-count">@s.OutOfDateLines of @s.TotalMatchedLines</span> need update</span>
                                                 }
                                             </div>
                                         }
@@ -254,7 +255,7 @@
                                         }
                                         else
                                         {
-                                            @("Use Update to sync file versions.")
+                                            @("Click to update file versions in this repository only.")
                                         }
                                     </div>
                                 </div>
@@ -328,6 +329,7 @@
     [Parameter] public EventCallback OnVersionMouseLeave { get; set; }
     [Parameter] public EventCallback OnBranchClick { get; set; }
     [Parameter] public EventCallback OnDependencyBadgeClick { get; set; }
+    [Parameter] public EventCallback OnFileDependencyBadgeClick { get; set; }
     [Parameter] public EventCallback<KeyboardEventArgs> OnDependencyBadgeKeydown { get; set; }
     [Parameter] public EventCallback OnDependencyBadgeMouseLeave { get; set; }
     [Parameter] public EventCallback OnPushBadgeClick { get; set; }
@@ -363,8 +365,12 @@
 
     private async Task HandleDependencyBadgeClick()
     {
-        if (!ActionsDisabled && Link?.IsOnTag != true && (Link?.UnmatchedDeps ?? 0) > 0)
+        if (ActionsDisabled || Link?.IsOnTag == true)
+            return;
+        if ((Link?.UnmatchedDeps ?? 0) > 0)
             await OnDependencyBadgeClick.InvokeAsync();
+        else if (FileLineStatuses.Any(s => s.OutOfDateLines > 0))
+            await OnFileDependencyBadgeClick.InvokeAsync();
     }
 
     private async Task HandleCopyDependencies()

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositoriesRow.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositoriesRow.razor
@@ -270,6 +270,10 @@
                                         @foreach (var line in MismatchedFileVersionLines)
                                         {
                                             <div class="dependency-badge-tooltip-line">
+                                                @if (!string.IsNullOrEmpty(line.FileName))
+                                                {
+                                                    <span class="dependency-badge-tooltip-file">@line.FileName</span>
+                                                }
                                                 <code>@line.TokenName</code>
                                                 <span class="dependency-badge-tooltip-versions">
                                                     @line.CurrentValue <span class="dependency-badge-tooltip-arrow">→</span> <span class="dependency-badge-tooltip-new-version">@line.ExpectedValue</span>
@@ -376,7 +380,7 @@
     /// <summary>All workspace-internal package dependencies of this repository (PackageId + version) used to populate the dependency-badge tooltip when everything is up to date.</summary>
     [Parameter] public IReadOnlyList<(string PackageId, string Version)> AllDependencyLines { get; set; } = Array.Empty<(string, string)>();
     [Parameter] public IReadOnlyList<string> CustomDependencyLines { get; set; } = Array.Empty<string>();
-    [Parameter] public IReadOnlyList<(string TokenName, string CurrentValue, string ExpectedValue)> MismatchedFileVersionLines { get; set; } = Array.Empty<(string, string, string)>();
+    [Parameter] public IReadOnlyList<(string FileName, string TokenName, string CurrentValue, string ExpectedValue)> MismatchedFileVersionLines { get; set; } = Array.Empty<(string, string, string, string)>();
     /// <summary>Legacy per-file line statuses; no longer used for badge display.</summary>
     [Parameter] public IReadOnlyList<WorkspaceFileLineStatus> FileLineStatuses { get; set; } = Array.Empty<WorkspaceFileLineStatus>();
     /// <summary>Per-token (FileName, TokenName, Version) entries for the badge and tooltip. TokenName is the repository name being tracked.</summary>

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositoriesRow.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositoriesRow.razor
@@ -13,9 +13,11 @@
         : null;
     var depCount = Link.Dependencies ?? 0;
     var unmatchedDeps = Link.UnmatchedDeps ?? 0;
-    var outOfDateFiles = FileLineStatuses.Sum(s => s.OutOfDateLines);
-    var totalWithFiles = depCount + TotalMatchedFileLines;
-    var unmatchedWithFiles = unmatchedDeps + outOfDateFiles;
+    var totalFileRepos = AllFileVersionLines.Select(l => l.TokenName).Distinct().Count();
+    var filesWithOutOfDate = FileLineStatuses.Where(s => s.OutOfDateLines > 0).Select(s => s.FileName).ToHashSet(StringComparer.OrdinalIgnoreCase);
+    var outOfDateFileRepos = AllFileVersionLines.Where(l => filesWithOutOfDate.Contains(l.FileName)).Select(l => l.TokenName).Distinct().Count();
+    var totalWithFiles = depCount + totalFileRepos;
+    var unmatchedWithFiles = unmatchedDeps + outOfDateFileRepos;
     var graphUrl = WorkspaceUrlHelper.GetDependencyGraphUrl(WorkspaceId, repositoryId: repo.RepositoryId);
 
     <tr>
@@ -187,7 +189,7 @@
                               @onkeydown="OnDependencyBadgeKeydown"
                               @onmouseleave="OnDependencyBadgeMouseLeave">
                             <span class="badge build-dep-badge @(depBadgeOnTag ? "build-dep-badge-none" : "build-dep-badge-mismatch")">@unmatchedWithFiles of @totalWithFiles</span>
-                            @if (MismatchedDependencyLines.Count > 0 || outOfDateFiles > 0)
+                            @if (MismatchedDependencyLines.Count > 0 || FileLineStatuses.Any(s => s.OutOfDateLines > 0))
                             {
                                 <div class="dependency-badge-tooltip">
                                     @if (MismatchedDependencyLines.Count > 0)
@@ -309,10 +311,8 @@
     [Parameter] public IReadOnlyList<(string PackageId, string Version)> AllDependencyLines { get; set; } = Array.Empty<(string, string)>();
     /// <summary>Out-of-date version-file line statuses for this repository loaded from DB (read-only, persisted at sync time).</summary>
     [Parameter] public IReadOnlyList<WorkspaceFileLineStatus> FileLineStatuses { get; set; } = Array.Empty<WorkspaceFileLineStatus>();
-    /// <summary>Per-token (FileName, TokenName, Version) entries for the OK badge tooltip. Populated when all file-tracked deps are up to date.</summary>
+    /// <summary>Per-token (FileName, TokenName, Version) entries for the badge and tooltip. TokenName is the repository name being tracked.</summary>
     [Parameter] public IReadOnlyList<(string FileName, string TokenName, string Version)> AllFileVersionLines { get; set; } = Array.Empty<(string, string, string)>();
-    /// <summary>Total count of version-file lines that matched configured patterns in this repository's files (matched lines, regardless of staleness).</summary>
-    [Parameter] public int TotalMatchedFileLines { get; set; }
     [Parameter] public bool IsVersionClicked { get; set; }
     [Parameter] public bool IsDependencyBadgeClicked { get; set; }
     [Parameter] public string? RepositoryError { get; set; }

--- a/src/GrayMoon.App/Components/Shared/WorkspaceActionNotificationPanel.razor
+++ b/src/GrayMoon.App/Components/Shared/WorkspaceActionNotificationPanel.razor
@@ -677,6 +677,12 @@
                 var (updated, failed, error, _) = await fileVersionService.UpdateAllVersionsAsync(
                     workspaceId, selectedRepositoryIds: null, cancellationToken: ct);
 
+                if (error == null)
+                {
+                    job.ReportProgress("Checking file versions...");
+                    await fileVersionService.CheckAndPersistFileVersionStatusAsync(workspaceId, ct, forceFresh: true);
+                }
+
                 if (!_disposed)
                     await InvokeAsync(() =>
                     {

--- a/src/GrayMoon.App/Data/AppDbContext.cs
+++ b/src/GrayMoon.App/Data/AppDbContext.cs
@@ -315,10 +315,9 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
             entity.ToTable("WorkspaceFileLineStatuses");
             entity.HasKey(s => s.StatusId);
             entity.Property(s => s.StatusId).ValueGeneratedOnAdd();
-            entity.HasIndex(s => new { s.WorkspaceId, s.RepositoryId, s.FilePath, s.TokenName }).IsUnique();
+            entity.HasIndex(s => new { s.WorkspaceId, s.RepositoryId, s.FilePath }).IsUnique();
             entity.Property(s => s.FilePath).IsRequired().HasMaxLength(2000);
             entity.Property(s => s.FileName).IsRequired().HasMaxLength(260);
-            entity.Property(s => s.TokenName).IsRequired().HasMaxLength(200);
         });
 
         modelBuilder.Entity<Setting>(entity =>

--- a/src/GrayMoon.App/Data/AppDbContext.cs
+++ b/src/GrayMoon.App/Data/AppDbContext.cs
@@ -17,6 +17,7 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
     public DbSet<WorkspaceFile> WorkspaceFiles => Set<WorkspaceFile>();
     public DbSet<WorkspaceFileVersionConfig> WorkspaceFileVersionConfigs => Set<WorkspaceFileVersionConfig>();
     public DbSet<WorkspaceFileLineStatus> WorkspaceFileLineStatuses => Set<WorkspaceFileLineStatus>();
+    public DbSet<WorkspaceRepositoryCustomDependency> WorkspaceRepositoryCustomDependencies => Set<WorkspaceRepositoryCustomDependency>();
     public DbSet<Setting> Settings => Set<Setting>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
@@ -318,6 +319,25 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
             entity.HasIndex(s => new { s.WorkspaceId, s.RepositoryId, s.FilePath }).IsUnique();
             entity.Property(s => s.FilePath).IsRequired().HasMaxLength(2000);
             entity.Property(s => s.FileName).IsRequired().HasMaxLength(260);
+        });
+
+        modelBuilder.Entity<WorkspaceRepositoryCustomDependency>(entity =>
+        {
+            entity.ToTable("WorkspaceRepositoryCustomDependencies");
+            entity.HasKey(d => d.CustomDependencyId);
+            entity.Property(d => d.CustomDependencyId).ValueGeneratedOnAdd();
+            entity.HasIndex(d => new { d.DependentWorkspaceRepositoryId, d.ReferencedWorkspaceRepositoryId })
+                .IsUnique();
+
+            entity.HasOne(d => d.DependentWorkspaceRepository)
+                .WithMany()
+                .HasForeignKey(d => d.DependentWorkspaceRepositoryId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            entity.HasOne(d => d.ReferencedWorkspaceRepository)
+                .WithMany()
+                .HasForeignKey(d => d.ReferencedWorkspaceRepositoryId)
+                .OnDelete(DeleteBehavior.Cascade);
         });
 
         modelBuilder.Entity<Setting>(entity =>

--- a/src/GrayMoon.App/Data/AppDbContext.cs
+++ b/src/GrayMoon.App/Data/AppDbContext.cs
@@ -287,6 +287,8 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
                 .IsRequired()
                 .HasMaxLength(2000);
 
+            entity.Property(f => f.IsMissingOnDisk);
+
             entity.HasOne(f => f.Workspace)
                 .WithMany()
                 .HasForeignKey(f => f.WorkspaceId)
@@ -316,9 +318,12 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
             entity.ToTable("WorkspaceFileLineStatuses");
             entity.HasKey(s => s.StatusId);
             entity.Property(s => s.StatusId).ValueGeneratedOnAdd();
-            entity.HasIndex(s => new { s.WorkspaceId, s.RepositoryId, s.FilePath }).IsUnique();
+            entity.HasIndex(s => new { s.WorkspaceId, s.RepositoryId, s.FilePath, s.TokenName }).IsUnique();
             entity.Property(s => s.FilePath).IsRequired().HasMaxLength(2000);
             entity.Property(s => s.FileName).IsRequired().HasMaxLength(260);
+            entity.Property(s => s.TokenName).IsRequired().HasMaxLength(260);
+            entity.Property(s => s.CurrentValue).HasMaxLength(100);
+            entity.Property(s => s.ExpectedValue).HasMaxLength(100);
         });
 
         modelBuilder.Entity<WorkspaceRepositoryCustomDependency>(entity =>

--- a/src/GrayMoon.App/Data/AppDbContext.cs
+++ b/src/GrayMoon.App/Data/AppDbContext.cs
@@ -16,6 +16,7 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
     public DbSet<RepositoryBranch> RepositoryBranches => Set<RepositoryBranch>();
     public DbSet<WorkspaceFile> WorkspaceFiles => Set<WorkspaceFile>();
     public DbSet<WorkspaceFileVersionConfig> WorkspaceFileVersionConfigs => Set<WorkspaceFileVersionConfig>();
+    public DbSet<WorkspaceFileLineStatus> WorkspaceFileLineStatuses => Set<WorkspaceFileLineStatus>();
     public DbSet<Setting> Settings => Set<Setting>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
@@ -307,6 +308,17 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
                 .WithMany()
                 .HasForeignKey(c => c.FileId)
                 .OnDelete(DeleteBehavior.Cascade);
+        });
+
+        modelBuilder.Entity<WorkspaceFileLineStatus>(entity =>
+        {
+            entity.ToTable("WorkspaceFileLineStatuses");
+            entity.HasKey(s => s.StatusId);
+            entity.Property(s => s.StatusId).ValueGeneratedOnAdd();
+            entity.HasIndex(s => new { s.WorkspaceId, s.RepositoryId, s.FilePath, s.TokenName }).IsUnique();
+            entity.Property(s => s.FilePath).IsRequired().HasMaxLength(2000);
+            entity.Property(s => s.FileName).IsRequired().HasMaxLength(260);
+            entity.Property(s => s.TokenName).IsRequired().HasMaxLength(200);
         });
 
         modelBuilder.Entity<Setting>(entity =>

--- a/src/GrayMoon.App/Hubs/AgentHub.cs
+++ b/src/GrayMoon.App/Hubs/AgentHub.cs
@@ -84,9 +84,15 @@ public sealed class AgentHub(
     }
 
     /// <summary>Invoked by the agent when a hook fires: agent ran GitVersion (and fetch/commit counts) and pushes result for app to persist.</summary>
-    public async Task SyncCommand(RepositorySyncNotification notification)
+    public Task SyncCommand(RepositorySyncNotification notification)
     {
-        await syncCommandHandler.HandleAsync(notification);
+        // Run HandleAsync on a background thread so this hub method returns immediately.
+        // ASP.NET Core SignalR serializes hub method invocations per connection, so awaiting
+        // HandleAsync here blocks the hub's message reader. HandleAsync sends CheckFileVersions
+        // to the agent and awaits the ResponseCommand - but ResponseCommand can never arrive
+        // because the hub reader is stuck in SyncCommand. Fire-and-forget breaks the deadlock.
+        _ = Task.Run(() => syncCommandHandler.HandleAsync(notification));
+        return Task.CompletedTask;
     }
 
     /// <summary>Invoked by the agent when it connects to report its SemVer version.</summary>

--- a/src/GrayMoon.App/Hubs/AgentHub.cs
+++ b/src/GrayMoon.App/Hubs/AgentHub.cs
@@ -8,7 +8,7 @@ namespace GrayMoon.App.Hubs;
 public sealed class AgentHub(
     AgentConnectionTracker connectionTracker,
     AgentQueueStateService agentQueueStateService,
-    SyncCommandHandler syncCommandHandler,
+    AgentSyncNotificationQueue syncNotificationQueue,
     IServiceScopeFactory scopeFactory,
     ILogger<AgentHub> logger) : Hub
 {
@@ -84,9 +84,10 @@ public sealed class AgentHub(
     }
 
     /// <summary>Invoked by the agent when a hook fires: agent ran GitVersion (and fetch/commit counts) and pushes result for app to persist.</summary>
-    public async Task SyncCommand(RepositorySyncNotification notification)
+    public Task SyncCommand(RepositorySyncNotification notification)
     {
-        await syncCommandHandler.HandleAsync(notification);
+        syncNotificationQueue.Enqueue(notification);
+        return Task.CompletedTask;
     }
 
     /// <summary>Invoked by the agent when it connects to report its SemVer version.</summary>

--- a/src/GrayMoon.App/Hubs/AgentHub.cs
+++ b/src/GrayMoon.App/Hubs/AgentHub.cs
@@ -84,15 +84,9 @@ public sealed class AgentHub(
     }
 
     /// <summary>Invoked by the agent when a hook fires: agent ran GitVersion (and fetch/commit counts) and pushes result for app to persist.</summary>
-    public Task SyncCommand(RepositorySyncNotification notification)
+    public async Task SyncCommand(RepositorySyncNotification notification)
     {
-        // Run HandleAsync on a background thread so this hub method returns immediately.
-        // ASP.NET Core SignalR serializes hub method invocations per connection, so awaiting
-        // HandleAsync here blocks the hub's message reader. HandleAsync sends CheckFileVersions
-        // to the agent and awaits the ResponseCommand - but ResponseCommand can never arrive
-        // because the hub reader is stuck in SyncCommand. Fire-and-forget breaks the deadlock.
-        _ = Task.Run(() => syncCommandHandler.HandleAsync(notification));
-        return Task.CompletedTask;
+        await syncCommandHandler.HandleAsync(notification);
     }
 
     /// <summary>Invoked by the agent when it connects to report its SemVer version.</summary>

--- a/src/GrayMoon.App/Migrations.cs
+++ b/src/GrayMoon.App/Migrations.cs
@@ -43,6 +43,7 @@ public static class Migrations
         await MigrateWorkspaceFileLineStatusTableAsync(dbContext);
         await MigrateOutOfDateFileLinesColumnAsync(dbContext);
         await MigrateTotalFileLinesColumnAsync(dbContext);
+        await MigrateOutOfDateFileReposColumnAsync(dbContext);
     }
 
     public static async Task MigrateRepositoriesTopicsAsync(AppDbContext dbContext)
@@ -1121,6 +1122,31 @@ public static class Migrations
                 if (Convert.ToInt32(await cmd.ExecuteScalarAsync()) == 0)
                 {
                     cmd.CommandText = "ALTER TABLE WorkspaceRepositories ADD COLUMN TotalFileLines INTEGER";
+                    await cmd.ExecuteNonQueryAsync();
+                }
+            }
+        }
+        catch
+        {
+            // Migration may already be applied or table doesn't exist yet
+        }
+    }
+
+    /// <summary>Adds OutOfDateFileRepos column to WorkspaceRepositories for distinct out-of-date file-dependency repo count on the badge.</summary>
+    public static async Task MigrateOutOfDateFileReposColumnAsync(AppDbContext dbContext)
+    {
+        try
+        {
+            var conn = dbContext.Database.GetDbConnection();
+            if (conn.State != System.Data.ConnectionState.Open)
+                await conn.OpenAsync();
+
+            await using (var cmd = conn.CreateCommand())
+            {
+                cmd.CommandText = "SELECT COUNT(*) FROM pragma_table_info('WorkspaceRepositories') WHERE name='OutOfDateFileRepos'";
+                if (Convert.ToInt32(await cmd.ExecuteScalarAsync()) == 0)
+                {
+                    cmd.CommandText = "ALTER TABLE WorkspaceRepositories ADD COLUMN OutOfDateFileRepos INTEGER";
                     await cmd.ExecuteNonQueryAsync();
                 }
             }

--- a/src/GrayMoon.App/Migrations.cs
+++ b/src/GrayMoon.App/Migrations.cs
@@ -1061,9 +1061,8 @@ public static class Migrations
                         RepositoryId INTEGER NOT NULL,
                         FilePath TEXT NOT NULL,
                         FileName TEXT NOT NULL,
-                        TokenName TEXT NOT NULL,
-                        CurrentValue TEXT,
-                        ExpectedValue TEXT
+                        TotalMatchedLines INTEGER NOT NULL DEFAULT 0,
+                        OutOfDateLines INTEGER NOT NULL DEFAULT 0
                     )";
                     await cmd.ExecuteNonQueryAsync();
                 }
@@ -1071,7 +1070,7 @@ public static class Migrations
                 cmd.CommandText = "SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name='IX_WorkspaceFileLineStatuses_Unique'";
                 if (Convert.ToInt32(await cmd.ExecuteScalarAsync()) == 0)
                 {
-                    cmd.CommandText = "CREATE UNIQUE INDEX IX_WorkspaceFileLineStatuses_Unique ON WorkspaceFileLineStatuses(WorkspaceId, RepositoryId, FilePath, TokenName)";
+                    cmd.CommandText = "CREATE UNIQUE INDEX IX_WorkspaceFileLineStatuses_Unique ON WorkspaceFileLineStatuses(WorkspaceId, RepositoryId, FilePath)";
                     await cmd.ExecuteNonQueryAsync();
                 }
             }

--- a/src/GrayMoon.App/Migrations.cs
+++ b/src/GrayMoon.App/Migrations.cs
@@ -49,6 +49,7 @@ public static class Migrations
         await MigrateWorkspaceFileIsMissingOnDiskAsync(dbContext);
         await MigrateTotalFileConfigReposColumnAsync(dbContext);
         await MigrateWorkspaceFileLineStatusTokenColumnsAsync(dbContext);
+        await MigrateWorkspaceFileLineStatusUniqueIndexFixAsync(dbContext);
     }
 
     public static async Task MigrateRepositoriesTopicsAsync(AppDbContext dbContext)
@@ -1113,7 +1114,7 @@ public static class Migrations
                 cmd.CommandText = "SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name='IX_WorkspaceFileLineStatuses_Unique'";
                 if (Convert.ToInt32(await cmd.ExecuteScalarAsync()) == 0)
                 {
-                    cmd.CommandText = "CREATE UNIQUE INDEX IX_WorkspaceFileLineStatuses_Unique ON WorkspaceFileLineStatuses(WorkspaceId, RepositoryId, FilePath)";
+                    cmd.CommandText = "CREATE UNIQUE INDEX IX_WorkspaceFileLineStatuses_Unique ON WorkspaceFileLineStatuses(WorkspaceId, RepositoryId, FilePath, TokenName)";
                     await cmd.ExecuteNonQueryAsync();
                 }
             }
@@ -1409,6 +1410,46 @@ public static class Migrations
                     cmd.CommandText = ddl;
                     await cmd.ExecuteNonQueryAsync();
                 }
+            }
+        }
+        catch
+        {
+            // Migration may already be applied or table doesn't exist yet
+        }
+    }
+
+    /// <summary>
+    /// Fixes the WorkspaceFileLineStatuses unique index to include TokenName.
+    /// The original index covered only (WorkspaceId, RepositoryId, FilePath), which violates when a
+    /// single file has multiple out-of-date tokens. The correct constraint is per-token per file.
+    /// </summary>
+    public static async Task MigrateWorkspaceFileLineStatusUniqueIndexFixAsync(AppDbContext dbContext)
+    {
+        try
+        {
+            var conn = dbContext.Database.GetDbConnection();
+            if (conn.State != System.Data.ConnectionState.Open)
+                await conn.OpenAsync();
+
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='WorkspaceFileLineStatuses'";
+            if (Convert.ToInt32(await cmd.ExecuteScalarAsync()) == 0)
+                return;
+
+            // If the named index exists but does not yet cover TokenName, drop it so we can recreate correctly.
+            cmd.CommandText = "SELECT sql FROM sqlite_master WHERE type='index' AND name='IX_WorkspaceFileLineStatuses_Unique'";
+            var indexSql = await cmd.ExecuteScalarAsync() as string;
+            if (indexSql != null && !indexSql.Contains("TokenName", StringComparison.OrdinalIgnoreCase))
+            {
+                cmd.CommandText = "DROP INDEX IX_WorkspaceFileLineStatuses_Unique";
+                await cmd.ExecuteNonQueryAsync();
+                indexSql = null;
+            }
+
+            if (indexSql == null)
+            {
+                cmd.CommandText = "CREATE UNIQUE INDEX IX_WorkspaceFileLineStatuses_Unique ON WorkspaceFileLineStatuses(WorkspaceId, RepositoryId, FilePath, TokenName)";
+                await cmd.ExecuteNonQueryAsync();
             }
         }
         catch

--- a/src/GrayMoon.App/Migrations.cs
+++ b/src/GrayMoon.App/Migrations.cs
@@ -44,6 +44,7 @@ public static class Migrations
         await MigrateOutOfDateFileLinesColumnAsync(dbContext);
         await MigrateTotalFileLinesColumnAsync(dbContext);
         await MigrateOutOfDateFileReposColumnAsync(dbContext);
+        await MigrateWorkspaceRepositoryCustomDependenciesAsync(dbContext);
     }
 
     public static async Task MigrateRepositoriesTopicsAsync(AppDbContext dbContext)
@@ -710,6 +711,43 @@ public static class Migrations
                     await cmd.ExecuteNonQueryAsync();
 
                     cmd.CommandText = "CREATE INDEX IX_WorkspaceFileVersionConfigs_FileId ON WorkspaceFileVersionConfigs(FileId)";
+                    await cmd.ExecuteNonQueryAsync();
+                }
+            }
+        }
+        catch
+        {
+            // Migration may already be applied or table doesn't exist yet
+        }
+    }
+
+    public static async Task MigrateWorkspaceRepositoryCustomDependenciesAsync(AppDbContext dbContext)
+    {
+        try
+        {
+            var conn = dbContext.Database.GetDbConnection();
+            if (conn.State != System.Data.ConnectionState.Open)
+                await conn.OpenAsync();
+
+            await using (var cmd = conn.CreateCommand())
+            {
+                cmd.CommandText = "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='WorkspaceRepositoryCustomDependencies'";
+                var tableExists = Convert.ToInt32(await cmd.ExecuteScalarAsync()) > 0;
+
+                if (!tableExists)
+                {
+                    cmd.CommandText = @"
+                    CREATE TABLE WorkspaceRepositoryCustomDependencies (
+                        CustomDependencyId INTEGER PRIMARY KEY AUTOINCREMENT,
+                        DependentWorkspaceRepositoryId INTEGER NOT NULL,
+                        ReferencedWorkspaceRepositoryId INTEGER NOT NULL,
+                        FOREIGN KEY (DependentWorkspaceRepositoryId) REFERENCES WorkspaceRepositories(WorkspaceRepositoryId) ON DELETE CASCADE,
+                        FOREIGN KEY (ReferencedWorkspaceRepositoryId) REFERENCES WorkspaceRepositories(WorkspaceRepositoryId) ON DELETE CASCADE
+                    )";
+                    await cmd.ExecuteNonQueryAsync();
+
+                    cmd.CommandText = @"CREATE UNIQUE INDEX IX_WorkspaceRepositoryCustomDependencies_Dependent_Referenced
+                        ON WorkspaceRepositoryCustomDependencies(DependentWorkspaceRepositoryId, ReferencedWorkspaceRepositoryId)";
                     await cmd.ExecuteNonQueryAsync();
                 }
             }

--- a/src/GrayMoon.App/Migrations.cs
+++ b/src/GrayMoon.App/Migrations.cs
@@ -46,6 +46,9 @@ public static class Migrations
         await MigrateTotalFileLinesColumnAsync(dbContext);
         await MigrateOutOfDateFileReposColumnAsync(dbContext);
         await MigrateWorkspaceRepositoryCustomDependenciesAsync(dbContext);
+        await MigrateWorkspaceFileIsMissingOnDiskAsync(dbContext);
+        await MigrateTotalFileConfigReposColumnAsync(dbContext);
+        await MigrateWorkspaceFileLineStatusTokenColumnsAsync(dbContext);
     }
 
     public static async Task MigrateRepositoriesTopicsAsync(AppDbContext dbContext)
@@ -1323,6 +1326,87 @@ public static class Migrations
                 if (Convert.ToInt32(await cmd.ExecuteScalarAsync()) == 0)
                 {
                     cmd.CommandText = "CREATE INDEX IX_Repositories_CloneUrl ON Repositories(CloneUrl)";
+                    await cmd.ExecuteNonQueryAsync();
+                }
+            }
+        }
+        catch
+        {
+            // Migration may already be applied or table doesn't exist yet
+        }
+    }
+
+    /// <summary>Adds IsMissingOnDisk column to WorkspaceFiles.</summary>
+    public static async Task MigrateWorkspaceFileIsMissingOnDiskAsync(AppDbContext dbContext)
+    {
+        try
+        {
+            var conn = dbContext.Database.GetDbConnection();
+            if (conn.State != System.Data.ConnectionState.Open)
+                await conn.OpenAsync();
+
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = "SELECT COUNT(*) FROM pragma_table_info('WorkspaceFiles') WHERE name='IsMissingOnDisk'";
+            if (Convert.ToInt32(await cmd.ExecuteScalarAsync()) == 0)
+            {
+                cmd.CommandText = "ALTER TABLE WorkspaceFiles ADD COLUMN IsMissingOnDisk INTEGER";
+                await cmd.ExecuteNonQueryAsync();
+            }
+        }
+        catch
+        {
+            // Migration may already be applied or table doesn't exist yet
+        }
+    }
+
+    /// <summary>Adds TotalFileConfigRepos column to WorkspaceRepositories for distinct file-config repo count.</summary>
+    public static async Task MigrateTotalFileConfigReposColumnAsync(AppDbContext dbContext)
+    {
+        try
+        {
+            var conn = dbContext.Database.GetDbConnection();
+            if (conn.State != System.Data.ConnectionState.Open)
+                await conn.OpenAsync();
+
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = "SELECT COUNT(*) FROM pragma_table_info('WorkspaceRepositories') WHERE name='TotalFileConfigRepos'";
+            if (Convert.ToInt32(await cmd.ExecuteScalarAsync()) == 0)
+            {
+                cmd.CommandText = "ALTER TABLE WorkspaceRepositories ADD COLUMN TotalFileConfigRepos INTEGER";
+                await cmd.ExecuteNonQueryAsync();
+            }
+        }
+        catch
+        {
+            // Migration may already be applied or table doesn't exist yet
+        }
+    }
+
+    /// <summary>Adds per-token columns to WorkspaceFileLineStatuses for dependency badge tooltips.</summary>
+    public static async Task MigrateWorkspaceFileLineStatusTokenColumnsAsync(AppDbContext dbContext)
+    {
+        try
+        {
+            var conn = dbContext.Database.GetDbConnection();
+            if (conn.State != System.Data.ConnectionState.Open)
+                await conn.OpenAsync();
+
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='WorkspaceFileLineStatuses'";
+            if (Convert.ToInt32(await cmd.ExecuteScalarAsync()) == 0)
+                return;
+
+            foreach (var (column, ddl) in new (string, string)[]
+            {
+                ("TokenName", "ALTER TABLE WorkspaceFileLineStatuses ADD COLUMN TokenName TEXT NOT NULL DEFAULT ''"),
+                ("CurrentValue", "ALTER TABLE WorkspaceFileLineStatuses ADD COLUMN CurrentValue TEXT"),
+                ("ExpectedValue", "ALTER TABLE WorkspaceFileLineStatuses ADD COLUMN ExpectedValue TEXT"),
+            })
+            {
+                cmd.CommandText = $"SELECT COUNT(*) FROM pragma_table_info('WorkspaceFileLineStatuses') WHERE name='{column}'";
+                if (Convert.ToInt32(await cmd.ExecuteScalarAsync()) == 0)
+                {
+                    cmd.CommandText = ddl;
                     await cmd.ExecuteNonQueryAsync();
                 }
             }

--- a/src/GrayMoon.App/Migrations.cs
+++ b/src/GrayMoon.App/Migrations.cs
@@ -40,6 +40,9 @@ public static class Migrations
         await MigrateRepositoryBranchesIsTagAsync(dbContext);
         await MigrateRepositoryBranchesSortIndexAsync(dbContext);
         await MigrateWorkspaceRepositoriesHasNewerTagAsync(dbContext);
+        await MigrateWorkspaceFileLineStatusTableAsync(dbContext);
+        await MigrateOutOfDateFileLinesColumnAsync(dbContext);
+        await MigrateTotalFileLinesColumnAsync(dbContext);
     }
 
     public static async Task MigrateRepositoriesTopicsAsync(AppDbContext dbContext)
@@ -1028,6 +1031,97 @@ public static class Migrations
                 if (!hasColumn)
                 {
                     cmd.CommandText = "ALTER TABLE WorkspaceRepositories ADD COLUMN HasNewerTag INTEGER";
+                    await cmd.ExecuteNonQueryAsync();
+                }
+            }
+        }
+        catch
+        {
+            // Migration may already be applied or table doesn't exist yet
+        }
+    }
+
+    /// <summary>Creates the WorkspaceFileLineStatuses table that persists per-line staleness for configured version files.</summary>
+    public static async Task MigrateWorkspaceFileLineStatusTableAsync(AppDbContext dbContext)
+    {
+        try
+        {
+            var conn = dbContext.Database.GetDbConnection();
+            if (conn.State != System.Data.ConnectionState.Open)
+                await conn.OpenAsync();
+
+            await using (var cmd = conn.CreateCommand())
+            {
+                cmd.CommandText = "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='WorkspaceFileLineStatuses'";
+                if (Convert.ToInt32(await cmd.ExecuteScalarAsync()) == 0)
+                {
+                    cmd.CommandText = @"CREATE TABLE WorkspaceFileLineStatuses (
+                        StatusId INTEGER PRIMARY KEY AUTOINCREMENT,
+                        WorkspaceId INTEGER NOT NULL,
+                        RepositoryId INTEGER NOT NULL,
+                        FilePath TEXT NOT NULL,
+                        FileName TEXT NOT NULL,
+                        TokenName TEXT NOT NULL,
+                        CurrentValue TEXT,
+                        ExpectedValue TEXT
+                    )";
+                    await cmd.ExecuteNonQueryAsync();
+                }
+
+                cmd.CommandText = "SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name='IX_WorkspaceFileLineStatuses_Unique'";
+                if (Convert.ToInt32(await cmd.ExecuteScalarAsync()) == 0)
+                {
+                    cmd.CommandText = "CREATE UNIQUE INDEX IX_WorkspaceFileLineStatuses_Unique ON WorkspaceFileLineStatuses(WorkspaceId, RepositoryId, FilePath, TokenName)";
+                    await cmd.ExecuteNonQueryAsync();
+                }
+            }
+        }
+        catch
+        {
+            // Migration may already be applied or table doesn't exist yet
+        }
+    }
+
+    /// <summary>Adds OutOfDateFileLines column to WorkspaceRepositories for the file-version staleness badge X count.</summary>
+    public static async Task MigrateOutOfDateFileLinesColumnAsync(AppDbContext dbContext)
+    {
+        try
+        {
+            var conn = dbContext.Database.GetDbConnection();
+            if (conn.State != System.Data.ConnectionState.Open)
+                await conn.OpenAsync();
+
+            await using (var cmd = conn.CreateCommand())
+            {
+                cmd.CommandText = "SELECT COUNT(*) FROM pragma_table_info('WorkspaceRepositories') WHERE name='OutOfDateFileLines'";
+                if (Convert.ToInt32(await cmd.ExecuteScalarAsync()) == 0)
+                {
+                    cmd.CommandText = "ALTER TABLE WorkspaceRepositories ADD COLUMN OutOfDateFileLines INTEGER";
+                    await cmd.ExecuteNonQueryAsync();
+                }
+            }
+        }
+        catch
+        {
+            // Migration may already be applied or table doesn't exist yet
+        }
+    }
+
+    /// <summary>Adds TotalFileLines column to WorkspaceRepositories for the file-version staleness badge Y denominator.</summary>
+    public static async Task MigrateTotalFileLinesColumnAsync(AppDbContext dbContext)
+    {
+        try
+        {
+            var conn = dbContext.Database.GetDbConnection();
+            if (conn.State != System.Data.ConnectionState.Open)
+                await conn.OpenAsync();
+
+            await using (var cmd = conn.CreateCommand())
+            {
+                cmd.CommandText = "SELECT COUNT(*) FROM pragma_table_info('WorkspaceRepositories') WHERE name='TotalFileLines'";
+                if (Convert.ToInt32(await cmd.ExecuteScalarAsync()) == 0)
+                {
+                    cmd.CommandText = "ALTER TABLE WorkspaceRepositories ADD COLUMN TotalFileLines INTEGER";
                     await cmd.ExecuteNonQueryAsync();
                 }
             }

--- a/src/GrayMoon.App/Migrations.cs
+++ b/src/GrayMoon.App/Migrations.cs
@@ -41,6 +41,7 @@ public static class Migrations
         await MigrateRepositoryBranchesSortIndexAsync(dbContext);
         await MigrateWorkspaceRepositoriesHasNewerTagAsync(dbContext);
         await MigrateWorkspaceFileLineStatusTableAsync(dbContext);
+        await MigrateWorkspaceFileLineStatusColumnsAsync(dbContext);
         await MigrateOutOfDateFileLinesColumnAsync(dbContext);
         await MigrateTotalFileLinesColumnAsync(dbContext);
         await MigrateOutOfDateFileReposColumnAsync(dbContext);
@@ -1110,6 +1111,42 @@ public static class Migrations
                 if (Convert.ToInt32(await cmd.ExecuteScalarAsync()) == 0)
                 {
                     cmd.CommandText = "CREATE UNIQUE INDEX IX_WorkspaceFileLineStatuses_Unique ON WorkspaceFileLineStatuses(WorkspaceId, RepositoryId, FilePath)";
+                    await cmd.ExecuteNonQueryAsync();
+                }
+            }
+        }
+        catch
+        {
+            // Migration may already be applied or table doesn't exist yet
+        }
+    }
+
+    /// <summary>Adds TotalMatchedLines and OutOfDateLines to WorkspaceFileLineStatuses when the table predates those columns.</summary>
+    public static async Task MigrateWorkspaceFileLineStatusColumnsAsync(AppDbContext dbContext)
+    {
+        try
+        {
+            var conn = dbContext.Database.GetDbConnection();
+            if (conn.State != System.Data.ConnectionState.Open)
+                await conn.OpenAsync();
+
+            await using (var cmd = conn.CreateCommand())
+            {
+                cmd.CommandText = "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='WorkspaceFileLineStatuses'";
+                if (Convert.ToInt32(await cmd.ExecuteScalarAsync()) == 0)
+                    return;
+
+                cmd.CommandText = "SELECT COUNT(*) FROM pragma_table_info('WorkspaceFileLineStatuses') WHERE name='TotalMatchedLines'";
+                if (Convert.ToInt32(await cmd.ExecuteScalarAsync()) == 0)
+                {
+                    cmd.CommandText = "ALTER TABLE WorkspaceFileLineStatuses ADD COLUMN TotalMatchedLines INTEGER NOT NULL DEFAULT 0";
+                    await cmd.ExecuteNonQueryAsync();
+                }
+
+                cmd.CommandText = "SELECT COUNT(*) FROM pragma_table_info('WorkspaceFileLineStatuses') WHERE name='OutOfDateLines'";
+                if (Convert.ToInt32(await cmd.ExecuteScalarAsync()) == 0)
+                {
+                    cmd.CommandText = "ALTER TABLE WorkspaceFileLineStatuses ADD COLUMN OutOfDateLines INTEGER NOT NULL DEFAULT 0";
                     await cmd.ExecuteNonQueryAsync();
                 }
             }

--- a/src/GrayMoon.App/Models/ImplicitReferencedRepoIdsBySource.cs
+++ b/src/GrayMoon.App/Models/ImplicitReferencedRepoIdsBySource.cs
@@ -1,0 +1,6 @@
+namespace GrayMoon.App.Models;
+
+/// <summary>Implicit (non-custom) referenced repository IDs for a dependent repo, split by source.</summary>
+public sealed record ImplicitReferencedRepoIdsBySource(
+    HashSet<int> FromProject,
+    HashSet<int> FromFile);

--- a/src/GrayMoon.App/Models/WorkspaceFile.cs
+++ b/src/GrayMoon.App/Models/WorkspaceFile.cs
@@ -29,4 +29,7 @@ public class WorkspaceFile
     [Required]
     [MaxLength(2000)]
     public string FilePath { get; set; } = string.Empty;
+
+    /// <summary>True when the file path no longer exists on disk. Excluded from dependency and badge computation until restored.</summary>
+    public bool? IsMissingOnDisk { get; set; }
 }

--- a/src/GrayMoon.App/Models/WorkspaceFileLineStatus.cs
+++ b/src/GrayMoon.App/Models/WorkspaceFileLineStatus.cs
@@ -3,7 +3,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace GrayMoon.App.Models;
 
-/// <summary>One row per configured version file per workspace repository. Stores aggregate line counts so the UI can display per-file "X of Y" summaries without storing every individual token value.</summary>
+/// <summary>One row per out-of-date file-config repository token on a dependent repo. Powers dependency badge tooltips.</summary>
 [Table("WorkspaceFileLineStatuses")]
 public sealed class WorkspaceFileLineStatus
 {
@@ -17,9 +17,19 @@ public sealed class WorkspaceFileLineStatus
     [MaxLength(260)]
     public string FileName { get; set; } = "";
 
-    /// <summary>Total number of pattern lines that matched in this file.</summary>
+    /// <summary>Referenced workspace repository name (file-config token).</summary>
+    [MaxLength(260)]
+    public string TokenName { get; set; } = "";
+
+    [MaxLength(100)]
+    public string? CurrentValue { get; set; }
+
+    [MaxLength(100)]
+    public string? ExpectedValue { get; set; }
+
+    /// <summary>Legacy aggregate fields; retained for schema compatibility.</summary>
     public int TotalMatchedLines { get; set; }
 
-    /// <summary>Number of matched lines whose current value differs from the expected repo GitVersion.</summary>
+    /// <summary>Legacy aggregate fields; retained for schema compatibility.</summary>
     public int OutOfDateLines { get; set; }
 }

--- a/src/GrayMoon.App/Models/WorkspaceFileLineStatus.cs
+++ b/src/GrayMoon.App/Models/WorkspaceFileLineStatus.cs
@@ -1,0 +1,24 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace GrayMoon.App.Models;
+
+[Table("WorkspaceFileLineStatuses")]
+public sealed class WorkspaceFileLineStatus
+{
+    public int StatusId { get; set; }
+    public int WorkspaceId { get; set; }
+    public int RepositoryId { get; set; }
+
+    [MaxLength(2000)]
+    public string FilePath { get; set; } = "";
+
+    [MaxLength(260)]
+    public string FileName { get; set; } = "";
+
+    [MaxLength(200)]
+    public string TokenName { get; set; } = "";
+
+    public string? CurrentValue { get; set; }
+    public string? ExpectedValue { get; set; }
+}

--- a/src/GrayMoon.App/Models/WorkspaceFileLineStatus.cs
+++ b/src/GrayMoon.App/Models/WorkspaceFileLineStatus.cs
@@ -3,6 +3,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace GrayMoon.App.Models;
 
+/// <summary>One row per configured version file per workspace repository. Stores aggregate line counts so the UI can display per-file "X of Y" summaries without storing every individual token value.</summary>
 [Table("WorkspaceFileLineStatuses")]
 public sealed class WorkspaceFileLineStatus
 {
@@ -16,9 +17,9 @@ public sealed class WorkspaceFileLineStatus
     [MaxLength(260)]
     public string FileName { get; set; } = "";
 
-    [MaxLength(200)]
-    public string TokenName { get; set; } = "";
+    /// <summary>Total number of pattern lines that matched in this file.</summary>
+    public int TotalMatchedLines { get; set; }
 
-    public string? CurrentValue { get; set; }
-    public string? ExpectedValue { get; set; }
+    /// <summary>Number of matched lines whose current value differs from the expected repo GitVersion.</summary>
+    public int OutOfDateLines { get; set; }
 }

--- a/src/GrayMoon.App/Models/WorkspaceRepositoryCustomDependency.cs
+++ b/src/GrayMoon.App/Models/WorkspaceRepositoryCustomDependency.cs
@@ -1,0 +1,23 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace GrayMoon.App.Models;
+
+/// <summary>User-declared repo-level dependency edge within a workspace (ordering only, no version sync).</summary>
+[Table("WorkspaceRepositoryCustomDependencies")]
+public class WorkspaceRepositoryCustomDependency
+{
+    public int CustomDependencyId { get; set; }
+
+    [Required]
+    public int DependentWorkspaceRepositoryId { get; set; }
+
+    [ForeignKey(nameof(DependentWorkspaceRepositoryId))]
+    public WorkspaceRepositoryLink? DependentWorkspaceRepository { get; set; }
+
+    [Required]
+    public int ReferencedWorkspaceRepositoryId { get; set; }
+
+    [ForeignKey(nameof(ReferencedWorkspaceRepositoryId))]
+    public WorkspaceRepositoryLink? ReferencedWorkspaceRepository { get; set; }
+}

--- a/src/GrayMoon.App/Models/WorkspaceRepositoryLink.cs
+++ b/src/GrayMoon.App/Models/WorkspaceRepositoryLink.cs
@@ -75,6 +75,9 @@ public class WorkspaceRepositoryLink
     /// <summary>Count of configured version-file lines whose current value does not match the expected repo GitVersion. Set when file version status is checked (same trigger as dep stats). Used to extend the badge X-of-Y count.</summary>
     public int? OutOfDateFileLines { get; set; }
 
+    /// <summary>Count of distinct workspace repositories referenced by out-of-date version-file tokens. Set when file version status is checked.</summary>
+    public int? OutOfDateFileRepos { get; set; }
+
     /// <summary>Total count of configured version-file lines that were matched in files (regardless of whether they are up to date). Set when file version status is checked. Used for badge Y denominator.</summary>
     public int? TotalFileLines { get; set; }
 

--- a/src/GrayMoon.App/Models/WorkspaceRepositoryLink.cs
+++ b/src/GrayMoon.App/Models/WorkspaceRepositoryLink.cs
@@ -72,13 +72,16 @@ public class WorkspaceRepositoryLink
     /// <summary>Number of those dependencies whose version does not match the referenced repo's GitVersion. Set when dependencies are merged. Used for badge (same logic as build).</summary>
     public int? UnmatchedDeps { get; set; }
 
-    /// <summary>Count of configured version-file lines whose current value does not match the expected repo GitVersion. Set when file version status is checked (same trigger as dep stats). Used to extend the badge X-of-Y count.</summary>
+    /// <summary>Count of configured version-file lines whose current value does not match the expected repo GitVersion. Diagnostic only; badge uses <see cref="OutOfDateFileRepos"/>.</summary>
     public int? OutOfDateFileLines { get; set; }
 
-    /// <summary>Count of distinct workspace repositories referenced by out-of-date version-file tokens. Set when file version status is checked.</summary>
+    /// <summary>Count of distinct workspace repositories referenced by out-of-date version-file tokens. Badge X for file-config portion.</summary>
     public int? OutOfDateFileRepos { get; set; }
 
-    /// <summary>Total count of configured version-file lines that were matched in files (regardless of whether they are up to date). Set when file version status is checked. Used for badge Y denominator.</summary>
+    /// <summary>Total count of distinct workspace repositories referenced by file-config tokens for this dependent repo. Badge diagnostics; main Y uses <see cref="Dependencies"/>.</summary>
+    public int? TotalFileConfigRepos { get; set; }
+
+    /// <summary>Legacy line-count field; no longer used for badge display.</summary>
     public int? TotalFileLines { get; set; }
 
     /// <summary>Dominant project type for this repository (Service &gt; Package &gt; Executable &gt; Library &gt; Test). Null when no projects are known. Set during sync and project refresh.</summary>

--- a/src/GrayMoon.App/Models/WorkspaceRepositoryLink.cs
+++ b/src/GrayMoon.App/Models/WorkspaceRepositoryLink.cs
@@ -72,6 +72,12 @@ public class WorkspaceRepositoryLink
     /// <summary>Number of those dependencies whose version does not match the referenced repo's GitVersion. Set when dependencies are merged. Used for badge (same logic as build).</summary>
     public int? UnmatchedDeps { get; set; }
 
+    /// <summary>Count of configured version-file lines whose current value does not match the expected repo GitVersion. Set when file version status is checked (same trigger as dep stats). Used to extend the badge X-of-Y count.</summary>
+    public int? OutOfDateFileLines { get; set; }
+
+    /// <summary>Total count of configured version-file lines that were matched in files (regardless of whether they are up to date). Set when file version status is checked. Used for badge Y denominator.</summary>
+    public int? TotalFileLines { get; set; }
+
     /// <summary>Dominant project type for this repository (Service &gt; Package &gt; Executable &gt; Library &gt; Test). Null when no projects are known. Set during sync and project refresh.</summary>
     public ProjectType? RepositoryType { get; set; }
 

--- a/src/GrayMoon.App/Program.cs
+++ b/src/GrayMoon.App/Program.cs
@@ -51,6 +51,7 @@ try
     builder.Services.AddScoped<WorkspaceProjectRepository>();
     builder.Services.AddScoped<WorkspaceFileRepository>();
     builder.Services.AddScoped<WorkspaceFileVersionConfigRepository>();
+    builder.Services.AddScoped<WorkspaceRepositoryCustomDependencyRepository>();
     builder.Services.AddScoped<WorkspaceRepository>();
     builder.Services.AddScoped<AppSettingRepository>();
     builder.Services.AddScoped<NavbarCollapseService>();

--- a/src/GrayMoon.App/Program.cs
+++ b/src/GrayMoon.App/Program.cs
@@ -38,9 +38,13 @@ try
     // Default SignalR incoming message limit is 32KB. SyncRepository ResponseCommand carries branch lists
     // plus full .csproj/package graphs; larger repos exceed that and the server closes the connection,
     // which surfaces on the agent as HubException during InvokeAsync (not a git failure).
-    builder.Services.Configure<HubOptions>(options =>
+    // MaximumParallelInvocationsPerClient > 1 allows the hub to process ResponseCommand while SyncCommand is
+    // still running its async work (DB + CheckFileVersions round-trip). Without this, the hub reader
+    // serializes invocations and deadlocks: SyncCommand awaits a ResponseCommand that can never arrive.
+    builder.Services.AddSignalR(options =>
     {
         options.MaximumReceiveMessageSize = 10 * 1024 * 1024;
+        options.MaximumParallelInvocationsPerClient = 4;
     });
 
     // Database (SQLite) for persisted data - stored in db/ for easy container volume mounting

--- a/src/GrayMoon.App/Program.cs
+++ b/src/GrayMoon.App/Program.cs
@@ -38,13 +38,11 @@ try
     // Default SignalR incoming message limit is 32KB. SyncRepository ResponseCommand carries branch lists
     // plus full .csproj/package graphs; larger repos exceed that and the server closes the connection,
     // which surfaces on the agent as HubException during InvokeAsync (not a git failure).
-    // MaximumParallelInvocationsPerClient > 1 allows the hub to process ResponseCommand while SyncCommand is
-    // still running its async work (DB + CheckFileVersions round-trip). Without this, the hub reader
-    // serializes invocations and deadlocks: SyncCommand awaits a ResponseCommand that can never arrive.
+    // SyncCommand no longer awaits agent responses inline - it enqueues to AgentSyncNotificationQueue and
+    // returns immediately - so the default MaximumParallelInvocationsPerClient = 1 is sufficient.
     builder.Services.AddSignalR(options =>
     {
         options.MaximumReceiveMessageSize = 10 * 1024 * 1024;
-        options.MaximumParallelInvocationsPerClient = 4;
     });
 
     // Database (SQLite) for persisted data - stored in db/ for easy container volume mounting
@@ -107,6 +105,8 @@ try
     // Background services
     builder.Services.AddSingleton<SyncBackgroundService>();
     builder.Services.AddHostedService(sp => sp.GetRequiredService<SyncBackgroundService>());
+    builder.Services.AddSingleton<AgentSyncNotificationQueue>();
+    builder.Services.AddHostedService(sp => sp.GetRequiredService<AgentSyncNotificationQueue>());
     builder.Services.AddHostedService<TokenHealthBackgroundService>();
 
     // Connector services

--- a/src/GrayMoon.App/Repositories/WorkspaceProjectRepository.cs
+++ b/src/GrayMoon.App/Repositories/WorkspaceProjectRepository.cs
@@ -9,6 +9,7 @@ namespace GrayMoon.App.Repositories;
 public sealed class WorkspaceProjectRepository(
     AppDbContext dbContext,
     WorkspaceFileVersionConfigRepository versionConfigRepository,
+    WorkspaceRepositoryCustomDependencyRepository customDependencyRepository,
     ILogger<WorkspaceProjectRepository> logger)
 {
     /// <summary>Gets projects that have a PackageId (NuGet packages) for repositories linked to the given workspace.</summary>
@@ -261,34 +262,15 @@ public sealed class WorkspaceProjectRepository(
             }
         }
 
-        var projectDerivedRepoEdges = new HashSet<(int DepRepoId, int RefRepoId)>();
         var byProject = workspaceProjects.Count > 0 ? workspaceProjects.ToDictionary(p => p.ProjectId) : new Dictionary<int, WorkspaceProject>();
-        foreach (var (depId, refId, _) in uniqueEdges)
-        {
-            if (!byProject.TryGetValue(depId, out var depProj) || !byProject.TryGetValue(refId, out var refProj)) continue;
-            if (depProj.RepositoryId == refProj.RepositoryId) continue;
-            if (!repoIdsInWorkspace.Contains(depProj.RepositoryId) || !repoIdsInWorkspace.Contains(refProj.RepositoryId)) continue;
-            projectDerivedRepoEdges.Add((depProj.RepositoryId, refProj.RepositoryId));
-        }
-
-        var fileConfigRepoEdges = new HashSet<(int DepRepoId, int RefRepoId)>();
-        var configs = await versionConfigRepository.GetByWorkspaceIdAsync(workspaceId, cancellationToken);
-        foreach (var cfg in configs)
-        {
-            var fileRepoId = cfg.File?.RepositoryId;
-            if (!fileRepoId.HasValue || fileRepoId.Value == 0 || !repoIdsInWorkspace.Contains(fileRepoId.Value)) continue;
-            var dependentRepoId = fileRepoId.Value;
-            var tokens = WorkspaceFileVersionService.ExtractTokens(cfg.VersionPattern);
-            foreach (var token in tokens)
-            {
-                if (string.IsNullOrWhiteSpace(token)) continue;
-                if (!nameToRepoId.TryGetValue(token.Trim(), out var referencedRepoId)) continue;
-                if (referencedRepoId == dependentRepoId) continue;
-                fileConfigRepoEdges.Add((dependentRepoId, referencedRepoId));
-            }
-        }
-
-        var allRepoEdges = projectDerivedRepoEdges.Union(fileConfigRepoEdges).Distinct().ToList();
+        var edgeSets = await BuildRepoDependencyEdgeSetsAsync(
+            workspaceId,
+            repoIdsInWorkspace,
+            nameToRepoId,
+            uniqueEdges,
+            byProject,
+            cancellationToken);
+        var allRepoEdges = edgeSets.All;
 
         var inDegree = repoIdsInWorkspace.ToDictionary(id => id, _ => 0);
         var revEdges = repoIdsInWorkspace.ToDictionary(id => id, _ => new List<int>());
@@ -775,7 +757,7 @@ public sealed class WorkspaceProjectRepository(
         return new ProjectDependencyGraph(nodes, edgeList);
     }
 
-    /// <summary>Returns repository-level dependency graph (nodes = repos, edges = repo depends on repo). Includes both project-derived and file-config-derived edges. For Cytoscape.</summary>
+    /// <summary>Returns repository-level dependency graph (nodes = repos, edges = repo depends on repo). Includes project-derived, file-config, and custom dependency edges. For Cytoscape.</summary>
     public async Task<RepositoryDependencyGraph> GetRepositoryDependencyGraphAsync(int workspaceId, CancellationToken cancellationToken = default)
     {
         var links = await dbContext.WorkspaceRepositories
@@ -797,18 +779,110 @@ public sealed class WorkspaceProjectRepository(
             }
         }
 
-        var projectDerivedRepoEdges = new HashSet<(int Dep, int Ref)>();
         var projects = await GetByWorkspaceIdAsync(workspaceId, cancellationToken);
-        var edges = await GetDependencyEdgesAsync(workspaceId, cancellationToken);
         var byProject = projects.ToDictionary(p => p.ProjectId);
-        foreach (var (depProjectId, refProjectId) in edges)
+        var projectEdges = await GetDependencyEdgesAsync(workspaceId, cancellationToken);
+        var uniqueEdges = projectEdges
+            .Where(e => byProject.ContainsKey(e.DependentProjectId) && byProject.ContainsKey(e.ReferencedProjectId))
+            .Select(e => (e.DependentProjectId, e.ReferencedProjectId, (string?)null))
+            .ToList();
+
+        var edgeSets = await BuildRepoDependencyEdgeSetsAsync(
+            workspaceId,
+            repoIdsInWorkspace,
+            nameToRepoId,
+            uniqueEdges,
+            byProject,
+            cancellationToken);
+
+        var repoNodes = links
+            .Where(wr => wr.Repository != null && !string.IsNullOrEmpty(wr.Repository.RepositoryName))
+            .Select(wr => new RepositoryDependencyNode(wr.RepositoryId, wr.Repository!.RepositoryName!, wr.RepositoryType))
+            .ToList();
+
+        var edgeList = edgeSets.All.Select(e => new RepositoryDependencyEdge(e.DepRepoId, e.RefRepoId)).ToList();
+
+        return new RepositoryDependencyGraph(repoNodes, edgeList);
+    }
+
+    /// <summary>Returns referenced repository IDs derived from csproj and file-version config for the given dependent repository (implicit, non-custom edges).</summary>
+    public async Task<HashSet<int>> GetImplicitReferencedRepoIdsAsync(
+        int workspaceId,
+        int dependentRepositoryId,
+        CancellationToken cancellationToken = default)
+    {
+        var links = await dbContext.WorkspaceRepositories
+            .AsNoTracking()
+            .Include(wr => wr.Repository)
+            .Where(wr => wr.WorkspaceId == workspaceId)
+            .ToListAsync(cancellationToken);
+        if (links.Count == 0) return [];
+
+        var repoIdsInWorkspace = links.Select(l => l.RepositoryId).ToHashSet();
+        if (!repoIdsInWorkspace.Contains(dependentRepositoryId))
+            return [];
+
+        var nameToRepoId = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        foreach (var wr in links)
         {
-            if (!byProject.TryGetValue(depProjectId, out var depProj) || !byProject.TryGetValue(refProjectId, out var refProj)) continue;
+            if (wr.Repository != null && !string.IsNullOrEmpty(wr.Repository.RepositoryName))
+            {
+                var name = wr.Repository.RepositoryName.Trim();
+                if (!nameToRepoId.ContainsKey(name))
+                    nameToRepoId[name] = wr.RepositoryId;
+            }
+        }
+
+        var projects = await GetByWorkspaceIdAsync(workspaceId, cancellationToken);
+        var byProject = projects.ToDictionary(p => p.ProjectId);
+        var projectEdges = await GetDependencyEdgesAsync(workspaceId, cancellationToken);
+        var uniqueEdges = projectEdges
+            .Where(e => byProject.ContainsKey(e.DependentProjectId) && byProject.ContainsKey(e.ReferencedProjectId))
+            .Select(e => (e.DependentProjectId, e.ReferencedProjectId, (string?)null))
+            .ToList();
+
+        var edgeSets = await BuildRepoDependencyEdgeSetsAsync(
+            workspaceId,
+            repoIdsInWorkspace,
+            nameToRepoId,
+            uniqueEdges,
+            byProject,
+            cancellationToken);
+
+        var implicitRefs = new HashSet<int>();
+        foreach (var (dep, @ref) in edgeSets.ProjectDerived.Union(edgeSets.FileConfig))
+        {
+            if (dep == dependentRepositoryId)
+                implicitRefs.Add(@ref);
+        }
+
+        return implicitRefs;
+    }
+
+    private sealed record RepoDependencyEdgeSets(
+        HashSet<(int DepRepoId, int RefRepoId)> ProjectDerived,
+        HashSet<(int DepRepoId, int RefRepoId)> FileConfig,
+        HashSet<(int DepRepoId, int RefRepoId)> Custom,
+        List<(int DepRepoId, int RefRepoId)> All);
+
+    private async Task<RepoDependencyEdgeSets> BuildRepoDependencyEdgeSetsAsync(
+        int workspaceId,
+        HashSet<int> repoIdsInWorkspace,
+        Dictionary<string, int> nameToRepoId,
+        List<(int DependentProjectId, int ReferencedProjectId, string? Version)> uniqueEdges,
+        Dictionary<int, WorkspaceProject> byProject,
+        CancellationToken cancellationToken)
+    {
+        var projectDerivedRepoEdges = new HashSet<(int DepRepoId, int RefRepoId)>();
+        foreach (var (depId, refId, _) in uniqueEdges)
+        {
+            if (!byProject.TryGetValue(depId, out var depProj) || !byProject.TryGetValue(refId, out var refProj)) continue;
             if (depProj.RepositoryId == refProj.RepositoryId) continue;
+            if (!repoIdsInWorkspace.Contains(depProj.RepositoryId) || !repoIdsInWorkspace.Contains(refProj.RepositoryId)) continue;
             projectDerivedRepoEdges.Add((depProj.RepositoryId, refProj.RepositoryId));
         }
 
-        var fileConfigRepoEdges = new HashSet<(int Dep, int Ref)>();
+        var fileConfigRepoEdges = new HashSet<(int DepRepoId, int RefRepoId)>();
         var configs = await versionConfigRepository.GetByWorkspaceIdAsync(workspaceId, cancellationToken);
         foreach (var cfg in configs)
         {
@@ -825,15 +899,15 @@ public sealed class WorkspaceProjectRepository(
             }
         }
 
-        var repoNodes = links
-            .Where(wr => wr.Repository != null && !string.IsNullOrEmpty(wr.Repository.RepositoryName))
-            .Select(wr => new RepositoryDependencyNode(wr.RepositoryId, wr.Repository!.RepositoryName!, wr.RepositoryType))
+        var customRepoEdges = await customDependencyRepository.GetRepoEdgesByWorkspaceIdAsync(workspaceId, cancellationToken);
+
+        var allRepoEdges = projectDerivedRepoEdges
+            .Union(fileConfigRepoEdges)
+            .Union(customRepoEdges)
+            .Distinct()
             .ToList();
 
-        var allRepoEdges = projectDerivedRepoEdges.Union(fileConfigRepoEdges).Distinct();
-        var edgeList = allRepoEdges.Select(e => new RepositoryDependencyEdge(e.Dep, e.Ref)).ToList();
-
-        return new RepositoryDependencyGraph(repoNodes, edgeList);
+        return new RepoDependencyEdgeSets(projectDerivedRepoEdges, fileConfigRepoEdges, customRepoEdges, allRepoEdges);
     }
 
 }

--- a/src/GrayMoon.App/Repositories/WorkspaceProjectRepository.cs
+++ b/src/GrayMoon.App/Repositories/WorkspaceProjectRepository.cs
@@ -811,17 +811,138 @@ public sealed class WorkspaceProjectRepository(
         int dependentRepositoryId,
         CancellationToken cancellationToken = default)
     {
+        var bySource = await GetImplicitReferencedRepoIdsBySourceAsync(workspaceId, dependentRepositoryId, cancellationToken);
+        var result = new HashSet<int>(bySource.FromProject);
+        result.UnionWith(bySource.FromFile);
+        return result;
+    }
+
+    /// <summary>Returns implicit referenced repository IDs for the given dependent, split by csproj vs version-file source.</summary>
+    public async Task<ImplicitReferencedRepoIdsBySource> GetImplicitReferencedRepoIdsBySourceAsync(
+        int workspaceId,
+        int dependentRepositoryId,
+        CancellationToken cancellationToken = default)
+    {
+        var graph = await LoadWorkspaceRepoDependencyGraphAsync(workspaceId, cancellationToken);
+        if (graph is null || !graph.RepoIdsInWorkspace.Contains(dependentRepositoryId))
+            return new ImplicitReferencedRepoIdsBySource([], []);
+
+        var fromProject = new HashSet<int>();
+        foreach (var (dep, @ref) in graph.EdgeSets.ProjectDerived)
+        {
+            if (dep == dependentRepositoryId)
+                fromProject.Add(@ref);
+        }
+
+        var fromFile = new HashSet<int>();
+        foreach (var (dep, @ref) in graph.EdgeSets.FileConfig)
+        {
+            if (dep == dependentRepositoryId)
+                fromFile.Add(@ref);
+        }
+
+        return new ImplicitReferencedRepoIdsBySource(fromProject, fromFile);
+    }
+
+    /// <summary>
+    /// Repo IDs that must not appear in the custom-dependencies picker for the given dependent
+    /// because adding them would create a cycle. Already-existing dependencies of the dependent are excluded from this set.
+    /// </summary>
+    public async Task<HashSet<int>> GetCircularCustomDependencyRepoIdsAsync(
+        int workspaceId,
+        int dependentRepositoryId,
+        CancellationToken cancellationToken = default)
+    {
+        var graph = await LoadWorkspaceRepoDependencyGraphAsync(workspaceId, cancellationToken);
+        if (graph is null || !graph.RepoIdsInWorkspace.Contains(dependentRepositoryId))
+            return [];
+
+        var allEdges = graph.EdgeSets.All.ToHashSet();
+        var forwardAdjacency = BuildForwardAdjacency(allEdges);
+        var existingDepsOfDependent = allEdges
+            .Where(e => e.DepRepoId == dependentRepositoryId)
+            .Select(e => e.RefRepoId)
+            .ToHashSet();
+
+        var circular = new HashSet<int>();
+        foreach (var candidateRepoId in graph.RepoIdsInWorkspace)
+        {
+            if (candidateRepoId == dependentRepositoryId)
+                continue;
+            if (existingDepsOfDependent.Contains(candidateRepoId))
+                continue;
+            if (WouldCreateCycleOnAdd(allEdges, forwardAdjacency, dependentRepositoryId, candidateRepoId))
+                circular.Add(candidateRepoId);
+        }
+
+        return circular;
+    }
+
+    private static Dictionary<int, List<int>> BuildForwardAdjacency(HashSet<(int DepRepoId, int RefRepoId)> edges)
+    {
+        var adjacency = new Dictionary<int, List<int>>();
+        foreach (var (dep, @ref) in edges)
+        {
+            if (!adjacency.TryGetValue(dep, out var refs))
+            {
+                refs = [];
+                adjacency[dep] = refs;
+            }
+
+            refs.Add(@ref);
+        }
+
+        return adjacency;
+    }
+
+    private static bool WouldCreateCycleOnAdd(
+        HashSet<(int DepRepoId, int RefRepoId)> edges,
+        Dictionary<int, List<int>> forwardAdjacency,
+        int dependentRepositoryId,
+        int candidateRepositoryId)
+    {
+        if (dependentRepositoryId == candidateRepositoryId)
+            return true;
+        if (edges.Contains((dependentRepositoryId, candidateRepositoryId)))
+            return false;
+
+        var visited = new HashSet<int> { candidateRepositoryId };
+        var queue = new Queue<int>();
+        queue.Enqueue(candidateRepositoryId);
+        while (queue.Count > 0)
+        {
+            var current = queue.Dequeue();
+            if (current == dependentRepositoryId)
+                return true;
+            if (!forwardAdjacency.TryGetValue(current, out var refs))
+                continue;
+            foreach (var next in refs)
+            {
+                if (visited.Add(next))
+                    queue.Enqueue(next);
+            }
+        }
+
+        return false;
+    }
+
+    private sealed record WorkspaceRepoDependencyGraph(
+        HashSet<int> RepoIdsInWorkspace,
+        RepoDependencyEdgeSets EdgeSets);
+
+    private async Task<WorkspaceRepoDependencyGraph?> LoadWorkspaceRepoDependencyGraphAsync(
+        int workspaceId,
+        CancellationToken cancellationToken)
+    {
         var links = await dbContext.WorkspaceRepositories
             .AsNoTracking()
             .Include(wr => wr.Repository)
             .Where(wr => wr.WorkspaceId == workspaceId)
             .ToListAsync(cancellationToken);
-        if (links.Count == 0) return [];
+        if (links.Count == 0)
+            return null;
 
         var repoIdsInWorkspace = links.Select(l => l.RepositoryId).ToHashSet();
-        if (!repoIdsInWorkspace.Contains(dependentRepositoryId))
-            return [];
-
         var nameToRepoId = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
         foreach (var wr in links)
         {
@@ -849,14 +970,7 @@ public sealed class WorkspaceProjectRepository(
             byProject,
             cancellationToken);
 
-        var implicitRefs = new HashSet<int>();
-        foreach (var (dep, @ref) in edgeSets.ProjectDerived.Union(edgeSets.FileConfig))
-        {
-            if (dep == dependentRepositoryId)
-                implicitRefs.Add(@ref);
-        }
-
-        return implicitRefs;
+        return new WorkspaceRepoDependencyGraph(repoIdsInWorkspace, edgeSets);
     }
 
     private sealed record RepoDependencyEdgeSets(

--- a/src/GrayMoon.App/Repositories/WorkspaceProjectRepository.cs
+++ b/src/GrayMoon.App/Repositories/WorkspaceProjectRepository.cs
@@ -886,6 +886,7 @@ public sealed class WorkspaceProjectRepository(
         var configs = await versionConfigRepository.GetByWorkspaceIdAsync(workspaceId, cancellationToken);
         foreach (var cfg in configs)
         {
+            if (cfg.File?.IsMissingOnDisk == true) continue;
             var fileRepoId = cfg.File?.RepositoryId;
             if (!fileRepoId.HasValue || fileRepoId.Value == 0 || !repoIdsInWorkspace.Contains(fileRepoId.Value)) continue;
             var dependentRepoId = fileRepoId.Value;

--- a/src/GrayMoon.App/Repositories/WorkspaceRepositoryCustomDependencyRepository.cs
+++ b/src/GrayMoon.App/Repositories/WorkspaceRepositoryCustomDependencyRepository.cs
@@ -1,0 +1,141 @@
+using GrayMoon.App.Data;
+using GrayMoon.App.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace GrayMoon.App.Repositories;
+
+public sealed class WorkspaceRepositoryCustomDependencyRepository(
+    AppDbContext dbContext,
+    ILogger<WorkspaceRepositoryCustomDependencyRepository> logger)
+{
+    /// <summary>Returns custom dependency repo edges as (dependentRepositoryId, referencedRepositoryId) pairs.</summary>
+    public async Task<HashSet<(int DepRepoId, int RefRepoId)>> GetRepoEdgesByWorkspaceIdAsync(
+        int workspaceId,
+        CancellationToken cancellationToken = default)
+    {
+        var rows = await dbContext.WorkspaceRepositoryCustomDependencies
+            .AsNoTracking()
+            .Include(d => d.DependentWorkspaceRepository)
+            .Include(d => d.ReferencedWorkspaceRepository)
+            .Where(d => d.DependentWorkspaceRepository!.WorkspaceId == workspaceId)
+            .ToListAsync(cancellationToken);
+
+        var edges = new HashSet<(int, int)>();
+        foreach (var row in rows)
+        {
+            var depRepoId = row.DependentWorkspaceRepository?.RepositoryId;
+            var refRepoId = row.ReferencedWorkspaceRepository?.RepositoryId;
+            if (!depRepoId.HasValue || !refRepoId.HasValue) continue;
+            if (depRepoId.Value == refRepoId.Value) continue;
+            edges.Add((depRepoId.Value, refRepoId.Value));
+        }
+
+        return edges;
+    }
+
+    /// <summary>Returns user-selected custom referenced repository IDs for the given dependent repository.</summary>
+    public async Task<HashSet<int>> GetCustomReferencedRepositoryIdsAsync(
+        int workspaceId,
+        int dependentRepositoryId,
+        CancellationToken cancellationToken = default)
+    {
+        var dependentLinkId = await dbContext.WorkspaceRepositories
+            .AsNoTracking()
+            .Where(wr => wr.WorkspaceId == workspaceId && wr.RepositoryId == dependentRepositoryId)
+            .Select(wr => (int?)wr.WorkspaceRepositoryId)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (!dependentLinkId.HasValue)
+            return [];
+
+        var referencedRepoIds = await dbContext.WorkspaceRepositoryCustomDependencies
+            .AsNoTracking()
+            .Where(d => d.DependentWorkspaceRepositoryId == dependentLinkId.Value)
+            .Select(d => d.ReferencedWorkspaceRepository!.RepositoryId)
+            .ToListAsync(cancellationToken);
+
+        return referencedRepoIds.ToHashSet();
+    }
+
+    /// <summary>Returns custom dependency repo names keyed by dependent repository ID (for badge tooltips).</summary>
+    public async Task<IReadOnlyDictionary<int, IReadOnlyList<string>>> GetCustomDependencyNamesByRepoAsync(
+        int workspaceId,
+        CancellationToken cancellationToken = default)
+    {
+        var rows = await dbContext.WorkspaceRepositoryCustomDependencies
+            .AsNoTracking()
+            .Include(d => d.DependentWorkspaceRepository)
+            .Include(d => d.ReferencedWorkspaceRepository)
+                .ThenInclude(wr => wr!.Repository)
+            .Where(d => d.DependentWorkspaceRepository!.WorkspaceId == workspaceId)
+            .ToListAsync(cancellationToken);
+
+        var dict = new Dictionary<int, List<string>>();
+        foreach (var row in rows)
+        {
+            var depRepoId = row.DependentWorkspaceRepository?.RepositoryId;
+            var refName = row.ReferencedWorkspaceRepository?.Repository?.RepositoryName;
+            if (!depRepoId.HasValue || string.IsNullOrWhiteSpace(refName)) continue;
+
+            if (!dict.TryGetValue(depRepoId.Value, out var names))
+            {
+                names = [];
+                dict[depRepoId.Value] = names;
+            }
+
+            names.Add(refName);
+        }
+
+        foreach (var key in dict.Keys.ToList())
+            dict[key] = dict[key].OrderBy(n => n, StringComparer.OrdinalIgnoreCase).ToList();
+
+        return dict.ToDictionary(kv => kv.Key, kv => (IReadOnlyList<string>)kv.Value);
+    }
+
+    /// <summary>Replaces user-selected custom dependencies for a dependent repository. Only stores custom edges, not implicit csproj/file refs.</summary>
+    public async Task ReplaceCustomDependenciesForDependentAsync(
+        int workspaceId,
+        int dependentRepositoryId,
+        IReadOnlySet<int> referencedRepositoryIds,
+        CancellationToken cancellationToken = default)
+    {
+        var links = await dbContext.WorkspaceRepositories
+            .AsNoTracking()
+            .Where(wr => wr.WorkspaceId == workspaceId)
+            .Select(wr => new { wr.WorkspaceRepositoryId, wr.RepositoryId })
+            .ToListAsync(cancellationToken);
+
+        var linkIdByRepoId = links.ToDictionary(l => l.RepositoryId, l => l.WorkspaceRepositoryId);
+        if (!linkIdByRepoId.TryGetValue(dependentRepositoryId, out var dependentLinkId))
+            throw new InvalidOperationException("Dependent repository is not in the workspace.");
+
+        var validReferencedLinkIds = new List<int>();
+        foreach (var refRepoId in referencedRepositoryIds)
+        {
+            if (refRepoId == dependentRepositoryId) continue;
+            if (!linkIdByRepoId.TryGetValue(refRepoId, out var refLinkId))
+                throw new InvalidOperationException($"Referenced repository {refRepoId} is not in the workspace.");
+            validReferencedLinkIds.Add(refLinkId);
+        }
+
+        var existing = await dbContext.WorkspaceRepositoryCustomDependencies
+            .Where(d => d.DependentWorkspaceRepositoryId == dependentLinkId)
+            .ToListAsync(cancellationToken);
+
+        dbContext.WorkspaceRepositoryCustomDependencies.RemoveRange(existing);
+
+        foreach (var refLinkId in validReferencedLinkIds.Distinct())
+        {
+            dbContext.WorkspaceRepositoryCustomDependencies.Add(new WorkspaceRepositoryCustomDependency
+            {
+                DependentWorkspaceRepositoryId = dependentLinkId,
+                ReferencedWorkspaceRepositoryId = refLinkId
+            });
+        }
+
+        await dbContext.SaveChangesAsync(cancellationToken);
+        logger.LogInformation(
+            "Replaced custom dependencies for workspace {WorkspaceId} dependent repo {DependentRepositoryId}: {Count} edge(s).",
+            workspaceId, dependentRepositoryId, validReferencedLinkIds.Distinct().Count());
+    }
+}

--- a/src/GrayMoon.App/Services/AgentSyncNotificationQueue.cs
+++ b/src/GrayMoon.App/Services/AgentSyncNotificationQueue.cs
@@ -1,0 +1,60 @@
+using System.Threading.Channels;
+using GrayMoon.Abstractions.Notifications;
+
+namespace GrayMoon.App.Services;
+
+/// <summary>
+/// Singleton BackgroundService that decouples incoming <see cref="RepositorySyncNotification"/> messages
+/// from the SignalR hub invocation slot. The hub's SyncCommand method enqueues immediately and returns,
+/// keeping hub slots free so ResponseCommand messages from the agent are never blocked.
+/// </summary>
+public sealed class AgentSyncNotificationQueue(
+    IServiceScopeFactory scopeFactory,
+    ILogger<AgentSyncNotificationQueue> logger) : BackgroundService
+{
+    private readonly Channel<RepositorySyncNotification> _channel =
+        Channel.CreateUnbounded<RepositorySyncNotification>(new UnboundedChannelOptions
+        {
+            SingleReader = true,
+            SingleWriter = false
+        });
+
+    /// <summary>Enqueues a notification for background processing. Always returns before any DB or agent work begins.</summary>
+    public bool Enqueue(RepositorySyncNotification notification) =>
+        _channel.Writer.TryWrite(notification);
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        logger.LogInformation("AgentSyncNotificationQueue starting");
+
+        // Single worker: serializes processing so concurrent SyncCommands for the same workspace
+        // don't race on DB writes. CheckAndPersistFileVersionStatusAsync already coalesces
+        // concurrent callers per workspace, so burst hooks still result in only one agent round-trip.
+        await foreach (var notification in _channel.Reader.ReadAllAsync(stoppingToken))
+        {
+            try
+            {
+                await using var scope = scopeFactory.CreateAsyncScope();
+                var handler = scope.ServiceProvider.GetRequiredService<SyncCommandHandler>();
+                await handler.HandleAsync(notification);
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "SyncNotification processing failed for workspace {WorkspaceId} repo {RepositoryId}",
+                    notification.WorkspaceId, notification.RepositoryId);
+            }
+        }
+
+        logger.LogInformation("AgentSyncNotificationQueue stopped");
+    }
+
+    public override Task StopAsync(CancellationToken cancellationToken)
+    {
+        _channel.Writer.TryComplete();
+        return base.StopAsync(cancellationToken);
+    }
+}

--- a/src/GrayMoon.App/Services/DependencyUpdateOrchestrator.cs
+++ b/src/GrayMoon.App/Services/DependencyUpdateOrchestrator.cs
@@ -139,11 +139,12 @@ public sealed class DependencyUpdateOrchestrator(
             }
         }
 
-        // Finalize: broadcast so grid refreshes.
+        // Finalize: broadcast so grid refreshes, then run one file-version check for the whole update.
         if (!hadError)
         {
             onAppSideComplete?.Invoke();
             await workspaceGitService.RecomputeAndBroadcastWorkspaceSyncedAsync(workspaceId, cancellationToken);
+            await fileVersionService.CheckAndPersistFileVersionStatusAsync(workspaceId, cancellationToken);
         }
     }
 

--- a/src/GrayMoon.App/Services/SyncCommandHandler.cs
+++ b/src/GrayMoon.App/Services/SyncCommandHandler.cs
@@ -143,29 +143,20 @@ public sealed class SyncCommandHandler(
         }
 
         var depsSw = Stopwatch.StartNew();
+        try
+        {
+            var fileVersionService = scope.ServiceProvider.GetRequiredService<WorkspaceFileVersionService>();
+            await fileVersionService.CheckAndPersistFileVersionStatusAsync(n.WorkspaceId);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "SyncCommand CheckAndPersist failed for workspace {WorkspaceId}", n.WorkspaceId);
+        }
+
         await workspaceProjectRepository.RecomputeAndPersistRepositoryDependencyStatsAsync(n.WorkspaceId);
         logger.LogDebug(
             "SyncCommand dependency stats persisted in {ElapsedMs}ms for workspace={WorkspaceId}, repo={RepositoryId}",
             depsSw.ElapsedMilliseconds, n.WorkspaceId, n.RepositoryId);
-
-        var workspaceId = n.WorkspaceId;
-        _ = Task.Run(async () =>
-        {
-            try
-            {
-                var checkSw = Stopwatch.StartNew();
-                await using var bgScope = scopeFactory.CreateAsyncScope();
-                var fileVersionService = bgScope.ServiceProvider.GetRequiredService<WorkspaceFileVersionService>();
-                await fileVersionService.CheckAndPersistFileVersionStatusAsync(workspaceId);
-                logger.LogDebug(
-                    "SyncCommand deferred CheckAndPersist completed in {ElapsedMs}ms for workspace={WorkspaceId}",
-                    checkSw.ElapsedMilliseconds, workspaceId);
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "SyncCommand deferred CheckAndPersist failed for workspace {WorkspaceId}", workspaceId);
-            }
-        });
 
         var prSw = Stopwatch.StartNew();
         var workspacePullRequestService = scope.ServiceProvider.GetRequiredService<WorkspacePullRequestService>();

--- a/src/GrayMoon.App/Services/SyncCommandHandler.cs
+++ b/src/GrayMoon.App/Services/SyncCommandHandler.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using GrayMoon.Abstractions.Notifications;
 using GrayMoon.App.Data;
 using GrayMoon.App.Hubs;
@@ -16,6 +17,7 @@ public sealed class SyncCommandHandler(
 {
     public async Task HandleAsync(RepositorySyncNotification n)
     {
+        var totalSw = Stopwatch.StartNew();
         await using var scope = scopeFactory.CreateAsyncScope();
         var dbContext = scope.ServiceProvider.GetRequiredService<AppDbContext>();
         var workspaceProjectRepository = scope.ServiceProvider.GetRequiredService<WorkspaceProjectRepository>();
@@ -140,19 +142,45 @@ public sealed class SyncCommandHandler(
             await dbContext.SaveChangesAsync();
         }
 
+        var depsSw = Stopwatch.StartNew();
         await workspaceProjectRepository.RecomputeAndPersistRepositoryDependencyStatsAsync(n.WorkspaceId);
+        logger.LogDebug(
+            "SyncCommand dependency stats persisted in {ElapsedMs}ms for workspace={WorkspaceId}, repo={RepositoryId}",
+            depsSw.ElapsedMilliseconds, n.WorkspaceId, n.RepositoryId);
 
-        var fileVersionService = scope.ServiceProvider.GetRequiredService<WorkspaceFileVersionService>();
-        await fileVersionService.CheckAndPersistFileVersionStatusAsync(n.WorkspaceId);
+        var workspaceId = n.WorkspaceId;
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                var checkSw = Stopwatch.StartNew();
+                await using var bgScope = scopeFactory.CreateAsyncScope();
+                var fileVersionService = bgScope.ServiceProvider.GetRequiredService<WorkspaceFileVersionService>();
+                await fileVersionService.CheckAndPersistFileVersionStatusAsync(workspaceId);
+                logger.LogDebug(
+                    "SyncCommand deferred CheckAndPersist completed in {ElapsedMs}ms for workspace={WorkspaceId}",
+                    checkSw.ElapsedMilliseconds, workspaceId);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "SyncCommand deferred CheckAndPersist failed for workspace {WorkspaceId}", workspaceId);
+            }
+        });
 
+        var prSw = Stopwatch.StartNew();
         var workspacePullRequestService = scope.ServiceProvider.GetRequiredService<WorkspacePullRequestService>();
         await workspacePullRequestService.RefreshPullRequestsAsync(n.WorkspaceId, [n.RepositoryId]);
+        logger.LogDebug(
+            "SyncCommand RefreshPullRequests completed in {ElapsedMs}ms for workspace={WorkspaceId}, repo={RepositoryId}",
+            prSw.ElapsedMilliseconds, n.WorkspaceId, n.RepositoryId);
 
         await hubContext.Clients.All.SendAsync("RepositorySynced", n.WorkspaceId, n.RepositoryId);
         await hubContext.Clients.All.SendAsync("WorkspaceSynced", n.WorkspaceId);
         if (!string.IsNullOrWhiteSpace(n.ErrorMessage))
             await hubContext.Clients.All.SendAsync("RepositoryError", n.WorkspaceId, n.RepositoryId, n.ErrorMessage);
-        logger.LogDebug("SyncCommand persisted: workspace={WorkspaceId}, repo={RepositoryId}, version={Version}, branch={Branch}",
-            n.WorkspaceId, n.RepositoryId, n.Version, n.Branch);
+
+        logger.LogDebug(
+            "SyncCommand persisted in {ElapsedMs}ms: workspace={WorkspaceId}, repo={RepositoryId}, version={Version}, branch={Branch}",
+            totalSw.ElapsedMilliseconds, n.WorkspaceId, n.RepositoryId, n.Version, n.Branch);
     }
 }

--- a/src/GrayMoon.App/Services/SyncCommandHandler.cs
+++ b/src/GrayMoon.App/Services/SyncCommandHandler.cs
@@ -142,6 +142,9 @@ public sealed class SyncCommandHandler(
 
         await workspaceProjectRepository.RecomputeAndPersistRepositoryDependencyStatsAsync(n.WorkspaceId);
 
+        var fileVersionService = scope.ServiceProvider.GetRequiredService<WorkspaceFileVersionService>();
+        await fileVersionService.CheckAndPersistFileVersionStatusAsync(n.WorkspaceId);
+
         var workspacePullRequestService = scope.ServiceProvider.GetRequiredService<WorkspacePullRequestService>();
         await workspacePullRequestService.RefreshPullRequestsAsync(n.WorkspaceId, [n.RepositoryId]);
 

--- a/src/GrayMoon.App/Services/WorkspaceFileVersionService.cs
+++ b/src/GrayMoon.App/Services/WorkspaceFileVersionService.cs
@@ -268,39 +268,34 @@ public sealed class WorkspaceFileVersionService(
             var result = AgentResponseJson.DeserializeAgentResponse<CheckFileVersionsAgentResponse>(resp.Data);
             if (result?.Files == null) return;
 
-            // Accumulate per-repo stats and new status rows
+            // Accumulate per-repo stats and new per-file status rows
             var newStatuses = new List<WorkspaceFileLineStatus>();
             var repoOutOfDate = new Dictionary<int, int>();
             var repoTotalMatched = new Dictionary<int, int>();
 
             foreach (var fileResult in result.Files)
             {
+                if (fileResult.TotalMatchedLines == 0) continue;
+
                 // Find repository id for this file result
                 var repoLink = workspace.Repositories.FirstOrDefault(r =>
                     string.Equals(r.Repository?.RepositoryName, fileResult.RepositoryName, StringComparison.OrdinalIgnoreCase));
                 if (repoLink == null) continue;
                 var repoId = repoLink.RepositoryId;
 
-                repoTotalMatched.TryGetValue(repoId, out var existingTotal);
-                repoTotalMatched[repoId] = existingTotal + fileResult.TotalMatchedLines;
-
-                if (fileResult.OutOfDateLines == null) continue;
-                foreach (var stale in fileResult.OutOfDateLines)
+                var outOfDateCount = fileResult.OutOfDateLines?.Count ?? 0;
+                newStatuses.Add(new WorkspaceFileLineStatus
                 {
-                    if (string.IsNullOrEmpty(stale.TokenName)) continue;
-                    newStatuses.Add(new WorkspaceFileLineStatus
-                    {
-                        WorkspaceId = workspaceId,
-                        RepositoryId = repoId,
-                        FilePath = fileResult.FilePath ?? "",
-                        FileName = fileResult.FileName ?? "",
-                        TokenName = stale.TokenName,
-                        CurrentValue = stale.CurrentValue,
-                        ExpectedValue = stale.ExpectedValue
-                    });
-                    repoOutOfDate.TryGetValue(repoId, out var existingOut);
-                    repoOutOfDate[repoId] = existingOut + 1;
-                }
+                    WorkspaceId = workspaceId,
+                    RepositoryId = repoId,
+                    FilePath = fileResult.FilePath ?? "",
+                    FileName = fileResult.FileName ?? "",
+                    TotalMatchedLines = fileResult.TotalMatchedLines,
+                    OutOfDateLines = outOfDateCount
+                });
+
+                repoTotalMatched[repoId] = (repoTotalMatched.TryGetValue(repoId, out var tot) ? tot : 0) + fileResult.TotalMatchedLines;
+                repoOutOfDate[repoId] = (repoOutOfDate.TryGetValue(repoId, out var ood) ? ood : 0) + outOfDateCount;
             }
 
             if (newStatuses.Count > 0)

--- a/src/GrayMoon.App/Services/WorkspaceFileVersionService.cs
+++ b/src/GrayMoon.App/Services/WorkspaceFileVersionService.cs
@@ -191,7 +191,7 @@ public sealed class WorkspaceFileVersionService(
 
     /// <summary>
     /// Reads all configured version files via the agent, compares current values to expected repo GitVersions,
-    /// and persists the results to WorkspaceFileLineStatuses and WorkspaceRepositoryLink (OutOfDateFileLines, TotalFileLines).
+    /// and persists the results to WorkspaceFileLineStatuses and WorkspaceRepositoryLink (OutOfDateFileLines, OutOfDateFileRepos, TotalFileLines).
     /// Called at the same trigger points as csproj dependency stat recomputation.
     /// Concurrent callers for the same workspace coalesce onto one in-flight check.
     /// </summary>
@@ -285,9 +285,10 @@ public sealed class WorkspaceFileVersionService(
         {
             // Reset counters on all repo links when there are no configured files
             await dbContext.WorkspaceRepositories
-                .Where(wr => wr.WorkspaceId == workspaceId && (wr.OutOfDateFileLines != null || wr.TotalFileLines != null))
+                .Where(wr => wr.WorkspaceId == workspaceId && (wr.OutOfDateFileLines != null || wr.OutOfDateFileRepos != null || wr.TotalFileLines != null))
                 .ExecuteUpdateAsync(s => s
                     .SetProperty(wr => wr.OutOfDateFileLines, (int?)null)
+                    .SetProperty(wr => wr.OutOfDateFileRepos, (int?)null)
                     .SetProperty(wr => wr.TotalFileLines, (int?)null),
                     cancellationToken);
             logger.LogDebug("CheckAndPersist completed for workspace {WorkspaceId} in {ElapsedMs}ms (no items)", workspaceId, sw.ElapsedMilliseconds);
@@ -319,6 +320,7 @@ public sealed class WorkspaceFileVersionService(
             // Accumulate per-repo stats and new per-file status rows
             var newStatuses = new List<WorkspaceFileLineStatus>();
             var repoOutOfDate = new Dictionary<int, int>();
+            var repoOutOfDateTokens = new Dictionary<int, HashSet<string>>();
             var repoTotalMatched = new Dictionary<int, int>();
 
             foreach (var fileResult in result.Files)
@@ -348,6 +350,16 @@ public sealed class WorkspaceFileVersionService(
 
                 repoTotalMatched[repoId] = (repoTotalMatched.TryGetValue(repoId, out var tot) ? tot : 0) + totalForStats;
                 repoOutOfDate[repoId] = (repoOutOfDate.TryGetValue(repoId, out var ood) ? ood : 0) + outOfDateCount;
+                if (outOfDateCount > 0 && fileResult.OutOfDateLines != null)
+                {
+                    if (!repoOutOfDateTokens.TryGetValue(repoId, out var tokens))
+                        repoOutOfDateTokens[repoId] = tokens = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                    foreach (var line in fileResult.OutOfDateLines)
+                    {
+                        if (!string.IsNullOrWhiteSpace(line.TokenName))
+                            tokens.Add(line.TokenName);
+                    }
+                }
             }
 
             if (newStatuses.Count > 0)
@@ -364,6 +376,9 @@ public sealed class WorkspaceFileVersionService(
             foreach (var link in allLinks)
             {
                 link.OutOfDateFileLines = repoOutOfDate.TryGetValue(link.RepositoryId, out var ood) ? ood : (int?)null;
+                link.OutOfDateFileRepos = repoOutOfDateTokens.TryGetValue(link.RepositoryId, out var tokens) && tokens.Count > 0
+                    ? tokens.Count
+                    : (int?)null;
                 link.TotalFileLines = repoTotalMatched.TryGetValue(link.RepositoryId, out var tot) ? tot : (int?)null;
             }
             await dbContext.SaveChangesAsync(cancellationToken);

--- a/src/GrayMoon.App/Services/WorkspaceFileVersionService.cs
+++ b/src/GrayMoon.App/Services/WorkspaceFileVersionService.cs
@@ -569,6 +569,61 @@ public sealed class WorkspaceFileVersionService(
         return result.ToDictionary(kvp => kvp.Key, kvp => (IReadOnlyList<(string, string, string)>)kvp.Value);
     }
 
+    /// <summary>
+    /// Checks which pattern lines from <paramref name="pattern"/> cannot be matched in the actual file on disk.
+    /// Used by the version config dialog to highlight pattern lines that no longer exist in the file.
+    /// Returns token names (repo names) whose pattern line was not found. Returns empty if the agent is
+    /// not connected, the file is missing, or the call fails.
+    /// </summary>
+    public async Task<IReadOnlyList<string>> ValidatePatternAgainstFileAsync(
+        int workspaceId,
+        string? repositoryName,
+        string? filePath,
+        string? pattern,
+        CancellationToken cancellationToken = default)
+    {
+        if (!agentBridge.IsAgentConnected) return [];
+        if (string.IsNullOrWhiteSpace(pattern) || string.IsNullOrWhiteSpace(repositoryName) || string.IsNullOrWhiteSpace(filePath))
+            return [];
+
+        var workspace = await workspaceRepository.GetByIdAsync(workspaceId);
+        if (workspace == null) return [];
+
+        try
+        {
+            var workspaceRoot = await workspaceService.GetRootPathForWorkspaceAsync(workspace, cancellationToken);
+            var resp = await agentBridge.SendCommandAsync("CheckFileVersions", new
+            {
+                workspaceName = workspace.Name,
+                workspaceRoot,
+                files = new[]
+                {
+                    new
+                    {
+                        repositoryName,
+                        filePath,
+                        pattern,
+                        expectedVersions = new Dictionary<string, string>()
+                    }
+                }
+            }, cancellationToken);
+
+            if (!resp.Success || resp.Data == null) return [];
+
+            var result = AgentResponseJson.DeserializeAgentResponse<CheckFileVersionsAgentResponse>(resp.Data);
+            var fileResult = result?.Files?.FirstOrDefault();
+            if (fileResult == null || fileResult.FileMissing) return [];
+
+            return (IReadOnlyList<string>)(fileResult.NotMatchedTokens ?? []);
+        }
+        catch (OperationCanceledException) { throw; }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "ValidatePatternAgainstFile failed for {FilePath}", filePath);
+            return [];
+        }
+    }
+
     private sealed class CheckFileVersionsAgentResponse
     {
         [System.Text.Json.Serialization.JsonPropertyName("files")]
@@ -584,6 +639,7 @@ public sealed class WorkspaceFileVersionService(
         [System.Text.Json.Serialization.JsonPropertyName("expectedTokenCount")] public int ExpectedTokenCount { get; set; }
         [System.Text.Json.Serialization.JsonPropertyName("fileMissing")] public bool FileMissing { get; set; }
         [System.Text.Json.Serialization.JsonPropertyName("outOfDateLines")] public List<CheckFileVersionsAgentOutOfDateLine>? OutOfDateLines { get; set; }
+        [System.Text.Json.Serialization.JsonPropertyName("notMatchedTokens")] public List<string>? NotMatchedTokens { get; set; }
     }
 
     private sealed class CheckFileVersionsAgentOutOfDateLine

--- a/src/GrayMoon.App/Services/WorkspaceFileVersionService.cs
+++ b/src/GrayMoon.App/Services/WorkspaceFileVersionService.cs
@@ -1,5 +1,8 @@
+using GrayMoon.App.Data;
+using GrayMoon.App.Models;
 using GrayMoon.App.Models.Api;
 using GrayMoon.App.Repositories;
+using Microsoft.EntityFrameworkCore;
 
 namespace GrayMoon.App.Services;
 
@@ -8,6 +11,7 @@ public sealed class WorkspaceFileVersionService(
     WorkspaceService workspaceService,
     WorkspaceRepository workspaceRepository,
     WorkspaceFileVersionConfigRepository versionConfigRepository,
+    AppDbContext dbContext,
     ILogger<WorkspaceFileVersionService> logger)
 {
     /// <summary>
@@ -179,5 +183,183 @@ public sealed class WorkspaceFileVersionService(
             lines.Add(line);
         }
         return string.Join("\n", lines);
+    }
+
+    /// <summary>
+    /// Reads all configured version files via the agent, compares current values to expected repo GitVersions,
+    /// and persists the results to WorkspaceFileLineStatuses and WorkspaceRepositoryLink (OutOfDateFileLines, TotalFileLines).
+    /// Called at the same trigger points as csproj dependency stat recomputation.
+    /// </summary>
+    public async Task CheckAndPersistFileVersionStatusAsync(int workspaceId, CancellationToken cancellationToken = default)
+    {
+        if (!agentBridge.IsAgentConnected)
+            return;
+
+        var workspace = await workspaceRepository.GetByIdAsync(workspaceId);
+        if (workspace == null) return;
+
+        var configs = await versionConfigRepository.GetByWorkspaceIdAsync(workspaceId, cancellationToken);
+
+        // Build expected version map: repo name -> GitVersion
+        var repoVersions = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var link in workspace.Repositories)
+        {
+            if (link.Repository == null || string.IsNullOrEmpty(link.GitVersion)) continue;
+            repoVersions[link.Repository.RepositoryName] = link.GitVersion;
+        }
+
+        // Build per-file check items (skip files whose tokens have no version in the workspace)
+        var items = new List<object>();
+        foreach (var cfg in configs)
+        {
+            if (cfg.File?.Repository == null) continue;
+            var tokens = ExtractTokens(cfg.VersionPattern);
+            var knownVersions = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var token in tokens)
+            {
+                if (repoVersions.TryGetValue(token, out var ver))
+                    knownVersions[token] = ver;
+            }
+            if (knownVersions.Count == 0) continue;
+
+            items.Add(new
+            {
+                repositoryName = cfg.File.Repository.RepositoryName,
+                filePath = cfg.File.FilePath,
+                pattern = cfg.VersionPattern,
+                expectedVersions = knownVersions
+            });
+        }
+
+        // Delete existing statuses for this workspace regardless of whether we have items to check
+        await dbContext.WorkspaceFileLineStatuses
+            .Where(s => s.WorkspaceId == workspaceId)
+            .ExecuteDeleteAsync(cancellationToken);
+
+        if (items.Count == 0)
+        {
+            // Reset counters on all repo links when there are no configured files
+            await dbContext.WorkspaceRepositories
+                .Where(wr => wr.WorkspaceId == workspaceId && (wr.OutOfDateFileLines != null || wr.TotalFileLines != null))
+                .ExecuteUpdateAsync(s => s
+                    .SetProperty(wr => wr.OutOfDateFileLines, (int?)null)
+                    .SetProperty(wr => wr.TotalFileLines, (int?)null),
+                    cancellationToken);
+            return;
+        }
+
+        var workspaceRoot = await workspaceService.GetRootPathForWorkspaceAsync(workspace, cancellationToken);
+
+        try
+        {
+            var resp = await agentBridge.SendCommandAsync("CheckFileVersions", new
+            {
+                workspaceName = workspace.Name,
+                workspaceRoot,
+                files = items
+            }, cancellationToken);
+
+            if (!resp.Success || resp.Data == null)
+            {
+                logger.LogWarning("CheckFileVersions failed for workspace {WorkspaceId}: {Error}", workspaceId, resp.Error);
+                return;
+            }
+
+            var result = AgentResponseJson.DeserializeAgentResponse<CheckFileVersionsAgentResponse>(resp.Data);
+            if (result?.Files == null) return;
+
+            // Accumulate per-repo stats and new status rows
+            var newStatuses = new List<WorkspaceFileLineStatus>();
+            var repoOutOfDate = new Dictionary<int, int>();
+            var repoTotalMatched = new Dictionary<int, int>();
+
+            foreach (var fileResult in result.Files)
+            {
+                // Find repository id for this file result
+                var repoLink = workspace.Repositories.FirstOrDefault(r =>
+                    string.Equals(r.Repository?.RepositoryName, fileResult.RepositoryName, StringComparison.OrdinalIgnoreCase));
+                if (repoLink == null) continue;
+                var repoId = repoLink.RepositoryId;
+
+                repoTotalMatched.TryGetValue(repoId, out var existingTotal);
+                repoTotalMatched[repoId] = existingTotal + fileResult.TotalMatchedLines;
+
+                if (fileResult.OutOfDateLines == null) continue;
+                foreach (var stale in fileResult.OutOfDateLines)
+                {
+                    if (string.IsNullOrEmpty(stale.TokenName)) continue;
+                    newStatuses.Add(new WorkspaceFileLineStatus
+                    {
+                        WorkspaceId = workspaceId,
+                        RepositoryId = repoId,
+                        FilePath = fileResult.FilePath ?? "",
+                        FileName = fileResult.FileName ?? "",
+                        TokenName = stale.TokenName,
+                        CurrentValue = stale.CurrentValue,
+                        ExpectedValue = stale.ExpectedValue
+                    });
+                    repoOutOfDate.TryGetValue(repoId, out var existingOut);
+                    repoOutOfDate[repoId] = existingOut + 1;
+                }
+            }
+
+            if (newStatuses.Count > 0)
+            {
+                dbContext.WorkspaceFileLineStatuses.AddRange(newStatuses);
+                await dbContext.SaveChangesAsync(cancellationToken);
+            }
+
+            // Update WorkspaceRepositoryLink counters
+            var allLinks = await dbContext.WorkspaceRepositories
+                .Where(wr => wr.WorkspaceId == workspaceId)
+                .ToListAsync(cancellationToken);
+
+            foreach (var link in allLinks)
+            {
+                link.OutOfDateFileLines = repoOutOfDate.TryGetValue(link.RepositoryId, out var ood) ? ood : (int?)null;
+                link.TotalFileLines = repoTotalMatched.TryGetValue(link.RepositoryId, out var tot) ? tot : (int?)null;
+            }
+            await dbContext.SaveChangesAsync(cancellationToken);
+        }
+        catch (OperationCanceledException) { throw; }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Unexpected error checking file version status for workspace {WorkspaceId}", workspaceId);
+        }
+    }
+
+    /// <summary>Returns out-of-date file line statuses for the workspace, grouped by RepositoryId.</summary>
+    public async Task<IReadOnlyDictionary<int, IReadOnlyList<WorkspaceFileLineStatus>>> GetFileLineStatusByWorkspaceAsync(
+        int workspaceId, CancellationToken cancellationToken = default)
+    {
+        var rows = await dbContext.WorkspaceFileLineStatuses
+            .AsNoTracking()
+            .Where(s => s.WorkspaceId == workspaceId)
+            .ToListAsync(cancellationToken);
+        return rows
+            .GroupBy(s => s.RepositoryId)
+            .ToDictionary(g => g.Key, g => (IReadOnlyList<WorkspaceFileLineStatus>)g.ToList());
+    }
+
+    private sealed class CheckFileVersionsAgentResponse
+    {
+        [System.Text.Json.Serialization.JsonPropertyName("files")]
+        public List<CheckFileVersionsAgentFileResult>? Files { get; set; }
+    }
+
+    private sealed class CheckFileVersionsAgentFileResult
+    {
+        [System.Text.Json.Serialization.JsonPropertyName("repositoryName")] public string? RepositoryName { get; set; }
+        [System.Text.Json.Serialization.JsonPropertyName("filePath")] public string? FilePath { get; set; }
+        [System.Text.Json.Serialization.JsonPropertyName("fileName")] public string? FileName { get; set; }
+        [System.Text.Json.Serialization.JsonPropertyName("totalMatchedLines")] public int TotalMatchedLines { get; set; }
+        [System.Text.Json.Serialization.JsonPropertyName("outOfDateLines")] public List<CheckFileVersionsAgentOutOfDateLine>? OutOfDateLines { get; set; }
+    }
+
+    private sealed class CheckFileVersionsAgentOutOfDateLine
+    {
+        [System.Text.Json.Serialization.JsonPropertyName("tokenName")] public string? TokenName { get; set; }
+        [System.Text.Json.Serialization.JsonPropertyName("currentValue")] public string? CurrentValue { get; set; }
+        [System.Text.Json.Serialization.JsonPropertyName("expectedValue")] public string? ExpectedValue { get; set; }
     }
 }

--- a/src/GrayMoon.App/Services/WorkspaceFileVersionService.cs
+++ b/src/GrayMoon.App/Services/WorkspaceFileVersionService.cs
@@ -506,7 +506,7 @@ public sealed class WorkspaceFileVersionService(
     }
 
     /// <summary>Returns out-of-date file-config token rows for the workspace, grouped by dependent RepositoryId.</summary>
-    public async Task<IReadOnlyDictionary<int, IReadOnlyList<(string TokenName, string CurrentValue, string ExpectedValue)>>> GetMismatchedFileVersionLinesByRepoAsync(
+    public async Task<IReadOnlyDictionary<int, IReadOnlyList<(string FileName, string TokenName, string CurrentValue, string ExpectedValue)>>> GetMismatchedFileVersionLinesByRepoAsync(
         int workspaceId, CancellationToken cancellationToken = default)
     {
         var rows = await dbContext.WorkspaceFileLineStatuses
@@ -517,8 +517,8 @@ public sealed class WorkspaceFileVersionService(
             .GroupBy(s => s.RepositoryId)
             .ToDictionary(
                 g => g.Key,
-                g => (IReadOnlyList<(string, string, string)>)g
-                    .Select(s => (s.TokenName, s.CurrentValue ?? "", s.ExpectedValue ?? ""))
+                g => (IReadOnlyList<(string, string, string, string)>)g
+                    .Select(s => (s.FileName, s.TokenName, s.CurrentValue ?? "", s.ExpectedValue ?? ""))
                     .ToList());
     }
 

--- a/src/GrayMoon.App/Services/WorkspaceFileVersionService.cs
+++ b/src/GrayMoon.App/Services/WorkspaceFileVersionService.cs
@@ -193,15 +193,38 @@ public sealed class WorkspaceFileVersionService(
     /// Reads all configured version files via the agent, compares current values to expected repo GitVersions,
     /// and persists the results to WorkspaceFileLineStatuses and WorkspaceRepositoryLink (OutOfDateFileLines, OutOfDateFileRepos, TotalFileLines).
     /// Called at the same trigger points as csproj dependency stat recomputation.
-    /// Concurrent callers for the same workspace coalesce onto one in-flight check.
+    /// Concurrent callers for the same workspace coalesce onto one in-flight check unless <paramref name="forceFresh"/> is true.
     /// </summary>
-    public Task CheckAndPersistFileVersionStatusAsync(int workspaceId, CancellationToken cancellationToken = default)
+    public async Task CheckAndPersistFileVersionStatusAsync(int workspaceId, CancellationToken cancellationToken = default, bool forceFresh = false)
     {
         var gate = CheckLocks.GetOrAdd(workspaceId, _ => new object());
+
+        if (forceFresh)
+        {
+            Task? inFlight = null;
+            lock (gate)
+            {
+                if (InFlightChecks.TryGetValue(workspaceId, out var existing) && existing is { IsCompleted: false })
+                    inFlight = existing;
+            }
+            if (inFlight != null)
+            {
+                logger.LogDebug("CheckAndPersist forceFresh: awaiting prior in-flight check for workspace {WorkspaceId}", workspaceId);
+                try
+                {
+                    await inFlight.ConfigureAwait(false);
+                }
+                catch
+                {
+                    // Prior check failed; still run a fresh check below.
+                }
+            }
+        }
+
         Task checkTask;
         lock (gate)
         {
-            if (InFlightChecks.TryGetValue(workspaceId, out var existing) && existing is { IsCompleted: false })
+            if (!forceFresh && InFlightChecks.TryGetValue(workspaceId, out var existing) && existing is { IsCompleted: false })
             {
                 logger.LogDebug("CheckAndPersist coalesced: joining in-flight check for workspace {WorkspaceId}", workspaceId);
                 checkTask = existing;
@@ -213,7 +236,7 @@ public sealed class WorkspaceFileVersionService(
             }
         }
 
-        return AwaitAndClearInFlightAsync(workspaceId, checkTask, gate);
+        await AwaitAndClearInFlightAsync(workspaceId, checkTask, gate).ConfigureAwait(false);
     }
 
     private static async Task AwaitAndClearInFlightAsync(int workspaceId, Task checkTask, object gate)

--- a/src/GrayMoon.App/Services/WorkspaceFileVersionService.cs
+++ b/src/GrayMoon.App/Services/WorkspaceFileVersionService.cs
@@ -336,6 +336,40 @@ public sealed class WorkspaceFileVersionService(
             .ToDictionary(g => g.Key, g => (IReadOnlyList<WorkspaceFileLineStatus>)g.ToList());
     }
 
+    /// <summary>
+    /// Returns per-repo (FileName, TokenName, Version) triples for the OK badge tooltip.
+    /// Each entry represents a tracked token in a version file whose expected value equals the current workspace GitVersion.
+    /// Only repos present in <paramref name="repoVersionMap"/> contribute entries.
+    /// </summary>
+    public async Task<IReadOnlyDictionary<int, IReadOnlyList<(string FileName, string TokenName, string Version)>>> GetAllFileVersionLinesByRepoAsync(
+        int workspaceId,
+        IReadOnlyDictionary<string, string> repoVersionMap,
+        CancellationToken cancellationToken = default)
+    {
+        var configs = await versionConfigRepository.GetByWorkspaceIdAsync(workspaceId, cancellationToken);
+        var result = new Dictionary<int, List<(string FileName, string TokenName, string Version)>>();
+
+        foreach (var cfg in configs)
+        {
+            if (cfg.File?.Repository == null) continue;
+            var repoId = cfg.File.RepositoryId;
+            var fileName = cfg.File.FileName;
+            var tokens = ExtractTokens(cfg.VersionPattern);
+
+            foreach (var token in tokens)
+            {
+                if (!repoVersionMap.TryGetValue(token, out var ver) || string.IsNullOrEmpty(ver)) continue;
+                if (!result.TryGetValue(repoId, out var list))
+                    result[repoId] = list = [];
+                if (!list.Any(e => string.Equals(e.FileName, fileName, StringComparison.OrdinalIgnoreCase)
+                                   && string.Equals(e.TokenName, token, StringComparison.OrdinalIgnoreCase)))
+                    list.Add((fileName, token, ver));
+            }
+        }
+
+        return result.ToDictionary(kvp => kvp.Key, kvp => (IReadOnlyList<(string, string, string)>)kvp.Value);
+    }
+
     private sealed class CheckFileVersionsAgentResponse
     {
         [System.Text.Json.Serialization.JsonPropertyName("files")]

--- a/src/GrayMoon.App/Services/WorkspaceFileVersionService.cs
+++ b/src/GrayMoon.App/Services/WorkspaceFileVersionService.cs
@@ -1,3 +1,5 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
 using GrayMoon.App.Data;
 using GrayMoon.App.Models;
 using GrayMoon.App.Models.Api;
@@ -14,6 +16,8 @@ public sealed class WorkspaceFileVersionService(
     AppDbContext dbContext,
     ILogger<WorkspaceFileVersionService> logger)
 {
+    private static readonly ConcurrentDictionary<int, object> CheckLocks = new();
+    private static readonly ConcurrentDictionary<int, Task?> InFlightChecks = new();
     /// <summary>
     /// For every file in the workspace that has a version pattern configured:
     ///   1. Resolves the current version for each repo from the workspace's repository links (DB state); no GitVersion is run.
@@ -189,9 +193,50 @@ public sealed class WorkspaceFileVersionService(
     /// Reads all configured version files via the agent, compares current values to expected repo GitVersions,
     /// and persists the results to WorkspaceFileLineStatuses and WorkspaceRepositoryLink (OutOfDateFileLines, TotalFileLines).
     /// Called at the same trigger points as csproj dependency stat recomputation.
+    /// Concurrent callers for the same workspace coalesce onto one in-flight check.
     /// </summary>
-    public async Task CheckAndPersistFileVersionStatusAsync(int workspaceId, CancellationToken cancellationToken = default)
+    public Task CheckAndPersistFileVersionStatusAsync(int workspaceId, CancellationToken cancellationToken = default)
     {
+        var gate = CheckLocks.GetOrAdd(workspaceId, _ => new object());
+        Task checkTask;
+        lock (gate)
+        {
+            if (InFlightChecks.TryGetValue(workspaceId, out var existing) && existing is { IsCompleted: false })
+            {
+                logger.LogDebug("CheckAndPersist coalesced: joining in-flight check for workspace {WorkspaceId}", workspaceId);
+                checkTask = existing;
+            }
+            else
+            {
+                checkTask = CheckAndPersistFileVersionStatusCoreAsync(workspaceId, cancellationToken);
+                InFlightChecks[workspaceId] = checkTask;
+            }
+        }
+
+        return AwaitAndClearInFlightAsync(workspaceId, checkTask, gate);
+    }
+
+    private static async Task AwaitAndClearInFlightAsync(int workspaceId, Task checkTask, object gate)
+    {
+        try
+        {
+            await checkTask.ConfigureAwait(false);
+        }
+        finally
+        {
+            lock (gate)
+            {
+                if (InFlightChecks.TryGetValue(workspaceId, out var current) && ReferenceEquals(current, checkTask))
+                    InFlightChecks.TryRemove(workspaceId, out _);
+            }
+        }
+    }
+
+    private async Task CheckAndPersistFileVersionStatusCoreAsync(int workspaceId, CancellationToken cancellationToken)
+    {
+        var sw = Stopwatch.StartNew();
+        logger.LogDebug("CheckAndPersist starting for workspace {WorkspaceId}", workspaceId);
+
         if (!agentBridge.IsAgentConnected)
             return;
 
@@ -245,6 +290,7 @@ public sealed class WorkspaceFileVersionService(
                     .SetProperty(wr => wr.OutOfDateFileLines, (int?)null)
                     .SetProperty(wr => wr.TotalFileLines, (int?)null),
                     cancellationToken);
+            logger.LogDebug("CheckAndPersist completed for workspace {WorkspaceId} in {ElapsedMs}ms (no items)", workspaceId, sw.ElapsedMilliseconds);
             return;
         }
 
@@ -252,12 +298,14 @@ public sealed class WorkspaceFileVersionService(
 
         try
         {
+            var agentSw = Stopwatch.StartNew();
             var resp = await agentBridge.SendCommandAsync("CheckFileVersions", new
             {
                 workspaceName = workspace.Name,
                 workspaceRoot,
                 files = items
             }, cancellationToken);
+            logger.LogDebug("CheckAndPersist CheckFileVersions agent call completed for workspace {WorkspaceId} in {ElapsedMs}ms", workspaceId, agentSw.ElapsedMilliseconds);
 
             if (!resp.Success || resp.Data == null)
             {
@@ -275,7 +323,9 @@ public sealed class WorkspaceFileVersionService(
 
             foreach (var fileResult in result.Files)
             {
-                if (fileResult.TotalMatchedLines == 0) continue;
+                var expectedCount = fileResult.ExpectedTokenCount;
+                if (fileResult.TotalMatchedLines == 0 && expectedCount == 0)
+                    continue;
 
                 // Find repository id for this file result
                 var repoLink = workspace.Repositories.FirstOrDefault(r =>
@@ -284,17 +334,19 @@ public sealed class WorkspaceFileVersionService(
                 var repoId = repoLink.RepositoryId;
 
                 var outOfDateCount = fileResult.OutOfDateLines?.Count ?? 0;
+                var totalForStats = fileResult.TotalMatchedLines > 0 ? fileResult.TotalMatchedLines : expectedCount;
+
                 newStatuses.Add(new WorkspaceFileLineStatus
                 {
                     WorkspaceId = workspaceId,
                     RepositoryId = repoId,
                     FilePath = fileResult.FilePath ?? "",
                     FileName = fileResult.FileName ?? "",
-                    TotalMatchedLines = fileResult.TotalMatchedLines,
+                    TotalMatchedLines = totalForStats,
                     OutOfDateLines = outOfDateCount
                 });
 
-                repoTotalMatched[repoId] = (repoTotalMatched.TryGetValue(repoId, out var tot) ? tot : 0) + fileResult.TotalMatchedLines;
+                repoTotalMatched[repoId] = (repoTotalMatched.TryGetValue(repoId, out var tot) ? tot : 0) + totalForStats;
                 repoOutOfDate[repoId] = (repoOutOfDate.TryGetValue(repoId, out var ood) ? ood : 0) + outOfDateCount;
             }
 
@@ -315,6 +367,7 @@ public sealed class WorkspaceFileVersionService(
                 link.TotalFileLines = repoTotalMatched.TryGetValue(link.RepositoryId, out var tot) ? tot : (int?)null;
             }
             await dbContext.SaveChangesAsync(cancellationToken);
+            logger.LogDebug("CheckAndPersist completed for workspace {WorkspaceId} in {ElapsedMs}ms", workspaceId, sw.ElapsedMilliseconds);
         }
         catch (OperationCanceledException) { throw; }
         catch (Exception ex)
@@ -382,6 +435,7 @@ public sealed class WorkspaceFileVersionService(
         [System.Text.Json.Serialization.JsonPropertyName("filePath")] public string? FilePath { get; set; }
         [System.Text.Json.Serialization.JsonPropertyName("fileName")] public string? FileName { get; set; }
         [System.Text.Json.Serialization.JsonPropertyName("totalMatchedLines")] public int TotalMatchedLines { get; set; }
+        [System.Text.Json.Serialization.JsonPropertyName("expectedTokenCount")] public int ExpectedTokenCount { get; set; }
         [System.Text.Json.Serialization.JsonPropertyName("outOfDateLines")] public List<CheckFileVersionsAgentOutOfDateLine>? OutOfDateLines { get; set; }
     }
 

--- a/src/GrayMoon.App/Services/WorkspaceFileVersionService.cs
+++ b/src/GrayMoon.App/Services/WorkspaceFileVersionService.cs
@@ -1,9 +1,11 @@
 using System.Collections.Concurrent;
 using System.Diagnostics;
 using GrayMoon.App.Data;
+using GrayMoon.App.Hubs;
 using GrayMoon.App.Models;
 using GrayMoon.App.Models.Api;
 using GrayMoon.App.Repositories;
+using Microsoft.AspNetCore.SignalR;
 using Microsoft.EntityFrameworkCore;
 
 namespace GrayMoon.App.Services;
@@ -12,8 +14,10 @@ public sealed class WorkspaceFileVersionService(
     IAgentBridge agentBridge,
     WorkspaceService workspaceService,
     WorkspaceRepository workspaceRepository,
+    WorkspaceProjectRepository workspaceProjectRepository,
     WorkspaceFileVersionConfigRepository versionConfigRepository,
     AppDbContext dbContext,
+    IHubContext<WorkspaceSyncHub> hubContext,
     ILogger<WorkspaceFileVersionService> logger)
 {
     private static readonly ConcurrentDictionary<int, object> CheckLocks = new();
@@ -90,6 +94,9 @@ public sealed class WorkspaceFileVersionService(
             var file = cfg.File;
             if (file?.Repository == null) continue;
 
+            if (file.IsMissingOnDisk == true)
+                continue;
+
             if (selectedRepositoryIds != null && selectedRepositoryIds.Count > 0 && !selectedRepositoryIds.Contains(file.RepositoryId))
                 continue;
 
@@ -125,7 +132,12 @@ public sealed class WorkspaceFileVersionService(
                         updatedFiles.Add((file.RepositoryId, file.Repository.RepositoryName ?? "", file.FilePath));
                     }
                     if (result?.ErrorMessage != null)
-                        logger.LogWarning("UpdateFileVersions warning for {FilePath}: {Msg}", file.FilePath, result.ErrorMessage);
+                    {
+                        if (result.ErrorMessage.StartsWith("File not found:", StringComparison.OrdinalIgnoreCase))
+                            logger.LogDebug("UpdateFileVersions skipped missing file {FilePath}", file.FilePath);
+                        else
+                            logger.LogWarning("UpdateFileVersions warning for {FilePath}: {Msg}", file.FilePath, result.ErrorMessage);
+                    }
                 }
                 else
                 {
@@ -191,7 +203,7 @@ public sealed class WorkspaceFileVersionService(
 
     /// <summary>
     /// Reads all configured version files via the agent, compares current values to expected repo GitVersions,
-    /// and persists the results to WorkspaceFileLineStatuses and WorkspaceRepositoryLink (OutOfDateFileLines, OutOfDateFileRepos, TotalFileLines).
+    /// and persists the results to WorkspaceFileLineStatuses and WorkspaceRepositoryLink file-config counters.
     /// Called at the same trigger points as csproj dependency stat recomputation.
     /// Concurrent callers for the same workspace coalesce onto one in-flight check unless <paramref name="forceFresh"/> is true.
     /// </summary>
@@ -267,8 +279,21 @@ public sealed class WorkspaceFileVersionService(
         if (workspace == null) return;
 
         var configs = await versionConfigRepository.GetByWorkspaceIdAsync(workspaceId, cancellationToken);
+        var trackedFiles = await dbContext.WorkspaceFiles
+            .Where(f => f.WorkspaceId == workspaceId)
+            .ToListAsync(cancellationToken);
 
-        // Build expected version map: repo name -> GitVersion
+        var nameToRepoId = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        foreach (var link in workspace.Repositories)
+        {
+            if (link.Repository != null && !string.IsNullOrEmpty(link.Repository.RepositoryName))
+            {
+                var name = link.Repository.RepositoryName.Trim();
+                if (!nameToRepoId.ContainsKey(name))
+                    nameToRepoId[name] = link.RepositoryId;
+            }
+        }
+
         var repoVersions = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         foreach (var link in workspace.Repositories)
         {
@@ -276,7 +301,6 @@ public sealed class WorkspaceFileVersionService(
             repoVersions[link.Repository.RepositoryName] = link.GitVersion;
         }
 
-        // Build per-file check items (skip files whose tokens have no version in the workspace)
         var items = new List<object>();
         foreach (var cfg in configs)
         {
@@ -299,21 +323,22 @@ public sealed class WorkspaceFileVersionService(
             });
         }
 
-        // Delete existing statuses for this workspace regardless of whether we have items to check
-        await dbContext.WorkspaceFileLineStatuses
-            .Where(s => s.WorkspaceId == workspaceId)
-            .ExecuteDeleteAsync(cancellationToken);
+        var missingFlagChanged = false;
 
         if (items.Count == 0)
         {
-            // Reset counters on all repo links when there are no configured files
-            await dbContext.WorkspaceRepositories
-                .Where(wr => wr.WorkspaceId == workspaceId && (wr.OutOfDateFileLines != null || wr.OutOfDateFileRepos != null || wr.TotalFileLines != null))
-                .ExecuteUpdateAsync(s => s
-                    .SetProperty(wr => wr.OutOfDateFileLines, (int?)null)
-                    .SetProperty(wr => wr.OutOfDateFileRepos, (int?)null)
-                    .SetProperty(wr => wr.TotalFileLines, (int?)null),
-                    cancellationToken);
+            await ApplyFileConfigLinkCountersAsync(
+                workspaceId,
+                configs,
+                nameToRepoId,
+                repoOutOfDateTokens: new Dictionary<int, HashSet<string>>(),
+                cancellationToken);
+
+            await dbContext.WorkspaceFileLineStatuses
+                .Where(s => s.WorkspaceId == workspaceId)
+                .ExecuteDeleteAsync(cancellationToken);
+
+            await hubContext.Clients.All.SendAsync("WorkspaceSynced", workspaceId, cancellationToken);
             logger.LogDebug("CheckAndPersist completed for workspace {WorkspaceId} in {ElapsedMs}ms (no items)", workspaceId, sw.ElapsedMilliseconds);
             return;
         }
@@ -340,71 +365,86 @@ public sealed class WorkspaceFileVersionService(
             var result = AgentResponseJson.DeserializeAgentResponse<CheckFileVersionsAgentResponse>(resp.Data);
             if (result?.Files == null) return;
 
-            // Accumulate per-repo stats and new per-file status rows
-            var newStatuses = new List<WorkspaceFileLineStatus>();
-            var repoOutOfDate = new Dictionary<int, int>();
+            var fileByRepoAndPath = trackedFiles.ToDictionary(
+                f => (RepoId: f.RepositoryId, Path: f.FilePath),
+                f => f);
+
             var repoOutOfDateTokens = new Dictionary<int, HashSet<string>>();
-            var repoTotalMatched = new Dictionary<int, int>();
+            var newStatuses = new List<WorkspaceFileLineStatus>();
+            var seenStaleTokens = new Dictionary<int, HashSet<string>>();
 
             foreach (var fileResult in result.Files)
             {
-                var expectedCount = fileResult.ExpectedTokenCount;
-                if (fileResult.TotalMatchedLines == 0 && expectedCount == 0)
-                    continue;
-
-                // Find repository id for this file result
                 var repoLink = workspace.Repositories.FirstOrDefault(r =>
                     string.Equals(r.Repository?.RepositoryName, fileResult.RepositoryName, StringComparison.OrdinalIgnoreCase));
                 if (repoLink == null) continue;
                 var repoId = repoLink.RepositoryId;
 
-                var outOfDateCount = fileResult.OutOfDateLines?.Count ?? 0;
-                var totalForStats = fileResult.TotalMatchedLines > 0 ? fileResult.TotalMatchedLines : expectedCount;
-
-                newStatuses.Add(new WorkspaceFileLineStatus
+                if (fileByRepoAndPath.TryGetValue((repoId, fileResult.FilePath ?? ""), out var trackedFile))
                 {
-                    WorkspaceId = workspaceId,
-                    RepositoryId = repoId,
-                    FilePath = fileResult.FilePath ?? "",
-                    FileName = fileResult.FileName ?? "",
-                    TotalMatchedLines = totalForStats,
-                    OutOfDateLines = outOfDateCount
-                });
-
-                repoTotalMatched[repoId] = (repoTotalMatched.TryGetValue(repoId, out var tot) ? tot : 0) + totalForStats;
-                repoOutOfDate[repoId] = (repoOutOfDate.TryGetValue(repoId, out var ood) ? ood : 0) + outOfDateCount;
-                if (outOfDateCount > 0 && fileResult.OutOfDateLines != null)
-                {
-                    if (!repoOutOfDateTokens.TryGetValue(repoId, out var tokens))
-                        repoOutOfDateTokens[repoId] = tokens = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-                    foreach (var line in fileResult.OutOfDateLines)
+                    var wasMissing = trackedFile.IsMissingOnDisk == true;
+                    var isMissing = fileResult.FileMissing;
+                    if (wasMissing != isMissing)
                     {
-                        if (!string.IsNullOrWhiteSpace(line.TokenName))
-                            tokens.Add(line.TokenName);
+                        trackedFile.IsMissingOnDisk = isMissing ? true : null;
+                        missingFlagChanged = true;
                     }
                 }
+
+                if (fileResult.FileMissing)
+                    continue;
+
+                if (fileResult.OutOfDateLines is not { Count: > 0 })
+                    continue;
+
+                if (!seenStaleTokens.TryGetValue(repoId, out var seen))
+                    seenStaleTokens[repoId] = seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+                if (!repoOutOfDateTokens.TryGetValue(repoId, out var staleTokens))
+                    repoOutOfDateTokens[repoId] = staleTokens = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+                foreach (var line in fileResult.OutOfDateLines)
+                {
+                    if (string.IsNullOrWhiteSpace(line.TokenName)) continue;
+                    if (!seen.Add(line.TokenName)) continue;
+
+                    staleTokens.Add(line.TokenName);
+                    newStatuses.Add(new WorkspaceFileLineStatus
+                    {
+                        WorkspaceId = workspaceId,
+                        RepositoryId = repoId,
+                        FilePath = fileResult.FilePath ?? "",
+                        FileName = fileResult.FileName ?? "",
+                        TokenName = line.TokenName,
+                        CurrentValue = line.CurrentValue,
+                        ExpectedValue = line.ExpectedValue
+                    });
+                }
             }
+
+            foreach (var cfg in configs)
+            {
+                if (cfg.File == null) continue;
+                var tracked = trackedFiles.FirstOrDefault(f => f.FileId == cfg.File.FileId);
+                if (tracked != null)
+                    cfg.File.IsMissingOnDisk = tracked.IsMissingOnDisk;
+            }
+
+            await dbContext.WorkspaceFileLineStatuses
+                .Where(s => s.WorkspaceId == workspaceId)
+                .ExecuteDeleteAsync(cancellationToken);
 
             if (newStatuses.Count > 0)
             {
                 dbContext.WorkspaceFileLineStatuses.AddRange(newStatuses);
-                await dbContext.SaveChangesAsync(cancellationToken);
             }
 
-            // Update WorkspaceRepositoryLink counters
-            var allLinks = await dbContext.WorkspaceRepositories
-                .Where(wr => wr.WorkspaceId == workspaceId)
-                .ToListAsync(cancellationToken);
+            await ApplyFileConfigLinkCountersAsync(workspaceId, configs, nameToRepoId, repoOutOfDateTokens, cancellationToken);
 
-            foreach (var link in allLinks)
-            {
-                link.OutOfDateFileLines = repoOutOfDate.TryGetValue(link.RepositoryId, out var ood) ? ood : (int?)null;
-                link.OutOfDateFileRepos = repoOutOfDateTokens.TryGetValue(link.RepositoryId, out var tokens) && tokens.Count > 0
-                    ? tokens.Count
-                    : (int?)null;
-                link.TotalFileLines = repoTotalMatched.TryGetValue(link.RepositoryId, out var tot) ? tot : (int?)null;
-            }
-            await dbContext.SaveChangesAsync(cancellationToken);
+            if (missingFlagChanged)
+                await workspaceProjectRepository.RecomputeAndPersistRepositoryDependencyStatsAsync(workspaceId, cancellationToken);
+
+            await hubContext.Clients.All.SendAsync("WorkspaceSynced", workspaceId, cancellationToken);
             logger.LogDebug("CheckAndPersist completed for workspace {WorkspaceId} in {ElapsedMs}ms", workspaceId, sw.ElapsedMilliseconds);
         }
         catch (OperationCanceledException) { throw; }
@@ -412,6 +452,74 @@ public sealed class WorkspaceFileVersionService(
         {
             logger.LogError(ex, "Unexpected error checking file version status for workspace {WorkspaceId}", workspaceId);
         }
+    }
+
+    private async Task ApplyFileConfigLinkCountersAsync(
+        int workspaceId,
+        IReadOnlyList<WorkspaceFileVersionConfig> configs,
+        Dictionary<string, int> nameToRepoId,
+        Dictionary<int, HashSet<string>> repoOutOfDateTokens,
+        CancellationToken cancellationToken)
+    {
+        var totalConfigRepos = BuildTotalFileConfigReposByDependentRepo(configs, nameToRepoId);
+
+        var allLinks = await dbContext.WorkspaceRepositories
+            .Where(wr => wr.WorkspaceId == workspaceId)
+            .ToListAsync(cancellationToken);
+
+        foreach (var link in allLinks)
+        {
+            link.OutOfDateFileRepos = repoOutOfDateTokens.TryGetValue(link.RepositoryId, out var tokens) && tokens.Count > 0
+                ? tokens.Count
+                : null;
+            link.OutOfDateFileLines = null;
+            link.TotalFileLines = null;
+            link.TotalFileConfigRepos = totalConfigRepos.TryGetValue(link.RepositoryId, out var total) && total.Count > 0
+                ? total.Count
+                : null;
+        }
+
+        await dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    private static Dictionary<int, HashSet<string>> BuildTotalFileConfigReposByDependentRepo(
+        IEnumerable<WorkspaceFileVersionConfig> configs,
+        IReadOnlyDictionary<string, int> nameToRepoId)
+    {
+        var result = new Dictionary<int, HashSet<string>>();
+        foreach (var cfg in configs)
+        {
+            if (cfg.File?.IsMissingOnDisk == true) continue;
+            var dependentRepoId = cfg.File!.RepositoryId;
+            foreach (var token in ExtractTokens(cfg.VersionPattern))
+            {
+                if (string.IsNullOrWhiteSpace(token)) continue;
+                if (!nameToRepoId.TryGetValue(token.Trim(), out var referencedRepoId)) continue;
+                if (referencedRepoId == dependentRepoId) continue;
+                if (!result.TryGetValue(dependentRepoId, out var set))
+                    result[dependentRepoId] = set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                set.Add(token.Trim());
+            }
+        }
+
+        return result;
+    }
+
+    /// <summary>Returns out-of-date file-config token rows for the workspace, grouped by dependent RepositoryId.</summary>
+    public async Task<IReadOnlyDictionary<int, IReadOnlyList<(string TokenName, string CurrentValue, string ExpectedValue)>>> GetMismatchedFileVersionLinesByRepoAsync(
+        int workspaceId, CancellationToken cancellationToken = default)
+    {
+        var rows = await dbContext.WorkspaceFileLineStatuses
+            .AsNoTracking()
+            .Where(s => s.WorkspaceId == workspaceId && s.TokenName != "")
+            .ToListAsync(cancellationToken);
+        return rows
+            .GroupBy(s => s.RepositoryId)
+            .ToDictionary(
+                g => g.Key,
+                g => (IReadOnlyList<(string, string, string)>)g
+                    .Select(s => (s.TokenName, s.CurrentValue ?? "", s.ExpectedValue ?? ""))
+                    .ToList());
     }
 
     /// <summary>Returns out-of-date file line statuses for the workspace, grouped by RepositoryId.</summary>
@@ -442,7 +550,7 @@ public sealed class WorkspaceFileVersionService(
 
         foreach (var cfg in configs)
         {
-            if (cfg.File?.Repository == null) continue;
+            if (cfg.File?.Repository == null || cfg.File.IsMissingOnDisk == true) continue;
             var repoId = cfg.File.RepositoryId;
             var fileName = cfg.File.FileName;
             var tokens = ExtractTokens(cfg.VersionPattern);
@@ -474,6 +582,7 @@ public sealed class WorkspaceFileVersionService(
         [System.Text.Json.Serialization.JsonPropertyName("fileName")] public string? FileName { get; set; }
         [System.Text.Json.Serialization.JsonPropertyName("totalMatchedLines")] public int TotalMatchedLines { get; set; }
         [System.Text.Json.Serialization.JsonPropertyName("expectedTokenCount")] public int ExpectedTokenCount { get; set; }
+        [System.Text.Json.Serialization.JsonPropertyName("fileMissing")] public bool FileMissing { get; set; }
         [System.Text.Json.Serialization.JsonPropertyName("outOfDateLines")] public List<CheckFileVersionsAgentOutOfDateLine>? OutOfDateLines { get; set; }
     }
 

--- a/src/GrayMoon.App/Services/WorkspaceGitService.cs
+++ b/src/GrayMoon.App/Services/WorkspaceGitService.cs
@@ -26,7 +26,8 @@ public class WorkspaceGitService(
     PackageRegistrySyncService? packageRegistrySyncService = null,
     NuGetService? nuGetService = null,
     ConnectorRepository? connectorRepository = null,
-    ConnectorHealthService? connectorHealthService = null)
+    ConnectorHealthService? connectorHealthService = null,
+    WorkspaceFileVersionService? fileVersionService = null)
 {
     private readonly IAgentBridge _agentBridge = agentBridge ?? throw new ArgumentNullException(nameof(agentBridge));
     private readonly WorkspaceService _workspaceService = workspaceService ?? throw new ArgumentNullException(nameof(workspaceService));
@@ -43,6 +44,7 @@ public class WorkspaceGitService(
     private readonly NuGetService? _nuGetService = nuGetService;
     private readonly ConnectorRepository? _connectorRepository = connectorRepository;
     private readonly ConnectorHealthService? _connectorHealthService = connectorHealthService;
+    private readonly WorkspaceFileVersionService? _fileVersionService = fileVersionService;
 
     public async Task<IReadOnlyDictionary<int, RepoGitVersionInfo>> SyncAsync(
         int workspaceId,
@@ -228,6 +230,8 @@ public class WorkspaceGitService(
 
         var resultsForDeps = syncResults.Select(r => (r.RepositoryId, r.ProjectsDetail)).ToList();
         await _workspaceProjectRepository.MergeWorkspaceProjectDependenciesAsync(workspaceId, resultsForDeps, persistDependencyLevel: true, cancellationToken);
+        if (_fileVersionService != null)
+            await _fileVersionService.CheckAndPersistFileVersionStatusAsync(workspaceId, cancellationToken);
 
         _logger.LogDebug("RefreshWorkspaceProjects completed for workspace {WorkspaceName}", workspace.Name);
     }
@@ -276,6 +280,8 @@ public class WorkspaceGitService(
         }
 
         await _workspaceProjectRepository.MergeWorkspaceProjectDependenciesAsync(workspaceId, [(repositoryId, projectsDetail)], persistDependencyLevel: true, cancellationToken);
+        if (_fileVersionService != null)
+            await _fileVersionService.CheckAndPersistFileVersionStatusAsync(workspaceId, cancellationToken);
         _logger.LogDebug("RefreshSingleRepositoryProjects completed for workspace {WorkspaceName}, repo {RepositoryId}", workspace.Name, repositoryId);
         return true;
     }
@@ -414,6 +420,8 @@ public class WorkspaceGitService(
             await _workspaceProjectRepository.UpdateProjectDependencyVersionsAsync(workspaceId, updatesToPersist, cancellationToken);
 
         await _workspaceProjectRepository.RecomputeAndPersistRepositoryDependencyStatsAsync(workspaceId, cancellationToken);
+        if (_fileVersionService != null)
+            await _fileVersionService.CheckAndPersistFileVersionStatusAsync(workspaceId, cancellationToken);
 
         _logger.LogDebug("Sync dependencies completed for workspace {WorkspaceName}. Updated {RepoCount} repos, persisted {UpdateCount} versions", workspace.Name, toSync.Count, updatesToPersist.Count);
         return toSync.Count;
@@ -493,6 +501,8 @@ public class WorkspaceGitService(
     public async Task RecomputeAndBroadcastWorkspaceSyncedAsync(int workspaceId, CancellationToken cancellationToken = default)
     {
         await _workspaceProjectRepository.RecomputeAndPersistRepositoryDependencyStatsAsync(workspaceId, cancellationToken);
+        if (_fileVersionService != null)
+            await _fileVersionService.CheckAndPersistFileVersionStatusAsync(workspaceId, cancellationToken);
         if (_hubContext != null)
             await _hubContext.Clients.All.SendAsync("WorkspaceSynced", workspaceId);
     }
@@ -752,6 +762,8 @@ public class WorkspaceGitService(
         await _workspaceRepository.UpdateSyncMetadataAsync(workspaceId, DateTime.UtcNow, isInSync);
 
         await _workspaceProjectRepository.RecomputeAndPersistRepositoryDependencyStatsAsync(workspaceId, cancellationToken);
+        if (_fileVersionService != null)
+            await _fileVersionService.CheckAndPersistFileVersionStatusAsync(workspaceId, cancellationToken);
 
         if (_hubContext != null)
             await _hubContext.Clients.All.SendAsync("WorkspaceSynced", workspaceId);

--- a/src/GrayMoon.App/Services/WorkspaceGitService.cs
+++ b/src/GrayMoon.App/Services/WorkspaceGitService.cs
@@ -230,8 +230,6 @@ public class WorkspaceGitService(
 
         var resultsForDeps = syncResults.Select(r => (r.RepositoryId, r.ProjectsDetail)).ToList();
         await _workspaceProjectRepository.MergeWorkspaceProjectDependenciesAsync(workspaceId, resultsForDeps, persistDependencyLevel: true, cancellationToken);
-        if (_fileVersionService != null)
-            await _fileVersionService.CheckAndPersistFileVersionStatusAsync(workspaceId, cancellationToken);
 
         _logger.LogDebug("RefreshWorkspaceProjects completed for workspace {WorkspaceName}", workspace.Name);
     }
@@ -280,8 +278,6 @@ public class WorkspaceGitService(
         }
 
         await _workspaceProjectRepository.MergeWorkspaceProjectDependenciesAsync(workspaceId, [(repositoryId, projectsDetail)], persistDependencyLevel: true, cancellationToken);
-        if (_fileVersionService != null)
-            await _fileVersionService.CheckAndPersistFileVersionStatusAsync(workspaceId, cancellationToken);
         _logger.LogDebug("RefreshSingleRepositoryProjects completed for workspace {WorkspaceName}, repo {RepositoryId}", workspace.Name, repositoryId);
         return true;
     }
@@ -501,8 +497,6 @@ public class WorkspaceGitService(
     public async Task RecomputeAndBroadcastWorkspaceSyncedAsync(int workspaceId, CancellationToken cancellationToken = default)
     {
         await _workspaceProjectRepository.RecomputeAndPersistRepositoryDependencyStatsAsync(workspaceId, cancellationToken);
-        if (_fileVersionService != null)
-            await _fileVersionService.CheckAndPersistFileVersionStatusAsync(workspaceId, cancellationToken);
         if (_hubContext != null)
             await _hubContext.Clients.All.SendAsync("WorkspaceSynced", workspaceId);
     }
@@ -762,8 +756,6 @@ public class WorkspaceGitService(
         await _workspaceRepository.UpdateSyncMetadataAsync(workspaceId, DateTime.UtcNow, isInSync);
 
         await _workspaceProjectRepository.RecomputeAndPersistRepositoryDependencyStatsAsync(workspaceId, cancellationToken);
-        if (_fileVersionService != null)
-            await _fileVersionService.CheckAndPersistFileVersionStatusAsync(workspaceId, cancellationToken);
 
         if (_hubContext != null)
             await _hubContext.Clients.All.SendAsync("WorkspaceSynced", workspaceId);

--- a/src/GrayMoon.App/Services/WorkspaceGitService.cs
+++ b/src/GrayMoon.App/Services/WorkspaceGitService.cs
@@ -415,9 +415,10 @@ public class WorkspaceGitService(
         if (updatesToPersist.Count > 0)
             await _workspaceProjectRepository.UpdateProjectDependencyVersionsAsync(workspaceId, updatesToPersist, cancellationToken);
 
-        await _workspaceProjectRepository.RecomputeAndPersistRepositoryDependencyStatsAsync(workspaceId, cancellationToken);
         if (_fileVersionService != null)
             await _fileVersionService.CheckAndPersistFileVersionStatusAsync(workspaceId, cancellationToken);
+
+        await _workspaceProjectRepository.RecomputeAndPersistRepositoryDependencyStatsAsync(workspaceId, cancellationToken);
 
         _logger.LogDebug("Sync dependencies completed for workspace {WorkspaceName}. Updated {RepoCount} repos, persisted {UpdateCount} versions", workspace.Name, toSync.Count, updatesToPersist.Count);
         return toSync.Count;
@@ -496,6 +497,9 @@ public class WorkspaceGitService(
     /// <summary>Broadcasts WorkspaceSynced so the grid refreshes. Call after SyncDependenciesAsync (which already recomputes and persists UnmatchedDeps).</summary>
     public async Task RecomputeAndBroadcastWorkspaceSyncedAsync(int workspaceId, CancellationToken cancellationToken = default)
     {
+        if (_fileVersionService != null)
+            await _fileVersionService.CheckAndPersistFileVersionStatusAsync(workspaceId, cancellationToken);
+
         await _workspaceProjectRepository.RecomputeAndPersistRepositoryDependencyStatsAsync(workspaceId, cancellationToken);
         if (_hubContext != null)
             await _hubContext.Clients.All.SendAsync("WorkspaceSynced", workspaceId);
@@ -754,6 +758,9 @@ public class WorkspaceGitService(
             .ToListAsync(cancellationToken);
         var isInSync = allLinks.Count > 0 && allLinks.All(s => s == RepoSyncStatus.InSync);
         await _workspaceRepository.UpdateSyncMetadataAsync(workspaceId, DateTime.UtcNow, isInSync);
+
+        if (_fileVersionService != null)
+            await _fileVersionService.CheckAndPersistFileVersionStatusAsync(workspaceId, cancellationToken);
 
         await _workspaceProjectRepository.RecomputeAndPersistRepositoryDependencyStatsAsync(workspaceId, cancellationToken);
 

--- a/src/GrayMoon.App/Services/WorkspaceGitService.cs
+++ b/src/GrayMoon.App/Services/WorkspaceGitService.cs
@@ -137,6 +137,9 @@ public class WorkspaceGitService(
         }
         await _workspaceRepository.UpdateSyncMetadataAsync(workspaceId, DateTime.UtcNow, isInSync);
 
+        if (_fileVersionService != null)
+            await _fileVersionService.CheckAndPersistFileVersionStatusAsync(workspaceId, cancellationToken);
+
         _logger.LogDebug("Sync completed for workspace {WorkspaceName}", workspace.Name);
         return results.ToDictionary(r => r.RepositoryId, r => r.info);
     }

--- a/src/GrayMoon.App/Services/WorkspaceRepositoryNameSearchMatcher.cs
+++ b/src/GrayMoon.App/Services/WorkspaceRepositoryNameSearchMatcher.cs
@@ -1,0 +1,12 @@
+using GrayMoon.Common.Search;
+
+namespace GrayMoon.App.Services;
+
+public static class WorkspaceRepositoryNameSearchMatcher
+{
+    public static bool IsValidQuery(string? query) => FilterSearchMatcher.IsValidQuery(query);
+
+    public static bool Matches(string? repositoryName, string? query) =>
+        FilterSearchMatcher.Matches(query, term =>
+            (repositoryName ?? string.Empty).Contains(term.Value, StringComparison.OrdinalIgnoreCase));
+}

--- a/src/GrayMoon.App/wwwroot/app.css
+++ b/src/GrayMoon.App/wwwroot/app.css
@@ -576,6 +576,17 @@ h1:focus {
     -webkit-overflow-scrolling: touch;
 }
 
+/* Dependency badge tooltips extend below the row; avoid clipping at tbody bottom while open */
+.grid-page-body .repositories-table tbody:has(.dependency-badge-tooltip-wrap:hover),
+.grid-page-body .repositories-table tbody:has(.dependency-badge-tooltip-wrap:focus-within) {
+    overflow: visible !important;
+}
+
+.grid-page-body .table-responsive:has(.repositories-table .dependency-badge-tooltip-wrap:hover),
+.grid-page-body .table-responsive:has(.repositories-table .dependency-badge-tooltip-wrap:focus-within) {
+    overflow: visible !important;
+}
+
 /* Custom scrollbar styling - narrow and gray, only in table body */
 .grid-page-body .table tbody::-webkit-scrollbar {
     width: 8px;

--- a/src/GrayMoon.App/wwwroot/app.css
+++ b/src/GrayMoon.App/wwwroot/app.css
@@ -576,17 +576,6 @@ h1:focus {
     -webkit-overflow-scrolling: touch;
 }
 
-/* Dependency badge tooltips extend below the row; avoid clipping at tbody bottom while open */
-.grid-page-body .repositories-table tbody:has(.dependency-badge-tooltip-wrap:hover),
-.grid-page-body .repositories-table tbody:has(.dependency-badge-tooltip-wrap:focus-within) {
-    overflow: visible !important;
-}
-
-.grid-page-body .table-responsive:has(.repositories-table .dependency-badge-tooltip-wrap:hover),
-.grid-page-body .table-responsive:has(.repositories-table .dependency-badge-tooltip-wrap:focus-within) {
-    overflow: visible !important;
-}
-
 /* Custom scrollbar styling - narrow and gray, only in table body */
 .grid-page-body .table tbody::-webkit-scrollbar {
     width: 8px;

--- a/src/GrayMoon.App/wwwroot/js/dependency-badge-tooltip.js
+++ b/src/GrayMoon.App/wwwroot/js/dependency-badge-tooltip.js
@@ -1,0 +1,74 @@
+/**
+
+ * Positions dependency-badge tooltips with position:fixed so they escape the scrolling tbody
+
+ * without toggling overflow (which would hide the grid scrollbar and shift header padding).
+
+ */
+
+(function () {
+
+    const TOOLTIP_SELECTOR = '.dependency-badge-tooltip-wrap';
+
+    const TIP_CLASS = 'dependency-badge-tooltip';
+
+
+
+    function positionTooltip(wrap) {
+
+        const tip = wrap.querySelector('.' + TIP_CLASS);
+
+        if (!tip) return;
+
+        const anchor = wrap.getBoundingClientRect();
+
+        const tipWidth = tip.offsetWidth || 480;
+
+        const margin = 8;
+
+        let left = anchor.right - tipWidth;
+
+        if (left < margin) left = margin;
+
+        const maxLeft = window.innerWidth - tipWidth - margin;
+
+        if (left > maxLeft) left = Math.max(margin, maxLeft);
+
+        tip.style.top = anchor.bottom + 'px';
+
+        tip.style.left = left + 'px';
+
+    }
+
+
+
+    function repositionOpenTooltips() {
+
+        document.querySelectorAll(TOOLTIP_SELECTOR + ':hover, ' + TOOLTIP_SELECTOR + ':focus-within')
+
+            .forEach(positionTooltip);
+
+    }
+
+
+
+    function onWrapActivated(e) {
+
+        const wrap = e.target.closest(TOOLTIP_SELECTOR);
+
+        if (wrap) positionTooltip(wrap);
+
+    }
+
+
+
+    document.addEventListener('mouseover', onWrapActivated, true);
+
+    document.addEventListener('focusin', onWrapActivated, true);
+
+    document.addEventListener('scroll', repositionOpenTooltips, true);
+
+    window.addEventListener('resize', repositionOpenTooltips);
+
+})();
+


### PR DESCRIPTION
## Summary

- Add agent `CheckFileVersions` and per-file `WorkspaceFileLineStatus` persistence so pinned workspace files report out-of-date tokens, unmatched tokens, and missing-on-disk files
- Merge csproj, file-config token, and user-declared custom dependency edges before topological sort, with circular-dependency protection and distinct repo-level badge counts
- Add Custom Dependencies modal and repository grid dependency badges with tooltips that distinguish project, file-config, and custom edges
- Extend `WorkspaceFileVersionService`, workspace repo link counters, and idempotent DB migrations for custom dependencies and file line status tables
- Large UI/service diff spans migrations, repositories grid, and modals - review full branch diff for omitted hunks

## Test plan

- [ ] Pin workspace files with version patterns; confirm out-of-date tokens appear on the repositories grid and clear after an update
- [ ] Add and remove custom dependencies between repos; verify level grouping and push/update ordering follow the combined graph
- [ ] Create a circular custom dependency and confirm it is rejected
- [ ] Delete a pinned file from disk; confirm missing-file state surfaces in the UI and workspace files API
- [ ] Hover a dependency badge tooltip and verify project, file-config, and custom sources are labeled correctly
- [ ] Restart the app against an existing database and confirm migrations apply without errors