### PR TITLE
Add safety countdown and PR state badges to Sync to Default dialog

### DIFF
--- a/src/GrayMoon.App/Components/Modals/SyncToDefaultOptionsModal.razor
+++ b/src/GrayMoon.App/Components/Modals/SyncToDefaultOptionsModal.razor
@@ -1,9 +1,5 @@
 @using Microsoft.AspNetCore.Components.Web
 
-@{
-    var anyCommitsWillBeLost = RepoItems.Any(r => r.CommitsAhead > 0 && r.PrState is not "merged" and not "closed");
-}
-
 @if (IsVisible)
 {
     <div class="modal show d-block" tabindex="-1" style="background-color: rgba(0,0,0,0.5);"
@@ -13,11 +9,11 @@
             <div class="modal-content">
                 <div class="modal-header">
                     <h5 class="modal-title">Sync to Default</h5>
-                    <button type="button" class="btn-close" aria-label="Close" @onclick="OnCancel"></button>
+                    <button type="button" class="btn-close" aria-label="Close" @onclick="HandleCancelClick"></button>
                 </div>
                 <div class="modal-body">
                     <p class="mb-2 small">@Message</p>
-                    @if (anyCommitsWillBeLost)
+                    @if (AnyCommitsWillBeLost)
                     {
                         <div class="alert alert-danger py-2 px-3 mb-3 small" role="alert">
                             <i class="bi bi-exclamation-triangle-fill me-1"></i>
@@ -79,8 +75,22 @@
                     </div>
                 </div>
                 <div class="modal-footer">
-                    <button type="button" class="btn @(anyCommitsWillBeLost ? "btn-danger" : "btn-primary")" @onclick="OnProceed">Proceed</button>
-                    <button type="button" class="btn btn-outline-secondary" @onclick="OnCancel">Cancel</button>
+                    <button type="button"
+                            class="btn @(AnyCommitsWillBeLost ? "btn-danger" : "btn-primary")"
+                            disabled="@_isCountingDown"
+                            @onclick="HandleProceedClick">
+                        @if (_isCountingDown)
+                        {
+                            @($"Syncing in {_countdownSecondsLeft}...")
+                        }
+                        else
+                        {
+                            @("Proceed")
+                        }
+                    </button>
+                    <button type="button"
+                            class="btn @(_isCountingDown ? "btn-warning text-dark" : "btn-outline-secondary")"
+                            @onclick="HandleCancelClick">Cancel</button>
                 </div>
             </div>
         </div>
@@ -99,11 +109,71 @@
     [Parameter] public EventCallback OnCancel { get; set; }
 
     private ElementReference _modalElement;
+    private int _countdownSecondsLeft;
+    private CancellationTokenSource? _countdownCts;
+    private bool _isCountingDown => _countdownSecondsLeft > 0;
+
+    private bool AnyCommitsWillBeLost =>
+        RepoItems.Any(r => r.CommitsAhead > 0 && r.PrState is not "merged" and not "closed");
+
+    protected override void OnParametersSet()
+    {
+        if (!IsVisible)
+            CancelCountdown();
+    }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        if (IsVisible)
+        if (IsVisible && !_isCountingDown)
             await _modalElement.FocusAsync();
+    }
+
+    private async Task HandleProceedClick()
+    {
+        if (!AnyCommitsWillBeLost)
+        {
+            await OnProceed.InvokeAsync();
+            return;
+        }
+
+        if (_isCountingDown)
+            return;
+
+        _countdownCts?.Dispose();
+        _countdownCts = new CancellationTokenSource();
+        var ct = _countdownCts.Token;
+        _countdownSecondsLeft = 5;
+        StateHasChanged();
+
+        try
+        {
+            while (_countdownSecondsLeft > 0)
+            {
+                await Task.Delay(1000, ct);
+                _countdownSecondsLeft--;
+                StateHasChanged();
+            }
+            await OnProceed.InvokeAsync();
+        }
+        catch (OperationCanceledException)
+        {
+            _countdownSecondsLeft = 0;
+            StateHasChanged();
+        }
+    }
+
+    private async Task HandleCancelClick()
+    {
+        CancelCountdown();
+        await OnCancel.InvokeAsync();
+    }
+
+    private void CancelCountdown()
+    {
+        _countdownCts?.Cancel();
+        _countdownCts?.Dispose();
+        _countdownCts = null;
+        _countdownSecondsLeft = 0;
     }
 
     private async Task OnDeleteRemoteChanged(ChangeEventArgs e)
@@ -121,8 +191,8 @@
     private async Task HandleKeyDown(KeyboardEventArgs e)
     {
         if (e.Key == "Escape")
-            await OnCancel.InvokeAsync();
-        else if (e.Key == "Enter")
-            await OnProceed.InvokeAsync();
+            await HandleCancelClick();
+        else if (e.Key == "Enter" && !_isCountingDown)
+            await HandleProceedClick();
     }
 }

