### PR TITLE
Restore only changed repos after prerelease push and dependency update

### DIFF
--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
@@ -1325,7 +1325,8 @@ public sealed partial class WorkspaceRepositories : IDisposable
         CancellationToken ct,
         IReadOnlySet<int> repoIds,
         bool synchronizedPush,
-        IReadOnlySet<string> requiredPackageIds)
+        IReadOnlySet<string> requiredPackageIds,
+        IReadOnlySet<int>? syncedRepoIds = null)
     {
         try
         {
@@ -1338,6 +1339,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
                 requiredPackageIds,
                 job.ReportProgress,
                 ToastService.Show,
+                syncedRepoIds: syncedRepoIds,
                 cancellationToken: ct);
         }
         catch (OperationCanceledException)
@@ -1849,6 +1851,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
         JobService.StartJob(PageJobKey, $"Updating Level {level}...", async (job, ct) =>
         {
             // Phase 1: update repos needing work up to the target level
+            IReadOnlySet<int> syncedRepoIds = new HashSet<int>();
             try
             {
                 var reposNeedingWork = workspaceRepositories
@@ -1860,7 +1863,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
                 await using (var updateScope = ServiceScopeFactory.CreateAsyncScope())
                 {
                     var updateHandler = updateScope.ServiceProvider.GetRequiredService<WorkspaceUpdateHandler>();
-                    await updateHandler.RunUpdateAsync(
+                    syncedRepoIds = await updateHandler.RunUpdateAsync(
                         WorkspaceId,
                         ct,
                         job.ReportProgress,
@@ -1909,10 +1912,10 @@ public sealed partial class WorkspaceRepositories : IDisposable
                 throw;
             }
 
-            // Phase 3: execute push for level repos only
+            // Phase 3: execute push (per-level restore of synced repos handled inside push service)
             try
             {
-                await ExecutePushCoreAsync(job, ct, pushRepoIds, synchronizedPush: true, requiredPackageIds);
+                await ExecutePushCoreAsync(job, ct, pushRepoIds, synchronizedPush: true, requiredPackageIds, syncedRepoIds);
             }
             catch (SynchronizedPushNotPossibleException ex)
             {
@@ -1922,17 +1925,14 @@ public sealed partial class WorkspaceRepositories : IDisposable
                     {
                         JobService.StartJob(PageJobKey, "Preparing push...", async (j, c) =>
                         {
-                            await ExecutePushCoreAsync(j, c, pushRepoIds, synchronizedPush: false, requiredPackageIds);
-                            await RestorePackagesCoreAsync(j, c);
+                            await ExecutePushCoreAsync(j, c, pushRepoIds, synchronizedPush: false, requiredPackageIds, syncedRepoIds);
+                            await RestoreSyncedPackagesCoreAsync(syncedRepoIds, j, c);
                         });
                         return Task.CompletedTask;
                     },
                     confirmButtonText: "Continue"));
                 return;
             }
-
-            // Phase 4: restore packages after successful push
-            await RestorePackagesCoreAsync(job, ct);
         });
 
         return Task.CompletedTask;
@@ -1948,6 +1948,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
         JobService.StartJob(PageJobKey, "Updating dependencies...", async (job, ct) =>
         {
             // Phase 1: update - fresh scope so DbContext does not compete with circuit page loads
+            IReadOnlySet<int> syncedRepoIds = new HashSet<int>();
             try
             {
                 var reposNeedingWork = workspaceRepositories
@@ -1959,7 +1960,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
                 await using (var updateScope = ServiceScopeFactory.CreateAsyncScope())
                 {
                     var updateHandler = updateScope.ServiceProvider.GetRequiredService<WorkspaceUpdateHandler>();
-                    await updateHandler.RunUpdateAsync(
+                    syncedRepoIds = await updateHandler.RunUpdateAsync(
                         WorkspaceId,
                         ct,
                         job.ReportProgress,
@@ -2006,10 +2007,10 @@ public sealed partial class WorkspaceRepositories : IDisposable
                 throw;
             }
 
-            // Phase 3: execute push
+            // Phase 3: execute push (per-level restore of synced repos handled inside push service)
             try
             {
-                await ExecutePushCoreAsync(job, ct, pushRepoIds, synchronizedPush: true, requiredPackageIds);
+                await ExecutePushCoreAsync(job, ct, pushRepoIds, synchronizedPush: true, requiredPackageIds, syncedRepoIds);
             }
             catch (SynchronizedPushNotPossibleException ex)
             {
@@ -2019,17 +2020,14 @@ public sealed partial class WorkspaceRepositories : IDisposable
                     {
                         JobService.StartJob(PageJobKey, "Preparing push...", async (j, c) =>
                         {
-                            await ExecutePushCoreAsync(j, c, pushRepoIds, synchronizedPush: false, requiredPackageIds);
-                            await RestorePackagesCoreAsync(j, c);
+                            await ExecutePushCoreAsync(j, c, pushRepoIds, synchronizedPush: false, requiredPackageIds, syncedRepoIds);
+                            await RestoreSyncedPackagesCoreAsync(syncedRepoIds, j, c);
                         });
                         return Task.CompletedTask;
                     },
                     confirmButtonText: "Continue"));
                 return;
             }
-
-            // Phase 4: restore packages after successful push
-            await RestorePackagesCoreAsync(job, ct);
         });
 
         return Task.CompletedTask;
@@ -2542,13 +2540,14 @@ public sealed partial class WorkspaceRepositories : IDisposable
         // runs, so DependencyUpdateOrchestrator never skips previously tag-pinned repos.
         JobService.StartJob(PageJobKey, "Creating branches...", async (job, ct) =>
         {
+            IReadOnlySet<int> syncedRepoIds = new HashSet<int>();
             try
             {
                 // Fresh scope so DbContext does not compete with circuit page loads
                 await using (var orchestratorScope = ServiceScopeFactory.CreateAsyncScope())
                 {
                     var orchestrator = orchestratorScope.ServiceProvider.GetRequiredService<NewFeatureOrchestrator>();
-                    await orchestrator.RunAsync(
+                    syncedRepoIds = await orchestrator.RunAsync(
                         WorkspaceId,
                         request.NewBranchName,
                         request.BaseBranch,
@@ -2583,7 +2582,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
             if (!request.PushChanges)
                 return;
 
-            // Phase 3: determine push plan and execute push
+            // Phase 3: determine push plan and execute push (per-level restore handled inside push service)
             job.ReportProgress("Preparing push...");
             IReadOnlySet<int> pushRepoIds;
             IReadOnlySet<string> requiredPackageIds;
@@ -2606,7 +2605,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
 
             try
             {
-                await ExecutePushCoreAsync(job, ct, pushRepoIds, synchronizedPush: true, requiredPackageIds);
+                await ExecutePushCoreAsync(job, ct, pushRepoIds, synchronizedPush: true, requiredPackageIds, syncedRepoIds);
             }
             catch (SynchronizedPushNotPossibleException ex)
             {
@@ -2614,9 +2613,6 @@ public sealed partial class WorkspaceRepositories : IDisposable
                     $"Synchronized push could not complete: {ex.MissingPackagesCount} required package mapping(s) are missing. Check NuGet connector configuration and token, then retry."));
                 return;
             }
-
-            // Phase 4: restore packages after successful push
-            await RestorePackagesCoreAsync(job, ct);
         });
 
         return Task.CompletedTask;
@@ -3814,6 +3810,45 @@ public sealed partial class WorkspaceRepositories : IDisposable
                 var workspaceGitService = scope.ServiceProvider.GetRequiredService<WorkspaceGitService>();
                 count = await workspaceGitService.RestoreAllWorkspacePackagesAsync(
                     WorkspaceId,
+                    job.ReportProgress,
+                    ct);
+            }
+
+            if (count > 0)
+                SafeInvoke(() => ToastService.Show($"Restored packages in {count} {(count == 1 ? "project" : "projects")}"));
+        }
+        catch (OperationCanceledException)
+        {
+            SafeInvoke(() => ToastService.Show("Restore cancelled."));
+            throw;
+        }
+        catch (AgentNotConnectedException ex)
+        {
+            Logger.LogError(ex, "Restore packages failed (agent not connected) for workspace {WorkspaceId}", WorkspaceId);
+            SafeInvoke(() => ToastService.ShowError($"Restore failed. {ex.Message}"));
+            throw;
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Restore packages failed for workspace {WorkspaceId}", WorkspaceId);
+            SafeInvoke(() => ToastService.ShowError($"Restore failed: {ex.Message}"));
+            throw;
+        }
+    }
+
+    private async Task RestoreSyncedPackagesCoreAsync(IReadOnlySet<int> syncedRepoIds, BackgroundJobHandle job, CancellationToken ct)
+    {
+        if (syncedRepoIds.Count == 0) return;
+        job.ReportProgress("Restoring packages...");
+        try
+        {
+            int count;
+            await using (var scope = ServiceScopeFactory.CreateAsyncScope())
+            {
+                var workspaceGitService = scope.ServiceProvider.GetRequiredService<WorkspaceGitService>();
+                count = await workspaceGitService.RestoreSyncedWorkspacePackagesAsync(
+                    WorkspaceId,
+                    syncedRepoIds,
                     job.ReportProgress,
                     ct);
             }

--- a/src/GrayMoon.App/Components/Shared/WorkspaceActionNotificationPanel.razor
+++ b/src/GrayMoon.App/Components/Shared/WorkspaceActionNotificationPanel.razor
@@ -899,7 +899,7 @@
             job.ReportProgress,
             ToastService.Show,
             onAppSideComplete: () => { },
-            ct);
+            cancellationToken: ct);
     }
 
     private Task OnPullBadgeClickAsync(WorkspaceNotification n, NotificationRepo repo)
