### PR TITLE
Add workspace-wide Sync to Default with dependency and file version refresh

### DIFF
--- a/src/GrayMoon.Agent/Commands/SyncToDefaultBranchCommand.cs
+++ b/src/GrayMoon.Agent/Commands/SyncToDefaultBranchCommand.cs
@@ -97,6 +97,9 @@ public sealed class SyncToDefaultBranchCommand(IGitService git, ILogger<SyncToDe
         var tags = await git.GetTagsAsync(repoPath, cancellationToken);
         var currentTag = await git.GetCheckedOutTagAsync(repoPath, cancellationToken);
 
+        var (versionResult, _) = await git.GetVersionAsync(repoPath, cancellationToken);
+        var gitVersion = versionResult?.InformationalVersion;
+
         return new SyncToDefaultBranchResponse
         {
             Success = true,
@@ -110,7 +113,8 @@ public sealed class SyncToDefaultBranchCommand(IGitService git, ILogger<SyncToDe
             IncomingCommits = incoming,
             HasUpstream = hasUpstream,
             DefaultBranchBehind = defaultBehind,
-            DefaultBranchAhead = defaultAhead
+            DefaultBranchAhead = defaultAhead,
+            GitVersion = gitVersion
         };
     }
 }

--- a/src/GrayMoon.Agent/Commands/SyncToDefaultBranchCommand.cs
+++ b/src/GrayMoon.Agent/Commands/SyncToDefaultBranchCommand.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.Logging;
 
 namespace GrayMoon.Agent.Commands;
 
-public sealed class SyncToDefaultBranchCommand(IGitService git, ILogger<SyncToDefaultBranchCommand> logger) : ICommandHandler<SyncToDefaultBranchRequest, SyncToDefaultBranchResponse>
+public sealed class SyncToDefaultBranchCommand(IGitService git, ICsProjFileService csProjFileService, ILogger<SyncToDefaultBranchCommand> logger) : ICommandHandler<SyncToDefaultBranchRequest, SyncToDefaultBranchResponse>
 {
     public async Task<SyncToDefaultBranchResponse> ExecuteAsync(SyncToDefaultBranchRequest request, CancellationToken cancellationToken = default)
     {
@@ -100,6 +100,8 @@ public sealed class SyncToDefaultBranchCommand(IGitService git, ILogger<SyncToDe
         var (versionResult, _) = await git.GetVersionAsync(repoPath, cancellationToken);
         var gitVersion = versionResult?.InformationalVersion;
 
+        var projects = await csProjFileService.FindAsync(repoPath, cancellationToken);
+
         return new SyncToDefaultBranchResponse
         {
             Success = true,
@@ -114,7 +116,8 @@ public sealed class SyncToDefaultBranchCommand(IGitService git, ILogger<SyncToDe
             HasUpstream = hasUpstream,
             DefaultBranchBehind = defaultBehind,
             DefaultBranchAhead = defaultAhead,
-            GitVersion = gitVersion
+            GitVersion = gitVersion,
+            Projects = projects
         };
     }
 }

--- a/src/GrayMoon.Agent/Jobs/Response/SyncToDefaultBranchResponse.cs
+++ b/src/GrayMoon.Agent/Jobs/Response/SyncToDefaultBranchResponse.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Serialization;
+using GrayMoon.Agent.Models;
 
 namespace GrayMoon.Agent.Jobs.Response;
 
@@ -45,4 +46,7 @@ public sealed class SyncToDefaultBranchResponse
 
     [JsonPropertyName("gitVersion")]
     public string? GitVersion { get; set; }
+
+    [JsonPropertyName("projects")]
+    public IReadOnlyList<CsProjFileInfo>? Projects { get; set; }
 }

--- a/src/GrayMoon.Agent/Jobs/Response/SyncToDefaultBranchResponse.cs
+++ b/src/GrayMoon.Agent/Jobs/Response/SyncToDefaultBranchResponse.cs
@@ -42,4 +42,7 @@ public sealed class SyncToDefaultBranchResponse
 
     [JsonPropertyName("defaultBranchAhead")]
     public int? DefaultBranchAhead { get; set; }
+
+    [JsonPropertyName("gitVersion")]
+    public string? GitVersion { get; set; }
 }

--- a/src/GrayMoon.App/Components/Modals/SyncToDefaultOptionsModal.razor
+++ b/src/GrayMoon.App/Components/Modals/SyncToDefaultOptionsModal.razor
@@ -13,6 +13,13 @@
                 </div>
                 <div class="modal-body">
                     <p class="mb-2 small">@Message</p>
