### PR TITLE
Upgrade GrayMoon.App and shared libraries to .NET 10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN dotnet publish "src/GrayMoon.Agent/GrayMoon.Agent.csproj" -c Release -r win-
 RUN cd /agent/publish-linux && zip -q -r /agent/graymoon-agent-linux.zip .
 RUN cd /agent/publish-win && zip -q -r /agent/graymoon-agent-windows.zip .
 
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build-app
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build-app
 WORKDIR /src
 
 ARG VERSION=1.0.0
@@ -23,7 +23,7 @@ RUN dotnet publish "src/GrayMoon.App/GrayMoon.App.csproj" -c Release -o /app/pub
   /p:UseAppHost=false \
   /p:Version=$VERSION /p:DisableGitVersionTask=true
 
-FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS runtime
 WORKDIR /app
 
 COPY --from=build-app /app/publish .

--- a/src/GrayMoon.Abstractions/GrayMoon.Abstractions.csproj
+++ b/src/GrayMoon.Abstractions/GrayMoon.Abstractions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>GrayMoon.Abstractions</RootNamespace>

--- a/src/GrayMoon.App/GrayMoon.App.csproj
+++ b/src/GrayMoon.App/GrayMoon.App.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>eec7d83f-6fc3-4f9d-93d7-29fd32d2f6dc</UserSecretsId>
@@ -24,13 +24,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.11" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.*" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.12.*">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.21" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.21" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.*" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.*" />
     <PackageReference Include="Polly" Version="8.4.2" />
     <PackageReference Include="Serilog.AspNetCore" Version="8.0.2" />
   </ItemGroup>

--- a/src/GrayMoon.Common.Tests/GrayMoon.Common.Tests.csproj
+++ b/src/GrayMoon.Common.Tests/GrayMoon.Common.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/src/GrayMoon.Common/GrayMoon.Common.csproj
+++ b/src/GrayMoon.Common/GrayMoon.Common.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>GrayMoon.Common</RootNamespace>
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\GrayMoon.Abstractions\GrayMoon.Abstractions.csproj" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.*" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

- Bump `GrayMoon.Abstractions`, `GrayMoon.Common`, `GrayMoon.Common.Tests`, and `GrayMoon.App` from `net8.0` to `net10.0`
- Update App and Common Microsoft package references (SignalR client, EF Core, logging abstractions) to `10.0.*`
- Switch Docker build and runtime images from .NET 8 to .NET 10 SDK and ASP.NET images
- Some changes are uncommitted only - commit and push before opening the PR

## Test plan

- [ ] Run `dotnet build GrayMoon.sln` and confirm all projects compile on .NET 10
- [ ] Run `dotnet test src/GrayMoon.Common.Tests/GrayMoon.Common.Tests.csproj`
- [ ] Run the App locally and smoke-test core pages (workspaces, repositories, settings)
- [ ] Build the Docker image and confirm the container starts and serves the UI