--- a/src/GrayMoon.App/Components/Modals/SyncToDefaultOptionsModal.razor
+++ b/src/GrayMoon.App/Components/Modals/SyncToDefaultOptionsModal.razor
@@ -1,5 +1,9 @@
 @using Microsoft.AspNetCore.Components.Web
 
+@{
+    var anyCommitsWillBeLost = RepoItems.Any(r => r.CommitsAhead > 0 && r.PrState is not "merged" and not "closed");
+}
+
 @if (IsVisible)
 {
     <div class="modal show d-block" tabindex="-1" style="background-color: rgba(0,0,0,0.5);"
@@ -13,7 +17,7 @@
                 </div>
                 <div class="modal-body">
                     <p class="mb-2 small">@Message</p>
-                    @if (RepoItems.Any(r => r.CommitsAhead > 0))
+                    @if (anyCommitsWillBeLost)
                     {
                         <div class="alert alert-danger py-2 px-3 mb-3 small" role="alert">
                             <i class="bi bi-exclamation-triangle-fill me-1"></i>
@@ -31,13 +35,21 @@
                                         <span class="text-muted ms-2">@item.BranchName</span>
                                         @if (item.HasRemote)
                                         {
-                                            <span class="badge bg-secondary ms-1" style="font-size:0.65em;">remote</span>
+                                            <span class="badge bg-secondary ms-1 sync-default-pr-badge">remote</span>
                                         }
-                                        @if (item.HasOpenPr)
+                                        @if (item.PrState == "open")
                                         {
-                                            <span class="badge bg-warning text-dark ms-1" style="font-size:0.65em;">PR open - will be closed</span>
+                                            <span class="badge bg-warning text-dark ms-1 sync-default-pr-badge">PR open</span>
                                         }
-                                        @if (item.CommitsAhead > 0)
+                                        else if (item.PrState == "merged")
+                                        {
+                                            <span class="badge ms-1 sync-default-pr-badge" style="background-color:#8957e5;color:#fff;">merged</span>
+                                        }
+                                        else if (item.PrState == "closed")
+                                        {
+                                            <span class="badge bg-secondary ms-1 sync-default-pr-badge">PR closed</span>
+                                        }
+                                        @if (item.CommitsAhead > 0 && item.PrState is not "merged" and not "closed")
                                         {
                                             <span class="text-danger ms-2" style="font-size:0.85em;">@item.CommitsAhead commit@(item.CommitsAhead == 1 ? "" : "s") will be lost</span>
                                         }
@@ -67,7 +79,7 @@
                     </div>
                 </div>
                 <div class="modal-footer">
-                    <button type="button" class="btn btn-danger" @onclick="OnProceed">Proceed</button>
+                    <button type="button" class="btn @(anyCommitsWillBeLost ? "btn-danger" : "btn-primary")" @onclick="OnProceed">Proceed</button>
                     <button type="button" class="btn btn-outline-secondary" @onclick="OnCancel">Cancel</button>
                 </div>
             </div>
@@ -78,7 +90,7 @@
 @code {
     [Parameter] public bool IsVisible { get; set; }
     [Parameter] public string Message { get; set; } = "";
-    [Parameter] public IReadOnlyList<(string RepoName, string BranchName, bool HasRemote, bool HasOpenPr, int CommitsAhead)> RepoItems { get; set; } = Array.Empty<(string, string, bool, bool, int)>();
+    [Parameter] public IReadOnlyList<(string RepoName, string BranchName, bool HasRemote, string? PrState, int CommitsAhead)> RepoItems { get; set; } = Array.Empty<(string, string, bool, string?, int)>();
     [Parameter] public bool DeleteRemoteBranches { get; set; } = true;
     [Parameter] public EventCallback<bool> DeleteRemoteBranchesChanged { get; set; }
     [Parameter] public bool AllowForceDeleteLocalBranch { get; set; } = true;

--- a/src/GrayMoon.App/Components/Modals/SyncToDefaultOptionsModal.razor.css
+++ b/src/GrayMoon.App/Components/Modals/SyncToDefaultOptionsModal.razor.css
@@ -37,3 +37,8 @@
 .sync-to-default-options-scroll::-webkit-scrollbar-thumb:hover {
     background: #5a6268;
 }
+
+.sync-default-pr-badge {
+    font-size: 0.65em;
+    vertical-align: middle;
+}

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
@@ -607,7 +607,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
             await action();
     }
 
-    private void ShowSyncToDefaultOptions(string message, IReadOnlyList<(string RepoName, string BranchName, bool HasRemote, bool HasOpenPr, int CommitsAhead)> repoItems, Func<bool, bool, Task> onProceed, bool defaultDeleteRemote = true)
+    private void ShowSyncToDefaultOptions(string message, IReadOnlyList<(string RepoName, string BranchName, bool HasRemote, string? PrState, int CommitsAhead)> repoItems, Func<bool, bool, Task> onProceed, bool defaultDeleteRemote = true)
     {
         _syncToDefaultOptionsModal = _syncToDefaultOptionsModal with
         {
@@ -1022,7 +1022,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
                             .Select(r =>
                             {
                                 var wr2 = workspaceRepositories.FirstOrDefault(w => w.RepositoryId == r.RepoId);
-                                return (RepoName: wr2?.Repository?.RepositoryName ?? r.RepoId.ToString(), BranchName: wr2?.BranchName ?? "", HasRemote: r.HasUpstream == true, HasOpenPr: false, CommitsAhead: 0);
+                                return (RepoName: wr2?.Repository?.RepositoryName ?? r.RepoId.ToString(), BranchName: wr2?.BranchName ?? "", HasRemote: r.HasUpstream == true, PrState: (string?)null, CommitsAhead: 0);
                             })
                             .ToList() ?? new();
                         ShowSyncToDefaultOptions(dialogMessage, repoItems, (deleteRemote, allowForce) => SyncToDefaultLevelAsync(safeRepoIds, deleteRemote, allowForce));
@@ -2932,9 +2932,11 @@ public sealed partial class WorkspaceRepositories : IDisposable
             if (hasUpstream)
             {
                 var branchName = wr?.BranchName ?? currentBranchName;
+                prByRepositoryId.TryGetValue(repositoryId, out var singlePr);
+                var singlePrState = singlePr == null ? null : singlePr.IsMerged ? "merged" : singlePr.IsClosed ? "closed" : "open";
                 ShowSyncToDefaultOptions(
                     "This will checkout the default branch, remove the current branch locally, and pull the latest.",
-                    [(repositoryName!, branchName, true, false, 0)],
+                    [(repositoryName!, branchName, true, singlePrState, defaultAhead)],
                     (deleteRemote, allowForce) => SyncToDefaultSingleRepoAfterCheckAsync(repositoryId, repositoryName, currentBranchName, deleteRemote, defaultBranch, allowForce));
             }
             else
@@ -3117,18 +3119,6 @@ public sealed partial class WorkspaceRepositories : IDisposable
 
         var eligibleIds = eligibleRepos.Select(wr => wr.RepositoryId).ToList();
 
-        try
-        {
-            await WorkspacePageService.WorkspacePullRequestService.RefreshPullRequestsAsync(WorkspaceId, eligibleIds, force: true);
-            await ReloadWorkspaceDataFromFreshScopeAsync();
-            ApplySyncStateFromWorkspace();
-            await InvokeAsync(StateHasChanged);
-        }
-        catch (Exception ex)
-        {
-            Logger.LogDebug(ex, "PR refresh before sync-all-to-default failed for workspace {WorkspaceId}", WorkspaceId);
-        }
-
         var totalCount = eligibleIds.Count;
         var dialogMessage = totalCount == 1
             ? "This will checkout the default branch, remove the current branch locally, and pull the latest. Uncommitted local changes can block checkout."
@@ -3140,6 +3130,17 @@ public sealed partial class WorkspaceRepositories : IDisposable
             {
                 try
                 {
+                    try
+                    {
+                        await using var prScope = ServiceScopeFactory.CreateAsyncScope();
+                        var prService = prScope.ServiceProvider.GetRequiredService<WorkspacePullRequestService>();
+                        await prService.RefreshPullRequestsAsync(WorkspaceId, eligibleIds, force: true, ct);
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.LogDebug(ex, "PR refresh before sync-all-to-default failed for workspace {WorkspaceId}", WorkspaceId);
+                    }
+
                     var fetchDone = 0;
                     using var fetchSemaphore = new SemaphoreSlim(8);
                     await Task.WhenAll(eligibleIds.Select(async repoId =>
@@ -3169,13 +3170,13 @@ public sealed partial class WorkspaceRepositories : IDisposable
                             {
                                 var wr2 = workspaceRepositories.FirstOrDefault(w => w.RepositoryId == repoId);
                                 prByRepositoryId.TryGetValue(repoId, out var pr);
-                                var hasOpenPr = pr != null && string.Equals(pr.State, "open", StringComparison.OrdinalIgnoreCase);
+                                var prState = pr == null ? null : pr.IsMerged ? "merged" : pr.IsClosed ? "closed" : "open";
                                 var commitsAhead = wr2?.DefaultBranchAheadCommits ?? 0;
                                 return (
                                     RepoName: wr2?.Repository?.RepositoryName ?? repoId.ToString(),
                                     BranchName: wr2?.BranchName ?? "",
                                     HasRemote: wr2?.BranchHasUpstream == true,
-                                    HasOpenPr: hasOpenPr,
+                                    PrState: prState,
                                     CommitsAhead: commitsAhead
                                 );
                             })
@@ -3200,7 +3201,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
     }
 
     private Task ExecuteSyncAllToDefaultAsync(
-        IReadOnlyList<(string RepoName, string BranchName, bool HasRemote, bool HasOpenPr, int CommitsAhead)> repoItems,
+        IReadOnlyList<(string RepoName, string BranchName, bool HasRemote, string? PrState, int CommitsAhead)> repoItems,
         bool deleteRemoteBranch)
     {
         if (workspace == null || repoItems.Count == 0 || IsJobRunning)
@@ -3210,7 +3211,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
             wr => wr.Repository?.RepositoryName ?? string.Empty,
             wr => wr.RepositoryId);
         var prNumberByRepoName = new Dictionary<string, int>();
-        foreach (var item in repoItems.Where(r => r.HasOpenPr))
+        foreach (var item in repoItems.Where(r => r.PrState == "open"))
         {
             if (!repoIdByName.TryGetValue(item.RepoName, out var repoId)) continue;
             if (prByRepositoryId.TryGetValue(repoId, out var pr) && pr != null && pr.Number > 0)
@@ -3248,7 +3249,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
                     await semaphore.WaitAsync(ct);
                     try
                     {
-                        if (item.HasOpenPr && prNumberByRepoName.TryGetValue(item.RepoName, out var prNumber))
+                        if (item.PrState == "open" && prNumberByRepoName.TryGetValue(item.RepoName, out var prNumber))
                         {
                             try
                             {
@@ -3832,7 +3833,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
     {
         public bool IsVisible { get; init; }
         public string Message { get; init; } = "";
-        public IReadOnlyList<(string RepoName, string BranchName, bool HasRemote, bool HasOpenPr, int CommitsAhead)> RepoItems { get; init; } = Array.Empty<(string, string, bool, bool, int)>();
+        public IReadOnlyList<(string RepoName, string BranchName, bool HasRemote, string? PrState, int CommitsAhead)> RepoItems { get; init; } = Array.Empty<(string, string, bool, string?, int)>();
         public bool DeleteRemoteBranches { get; init; } = true;
         public bool AllowForceDeleteLocalBranch { get; init; } = true;
         public Func<bool, bool, Task>? PendingAction { get; init; }


### PR DESCRIPTION
## Summary

- Add a 5-second countdown on the Proceed button when commits would be lost: button shows "Syncing in 5..." and is disabled while the Cancel button turns yellow, giving users a window to abort
- Replace the boolean open-PR flag with a typed PR state string and show per-repo badges (yellow "PR open", purple "merged", gray "PR closed") with correct vertical alignment
- Suppress the danger alert, "commits will be lost" text, and red button when all PRs are merged or closed; Proceed is only red when data loss is genuinely possible
- Move PR status fetch inside the background job so the loading overlay appears immediately on click

## Test plan

- [ ] Trigger Sync to Default for a repo with unmerged commits and confirm the 5-second countdown runs, Cancel turns yellow, and clicking Cancel aborts without syncing
- [ ] Let the countdown complete and confirm sync proceeds normally
- [ ] Verify the danger alert and red button do not appear when all repos have merged or closed PRs
- [ ] Confirm badge colors match the PR state for open, merged, and closed PRs in the repo list