+                    @if (RepoItems.Any(r => r.CommitsAhead > 0))
+                    {
+                        <div class="alert alert-danger py-2 px-3 mb-3 small" role="alert">
+                            <i class="bi bi-exclamation-triangle-fill me-1"></i>
+                            One or more repositories have local commits that are not on the default branch. These commits will be permanently lost when the branch is deleted. This cannot be undone.
+                        </div>
+                    }
                     @if (RepoItems.Count > 0)
                     {
                         <div class="default-branch-warning-scroll small mb-3">
@@ -25,6 +32,14 @@
                                         @if (item.HasRemote)
                                         {
                                             <span class="badge bg-secondary ms-1" style="font-size:0.65em;">remote</span>
+                                        }
+                                        @if (item.HasOpenPr)
+                                        {
+                                            <span class="badge bg-warning text-dark ms-1" style="font-size:0.65em;">PR open - will be closed</span>
+                                        }
+                                        @if (item.CommitsAhead > 0)
+                                        {
+                                            <span class="text-danger ms-2" style="font-size:0.85em;">@item.CommitsAhead commit@(item.CommitsAhead == 1 ? "" : "s") will be lost</span>
                                         }
                                     </li>
                                 }
@@ -63,7 +78,7 @@
 @code {
     [Parameter] public bool IsVisible { get; set; }
     [Parameter] public string Message { get; set; } = "";
-    [Parameter] public IReadOnlyList<(string RepoName, string BranchName, bool HasRemote)> RepoItems { get; set; } = Array.Empty<(string, string, bool)>();
+    [Parameter] public IReadOnlyList<(string RepoName, string BranchName, bool HasRemote, bool HasOpenPr, int CommitsAhead)> RepoItems { get; set; } = Array.Empty<(string, string, bool, bool, int)>();
     [Parameter] public bool DeleteRemoteBranches { get; set; } = true;
     [Parameter] public EventCallback<bool> DeleteRemoteBranchesChanged { get; set; }
     [Parameter] public bool AllowForceDeleteLocalBranch { get; set; } = true;

--- a/src/GrayMoon.App/Components/Modals/SyncToDefaultOptionsModal.razor
+++ b/src/GrayMoon.App/Components/Modals/SyncToDefaultOptionsModal.razor
@@ -67,7 +67,7 @@
                     </div>
                 </div>
                 <div class="modal-footer">
-                    <button type="button" class="btn btn-primary" @onclick="OnProceed">Proceed</button>
+                    <button type="button" class="btn btn-danger" @onclick="OnProceed">Proceed</button>
                     <button type="button" class="btn btn-outline-secondary" @onclick="OnCancel">Cancel</button>
                 </div>
             </div>

--- a/src/GrayMoon.App/Components/Modals/SyncToDefaultOptionsModal.razor
+++ b/src/GrayMoon.App/Components/Modals/SyncToDefaultOptionsModal.razor
@@ -5,7 +5,7 @@
     <div class="modal show d-block" tabindex="-1" style="background-color: rgba(0,0,0,0.5);"
          @onkeydown="HandleKeyDown"
          @ref="_modalElement">
-        <div class="modal-dialog modal-dialog-scrollable modal-lg default-branch-warning-modal">
+        <div class="modal-dialog modal-lg sync-to-default-options-modal">
             <div class="modal-content">
                 <div class="modal-header">
                     <h5 class="modal-title">Sync to Default</h5>
@@ -22,7 +22,7 @@
                     }
                     @if (RepoItems.Count > 0)
                     {
-                        <div class="default-branch-warning-scroll small mb-3">
+                        <div class="sync-to-default-options-scroll small mb-3">
                             <ul class="list-unstyled mb-0 ps-0">
                                 @foreach (var item in RepoItems)
                                 {

--- a/src/GrayMoon.App/Components/Modals/SyncToDefaultOptionsModal.razor.css
+++ b/src/GrayMoon.App/Components/Modals/SyncToDefaultOptionsModal.razor.css
@@ -1,0 +1,39 @@
+/* Keep the dialog within the viewport */
+.sync-to-default-options-modal {
+    max-height: calc(100vh - 2rem);
+    margin: 1rem auto;
+}
+
+.sync-to-default-options-modal .modal-body {
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    overflow: visible;
+}
+
+/* Only the repo list scrolls */
+.sync-to-default-options-scroll {
+    flex: 0 1 auto;
+    max-height: 12rem;
+    overflow-y: auto;
+    overflow-x: hidden;
+    scrollbar-width: thin;
+    scrollbar-color: #6c757d transparent;
+}
+
+.sync-to-default-options-scroll::-webkit-scrollbar {
+    width: 0.35rem;
+}
+
+.sync-to-default-options-scroll::-webkit-scrollbar-track {
+    background: transparent;
+}
+
+.sync-to-default-options-scroll::-webkit-scrollbar-thumb {
+    background: #6c757d;
+    border-radius: 0.2rem;
+}
+
+.sync-to-default-options-scroll::-webkit-scrollbar-thumb:hover {
+    background: #5a6268;
+}

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor
@@ -55,6 +55,7 @@
                                     OnShowBranch="() => ShowBranchModalAsync()"
                                     OnShowSwitchBranch='() => ShowBranchModalAsync("switchbranch")'
                                     OnNewPullRequest="OpenPullRequestDialogForAllRepositoriesAsync"
+                                    OnSyncAllToDefault="SyncAllToDefaultAsync"
                                     OnUpdate="OnUpdateClickAsync"
                                     OnUpdateFiles="OnUpdateFilesClickAsync"
                                     OnUpdateAndPush="OnUpdateAndPushClickAsync"

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
@@ -607,7 +607,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
             await action();
     }
 
-    private void ShowSyncToDefaultOptions(string message, IReadOnlyList<(string RepoName, string BranchName, bool HasRemote)> repoItems, Func<bool, bool, Task> onProceed, bool defaultDeleteRemote = true)
+    private void ShowSyncToDefaultOptions(string message, IReadOnlyList<(string RepoName, string BranchName, bool HasRemote, bool HasOpenPr, int CommitsAhead)> repoItems, Func<bool, bool, Task> onProceed, bool defaultDeleteRemote = true)
     {
         _syncToDefaultOptionsModal = _syncToDefaultOptionsModal with
         {
@@ -1022,7 +1022,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
                             .Select(r =>
                             {
                                 var wr2 = workspaceRepositories.FirstOrDefault(w => w.RepositoryId == r.RepoId);
-                                return (RepoName: wr2?.Repository?.RepositoryName ?? r.RepoId.ToString(), BranchName: wr2?.BranchName ?? "", HasRemote: r.HasUpstream == true);
+                                return (RepoName: wr2?.Repository?.RepositoryName ?? r.RepoId.ToString(), BranchName: wr2?.BranchName ?? "", HasRemote: r.HasUpstream == true, HasOpenPr: false, CommitsAhead: 0);
                             })
                             .ToList() ?? new();
                         ShowSyncToDefaultOptions(dialogMessage, repoItems, (deleteRemote, allowForce) => SyncToDefaultLevelAsync(safeRepoIds, deleteRemote, allowForce));
@@ -2934,7 +2934,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
                 var branchName = wr?.BranchName ?? currentBranchName;
                 ShowSyncToDefaultOptions(
                     "This will checkout the default branch, remove the current branch locally, and pull the latest.",
-                    [(repositoryName!, branchName, true)],
+                    [(repositoryName!, branchName, true, false, 0)],
                     (deleteRemote, allowForce) => SyncToDefaultSingleRepoAfterCheckAsync(repositoryId, repositoryName, currentBranchName, deleteRemote, defaultBranch, allowForce));
             }
             else
@@ -3088,6 +3088,241 @@ public sealed partial class WorkspaceRepositories : IDisposable
             catch (Exception ex)
             {
                 Logger.LogError(ex, "Error syncing to default branch for level");
+                SafeInvoke(() => errorMessage = "An error occurred while syncing to default branch. The GrayMoon Agent may be offline.");
+                throw;
+            }
+        });
+
+        return Task.CompletedTask;
+    }
+
+    private async Task SyncAllToDefaultAsync()
+    {
+        if (workspace == null || IsJobRunning)
+            return;
+
+        var eligibleRepos = workspaceRepositories
+            .Where(wr =>
+                !wr.IsOnTag &&
+                !string.IsNullOrWhiteSpace(wr.BranchName) &&
+                !string.IsNullOrWhiteSpace(wr.DefaultBranchName) &&
+                !string.Equals(wr.BranchName, wr.DefaultBranchName, StringComparison.Ordinal))
+            .ToList();
+
+        if (eligibleRepos.Count == 0)
+        {
+            ToastService.Show("All repositories are already on the default branch.");
+            return;
+        }
+
+        var eligibleIds = eligibleRepos.Select(wr => wr.RepositoryId).ToList();
+
+        try
+        {
+            await WorkspacePageService.WorkspacePullRequestService.RefreshPullRequestsAsync(WorkspaceId, eligibleIds, force: true);
+            await ReloadWorkspaceDataFromFreshScopeAsync();
+            ApplySyncStateFromWorkspace();
+            await InvokeAsync(StateHasChanged);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogDebug(ex, "PR refresh before sync-all-to-default failed for workspace {WorkspaceId}", WorkspaceId);
+        }
+
+        var totalCount = eligibleIds.Count;
+        var dialogMessage = totalCount == 1
+            ? "This will checkout the default branch, remove the current branch locally, and pull the latest. Uncommitted local changes can block checkout."
+            : $"This will sync {totalCount} repositories to their default branch: checkout default, remove the current branch locally, and pull. Uncommitted local changes can block checkout for that repo.";
+
+        JobService.StartJob(PageJobKey,
+            totalCount == 1 ? "Fetching latest branch state..." : $"Fetching latest branch state for {totalCount} repositories...",
+            async (job, ct) =>
+            {
+                try
+                {
+                    var fetchDone = 0;
+                    using var fetchSemaphore = new SemaphoreSlim(8);
+                    await Task.WhenAll(eligibleIds.Select(async repoId =>
+                    {
+                        await fetchSemaphore.WaitAsync(ct);
+                        try
+                        {
+                            await using var scope = ServiceScopeFactory.CreateAsyncScope();
+                            var gitService = scope.ServiceProvider.GetRequiredService<WorkspaceGitService>();
+                            await gitService.RefreshBranchesForRepositoryAsync(repoId, WorkspaceId, ct);
+                        }
+                        finally
+                        {
+                            fetchSemaphore.Release();
+                            var c = Interlocked.Increment(ref fetchDone);
+                            job.ReportProgress($"Fetched {c} of {totalCount}...");
+                        }
+                    }));
+
+                    await InvokeAsync(async () =>
+                    {
+                        if (_disposed) return;
+                        await RefreshFromSync();
+
+                        var repoItems = eligibleIds
+                            .Select(repoId =>
+                            {
+                                var wr2 = workspaceRepositories.FirstOrDefault(w => w.RepositoryId == repoId);
+                                prByRepositoryId.TryGetValue(repoId, out var pr);
+                                var hasOpenPr = pr != null && string.Equals(pr.State, "open", StringComparison.OrdinalIgnoreCase);
+                                var commitsAhead = wr2?.DefaultBranchAheadCommits ?? 0;
+                                return (
+                                    RepoName: wr2?.Repository?.RepositoryName ?? repoId.ToString(),
+                                    BranchName: wr2?.BranchName ?? "",
+                                    HasRemote: wr2?.BranchHasUpstream == true,
+                                    HasOpenPr: hasOpenPr,
+                                    CommitsAhead: commitsAhead
+                                );
+                            })
+                            .ToList();
+
+                        ShowSyncToDefaultOptions(dialogMessage, repoItems, (deleteRemote, allowForce) => ExecuteSyncAllToDefaultAsync(repoItems, deleteRemote));
+                        StateHasChanged();
+                    });
+                }
+                catch (OperationCanceledException)
+                {
+                    SafeInvoke(() => ToastService.Show("Fetch cancelled."));
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    Logger.LogError(ex, "Error fetching branch state before sync all to default");
+                    SafeInvoke(() => ToastService.Show("Failed to prepare sync to default."));
+                    throw;
+                }
+            });
+    }
+
+    private Task ExecuteSyncAllToDefaultAsync(
+        IReadOnlyList<(string RepoName, string BranchName, bool HasRemote, bool HasOpenPr, int CommitsAhead)> repoItems,
+        bool deleteRemoteBranch)
+    {
+        if (workspace == null || repoItems.Count == 0 || IsJobRunning)
+            return Task.CompletedTask;
+
+        var repoIdByName = workspaceRepositories.ToDictionary(
+            wr => wr.Repository?.RepositoryName ?? string.Empty,
+            wr => wr.RepositoryId);
+        var prNumberByRepoName = new Dictionary<string, int>();
+        foreach (var item in repoItems.Where(r => r.HasOpenPr))
+        {
+            if (!repoIdByName.TryGetValue(item.RepoName, out var repoId)) continue;
+            if (prByRepositoryId.TryGetValue(repoId, out var pr) && pr != null && pr.Number > 0)
+                prNumberByRepoName[item.RepoName] = pr.Number;
+        }
+
+        var total = repoItems.Count;
+        errorMessage = null;
+
+        JobService.StartJob(PageJobKey, "Synchronizing to default branch...", async (job, ct) =>
+        {
+            var maxParallel = Math.Max(1, WorkspaceOptions?.Value?.MaxParallelOperations ?? 16);
+            var completedCount = 0;
+
+            try
+            {
+                using var semaphore = new SemaphoreSlim(maxParallel, maxParallel);
+
+                var tasks = repoItems.Select(async item =>
+                {
+                    if (!repoIdByName.TryGetValue(item.RepoName, out var repoId))
+                    {
+                        Interlocked.Increment(ref completedCount);
+                        return (RepoId: 0, Success: false, ErrorMsg: (string?)"Repository not found");
+                    }
+
+                    var wr = workspaceRepositories.FirstOrDefault(w => w.RepositoryId == repoId);
+                    var currentBranch = wr?.BranchName ?? item.BranchName;
+                    if (string.IsNullOrWhiteSpace(currentBranch))
+                    {
+                        Interlocked.Increment(ref completedCount);
+                        return (RepoId: repoId, Success: true, ErrorMsg: (string?)null);
+                    }
+
+                    await semaphore.WaitAsync(ct);
+                    try
+                    {
+                        if (item.HasOpenPr && prNumberByRepoName.TryGetValue(item.RepoName, out var prNumber))
+                        {
+                            try
+                            {
+                                await using var prScope = ServiceScopeFactory.CreateAsyncScope();
+                                var prService = prScope.ServiceProvider.GetRequiredService<WorkspacePullRequestService>();
+                                await prService.ClosePullRequestAsync(WorkspaceId, repoId, prNumber, ct);
+                            }
+                            catch (Exception ex)
+                            {
+                                Logger.LogWarning(ex, "Failed to close PR {PrNumber} for repo {RepoName} before sync to default", prNumber, item.RepoName);
+                            }
+                        }
+
+                        await using var taskScope = ServiceScopeFactory.CreateAsyncScope();
+                        var taskGitService = taskScope.ServiceProvider.GetRequiredService<WorkspaceGitService>();
+                        var (success, errMsg) = await taskGitService.SyncToDefaultDirectAsync(
+                            WorkspaceId,
+                            repoId,
+                            currentBranch,
+                            deleteRemoteBranch && item.HasRemote,
+                            allowForceDeleteLocalBranch: true,
+                            ct);
+
+                        return (RepoId: repoId, Success: success, ErrorMsg: errMsg);
+                    }
+                    finally
+                    {
+                        semaphore.Release();
+                        var c = Interlocked.Increment(ref completedCount);
+                        if (total > 1)
+                            job.ReportProgress($"Synchronized {c} of {total} to default branch");
+                    }
+                });
+
+                var results = await Task.WhenAll(tasks);
+
+                var successCount = results.Count(r => r.Success);
+                var failureCount = results.Count(r => !r.Success);
+
+                SafeInvoke(() =>
+                {
+                    foreach (var (repoId, success, errMsg) in results)
+                    {
+                        if (repoId == 0) continue;
+                        if (success)
+                        {
+                            repositoryErrors.Remove(repoId);
+                        }
+                        else if (errMsg != null)
+                        {
+                            repositoryErrors[repoId] = errMsg;
+                            var repoName = workspaceRepositories.FirstOrDefault(w => w.RepositoryId == repoId)?.Repository?.RepositoryName ?? repoId.ToString();
+                            ToastService.Show($"{repoName}: {errMsg}");
+                        }
+                    }
+
+                    if (total > 1)
+                    {
+                        if (failureCount == 0)
+                            ToastService.Show($"Synced {successCount} of {total} repositories to default branch.");
+                        else
+                            ToastService.Show($"Synced {successCount} of {total} repositories to default branch ({failureCount} failed).");
+                    }
+                });
+
+                await InvokeAsync(async () =>
+                {
+                    if (_disposed) return;
+                    await RefreshFromSync();
+                });
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "Error syncing all repositories to default branch");
                 SafeInvoke(() => errorMessage = "An error occurred while syncing to default branch. The GrayMoon Agent may be offline.");
                 throw;
             }
@@ -3597,7 +3832,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
     {
         public bool IsVisible { get; init; }
         public string Message { get; init; } = "";
-        public IReadOnlyList<(string RepoName, string BranchName, bool HasRemote)> RepoItems { get; init; } = Array.Empty<(string, string, bool)>();
+        public IReadOnlyList<(string RepoName, string BranchName, bool HasRemote, bool HasOpenPr, int CommitsAhead)> RepoItems { get; init; } = Array.Empty<(string, string, bool, bool, int)>();
         public bool DeleteRemoteBranches { get; init; } = true;
         public bool AllowForceDeleteLocalBranch { get; init; } = true;
         public Func<bool, bool, Task>? PendingAction { get; init; }

--- a/src/GrayMoon.App/Components/Shared/WorkspaceRepositoriesHeader.razor
+++ b/src/GrayMoon.App/Components/Shared/WorkspaceRepositoriesHeader.razor
@@ -99,6 +99,15 @@
                             Create PRs...
                         </button>
                     </li>
+                    <li><hr class="dropdown-divider branch-menu-divider" /></li>
+                    <li>
+                        <button class="dropdown-item" type="button"
+                                role="menuitem"
+                                @onclick="HandleSyncAllToDefaultClick"
+                                disabled="@BranchActionsDisabled">
+                            Sync To Default
+                        </button>
+                    </li>
                 </ul>
             }
         </div>
@@ -339,6 +348,7 @@
     [Parameter] public EventCallback OnShowBranch { get; set; }
     [Parameter] public EventCallback OnShowSwitchBranch { get; set; }
     [Parameter] public EventCallback OnNewPullRequest { get; set; }
+    [Parameter] public EventCallback OnSyncAllToDefault { get; set; }
     [Parameter] public EventCallback OnUpdate { get; set; }
     [Parameter] public EventCallback OnUpdateFiles { get; set; }
     [Parameter] public EventCallback OnUpdateAndPush { get; set; }
@@ -476,6 +486,12 @@
     {
         CloseBranchMenu();
         await OnNewPullRequest.InvokeAsync();
+    }
+
+    private async Task HandleSyncAllToDefaultClick()
+    {
+        CloseBranchMenu();
+        await OnSyncAllToDefault.InvokeAsync();
     }
 
     private async Task OnSearchValueChangedAsync(string value)

--- a/src/GrayMoon.App/Models/Api/BranchesApiModels.cs
+++ b/src/GrayMoon.App/Models/Api/BranchesApiModels.cs
@@ -161,6 +161,9 @@ public sealed class SyncToDefaultBranchResponse
 
     [JsonPropertyName("defaultBranchAhead")]
     public int? DefaultBranchAhead { get; set; }
+
+    [JsonPropertyName("gitVersion")]
+    public string? GitVersion { get; set; }
 }
 
 /// <summary>API response for POST /api/branches/delete (camelCase).</summary>

--- a/src/GrayMoon.App/Models/Api/BranchesApiModels.cs
+++ b/src/GrayMoon.App/Models/Api/BranchesApiModels.cs
@@ -164,6 +164,9 @@ public sealed class SyncToDefaultBranchResponse
 
     [JsonPropertyName("gitVersion")]
     public string? GitVersion { get; set; }
+
+    [JsonPropertyName("projects")]
+    public List<AgentProjectDto>? Projects { get; set; }
 }
 
 /// <summary>API response for POST /api/branches/delete (camelCase).</summary>