@@ -1005,7 +1005,7 @@
                     job.ReportProgress,
                     ToastService.Show,
                     onAppSideComplete: () => { },
-                    ct);
+                    cancellationToken: ct);
             }
             catch (OperationCanceledException) { throw; }
             catch (Exception ex)

--- a/src/GrayMoon.App/Services/DependencyUpdateOrchestrator.cs
+++ b/src/GrayMoon.App/Services/DependencyUpdateOrchestrator.cs
@@ -27,7 +27,7 @@ public sealed class DependencyUpdateOrchestrator(
     /// <param name="commitMessage">Optional user-supplied commit subject line. When provided, replaces the default subject in all commits created during this update.</param>
     /// <param name="includeDepsInCommitMessage">When true, the list of updated packages is appended to the commit message body.</param>
     /// <param name="maxLevel">Optional. When set, only repositories at or below this dependency level are processed; higher levels are skipped.</param>
-    public async Task RunAsync(
+    public async Task<IReadOnlySet<int>> RunAsync(
         int workspaceId,
         CancellationToken cancellationToken,
         Action<string> setProgress,
@@ -40,9 +40,10 @@ public sealed class DependencyUpdateOrchestrator(
     {
         // Non-null empty set means the caller determined no repos need work.
         if (repoIdsToUpdate is { Count: 0 })
-            return;
+            return new HashSet<int>();
 
         var hadError = false;
+        var allSyncedRepoIds = new HashSet<int>();
         void OnRepoError(int repoId, string msg)
         {
             hadError = true;
@@ -66,7 +67,7 @@ public sealed class DependencyUpdateOrchestrator(
             repositoryIds: repoIdsToUpdate,
             cancellationToken);
         if (hadError)
-            return;
+            return new HashSet<int>();
 
         // Step 2+: Process repositories by dependency level.
         var levelRepoIds = await GetRepositoryIdsByDependencyLevelAsync(workspaceId, repoIdsToUpdate, OnRepoError);
@@ -74,6 +75,8 @@ public sealed class DependencyUpdateOrchestrator(
             levelRepoIds = levelRepoIds.Where(x => x.Level <= maxLevel.Value).ToList();
         if (levelRepoIds.Count == 0)
             hadError = true;
+        if (hadError)
+            return new HashSet<int>();
 
         foreach (var (level, repoIds) in levelRepoIds)
         {
@@ -125,6 +128,7 @@ public sealed class DependencyUpdateOrchestrator(
                 onRepoError: OnRepoError,
                 repoIdsToSync: repoIds,
                 cancellationToken);
+            allSyncedRepoIds.UnionWith(syncedRepoIds);
             if (hadError)
                 break;
 
@@ -185,6 +189,8 @@ public sealed class DependencyUpdateOrchestrator(
             await workspaceGitService.RecomputeAndBroadcastWorkspaceSyncedAsync(workspaceId, cancellationToken);
             await fileVersionService.CheckAndPersistFileVersionStatusAsync(workspaceId, cancellationToken);
         }
+
+        return hadError ? new HashSet<int>() : allSyncedRepoIds;
     }
 
     private async Task<IReadOnlyList<(int Level, IReadOnlySet<int> RepoIds)>> GetRepositoryIdsByDependencyLevelAsync(

--- a/src/GrayMoon.App/Services/NewFeatureOrchestrator.cs
+++ b/src/GrayMoon.App/Services/NewFeatureOrchestrator.cs
@@ -10,7 +10,7 @@ public sealed class NewFeatureOrchestrator(
     DependencyUpdateOrchestrator dependencyUpdateOrchestrator,
     ILogger<NewFeatureOrchestrator> logger)
 {
-    public async Task RunAsync(
+    public async Task<IReadOnlySet<int>> RunAsync(
         int workspaceId,
         string newBranchName,
         string baseBranch,
@@ -34,10 +34,11 @@ public sealed class NewFeatureOrchestrator(
             syncState: true,
             cancellationToken);
 
+        IReadOnlySet<int> syncedRepoIds = new HashSet<int>();
         if (updateDependencies)
         {
             setProgress("Updating dependencies...");
-            await dependencyUpdateOrchestrator.RunAsync(
+            syncedRepoIds = await dependencyUpdateOrchestrator.RunAsync(
                 workspaceId,
                 cancellationToken,
                 setProgress,
@@ -49,5 +50,6 @@ public sealed class NewFeatureOrchestrator(
         }
 
         logger.LogInformation("NewFeatureOrchestrator completed for workspace {WorkspaceId}", workspaceId);
+        return syncedRepoIds;
     }
 }

--- a/src/GrayMoon.App/Services/PushOrchestrator.cs
+++ b/src/GrayMoon.App/Services/PushOrchestrator.cs
@@ -19,6 +19,7 @@ public sealed class PushOrchestrator(
         Action<string> setProgress,
         Action<string> showToast,
         Action? onAppSideComplete = null,
+        IReadOnlySet<int>? syncedRepoIds = null,
         CancellationToken cancellationToken = default)
     {
         if (synchronizedPush)
@@ -35,6 +36,7 @@ public sealed class PushOrchestrator(
                 (id, err) => showToast($"{id}: {err}"),
                 onAppSideComplete,
                 packageRegistriesAlreadySynced: requiredPackageIds.Count > 0,
+                syncedRepoIds: syncedRepoIds,
                 cancellationToken: cancellationToken);
         }
         else

--- a/src/GrayMoon.App/Services/WorkspaceGitService.cs
+++ b/src/GrayMoon.App/Services/WorkspaceGitService.cs
@@ -506,6 +506,47 @@ public class WorkspaceGitService(
         return totalCount;
     }
 
+    public async Task<int> RestoreSyncedWorkspacePackagesAsync(
+        int workspaceId,
+        IReadOnlySet<int> syncedRepoIds,
+        Action<string> setProgress,
+        CancellationToken cancellationToken)
+    {
+        if (!_agentBridge.IsAgentConnected)
+            throw new AgentNotConnectedException();
+
+        if (syncedRepoIds.Count == 0)
+            return 0;
+
+        setProgress("Restoring packages...");
+
+        var workspace = await _workspaceRepository.GetByIdAsync(workspaceId);
+        if (workspace == null)
+            return 0;
+
+        var tagPinnedIds = workspace.Repositories
+            .Where(l => !string.IsNullOrWhiteSpace(l.CheckedOutTag))
+            .Select(l => l.RepositoryId)
+            .ToHashSet();
+
+        var projects = await _workspaceProjectRepository.GetByWorkspaceIdAsync(workspaceId);
+        var repoGroups = projects
+            .Where(p => p.Repository != null
+                        && !string.IsNullOrWhiteSpace(p.ProjectFilePath)
+                        && syncedRepoIds.Contains(p.RepositoryId)
+                        && !tagPinnedIds.Contains(p.RepositoryId))
+            .GroupBy(p => (p.RepositoryId, RepoName: p.Repository!.RepositoryName))
+            .Select(g => (g.Key.RepoName, ProjectPaths: (IReadOnlyList<string>)g.Select(p => p.ProjectFilePath!).ToList()))
+            .ToList();
+
+        var totalCount = repoGroups.Sum(r => r.ProjectPaths.Count);
+        if (totalCount == 0)
+            return 0;
+
+        await RestoreDependenciesAsync(workspaceId, repoGroups, cancellationToken);
+        return totalCount;
+    }
+
     /// <summary>Broadcasts WorkspaceSynced so the grid refreshes. Call after SyncDependenciesAsync (which already recomputes and persists UnmatchedDeps).</summary>
     public async Task RecomputeAndBroadcastWorkspaceSyncedAsync(int workspaceId, CancellationToken cancellationToken = default)
     {

--- a/src/GrayMoon.App/Services/WorkspacePushHandler.cs
+++ b/src/GrayMoon.App/Services/WorkspacePushHandler.cs
@@ -1,77 +1,79 @@
-using GrayMoon.App.Models;
-
-namespace GrayMoon.App.Services;
-
-/// <summary>
-/// Handles push-related operations (push plan, push with dependencies, single push with upstream).
-/// Stateless; all UI state is owned by the caller.
-/// </summary>
-public sealed class WorkspacePushHandler(
-    PushOrchestrator pushOrchestrator,
-    WorkspacePushService workspacePushService,
-    ILogger<WorkspacePushHandler> logger)
-{
-    public async Task<(IReadOnlyList<PushRepoPayload> Payload, IReadOnlySet<int> PushRepoIds, bool HasUnpushed)> GetPushPlanAsync(
-        int workspaceId,
-        IReadOnlyList<WorkspaceRepositoryLink> workspaceRepositories,
-        CancellationToken cancellationToken,
-        int? maxLevel = null)
-    {
-        var (payload, _) = await workspacePushService.GetPushPlanAsync(workspaceId, cancellationToken);
-        var repoIdsWithUnpushed = workspaceRepositories
-            .Where(wr => !wr.IsOnTag && ((wr.OutgoingCommits ?? 0) > 0 || wr.BranchHasUpstream == false))
-            .Where(wr => !maxLevel.HasValue || (wr.DependencyLevel ?? 0) <= maxLevel.Value)
-            .Select(wr => wr.RepositoryId)
-            .ToHashSet();
-        var toPush = payload.Where(p => repoIdsWithUnpushed.Contains(p.RepoId)).ToList();
-        var pushRepoIds = toPush.Select(p => p.RepoId).ToHashSet();
-        return (toPush, pushRepoIds, toPush.Count > 0);
-    }
-
-    public async Task RunPushWithDependenciesAsync(
-        int workspaceId,
-        IReadOnlySet<int> repoIds,
-        bool synchronizedPush,
-        IReadOnlySet<string> requiredPackageIds,
-        Action<string> setProgress,
-        Action<string> showToast,
-        Action? onAppSideComplete = null,
-        CancellationToken cancellationToken = default)
-    {
-        try
-        {
-            await pushOrchestrator.RunAsync(
-                workspaceId,
-                repoIds,
-                synchronizedPush,
-                requiredPackageIds,
-                setProgress,
-                showToast,
-                onAppSideComplete,
-                cancellationToken);
-        }
-        catch (Exception ex) when (ex is not OperationCanceledException)
-        {
-            if (ex is SynchronizedPushNotPossibleException)
-                throw;
-            logger.LogError(ex, "Push with dependencies failed for workspace {WorkspaceId}", workspaceId);
-            showToast(ex.Message);
-            throw;
-        }
-    }
-
-    public async Task<(bool Success, string? ErrorMessage)> PushSingleRepositoryWithUpstreamAsync(
-        int workspaceId,
-        int repositoryId,
-        string? branchName,
-        Action<string> setProgress,
-        CancellationToken cancellationToken)
-    {
-        return await pushOrchestrator.PushSingleAsync(
-            workspaceId,
-            repositoryId,
-            branchName,
-            setProgress,
-            cancellationToken);
-    }
-}
+using GrayMoon.App.Models;
+
+namespace GrayMoon.App.Services;
+
+/// <summary>
+/// Handles push-related operations (push plan, push with dependencies, single push with upstream).
+/// Stateless; all UI state is owned by the caller.
+/// </summary>
+public sealed class WorkspacePushHandler(
+    PushOrchestrator pushOrchestrator,
+    WorkspacePushService workspacePushService,
+    ILogger<WorkspacePushHandler> logger)
+{
+    public async Task<(IReadOnlyList<PushRepoPayload> Payload, IReadOnlySet<int> PushRepoIds, bool HasUnpushed)> GetPushPlanAsync(
+        int workspaceId,
+        IReadOnlyList<WorkspaceRepositoryLink> workspaceRepositories,
+        CancellationToken cancellationToken,
+        int? maxLevel = null)
+    {
+        var (payload, _) = await workspacePushService.GetPushPlanAsync(workspaceId, cancellationToken);
+        var repoIdsWithUnpushed = workspaceRepositories
+            .Where(wr => !wr.IsOnTag && ((wr.OutgoingCommits ?? 0) > 0 || wr.BranchHasUpstream == false))
+            .Where(wr => !maxLevel.HasValue || (wr.DependencyLevel ?? 0) <= maxLevel.Value)
+            .Select(wr => wr.RepositoryId)
+            .ToHashSet();
+        var toPush = payload.Where(p => repoIdsWithUnpushed.Contains(p.RepoId)).ToList();
+        var pushRepoIds = toPush.Select(p => p.RepoId).ToHashSet();
+        return (toPush, pushRepoIds, toPush.Count > 0);
+    }
+
+    public async Task RunPushWithDependenciesAsync(
+        int workspaceId,
+        IReadOnlySet<int> repoIds,
+        bool synchronizedPush,
+        IReadOnlySet<string> requiredPackageIds,
+        Action<string> setProgress,
+        Action<string> showToast,
+        Action? onAppSideComplete = null,
+        IReadOnlySet<int>? syncedRepoIds = null,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await pushOrchestrator.RunAsync(
+                workspaceId,
+                repoIds,
+                synchronizedPush,
+                requiredPackageIds,
+                setProgress,
+                showToast,
+                onAppSideComplete,
+                syncedRepoIds,
+                cancellationToken);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            if (ex is SynchronizedPushNotPossibleException)
+                throw;
+            logger.LogError(ex, "Push with dependencies failed for workspace {WorkspaceId}", workspaceId);
+            showToast(ex.Message);
+            throw;
+        }
+    }
+
+    public async Task<(bool Success, string? ErrorMessage)> PushSingleRepositoryWithUpstreamAsync(
+        int workspaceId,
+        int repositoryId,
+        string? branchName,
+        Action<string> setProgress,
+        CancellationToken cancellationToken)
+    {
+        return await pushOrchestrator.PushSingleAsync(
+            workspaceId,
+            repositoryId,
+            branchName,
+            setProgress,
+            cancellationToken);
+    }
+}

--- a/src/GrayMoon.App/Services/WorkspacePushService.cs
+++ b/src/GrayMoon.App/Services/WorkspacePushService.cs
@@ -75,6 +75,7 @@ public sealed class WorkspacePushService(
         Action<int, string>? onRepoError = null,
         Action? onAppSideComplete = null,
         bool packageRegistriesAlreadySynced = false,
+        IReadOnlySet<int>? syncedRepoIds = null,
         CancellationToken cancellationToken = default)
     {
         if (!_agentBridge.IsAgentConnected)
@@ -294,7 +295,10 @@ public sealed class WorkspacePushService(
             }
 
             levelProgress?.Invoke("Restoring packages...");
-            await TryRestoreReposAtLevelAsync(workspaceId, workspace.Name, workspaceRoot, reposAtLevel, cancellationToken);
+            if (syncedRepoIds is { Count: > 0 })
+                await RestoreUpdatedReposAtLevelAsync(workspaceId, workspace.Name, workspaceRoot, reposAtLevel, syncedRepoIds, cancellationToken);
+            else
+                await TryRestoreReposAtLevelAsync(workspaceId, workspace.Name, workspaceRoot, reposAtLevel, cancellationToken);
 
             levelProgress?.Invoke($"Pushing {reposAtLevel.Count} {(reposAtLevel.Count == 1 ? "repository" : "repositories")}...");
             await PushReposAsync(
@@ -595,6 +599,55 @@ public sealed class WorkspacePushService(
             foreach (var line in update.NewLines)
                 _overlayCommandTerminalService.Append(label, AgentCommandStreamKind.Stdout, line);
         }
+    }
+
+    private async Task RestoreUpdatedReposAtLevelAsync(
+        int workspaceId,
+        string workspaceName,
+        string? workspaceRoot,
+        IReadOnlyList<PushRepoPayload> repos,
+        IReadOnlySet<int> syncedRepoIds,
+        CancellationToken cancellationToken)
+    {
+        var repoIdsToRestore = repos
+            .Select(r => r.RepoId)
+            .Where(id => syncedRepoIds.Contains(id))
+            .ToHashSet();
+
+        if (repoIdsToRestore.Count == 0) return;
+
+        var repoNameById = repos
+            .Where(r => repoIdsToRestore.Contains(r.RepoId))
+            .ToDictionary(r => r.RepoId, r => r.RepoName);
+
+        var projects = await _dbContext.WorkspaceProjects
+            .AsNoTracking()
+            .Where(p => p.WorkspaceId == workspaceId && repoIdsToRestore.Contains(p.RepositoryId) && p.ProjectFilePath != null)
+            .ToListAsync(cancellationToken);
+
+        if (projects.Count == 0) return;
+
+        var pathsByRepoId = projects
+            .GroupBy(p => p.RepositoryId)
+            .ToDictionary(g => g.Key, g => (IReadOnlyList<string>)g.Select(p => p.ProjectFilePath!).ToList());
+
+        var tasks = pathsByRepoId.Select(async kvp =>
+        {
+            if (!repoNameById.TryGetValue(kvp.Key, out var repositoryName)) return;
+            try
+            {
+                await _agentBridge.SendCommandAsync(
+                    "DotnetRestore",
+                    new { workspaceName, repositoryName, projectPaths = kvp.Value, workspaceRoot },
+                    cancellationToken);
+            }
+            catch (OperationCanceledException) { throw; }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "dotnet restore failed for {RepoName} in workspace {WorkspaceName}, continuing", repositoryName, workspaceName);
+            }
+        });
+        await Task.WhenAll(tasks);
     }
 
     private async Task TryRestoreReposAtLevelAsync(

--- a/src/GrayMoon.App/Services/WorkspaceUpdateHandler.cs
+++ b/src/GrayMoon.App/Services/WorkspaceUpdateHandler.cs
@@ -12,7 +12,7 @@ public sealed class WorkspaceUpdateHandler(
     /// Runs the full update flow (refresh, sync deps, commit per level, refresh version, version-file updates) via the orchestrator.
     /// </summary>
     /// <param name="maxLevel">Optional. When set, only repositories at or below this dependency level are processed.</param>
-    public async Task RunUpdateAsync(
+    public async Task<IReadOnlySet<int>> RunUpdateAsync(
         int workspaceId,
         CancellationToken cancellationToken,
         Action<string> setProgress,
@@ -25,7 +25,7 @@ public sealed class WorkspaceUpdateHandler(
     {
         try
         {
-            await dependencyUpdateOrchestrator.RunAsync(
+            return await dependencyUpdateOrchestrator.RunAsync(
                 workspaceId,
                 cancellationToken,
                 setProgress,


### PR DESCRIPTION
## Summary

- Track which repos were synced during dependency update and return their IDs from orchestrators and handlers, instead of always restoring all workspace repos after a push
- Replace the blanket post-push `RestorePackagesCoreAsync` phase with `RestoreSyncedPackagesCoreAsync`, which targets only repos that received a version bump, reducing unnecessary dotnet restore calls
- Add `RestoreUpdatedReposAtLevelAsync` to `WorkspacePushService` to run per-level restores scoped to synced repo IDs when available, falling back to the original all-repos restore when no synced set is provided
- Fix trailing whitespace / blank-line formatting in `WorkspacePushHandler.cs`

## Test plan

- [ ] Run a dependency update + push flow and confirm dotnet restore runs only for repos that were updated, not every repo in the workspace
- [ ] Run a push flow with no prior dependency update (empty synced set) and confirm the original all-repos restore path is taken
- [ ] Verify the new feature orchestrator flow (`NewFeatureOrchestrator`) propagates synced repo IDs through correctly