### PR TITLE
Fix Undo Push Commits when remote branch does not exist

### DIFF
--- a/src/GrayMoon.Agent/Abstractions/IGitService.cs
+++ b/src/GrayMoon.Agent/Abstractions/IGitService.cs
@@ -60,8 +60,8 @@ public interface IGitService
     Task<string?> GetDefaultBranchOriginRefAsync(string repoPath, CancellationToken ct);
     /// <summary>Stages the given paths (relative to repo root) and creates a commit with the given message. Returns (success, errorMessage).</summary>
     Task<(bool Success, bool Committed, string? ErrorMessage)> StageAndCommitAsync(string repoPath, IReadOnlyList<string> pathsToStage, string commitMessage, CancellationToken ct);
-    /// <summary>Resets the current branch to origin/<paramref name="branchName"/>. When <paramref name="keepChanges"/> is true uses --mixed (changes remain in working tree); otherwise --hard. Returns (success, errorMessage).</summary>
-    Task<(bool Success, string? ErrorMessage)> ResetToRemoteAsync(string repoPath, string branchName, bool keepChanges, CancellationToken ct);
+    /// <summary>Resets the current branch to origin/<paramref name="branchName"/>. When <paramref name="keepChanges"/> is true uses --mixed (changes remain in working tree); otherwise --hard. If the remote branch does not exist, pushes it upstream first using <paramref name="bearerToken"/>. Returns (success, errorMessage).</summary>
+    Task<(bool Success, string? ErrorMessage)> ResetToRemoteAsync(string repoPath, string branchName, bool keepChanges, string? bearerToken, CancellationToken ct);
     void CreateDirectory(string path);
     bool DirectoryExists(string path);
     string[] GetDirectories(string path);

--- a/src/GrayMoon.Agent/Commands/UndoPushCommand.cs
+++ b/src/GrayMoon.Agent/Commands/UndoPushCommand.cs
@@ -42,7 +42,7 @@ public sealed class UndoPushCommand(IGitService git, IHubConnectionProvider hubP
                 return new UndoPushResponse { Success = false, ErrorMessage = "Could not determine branch name" };
         }
 
-        var (success, errorMessage) = await git.ResetToRemoteAsync(repoPath, branch, request.KeepChanges, cancellationToken);
+        var (success, errorMessage) = await git.ResetToRemoteAsync(repoPath, branch, request.KeepChanges, request.BearerToken, cancellationToken);
 
         if (success)
             _ = SendPostResetSyncAsync(request.WorkspaceId, request.RepositoryId, repoPath, branch);

--- a/src/GrayMoon.Agent/Jobs/Requests/UndoPushRequest.cs
+++ b/src/GrayMoon.Agent/Jobs/Requests/UndoPushRequest.cs
@@ -21,4 +21,7 @@ public sealed class UndoPushRequest : WorkspaceCommandRequest
 
     [JsonPropertyName("keepChanges")]
     public bool KeepChanges { get; set; }
+
+    [JsonPropertyName("bearerToken")]
+    public string? BearerToken { get; set; }
 }

--- a/src/GrayMoon.Agent/Services/GitService.cs
+++ b/src/GrayMoon.Agent/Services/GitService.cs
@@ -927,10 +927,19 @@ public sealed class GitService(IOptions<AgentOptions> options, ILogger<GitServic
         return (true, true, null);
     }
 