--- a/src/GrayMoon.App/Services/GitHubPullRequestService.cs
+++ b/src/GrayMoon.App/Services/GitHubPullRequestService.cs
@@ -61,6 +61,26 @@ public sealed class GitHubPullRequestService(
         }
     }
 
+    /// <summary>Closes an open pull request for the given repository. Logs and returns silently on error - callers should not abort on close failure.</summary>
+    public async Task ClosePullRequestAsync(Repository repository, Connector? connector, int prNumber, CancellationToken cancellationToken = default)
+    {
+        if (repository == null || prNumber <= 0)
+            return;
+        if (connector == null || connector.ConnectorType != ConnectorType.GitHub || string.IsNullOrWhiteSpace(connector.UserToken))
+            return;
+        if (!RepositoryUrlHelper.TryParseGitHubOwnerRepo(repository.CloneUrl, out var owner, out var repo) || owner == null || repo == null)
+            return;
+
+        try
+        {
+            await gitHubService.ClosePullRequestAsync(connector, owner, repo, prNumber, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            logger.LogDebug(ex, "ClosePullRequest failed. Repo={Repo}, PrNumber={PrNumber}", repository.RepositoryName, prNumber);
+        }
+    }
+
     /// <summary>Fetches PR info for all workspace repo links in parallel (bounded concurrency). Returns a dictionary keyed by RepositoryId.</summary>
     public async Task<IReadOnlyDictionary<int, PullRequestInfo?>> GetPullRequestsForWorkspaceAsync(
         IEnumerable<WorkspaceRepositoryLink> links,

--- a/src/GrayMoon.App/Services/GitHubService.cs
+++ b/src/GrayMoon.App/Services/GitHubService.cs
@@ -529,6 +529,28 @@ public class GitHubService : IConnectorService
         }
     }
 
