### PR TITLE
Fix sync-to-default branch state not updating in the UI

### DIFF
--- a/src/GrayMoon.Agent/Commands/SyncToDefaultBranchCommand.cs
+++ b/src/GrayMoon.Agent/Commands/SyncToDefaultBranchCommand.cs
@@ -88,6 +88,10 @@ public sealed class SyncToDefaultBranchCommand(IGitService git, ILogger<SyncToDe
             };
         }
 
+        var defaultRef = await git.GetDefaultBranchOriginRefAsync(repoPath, cancellationToken);
+        var (outgoing, incoming, hasUpstream) = await git.GetCommitCountsAsync(repoPath, defaultBranch, defaultRef, cancellationToken);
+        var (defaultBehind, defaultAhead, _) = await git.GetCommitCountsVsDefaultAsync(repoPath, defaultRef, cancellationToken);
+
         var localBranches = await git.GetLocalBranchesAsync(repoPath, cancellationToken);
         var remoteBranches = await git.GetRemoteBranchesFromRefsAsync(repoPath, cancellationToken);
         var tags = await git.GetTagsAsync(repoPath, cancellationToken);
@@ -101,7 +105,12 @@ public sealed class SyncToDefaultBranchCommand(IGitService git, ILogger<SyncToDe
             LocalBranches = localBranches,
             RemoteBranches = remoteBranches,
             Tags = tags,
-            CurrentTag = currentTag
+            CurrentTag = currentTag,
+            OutgoingCommits = outgoing,
+            IncomingCommits = incoming,
+            HasUpstream = hasUpstream,
+            DefaultBranchBehind = defaultBehind,
+            DefaultBranchAhead = defaultAhead
         };
     }
 }

--- a/src/GrayMoon.Agent/Jobs/Response/SyncToDefaultBranchResponse.cs
+++ b/src/GrayMoon.Agent/Jobs/Response/SyncToDefaultBranchResponse.cs
@@ -27,4 +27,19 @@ public sealed class SyncToDefaultBranchResponse
 
     [JsonPropertyName("currentTag")]
     public string? CurrentTag { get; set; }
+
+    [JsonPropertyName("outgoingCommits")]
+    public int? OutgoingCommits { get; set; }
+
+    [JsonPropertyName("incomingCommits")]
+    public int? IncomingCommits { get; set; }
+
+    [JsonPropertyName("hasUpstream")]
+    public bool? HasUpstream { get; set; }
+
+    [JsonPropertyName("defaultBranchBehind")]
+    public int? DefaultBranchBehind { get; set; }
+
+    [JsonPropertyName("defaultBranchAhead")]
+    public int? DefaultBranchAhead { get; set; }
 }

--- a/src/GrayMoon.App/Models/Api/BranchesApiModels.cs
+++ b/src/GrayMoon.App/Models/Api/BranchesApiModels.cs
@@ -146,6 +146,21 @@ public sealed class SyncToDefaultBranchResponse
 
     [JsonPropertyName("currentTag")]
     public string? CurrentTag { get; set; }
+
+    [JsonPropertyName("outgoingCommits")]
+    public int? OutgoingCommits { get; set; }
+
+    [JsonPropertyName("incomingCommits")]
+    public int? IncomingCommits { get; set; }
+
+    [JsonPropertyName("hasUpstream")]
+    public bool? HasUpstream { get; set; }
+
+    [JsonPropertyName("defaultBranchBehind")]
+    public int? DefaultBranchBehind { get; set; }
+
+    [JsonPropertyName("defaultBranchAhead")]
+    public int? DefaultBranchAhead { get; set; }
 }
 
 /// <summary>API response for POST /api/branches/delete (camelCase).</summary>

--- a/src/GrayMoon.App/Services/WorkspaceGitService.cs
+++ b/src/GrayMoon.App/Services/WorkspaceGitService.cs
@@ -847,6 +847,20 @@ public class WorkspaceGitService(
             }
         }
 
+        // Persist BranchName and commit counts from the agent response so the UI is up to date
+        // immediately without waiting for the async post-merge hook (which only fires when pull merges).
+        if (syncResponse != null)
+        {
+            wr.BranchName = syncResponse.CurrentBranch ?? syncResponse.DefaultBranch;
+            wr.CheckedOutTag = null;
+            if (syncResponse.OutgoingCommits.HasValue) wr.OutgoingCommits = syncResponse.OutgoingCommits;
+            if (syncResponse.IncomingCommits.HasValue) wr.IncomingCommits = syncResponse.IncomingCommits;
+            if (syncResponse.HasUpstream.HasValue) wr.BranchHasUpstream = syncResponse.HasUpstream.Value;
+            if (syncResponse.DefaultBranchBehind.HasValue) wr.DefaultBranchBehindCommits = syncResponse.DefaultBranchBehind;
+            if (syncResponse.DefaultBranchAhead.HasValue) wr.DefaultBranchAheadCommits = syncResponse.DefaultBranchAhead;
+            await _dbContext.SaveChangesAsync(cancellationToken);
+        }
+
         if (_hubContext != null)
             await _hubContext.Clients.All.SendAsync("WorkspaceSynced", workspaceId, cancellationToken);
 


### PR DESCRIPTION
## Summary

- Return outgoing/incoming commit counts, upstream status, and default-branch ahead/behind from the Agent `SyncToDefaultBranch` command so the App has fresh git state after sync
- Persist branch name and commit counters from the sync response in `WorkspaceGitService` immediately, instead of relying on the post-merge hook (which only runs when a pull actually merges)
- Extend `SyncToDefaultBranchResponse` DTOs on Agent and App with the new commit-count fields

## Test plan

- [ ] Sync a workspace repo to its default branch and confirm branch name and commit badges update right away without waiting for a hook
- [ ] Verify outgoing/incoming counts and default-branch ahead/behind match git status after sync
- [ ] Sync a repo that is already on default with no merge needed and confirm counts still refresh correctly