-    public async Task<(bool Success, string? ErrorMessage)> ResetToRemoteAsync(string repoPath, string branchName, bool keepChanges, CancellationToken ct)
+    public async Task<(bool Success, string? ErrorMessage)> ResetToRemoteAsync(string repoPath, string branchName, bool keepChanges, string? bearerToken, CancellationToken ct)
     {
         if (string.IsNullOrWhiteSpace(repoPath) || !Directory.Exists(repoPath) || string.IsNullOrWhiteSpace(branchName))
             return (false, "Invalid repository path or branch name");
+
+        var (exitVerify, _, _) = await runner.RunAsync("git", $"rev-parse --verify origin/{branchName}", repoPath, ct);
+        if (exitVerify != 0)
+        {
+            logger.LogInformation("Remote ref origin/{BranchName} not found in {RepoPath} - pushing branch upstream first", branchName, repoPath);
+            var (pushOk, pushErr) = await PushAsync(repoPath, branchName, bearerToken, setTracking: true, ct: ct);
+            if (!pushOk)
+                return (false, pushErr ?? "Failed to push branch upstream before reset");
+        }
 
         var mode = keepChanges ? "--mixed" : "--hard";
         var target = $"origin/{branchName}";

--- a/src/GrayMoon.App/Services/DependencyUpdateOrchestrator.cs
+++ b/src/GrayMoon.App/Services/DependencyUpdateOrchestrator.cs
@@ -50,14 +50,6 @@ public sealed class DependencyUpdateOrchestrator(
             onRepoError(repoId, msg);
         }
 
-        // Load workspace links once: used to scope version-file work to repos with out-of-date files.
-        var workspace = await workspaceRepository.GetByIdAsync(workspaceId);
-        var workspaceLinks = workspace?.Repositories ?? (ICollection<WorkspaceRepositoryLink>)[];
-        var outOfDateFileRepoIds = workspaceLinks
-            .Where(l => (l.OutOfDateFileRepos ?? 0) > 0)
-            .Select(l => l.RepositoryId)
-            .ToHashSet();
-
         // Step 1: Refresh project data from .csproj files on disk.
         setProgress("Reading project files...");
         await workspaceGitService.RefreshWorkspaceProjectsAsync(
@@ -85,6 +77,15 @@ public sealed class DependencyUpdateOrchestrator(
 
             if (repoIds.Count == 0)
                 break;
+
+            // Re-fetch per level: RefreshRepositoryVersionsAsync updates OutOfDateFileRepos in the DB
+            // after each level commits, so re-reading here ensures newly out-of-date files at higher
+            // levels are not skipped.
+            var freshWorkspace = await workspaceRepository.GetByIdAsync(workspaceId);
+            var outOfDateFileRepoIds = (freshWorkspace?.Repositories ?? (ICollection<WorkspaceRepositoryLink>)[])
+                .Where(l => (l.OutOfDateFileRepos ?? 0) > 0)
+                .Select(l => l.RepositoryId)
+                .ToHashSet();
 
             Action<string> levelProgress = msg => setProgress($"{msg}\nLevel {level}");
 

--- a/src/GrayMoon.App/Services/WorkspaceUndoPushHandler.cs
+++ b/src/GrayMoon.App/Services/WorkspaceUndoPushHandler.cs
@@ -51,6 +51,7 @@ public sealed class WorkspaceUndoPushHandler(
                     branchName = wr.BranchName,
                     keepChanges,
                     workspaceRoot,
+                    bearerToken = ConnectorHelpers.UnprotectToken(wr.Repository?.Connector?.UserToken),
                 };
                 var response = await agentBridge.SendCommandAsync("UndoPush", args, ct);
                 if (!response.Success || response.Data == null)


### PR DESCRIPTION
## Summary

- Push the branch upstream (creating `origin/{branchName}`) before resetting when the remote ref is missing, preventing the "ambiguous argument" fatal error on branches that have never been pushed
- Pass the connector bearer token through `UndoPushRequest` and `ResetToRemoteAsync` so the upstream push can authenticate
- Re-fetch out-of-date file repo IDs per dependency level in `DependencyUpdateOrchestrator` so newly out-of-date files at higher levels are not skipped after lower-level commits update the DB

## Test plan

- [ ] On a branch with local commits that has never been pushed, trigger Undo Push Commits and confirm it succeeds without an "ambiguous argument" error
- [ ] Confirm outgoing commit count resets to 0 after the operation completes
- [ ] On a branch that is already pushed, confirm Undo Push Commits still resets correctly (no regression)
- [ ] Run a dependency update across multiple levels and verify version-file updates at higher levels are applied when lower levels made them out of date