+    /// <summary>Closes an open pull request via PATCH /repos/{owner}/{repo}/pulls/{pull_number}. Throws on non-success.</summary>
+    public async Task ClosePullRequestAsync(
+        Connector connector,
+        string owner,
+        string repo,
+        int pullNumber,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(owner))
+            throw new ArgumentException("Owner is required.", nameof(owner));
+        if (string.IsNullOrWhiteSpace(repo))
+            throw new ArgumentException("Repository is required.", nameof(repo));
+        if (pullNumber <= 0)
+            throw new ArgumentOutOfRangeException(nameof(pullNumber));
+
+        EnsureConnectorConfigured(connector);
+
+        var requestUri = $"repos/{owner}/{repo}/pulls/{pullNumber}";
+        var payload = "{\"state\":\"closed\"}";
+        await PatchAsync(connector, requestUri, payload, cancellationToken);
+    }
+
     /// <summary>Creates a pull request via POST /repos/{owner}/{repo}/pulls. Throws on non-success.</summary>
     public async Task<GitHubPullRequestDto> CreatePullRequestAsync(
         Connector connector,
@@ -766,6 +788,41 @@ public class GitHubService : IConnectorService
             throw new InvalidOperationException("Connector token is not configured.");
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
         return request;
+    }
+
+    private async Task PatchAsync(Connector connector, string requestUri, string? payload = null, CancellationToken cancellationToken = default)
+    {
+        var baseUrl = string.IsNullOrWhiteSpace(connector.ApiBaseUrl)
+            ? "https://api.github.com/"
+            : connector.ApiBaseUrl.TrimEnd('/') + "/";
+
+        using var response = await GitHubMutationRetryPipeline.ExecuteAsync(async ct =>
+        {
+            var request = new HttpRequestMessage(HttpMethod.Patch, new Uri(new Uri(baseUrl), requestUri));
+            if (payload != null)
+                request.Content = new StringContent(payload, Encoding.UTF8, "application/json");
+            else
+                request.Content = new StringContent("{}", Encoding.UTF8, "application/json");
+            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.github+json"));
+            request.Headers.UserAgent.ParseAdd("GrayMoon");
+            request.Headers.Add("X-GitHub-Api-Version", "2022-11-28");
+            var token = ConnectorHelpers.UnprotectToken(connector.UserToken);
+            if (string.IsNullOrWhiteSpace(token))
+                throw new InvalidOperationException("Connector token is not configured.");
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            return await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, ct);
+        }, cancellationToken);
+
+        if (response.IsSuccessStatusCode)
+            return;
+
+        var errorContent = await response.Content.ReadAsStringAsync(cancellationToken);
+        _logger.LogError("GitHub API PATCH failed. Status: {StatusCode}, URL: {Url}, Response: {Response}",
+            response.StatusCode,
+            new Uri(new Uri(baseUrl), requestUri),
+            errorContent);
+
+        throw GitHubApiErrorHelper.CreateHttpRequestException(response.StatusCode, errorContent, response);
     }
 
     private async Task PostAsync(Connector connector, string requestUri, string? payload = null, CancellationToken cancellationToken = default)

--- a/src/GrayMoon.App/Services/WorkspaceGitService.cs
+++ b/src/GrayMoon.App/Services/WorkspaceGitService.cs
@@ -920,7 +920,14 @@ public class WorkspaceGitService(
             await _dbContext.SaveChangesAsync(cancellationToken);
         }
 
-        // Recompute dependency and file-version stats now that GitVersion is fresh, then broadcast.
+        // Persist fresh csproj data from the default branch so dependency stats reflect the new branch content.
+        var projectsDetail = GetProjectsDetail(syncResponse?.Projects);
+        if (projectsDetail is { Count: > 0 })
+            await _workspaceProjectRepository.MergeWorkspaceProjectsAsync(workspaceId, repositoryId, projectsDetail, cancellationToken);
+        await _workspaceProjectRepository.MergeWorkspaceProjectDependenciesAsync(
+            workspaceId, [(repositoryId, projectsDetail)], persistDependencyLevel: false, cancellationToken);
+
+        // Recompute dependency and file-version stats now that GitVersion and ProjectDependencies are fresh, then broadcast.
         await RecomputeAndBroadcastWorkspaceSyncedAsync(workspaceId, cancellationToken);
 
         return (true, null);
@@ -1150,7 +1157,11 @@ public class WorkspaceGitService(
     private static IReadOnlyList<SyncProjectInfo>? GetProjectsDetail(object data)
     {
         var r = AgentResponseJson.DeserializeAgentResponse<AgentSyncProjectsResponse>(data);
-        var projects = r?.Projects;
+        return GetProjectsDetail(r?.Projects);
+    }
+
+    private static IReadOnlyList<SyncProjectInfo>? GetProjectsDetail(List<AgentProjectDto>? projects)
+    {
         if (projects == null || projects.Count == 0) return null;
         var list = new List<SyncProjectInfo>();
         foreach (var p in projects)

--- a/src/GrayMoon.App/Services/WorkspaceGitService.cs
+++ b/src/GrayMoon.App/Services/WorkspaceGitService.cs
@@ -905,8 +905,8 @@ public class WorkspaceGitService(
             }
         }
 
-        // Persist BranchName and commit counts from the agent response so the UI is up to date
-        // immediately without waiting for the async post-merge hook (which only fires when pull merges).
+        // Persist BranchName, commit counts, and GitVersion from the agent response so the UI is up
+        // to date immediately without waiting for the async post-merge hook.
         if (syncResponse != null)
         {
             wr.BranchName = syncResponse.CurrentBranch ?? syncResponse.DefaultBranch;
@@ -916,11 +916,12 @@ public class WorkspaceGitService(
             if (syncResponse.HasUpstream.HasValue) wr.BranchHasUpstream = syncResponse.HasUpstream.Value;
             if (syncResponse.DefaultBranchBehind.HasValue) wr.DefaultBranchBehindCommits = syncResponse.DefaultBranchBehind;
             if (syncResponse.DefaultBranchAhead.HasValue) wr.DefaultBranchAheadCommits = syncResponse.DefaultBranchAhead;
+            if (!string.IsNullOrWhiteSpace(syncResponse.GitVersion)) wr.GitVersion = syncResponse.GitVersion;
             await _dbContext.SaveChangesAsync(cancellationToken);
         }
 
-        if (_hubContext != null)
-            await _hubContext.Clients.All.SendAsync("WorkspaceSynced", workspaceId, cancellationToken);
+        // Recompute dependency and file-version stats now that GitVersion is fresh, then broadcast.
+        await RecomputeAndBroadcastWorkspaceSyncedAsync(workspaceId, cancellationToken);
 
         return (true, null);
     }

--- a/src/GrayMoon.App/Services/WorkspacePullRequestService.cs
+++ b/src/GrayMoon.App/Services/WorkspacePullRequestService.cs
@@ -77,6 +77,23 @@ public sealed class WorkspacePullRequestService(
         logger.LogTrace("Refreshed PR for {Count} repo(s) in workspace {WorkspaceId}", toRefresh.Count, workspaceId);
     }
 
+    /// <summary>Closes an open pull request for the given repository. Looks up the connector from the workspace link and calls GitHub API. Logs and returns silently on error.</summary>
+    public async Task ClosePullRequestAsync(int workspaceId, int repositoryId, int prNumber, CancellationToken cancellationToken = default)
+    {
+        if (prNumber <= 0) return;
+
+        var link = await dbContext.WorkspaceRepositories
+            .AsNoTracking()
+            .Include(wr => wr.Repository)
+            .ThenInclude(r => r!.Connector)
+            .FirstOrDefaultAsync(wr => wr.WorkspaceId == workspaceId && wr.RepositoryId == repositoryId, cancellationToken);
+
+        if (link?.Repository == null)
+            return;
+
+        await gitHubPullRequestService.ClosePullRequestAsync(link.Repository, link.Repository.Connector, prNumber, cancellationToken);
+    }
+
     /// <summary>Refreshes PR for all repositories in the workspace.</summary>
     public async Task RefreshPullRequestsForWorkspaceAsync(int workspaceId, CancellationToken cancellationToken = default)
     {


### PR DESCRIPTION
## Summary

- Add a "Sync To Default" action to the workspace branch header menu that syncs all (or a filtered subset of) repositories to their default branch in parallel
- Extend the options modal with open-PR and uncommitted-commits warnings per repo, a danger-styled proceed button, and a dedicated scrollable CSS layout
- Fix dependency badges not clearing after single-repo Sync to Default by scanning csproj files in the agent command and persisting fresh ProjectDependencies before the recompute step
- Add `ClosePullRequestAsync` to `GitHubPullRequestService` / `GitHubService` and `WorkspacePullRequestService` so open PRs can be closed automatically before branch deletion during bulk sync

## Test plan

- [ ] Trigger "Sync To Default" from the branch header menu with multiple repos on feature branches and confirm all switch to default and badges resolve
- [ ] Verify the options modal shows "PR open - will be closed" and "N commits will be lost" warnings for affected repos
- [ ] Confirm a single-repo Sync to Default clears dependency badges without requiring a separate full sync
- [ ] Confirm open PRs are closed on GitHub when the remote branch is deleted during sync