### PR TITLE
Add server-driven list queries with infinite and virtual scroll

### DIFF
--- a/GrayMoon.sln
+++ b/GrayMoon.sln
@@ -15,6 +15,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GrayMoon.Common", "src\Gray
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GrayMoon.Common.Tests", "src\GrayMoon.Common.Tests\GrayMoon.Common.Tests.csproj", "{D4E5F6A7-B8C9-0123-DEF0-234567890123}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GrayMoon.App.Tests", "src\GrayMoon.App.Tests\GrayMoon.App.Tests.csproj", "{523046F8-9FC8-48AD-B903-DB3154CDF619}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -85,6 +87,18 @@ Global
 		{D4E5F6A7-B8C9-0123-DEF0-234567890123}.Release|x64.Build.0 = Release|Any CPU
 		{D4E5F6A7-B8C9-0123-DEF0-234567890123}.Release|x86.ActiveCfg = Release|Any CPU
 		{D4E5F6A7-B8C9-0123-DEF0-234567890123}.Release|x86.Build.0 = Release|Any CPU
+		{523046F8-9FC8-48AD-B903-DB3154CDF619}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{523046F8-9FC8-48AD-B903-DB3154CDF619}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{523046F8-9FC8-48AD-B903-DB3154CDF619}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{523046F8-9FC8-48AD-B903-DB3154CDF619}.Debug|x64.Build.0 = Debug|Any CPU
+		{523046F8-9FC8-48AD-B903-DB3154CDF619}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{523046F8-9FC8-48AD-B903-DB3154CDF619}.Debug|x86.Build.0 = Debug|Any CPU
+		{523046F8-9FC8-48AD-B903-DB3154CDF619}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{523046F8-9FC8-48AD-B903-DB3154CDF619}.Release|Any CPU.Build.0 = Release|Any CPU
+		{523046F8-9FC8-48AD-B903-DB3154CDF619}.Release|x64.ActiveCfg = Release|Any CPU
+		{523046F8-9FC8-48AD-B903-DB3154CDF619}.Release|x64.Build.0 = Release|Any CPU
+		{523046F8-9FC8-48AD-B903-DB3154CDF619}.Release|x86.ActiveCfg = Release|Any CPU
+		{523046F8-9FC8-48AD-B903-DB3154CDF619}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -95,6 +109,7 @@ Global
 		{B2C3D4E5-F6A7-8901-BCDE-F12345678901} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{C3D4E5F6-A7B8-9012-CDEF-123456789012} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{D4E5F6A7-B8C9-0123-DEF0-234567890123} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{523046F8-9FC8-48AD-B903-DB3154CDF619} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7EF19D89-3A25-48BC-B883-340C882F21EF}

--- a/src/GrayMoon.App.Tests/DebouncedQueryLoaderTests.cs
+++ b/src/GrayMoon.App.Tests/DebouncedQueryLoaderTests.cs
@@ -1,0 +1,28 @@
+using GrayMoon.App.Components.Shared;
+
+namespace GrayMoon.App.Tests;
+
+public class DebouncedQueryLoaderTests
+{
+    [Fact]
+    public async Task BeginQueryCycle_increments_generation()
+    {
+        using var loader = new DebouncedQueryLoader();
+        loader.BeginQueryCycle(out var gen1);
+        loader.BeginQueryCycle(out var gen2);
+        Assert.Equal(1, gen1);
+        Assert.Equal(2, gen2);
+    }
+
+    [Fact]
+    public async Task DebounceSearchAsync_cancels_prior_delay()
+    {
+        using var loader = new DebouncedQueryLoader();
+        var runs = 0;
+        var first = loader.DebounceSearchAsync(async () => { runs++; await Task.CompletedTask; }, 200);
+        await Task.Delay(50);
+        var second = loader.DebounceSearchAsync(async () => { runs++; await Task.CompletedTask; }, 200);
+        await Task.WhenAll(first, second);
+        Assert.Equal(1, runs);
+    }
+}

--- a/src/GrayMoon.App.Tests/GrayMoon.App.Tests.csproj
+++ b/src/GrayMoon.App.Tests/GrayMoon.App.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.*" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\GrayMoon.App\GrayMoon.App.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/GrayMoon.App.Tests/ListQueryTestContext.cs
+++ b/src/GrayMoon.App.Tests/ListQueryTestContext.cs
@@ -1,0 +1,90 @@
+using GrayMoon.App.Data;
+using GrayMoon.App.Models;
+using GrayMoon.App.Services.Queries;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+
+namespace GrayMoon.App.Tests;
+
+public sealed class ListQueryTestContext : IAsyncDisposable
+{
+    private readonly SqliteConnection _connection;
+
+    public AppDbContext DbContext { get; }
+    public RepositoryListQueryService RepositoryQuery { get; }
+    public WorkspaceProjectListQueryService ProjectQuery { get; }
+
+    private ListQueryTestContext(SqliteConnection connection, AppDbContext dbContext)
+    {
+        _connection = connection;
+        DbContext = dbContext;
+        RepositoryQuery = new RepositoryListQueryService(dbContext);
+        ProjectQuery = new WorkspaceProjectListQueryService(dbContext);
+    }
+
+    public static async Task<ListQueryTestContext> CreateAsync(int repositoryCount = 120)
+    {
+        var connection = new SqliteConnection("Data Source=:memory:");
+        await connection.OpenAsync();
+
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseSqlite(connection)
+            .Options;
+
+        var dbContext = new AppDbContext(options);
+        await dbContext.Database.EnsureCreatedAsync();
+
+        var connector = new Connector
+        {
+            ConnectorName = "github-prod",
+            ConnectorType = ConnectorType.GitHub,
+            ApiBaseUrl = "https://api.github.com",
+            IsActive = true,
+        };
+        dbContext.Connectors.Add(connector);
+        await dbContext.SaveChangesAsync();
+
+        for (var i = 1; i <= repositoryCount; i++)
+        {
+            var suffix = i.ToString("D4");
+            dbContext.Repositories.Add(new Repository
+            {
+                ConnectorId = connector.ConnectorId,
+                RepositoryName = i % 2 == 0 ? "graymoon-api" : $"repo-{suffix}",
+                OrgName = i % 3 == 0 ? "acme" : "other",
+                Visibility = "Public",
+                CloneUrl = $"https://github.com/acme/repo-{suffix}.git",
+                Topics = i % 5 == 0 ? "blazor,angular" : null,
+            });
+        }
+
+        await dbContext.SaveChangesAsync();
+
+        var workspace = new Workspace { Name = "test-ws" };
+        dbContext.Workspaces.Add(workspace);
+        await dbContext.SaveChangesAsync();
+
+        var repos = await dbContext.Repositories.OrderBy(r => r.RepositoryName).ThenBy(r => r.RepositoryId).Take(10).ToListAsync();
+        foreach (var repo in repos)
+        {
+            dbContext.WorkspaceProjects.Add(new WorkspaceProject
+            {
+                WorkspaceId = workspace.WorkspaceId,
+                RepositoryId = repo.RepositoryId,
+                ProjectName = $"Project-{repo.RepositoryName}",
+                ProjectType = ProjectType.Service,
+                ProjectFilePath = $"src/{repo.RepositoryName}/{repo.RepositoryName}.csproj",
+                TargetFramework = "net10.0",
+            });
+        }
+
+        await dbContext.SaveChangesAsync();
+        return new ListQueryTestContext(connection, dbContext);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await DbContext.DisposeAsync();
+        await _connection.DisposeAsync();
+    }
+}

--- a/src/GrayMoon.App.Tests/ListQueryTestContext.cs
+++ b/src/GrayMoon.App.Tests/ListQueryTestContext.cs
@@ -13,6 +13,7 @@ public sealed class ListQueryTestContext : IAsyncDisposable
     public AppDbContext DbContext { get; }
     public RepositoryListQueryService RepositoryQuery { get; }
     public WorkspaceProjectListQueryService ProjectQuery { get; }
+    public WorkspaceRepositoryLinkListQueryService WorkspaceRepoLinkQuery { get; }
 
     private ListQueryTestContext(SqliteConnection connection, AppDbContext dbContext)
     {
@@ -20,6 +21,7 @@ public sealed class ListQueryTestContext : IAsyncDisposable
         DbContext = dbContext;
         RepositoryQuery = new RepositoryListQueryService(dbContext);
         ProjectQuery = new WorkspaceProjectListQueryService(dbContext);
+        WorkspaceRepoLinkQuery = new WorkspaceRepositoryLinkListQueryService(dbContext);
     }
 
     public static async Task<ListQueryTestContext> CreateAsync(int repositoryCount = 120)
@@ -79,7 +81,38 @@ public sealed class ListQueryTestContext : IAsyncDisposable
         }
 
         await dbContext.SaveChangesAsync();
+
+        var allRepos = await dbContext.Repositories.OrderBy(r => r.RepositoryId).ToListAsync();
+        for (var i = 0; i < allRepos.Count; i++)
+        {
+            var repo = allRepos[i];
+            dbContext.WorkspaceRepositories.Add(new WorkspaceRepositoryLink
+            {
+                WorkspaceId = workspace.WorkspaceId,
+                RepositoryId = repo.RepositoryId,
+                GitVersion = $"1.0.{i}",
+                BranchName = i % 4 == 0 ? "main" : $"feature-{i % 10}",
+                DefaultBranchName = "main",
+                DependencyLevel = i % 5,
+                Dependencies = i % 7,
+                UnmatchedDeps = i % 11 == 0 ? 1 : 0,
+                OutOfDateFileRepos = i % 13 == 0 ? 1 : 0,
+                OutgoingCommits = i % 3 == 0 ? 2 : 0,
+                IncomingCommits = i % 6 == 0 ? 1 : 0,
+                RepositoryType = i % 3 == 0 ? ProjectType.Service : ProjectType.Library,
+                SyncStatus = i % 8 == 0 ? RepoSyncStatus.NeedsSync : RepoSyncStatus.InSync,
+            });
+        }
+
+        await dbContext.SaveChangesAsync();
         return new ListQueryTestContext(connection, dbContext);
+    }
+
+    public static async Task<(ListQueryTestContext Context, int WorkspaceId)> CreateWithWorkspaceLinksAsync(int repositoryCount = 120)
+    {
+        var ctx = await CreateAsync(repositoryCount);
+        var workspaceId = ctx.DbContext.Workspaces.Select(w => w.WorkspaceId).First();
+        return (ctx, workspaceId);
     }
 
     public async ValueTask DisposeAsync()

--- a/src/GrayMoon.App.Tests/RepositoryListQueryServiceTests.cs
+++ b/src/GrayMoon.App.Tests/RepositoryListQueryServiceTests.cs
@@ -92,6 +92,17 @@ public class RepositoryListQueryServiceTests
     }
 
     [Fact]
+    public async Task GetByIds_returns_rows_in_request_order()
+    {
+        await using var ctx = await ListQueryTestContext.CreateAsync();
+        var ids = await ctx.RepositoryQuery.GetMatchingIdsAsync(new RepositoryListFilter(null, null));
+        var subset = ids.Skip(2).Take(5).Reverse().ToList();
+        var rows = await ctx.RepositoryQuery.GetByIdsAsync(subset);
+        Assert.Equal(subset, rows.Select(r => r.RepositoryId).ToList());
+        Assert.All(rows, r => Assert.False(string.IsNullOrWhiteSpace(r.RepositoryName)));
+    }
+
+    [Fact]
     public async Task Query_uses_take_in_sql()
     {
         await using var ctx = await ListQueryTestContext.CreateAsync();

--- a/src/GrayMoon.App.Tests/RepositoryListQueryServiceTests.cs
+++ b/src/GrayMoon.App.Tests/RepositoryListQueryServiceTests.cs
@@ -1,0 +1,114 @@
+using GrayMoon.App.Services.Queries;
+using Microsoft.EntityFrameworkCore;
+
+namespace GrayMoon.App.Tests;
+
+public class RepositoryListQueryServiceTests
+{
+    [Fact]
+    public async Task First_chunk_is_bounded()
+    {
+        await using var ctx = await ListQueryTestContext.CreateAsync();
+        var page = await ctx.RepositoryQuery.GetPageAsync(
+            new RepositoryListRequest(null, null, RepositorySortField.Name, false, 50, null));
+
+        Assert.Equal(50, page.Items.Count);
+        Assert.True(page.HasMore);
+        Assert.NotNull(page.NextCursor);
+    }
+
+    [Fact]
+    public async Task Second_chunk_has_no_duplicates_and_continues_order()
+    {
+        await using var ctx = await ListQueryTestContext.CreateAsync();
+        var first = await ctx.RepositoryQuery.GetPageAsync(
+            new RepositoryListRequest(null, null, RepositorySortField.Name, false, 50, null));
+        var second = await ctx.RepositoryQuery.GetPageAsync(
+            new RepositoryListRequest(null, null, RepositorySortField.Name, false, 50, first.NextCursor));
+
+        var firstIds = first.Items.Select(i => i.RepositoryId).ToHashSet();
+        Assert.All(second.Items, item => Assert.DoesNotContain(item.RepositoryId, firstIds));
+
+        var lastFirst = first.Items[^1];
+        var firstSecond = second.Items[0];
+        Assert.True(
+            string.Compare(lastFirst.RepositoryName, firstSecond.RepositoryName, StringComparison.Ordinal) < 0
+            || (lastFirst.RepositoryName == firstSecond.RepositoryName && lastFirst.RepositoryId < firstSecond.RepositoryId));
+    }
+
+    [Fact]
+    public async Task Search_is_case_insensitive_and_matches_org()
+    {
+        await using var ctx = await ListQueryTestContext.CreateAsync();
+        var filter = new RepositoryListFilter("ACME", null);
+        var count = await ctx.RepositoryQuery.CountAsync(filter);
+        var page = await ctx.RepositoryQuery.GetPageAsync(
+            new RepositoryListRequest("ACME", null, RepositorySortField.Name, false, 50, null));
+
+        Assert.True(count > 0);
+        Assert.True(page.Items.Count <= 50);
+        Assert.True(page.Items.Count <= count);
+        Assert.All(page.Items, item =>
+            Assert.True(
+                (item.OrgName ?? string.Empty).Contains("acme", StringComparison.OrdinalIgnoreCase)
+                || item.RepositoryName.Contains("acme", StringComparison.OrdinalIgnoreCase)
+                || (item.Topics ?? string.Empty).Contains("acme", StringComparison.OrdinalIgnoreCase)
+                || item.ConnectorName.Contains("acme", StringComparison.OrdinalIgnoreCase)));
+    }
+
+    [Fact]
+    public async Task Empty_search_returns_all_with_count()
+    {
+        await using var ctx = await ListQueryTestContext.CreateAsync();
+        var count = await ctx.RepositoryQuery.CountAsync(new RepositoryListFilter("   ", null));
+        Assert.Equal(120, count);
+    }
+
+    [Fact]
+    public async Task Topic_field_search()
+    {
+        await using var ctx = await ListQueryTestContext.CreateAsync();
+        var count = await ctx.RepositoryQuery.CountAsync(new RepositoryListFilter("topic:blazor", null));
+        Assert.True(count > 0);
+    }
+
+    [Fact]
+    public async Task RestrictToRepositoryIds_limits_results()
+    {
+        await using var ctx = await ListQueryTestContext.CreateAsync();
+        var ids = await ctx.RepositoryQuery.GetMatchingIdsAsync(new RepositoryListFilter(null, null));
+        var subset = ids.Take(3).ToList();
+        var count = await ctx.RepositoryQuery.CountAsync(new RepositoryListFilter(null, subset));
+        Assert.Equal(3, count);
+    }
+
+    [Fact]
+    public async Task GetMatchingIds_supports_toggle_all_semantics()
+    {
+        await using var ctx = await ListQueryTestContext.CreateAsync();
+        var ids = await ctx.RepositoryQuery.GetMatchingIdsAsync(new RepositoryListFilter("gray", null));
+        Assert.True(ids.Count > 0);
+        Assert.Equal(ids.Count, ids.Distinct().Count());
+    }
+
+    [Fact]
+    public async Task Query_uses_take_in_sql()
+    {
+        await using var ctx = await ListQueryTestContext.CreateAsync();
+        var query = ctx.DbContext.Repositories.AsNoTracking()
+            .OrderBy(r => r.RepositoryName)
+            .ThenBy(r => r.RepositoryId)
+            .Select(r => new RepositoryListItemDto(
+                r.RepositoryId,
+                r.RepositoryName,
+                r.OrgName,
+                r.Connector != null ? r.Connector.ConnectorName : "Unknown",
+                r.Visibility,
+                r.Archived,
+                r.Topics))
+            .Take(51);
+
+        var sql = query.ToQueryString();
+        Assert.Contains("LIMIT", sql, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/GrayMoon.App.Tests/WorkspaceProjectListQueryServiceTests.cs
+++ b/src/GrayMoon.App.Tests/WorkspaceProjectListQueryServiceTests.cs
@@ -1,0 +1,51 @@
+using GrayMoon.App.Services.Queries;
+
+namespace GrayMoon.App.Tests;
+
+public class WorkspaceProjectListQueryServiceTests
+{
+    [Fact]
+    public async Task First_chunk_is_bounded_for_workspace()
+    {
+        await using var ctx = await ListQueryTestContext.CreateAsync();
+        var workspaceId = ctx.DbContext.Workspaces.Select(w => w.WorkspaceId).First();
+        var page = await ctx.ProjectQuery.GetPageAsync(
+            new WorkspaceProjectListRequest(workspaceId, null, 50, null));
+
+        Assert.True(page.Items.Count <= 50);
+        Assert.All(page.Items, p => Assert.False(string.IsNullOrWhiteSpace(p.ProjectName)));
+    }
+
+    [Fact]
+    public async Task Search_filters_projects()
+    {
+        await using var ctx = await ListQueryTestContext.CreateAsync();
+        var workspaceId = ctx.DbContext.Workspaces.Select(w => w.WorkspaceId).First();
+        var count = await ctx.ProjectQuery.CountAsync(new WorkspaceProjectListFilter(workspaceId, "csproj"));
+        Assert.True(count > 0);
+
+        var page = await ctx.ProjectQuery.GetPageAsync(
+            new WorkspaceProjectListRequest(workspaceId, "csproj", 50, null));
+        Assert.True(page.Items.Count > 0);
+        Assert.All(page.Items, p =>
+            Assert.Contains("csproj", $"{p.ProjectName} {p.ProjectFilePath} {p.ProjectType} {p.TargetFramework}", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task Empty_search_returns_total_count()
+    {
+        await using var ctx = await ListQueryTestContext.CreateAsync();
+        var workspaceId = ctx.DbContext.Workspaces.Select(w => w.WorkspaceId).First();
+        var count = await ctx.ProjectQuery.CountAsync(new WorkspaceProjectListFilter(workspaceId, null));
+        Assert.Equal(10, count);
+    }
+
+    [Fact]
+    public async Task No_results_for_missing_search()
+    {
+        await using var ctx = await ListQueryTestContext.CreateAsync();
+        var workspaceId = ctx.DbContext.Workspaces.Select(w => w.WorkspaceId).First();
+        var count = await ctx.ProjectQuery.CountAsync(new WorkspaceProjectListFilter(workspaceId, "zzzz-not-found"));
+        Assert.Equal(0, count);
+    }
+}

--- a/src/GrayMoon.App.Tests/WorkspaceRepositoryLinkListQueryServiceTests.cs
+++ b/src/GrayMoon.App.Tests/WorkspaceRepositoryLinkListQueryServiceTests.cs
@@ -118,4 +118,49 @@ public class WorkspaceRepositoryLinkListQueryServiceTests
             Assert.True(count > 0);
         }
     }
+
+    [Fact]
+    public async Task GetIndex_matches_count_and_order_of_pages()
+    {
+        var (ctx, workspaceId) = await ListQueryTestContext.CreateWithWorkspaceLinksAsync(80);
+        await using (ctx)
+        {
+            var filter = new WorkspaceRepositoryLinkListFilter(workspaceId, null);
+            var index = await ctx.WorkspaceRepoLinkQuery.GetIndexAsync(filter);
+            Assert.Equal(80, index.Count);
+
+            var page = await ctx.WorkspaceRepoLinkQuery.GetPageAsync(
+                new WorkspaceRepositoryLinkListRequest(workspaceId, null, 50, null));
+            Assert.Equal(
+                page.Items.Select(i => i.WorkspaceRepositoryId),
+                index.Take(page.Items.Count).Select(i => i.WorkspaceRepositoryId));
+        }
+    }
+
+    [Fact]
+    public async Task GetByIds_returns_requested_rows_in_request_order()
+    {
+        var (ctx, workspaceId) = await ListQueryTestContext.CreateWithWorkspaceLinksAsync(40);
+        await using (ctx)
+        {
+            var index = await ctx.WorkspaceRepoLinkQuery.GetIndexAsync(new WorkspaceRepositoryLinkListFilter(workspaceId, null));
+            var ids = index.Skip(5).Take(7).Select(i => i.WorkspaceRepositoryId).Reverse().ToList();
+            var rows = await ctx.WorkspaceRepoLinkQuery.GetByIdsAsync(workspaceId, ids);
+            Assert.Equal(ids, rows.Select(r => r.WorkspaceRepositoryId).ToList());
+            Assert.All(rows, r => Assert.False(string.IsNullOrWhiteSpace(r.RepositoryName)));
+        }
+    }
+
+    [Fact]
+    public async Task Header_state_aggregates_without_loading_all_columns()
+    {
+        var (ctx, workspaceId) = await ListQueryTestContext.CreateWithWorkspaceLinksAsync(15);
+        await using (ctx)
+        {
+            var header = await ctx.WorkspaceRepoLinkQuery.GetHeaderStateAsync(workspaceId);
+            Assert.Equal(15, header.TotalCount);
+            Assert.True(header.HasUnmatchedDependencies);
+            Assert.True(header.IsPushRecommended);
+        }
+    }
 }

--- a/src/GrayMoon.App.Tests/WorkspaceRepositoryLinkListQueryServiceTests.cs
+++ b/src/GrayMoon.App.Tests/WorkspaceRepositoryLinkListQueryServiceTests.cs
@@ -1,0 +1,121 @@
+using GrayMoon.App.Models;
+using GrayMoon.App.Services.Queries;
+using Microsoft.EntityFrameworkCore;
+
+namespace GrayMoon.App.Tests;
+
+public class WorkspaceRepositoryLinkListQueryServiceTests
+{
+    [Fact]
+    public async Task First_and_next_page_have_no_gaps_or_duplicates()
+    {
+        var (ctx, workspaceId) = await ListQueryTestContext.CreateWithWorkspaceLinksAsync(120);
+        await using (ctx)
+        {
+            const int pageSize = 50;
+            var allIds = new List<int>();
+            WorkspaceRepositoryLinkListCursor? cursor = null;
+
+            for (var pageIndex = 0; pageIndex < 5; pageIndex++)
+            {
+                var page = await ctx.WorkspaceRepoLinkQuery.GetPageAsync(
+                    new WorkspaceRepositoryLinkListRequest(workspaceId, null, pageSize, cursor));
+                allIds.AddRange(page.Items.Select(i => i.WorkspaceRepositoryId));
+                if (!page.HasMore)
+                {
+                    break;
+                }
+
+                cursor = page.NextCursor;
+                Assert.NotNull(cursor);
+            }
+
+            Assert.Equal(allIds.Count, allIds.Distinct().Count());
+            var total = await ctx.WorkspaceRepoLinkQuery.CountAsync(new WorkspaceRepositoryLinkListFilter(workspaceId, null));
+            Assert.Equal(total, allIds.Count);
+        }
+    }
+
+    [Fact]
+    public async Task Search_filters_by_branch_name()
+    {
+        var (ctx, workspaceId) = await ListQueryTestContext.CreateWithWorkspaceLinksAsync(60);
+        await using (ctx)
+        {
+            var count = await ctx.WorkspaceRepoLinkQuery.CountAsync(new WorkspaceRepositoryLinkListFilter(workspaceId, "main"));
+            Assert.True(count > 0);
+
+            var page = await ctx.WorkspaceRepoLinkQuery.GetPageAsync(
+                new WorkspaceRepositoryLinkListRequest(workspaceId, "main", 50, null));
+            Assert.True(page.Items.Count > 0);
+            Assert.All(page.Items, item =>
+                Assert.True(
+                    (item.BranchName ?? string.Empty).Contains("main", StringComparison.OrdinalIgnoreCase)
+                    || (item.DefaultBranchName ?? string.Empty).Contains("main", StringComparison.OrdinalIgnoreCase)
+                    || item.RepositoryName.Contains("main", StringComparison.OrdinalIgnoreCase)));
+        }
+    }
+
+    [Fact]
+    public async Task Count_matches_filter()
+    {
+        var (ctx, workspaceId) = await ListQueryTestContext.CreateWithWorkspaceLinksAsync(30);
+        await using (ctx)
+        {
+            var count = await ctx.WorkspaceRepoLinkQuery.CountAsync(new WorkspaceRepositoryLinkListFilter(workspaceId, null));
+            Assert.Equal(30, count);
+        }
+    }
+
+    [Fact]
+    public async Task Header_state_reflects_seeded_workspace()
+    {
+        var (ctx, workspaceId) = await ListQueryTestContext.CreateWithWorkspaceLinksAsync(30);
+        await using (ctx)
+        {
+            var header = await ctx.WorkspaceRepoLinkQuery.GetHeaderStateAsync(workspaceId);
+            Assert.Equal(30, header.TotalCount);
+            Assert.True(header.HasUnmatchedDependencies);
+            Assert.True(header.IsPushRecommended);
+        }
+    }
+
+    [Fact]
+    public async Task GetRepositoryIdsAtLevel_returns_all_at_level()
+    {
+        var (ctx, workspaceId) = await ListQueryTestContext.CreateWithWorkspaceLinksAsync(60);
+        await using (ctx)
+        {
+            var level = 2;
+            var ids = await ctx.WorkspaceRepoLinkQuery.GetRepositoryIdsAtLevelAsync(workspaceId, level, null);
+            var expected = await ctx.DbContext.WorkspaceRepositories
+                .Where(wr => wr.WorkspaceId == workspaceId && wr.DependencyLevel == level)
+                .Select(wr => wr.RepositoryId)
+                .ToListAsync();
+            Assert.Equal(expected.OrderBy(x => x), ids.OrderBy(x => x));
+        }
+    }
+
+    [Fact]
+    public async Task GetAllSnapshots_returns_full_workspace()
+    {
+        var (ctx, workspaceId) = await ListQueryTestContext.CreateWithWorkspaceLinksAsync(25);
+        await using (ctx)
+        {
+            var snapshots = await ctx.WorkspaceRepoLinkQuery.GetAllSnapshotsAsync(workspaceId);
+            Assert.Equal(25, snapshots.Count);
+            Assert.All(snapshots, s => Assert.False(string.IsNullOrWhiteSpace(s.RepositoryName)));
+        }
+    }
+
+    [Fact]
+    public async Task Search_sync_badge_text()
+    {
+        var (ctx, workspaceId) = await ListQueryTestContext.CreateWithWorkspaceLinksAsync(30);
+        await using (ctx)
+        {
+            var count = await ctx.WorkspaceRepoLinkQuery.CountAsync(new WorkspaceRepositoryLinkListFilter(workspaceId, "in sync"));
+            Assert.True(count > 0);
+        }
+    }
+}

--- a/src/GrayMoon.App/Components/App.razor
+++ b/src/GrayMoon.App/Components/App.razor
@@ -29,6 +29,7 @@
     <script src="js/versionPatternEditor.js"></script>
     <script src="js/fileViewer.js"></script>
     <script src="js/filterSearchInput.js"></script>
+    <script src="js/infinite-scroll.js"></script>
     <script src="js/ghaLogs.js"></script>
     <script>
         window.focusFirstModalInput = (id) => {

--- a/src/GrayMoon.App/Components/App.razor
+++ b/src/GrayMoon.App/Components/App.razor
@@ -30,6 +30,7 @@
     <script src="js/fileViewer.js"></script>
     <script src="js/filterSearchInput.js"></script>
     <script src="js/infinite-scroll.js"></script>
+    <script src="js/virtual-scroll.js"></script>
     <script src="js/ghaLogs.js"></script>
     <script>
         window.focusFirstModalInput = (id) => {

--- a/src/GrayMoon.App/Components/Modals/WorkspaceRepositoriesModal.razor
+++ b/src/GrayMoon.App/Components/Modals/WorkspaceRepositoriesModal.razor
@@ -2,6 +2,7 @@
 @using GrayMoon.App.Services
 @using GrayMoon.App.Services.Queries
 @using GrayMoon.App.Components.Shared
+@using static GrayMoon.App.Components.Shared.VirtualScrollUi
 
 @if (IsVisible)
 {
@@ -60,7 +61,7 @@
                             }
                             else
                             {
-                                <table class="table table-sm mb-0 repository-grid workspaces-table resizable-columns">
+                                <table class="table table-sm mb-0 repository-grid workspaces-table resizable-columns virtual-scroll-table">
                                     <thead class="table-dark">
                                         <tr>
                                             <th class="col-select no-resize" data-width="26">
@@ -90,17 +91,17 @@
                                                     <td colspan="5" style="height:@(_virtual.TopSpacerPx.ToString("0.###", System.Globalization.CultureInfo.InvariantCulture))px;padding:0;border:0;line-height:0;"></td>
                                                 </tr>
                                             }
-                                            @foreach (var (id, repository) in _virtual.VisibleRows)
+                                            @foreach (var (index, id, repository) in _virtual.VisibleRows)
                                             {
                                                 if (repository is null)
                                                 {
-                                                    <tr @key="@id" class="virtual-scroll-placeholder">
+                                                    <tr @key="@id" class="virtual-scroll-placeholder @StripeClass(index)">
                                                         <td colspan="5">&nbsp;</td>
                                                     </tr>
                                                 }
                                                 else
                                                 {
-                                                    <tr @key="@id">
+                                                    <tr @key="@id" class="@StripeClass(index)">
                                                         <td class="col-select">
                                                             <input class="form-check-input workspace-repo-checkbox"
                                                                    type="checkbox"

--- a/src/GrayMoon.App/Components/Modals/WorkspaceRepositoriesModal.razor
+++ b/src/GrayMoon.App/Components/Modals/WorkspaceRepositoriesModal.razor
@@ -94,7 +94,7 @@
                                             {
                                                 if (repository is null)
                                                 {
-                                                    <tr @key="@($"ph-{id}")" class="virtual-scroll-placeholder">
+                                                    <tr @key="@id" class="virtual-scroll-placeholder">
                                                         <td colspan="5">&nbsp;</td>
                                                     </tr>
                                                 }

--- a/src/GrayMoon.App/Components/Modals/WorkspaceRepositoriesModal.razor
+++ b/src/GrayMoon.App/Components/Modals/WorkspaceRepositoriesModal.razor
@@ -46,7 +46,7 @@
                             {
                                 <div class="text-muted p-2">No GitHub connectors configured.</div>
                             }
-                            else if (isInitialLoading && _items.Count == 0)
+                            else if (isInitialLoading && _virtual.Count == 0)
                             {
                                 <div class="text-muted p-2">Loading repositories...</div>
                             }
@@ -75,8 +75,8 @@
                                             <th>Connector</th>
                                         </tr>
                                     </thead>
-                                    <tbody>
-                                        @if (_items.Count == 0 && !isInitialLoading)
+                                    <tbody @ref="_tbodyRef">
+                                        @if (_virtual.Count == 0 && !isInitialLoading)
                                         {
                                             <tr>
                                                 <td colspan="5" class="text-muted p-2">No repositories match your search.</td>
@@ -84,53 +84,60 @@
                                         }
                                         else
                                         {
-                                            @foreach (var repository in _items)
+                                            @if (_virtual.TopSpacerPx > 0)
                                             {
-                                                <tr>
-                                                    <td class="col-select">
-                                                        <input class="form-check-input workspace-repo-checkbox"
-                                                               type="checkbox"
-                                                               checked="@IsRowSelected(repository.RepositoryId)"
-                                                               @onchange="(ChangeEventArgs e) => _ = ToggleRepository(repository.RepositoryId, (bool)e.Value!)" />
-                                                    </td>
-                                                    <td>
-                                                        <span class="repo-name-cell" title="@repository.RepositoryName">
-                                                            @repository.RepositoryName
-                                                        </span>
-                                                    </td>
-                                                    <td>
-                                                        <span class="repo-name-cell" title="@(repository.OrgName ?? "-")">
-                                                            @(repository.OrgName ?? "-")
-                                                        </span>
-                                                    </td>
-                                                    <td class="col-topics">
-                                                        @if (!string.IsNullOrWhiteSpace(repository.Topics))
-                                                        {
-                                                            @foreach (var topic in repository.Topics.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+                                                <tr class="virtual-scroll-spacer" aria-hidden="true">
+                                                    <td colspan="5" style="height:@(_virtual.TopSpacerPx.ToString("0.###", System.Globalization.CultureInfo.InvariantCulture))px;padding:0;border:0;line-height:0;"></td>
+                                                </tr>
+                                            }
+                                            @foreach (var (id, repository) in _virtual.VisibleRows)
+                                            {
+                                                if (repository is null)
+                                                {
+                                                    <tr @key="@($"ph-{id}")" class="virtual-scroll-placeholder">
+                                                        <td colspan="5">&nbsp;</td>
+                                                    </tr>
+                                                }
+                                                else
+                                                {
+                                                    <tr @key="@id">
+                                                        <td class="col-select">
+                                                            <input class="form-check-input workspace-repo-checkbox"
+                                                                   type="checkbox"
+                                                                   checked="@IsRowSelected(repository.RepositoryId)"
+                                                                   @onchange="(ChangeEventArgs e) => _ = ToggleRepository(repository.RepositoryId, (bool)e.Value!)" />
+                                                        </td>
+                                                        <td>
+                                                            <span class="repo-name-cell" title="@repository.RepositoryName">
+                                                                @repository.RepositoryName
+                                                            </span>
+                                                        </td>
+                                                        <td>
+                                                            <span class="repo-name-cell" title="@(repository.OrgName ?? "-")">
+                                                                @(repository.OrgName ?? "-")
+                                                            </span>
+                                                        </td>
+                                                        <td class="col-topics">
+                                                            @if (!string.IsNullOrWhiteSpace(repository.Topics))
                                                             {
-                                                                <span class="badge badge-topic">@topic</span>
+                                                                @foreach (var topic in repository.Topics.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+                                                                {
+                                                                    <span class="badge badge-topic">@topic</span>
+                                                                }
                                                             }
-                                                        }
-                                                    </td>
-                                                    <td>
-                                                        <span class="repo-name-cell" title="@repository.ConnectorName">
-                                                            @repository.ConnectorName
-                                                        </span>
-                                                    </td>
-                                                </tr>
+                                                        </td>
+                                                        <td>
+                                                            <span class="repo-name-cell" title="@repository.ConnectorName">
+                                                                @repository.ConnectorName
+                                                            </span>
+                                                        </td>
+                                                    </tr>
+                                                }
                                             }
-                                            @if (isLoadingMore)
+                                            @if (_virtual.BottomSpacerPx > 0)
                                             {
-                                                <tr>
-                                                    <td colspan="5" class="text-muted p-2 text-center">Loading more...</td>
-                                                </tr>
-                                            }
-                                            @if (hasMore && !isLoadingMore)
-                                            {
-                                                <tr>
-                                                    <td colspan="5" class="p-0">
-                                                        <InfiniteScrollLoadTrigger IsEnabled="true" OnLoadMore="LoadNextChunkAsync" />
-                                                    </td>
+                                                <tr class="virtual-scroll-spacer" aria-hidden="true">
+                                                    <td colspan="5" style="height:@(_virtual.BottomSpacerPx.ToString("0.###", System.Globalization.CultureInfo.InvariantCulture))px;padding:0;border:0;line-height:0;"></td>
                                                 </tr>
                                             }
                                         }

--- a/src/GrayMoon.App/Components/Modals/WorkspaceRepositoriesModal.razor
+++ b/src/GrayMoon.App/Components/Modals/WorkspaceRepositoriesModal.razor
@@ -1,5 +1,7 @@
 @using GrayMoon.App.Models
 @using GrayMoon.App.Services
+@using GrayMoon.App.Services.Queries
+@using GrayMoon.App.Components.Shared
 
 @if (IsVisible)
 {
@@ -26,7 +28,8 @@
                             </div>
                         </div>
                         <div class="d-flex align-items-center mb-3">
-                            <FilterSearchInput @bind-Value="repositorySearch"
+                            <FilterSearchInput Value="@repositorySearch"
+                                               ValueChanged="OnRepositorySearchChangedAsync"
                                                @ref="filterSearchInput"
                                                WrapperAdditionalClass="flex-grow-1 min-width-0"
                                                Placeholder="Search repositories…"
@@ -39,29 +42,32 @@
                             </button>
                         </div>
                         <div class="repository-list border rounded">
-                            @if (Repositories == null)
-                            {
-                                <div class="text-muted p-2">Loading repositories...</div>
-                            }
-                            else if (!HasConnectors)
+                            @if (!HasConnectors)
                             {
                                 <div class="text-muted p-2">No GitHub connectors configured.</div>
                             }
-                            else if (Repositories.Count == 0)
+                            else if (isInitialLoading && _items.Count == 0)
+                            {
+                                <div class="text-muted p-2">Loading repositories...</div>
+                            }
+                            else if (hasLoadedOnce && !HasConnectors)
+                            {
+                                <div class="text-muted p-2">No GitHub connectors configured.</div>
+                            }
+                            else if (hasLoadedOnce && totalCount == 0 && !isInitialLoading)
                             {
                                 <div class="text-muted p-2">No repositories available. Fetch repositories first.</div>
                             }
                             else
                             {
-                                var filtered = GetFilteredRepositories();
                                 <table class="table table-sm mb-0 repository-grid workspaces-table resizable-columns">
                                     <thead class="table-dark">
                                         <tr>
                                             <th class="col-select no-resize" data-width="26">
                                                 <input class="form-check-input workspace-repo-checkbox"
                                                        type="checkbox"
-                                                       checked="@AreAllFilteredSelected(filtered)"
-                                                       @onchange="(ChangeEventArgs e) => _ = ToggleAllFiltered(filtered, (bool)e.Value!)" />
+                                                       checked="@AreAllFilteredSelected()"
+                                                       @onchange="(ChangeEventArgs e) => _ = ToggleAllFiltered((bool)e.Value!)" />
                                             </th>
                                             <th>Repository</th>
                                             <th>Owner</th>
@@ -70,7 +76,7 @@
                                         </tr>
                                     </thead>
                                     <tbody>
-                                        @if (filtered.Count == 0)
+                                        @if (_items.Count == 0 && !isInitialLoading)
                                         {
                                             <tr>
                                                 <td colspan="5" class="text-muted p-2">No repositories match your search.</td>
@@ -78,13 +84,13 @@
                                         }
                                         else
                                         {
-                                            @foreach (var repository in filtered)
+                                            @foreach (var repository in _items)
                                             {
                                                 <tr>
                                                     <td class="col-select">
                                                         <input class="form-check-input workspace-repo-checkbox"
                                                                type="checkbox"
-                                                               checked="@SelectedRepositoryIds.Contains(repository.RepositoryId)"
+                                                               checked="@IsRowSelected(repository.RepositoryId)"
                                                                @onchange="(ChangeEventArgs e) => _ = ToggleRepository(repository.RepositoryId, (bool)e.Value!)" />
                                                     </td>
                                                     <td>
@@ -110,6 +116,20 @@
                                                         <span class="repo-name-cell" title="@repository.ConnectorName">
                                                             @repository.ConnectorName
                                                         </span>
+                                                    </td>
+                                                </tr>
+                                            }
+                                            @if (isLoadingMore)
+                                            {
+                                                <tr>
+                                                    <td colspan="5" class="text-muted p-2 text-center">Loading more...</td>
+                                                </tr>
+                                            }
+                                            @if (hasMore && !isLoadingMore)
+                                            {
+                                                <tr>
+                                                    <td colspan="5" class="p-0">
+                                                        <InfiniteScrollLoadTrigger IsEnabled="true" OnLoadMore="LoadNextChunkAsync" />
                                                     </td>
                                                 </tr>
                                             }
@@ -159,133 +179,4 @@
     </div>
 }
 
-@code {
-    private FilterSearchInput? filterSearchInput;
-
-    [Parameter] public bool IsVisible { get; set; }
-    [Parameter] public string Title { get; set; } = "Select repositories";
-    [Parameter] public List<GitHubRepositoryEntry>? Repositories { get; set; }
-    [Parameter] public HashSet<int> SelectedRepositoryIds { get; set; } = new();
-    [Parameter] public bool HasConnectors { get; set; }
-    [Parameter] public bool IsSaving { get; set; }
-    [Parameter] public bool IsFetching { get; set; }
-    [Parameter] public string? ErrorMessage { get; set; }
-    [Parameter] public IReadOnlyList<RenamedRepositoryInfo>? RenameWarnings { get; set; }
-    [Parameter] public EventCallback OnSave { get; set; }
-    [Parameter] public EventCallback OnCancel { get; set; }
-    [Parameter] public EventCallback OnFetchRepositories { get; set; }
-    [Parameter] public bool DefaultSelectedOnly { get; set; }
-
-    private string repositorySearch = string.Empty;
-    private bool _wasVisible;
-    private bool _needsFocus;
-    private bool _showOnlySelected;
-    private HashSet<int> _selectedOnlySnapshot = new();
-
-    protected override void OnParametersSet()
-    {
-        if (IsVisible && !_wasVisible)
-        {
-            _wasVisible = true;
-            _needsFocus = true;
-            _showOnlySelected = DefaultSelectedOnly;
-            _selectedOnlySnapshot = new HashSet<int>(SelectedRepositoryIds);
-        }
-        else if (!IsVisible)
-        {
-            _wasVisible = false;
-        }
-    }
-
-    protected override async Task OnAfterRenderAsync(bool firstRender)
-    {
-        if (_needsFocus)
-        {
-            _needsFocus = false;
-            if (filterSearchInput != null)
-            {
-                await filterSearchInput.FocusAsync();
-            }
-        }
-    }
-
-    private void ToggleSelectedOnly(bool value)
-    {
-        _showOnlySelected = value;
-        if (value)
-        {
-            _selectedOnlySnapshot = new HashSet<int>(SelectedRepositoryIds);
-        }
-    }
-
-    private async Task HandleKeyDown(KeyboardEventArgs e)
-    {
-        if (e.Key == "Escape")
-        {
-            await OnCancel.InvokeAsync();
-        }
-        else if (e.Key == "Enter")
-        {
-            await OnSave.InvokeAsync();
-        }
-    }
-
-    private List<GitHubRepositoryEntry> GetFilteredRepositories()
-    {
-        if (Repositories == null)
-        {
-            return new List<GitHubRepositoryEntry>();
-        }
-
-        IEnumerable<GitHubRepositoryEntry> source = Repositories;
-
-        if (_showOnlySelected)
-        {
-            source = source.Where(r => _selectedOnlySnapshot.Contains(r.RepositoryId));
-        }
-
-        if (string.IsNullOrWhiteSpace(repositorySearch))
-        {
-            return source.ToList();
-        }
-
-        return source.Where(r => GitHubRepositorySearchMatcher.Matches(r, repositorySearch)).ToList();
-    }
-
-    private async Task ToggleRepository(int repositoryId, bool isSelected)
-    {
-        if (isSelected)
-        {
-            SelectedRepositoryIds.Add(repositoryId);
-        }
-        else
-        {
-            SelectedRepositoryIds.Remove(repositoryId);
-        }
-        await InvokeAsync(StateHasChanged);
-    }
-
-    private bool AreAllFilteredSelected(IReadOnlyCollection<GitHubRepositoryEntry> filtered)
-    {
-        return filtered.Count > 0 && filtered.All(item => SelectedRepositoryIds.Contains(item.RepositoryId));
-    }
-
-    private async Task ToggleAllFiltered(IReadOnlyCollection<GitHubRepositoryEntry> filtered, bool isSelected)
-    {
-        if (isSelected)
-        {
-            foreach (var repository in filtered)
-            {
-                SelectedRepositoryIds.Add(repository.RepositoryId);
-            }
-        }
-        else
-        {
-            foreach (var repository in filtered)
-            {
-                SelectedRepositoryIds.Remove(repository.RepositoryId);
-            }
-        }
-        await InvokeAsync(StateHasChanged);
-    }
-}
+@inject IRepositoryListQueryService RepositoryListQueryService

--- a/src/GrayMoon.App/Components/Modals/WorkspaceRepositoriesModal.razor.cs
+++ b/src/GrayMoon.App/Components/Modals/WorkspaceRepositoriesModal.razor.cs
@@ -215,21 +215,22 @@ public sealed partial class WorkspaceRepositoriesModal : IAsyncDisposable
         }
     }
 
-    private async Task EnsureVisibleHydratedAsync(CancellationToken cancellationToken)
+    private async Task<bool> EnsureVisibleHydratedAsync(CancellationToken cancellationToken)
     {
         var missing = _virtual.GetMissingIds(_virtual.VisibleStart, _virtual.VisibleEnd);
         if (missing.Count == 0)
         {
-            return;
+            return false;
         }
 
         var rows = await RepositoryListQueryService.GetByIdsAsync(missing, cancellationToken);
         if (cancellationToken.IsCancellationRequested || _disposed)
         {
-            return;
+            return false;
         }
 
         _virtual.CacheItems(rows.Select(r => (r.RepositoryId, r)));
+        return rows.Count > 0;
     }
 
     [JSInvokable]
@@ -240,17 +241,23 @@ public sealed partial class WorkspaceRepositoriesModal : IAsyncDisposable
             return;
         }
 
-        var generation = _queryLoader.Generation;
+        var scrollGeneration = _virtual.BeginScrollUpdate();
+        var queryGeneration = _queryLoader.Generation;
         var token = _queryLoader.GetQueryToken();
         var (start, end) = _virtual.ComputeRange(scrollTop, clientHeight);
-        _virtual.UpdateVisibleRange(start, end);
-        await EnsureVisibleHydratedAsync(token);
-        if (generation != _queryLoader.Generation || _disposed)
+        var rangeChanged = _virtual.UpdateVisibleRange(start, end);
+        var itemsHydrated = await EnsureVisibleHydratedAsync(token);
+        if (!_virtual.IsCurrentScroll(scrollGeneration)
+            || queryGeneration != _queryLoader.Generation
+            || _disposed)
         {
             return;
         }
 
-        await InvokeAsync(StateHasChanged);
+        if (rangeChanged || itemsHydrated)
+        {
+            await InvokeAsync(StateHasChanged);
+        }
     }
 
     private RepositoryListFilter BuildFilter()

--- a/src/GrayMoon.App/Components/Modals/WorkspaceRepositoriesModal.razor.cs
+++ b/src/GrayMoon.App/Components/Modals/WorkspaceRepositoriesModal.razor.cs
@@ -246,6 +246,11 @@ public sealed partial class WorkspaceRepositoriesModal : IAsyncDisposable
         var token = _queryLoader.GetQueryToken();
         var (start, end) = _virtual.ComputeRange(scrollTop, clientHeight);
         var rangeChanged = _virtual.UpdateVisibleRange(start, end);
+        if (rangeChanged && _virtual.IsCurrentScroll(scrollGeneration) && !_disposed)
+        {
+            await InvokeAsync(StateHasChanged);
+        }
+
         var itemsHydrated = await EnsureVisibleHydratedAsync(token);
         if (!_virtual.IsCurrentScroll(scrollGeneration)
             || queryGeneration != _queryLoader.Generation
@@ -254,7 +259,7 @@ public sealed partial class WorkspaceRepositoriesModal : IAsyncDisposable
             return;
         }
 
-        if (rangeChanged || itemsHydrated)
+        if (itemsHydrated)
         {
             await InvokeAsync(StateHasChanged);
         }

--- a/src/GrayMoon.App/Components/Modals/WorkspaceRepositoriesModal.razor.cs
+++ b/src/GrayMoon.App/Components/Modals/WorkspaceRepositoriesModal.razor.cs
@@ -3,13 +3,15 @@ using GrayMoon.App.Models;
 using GrayMoon.App.Services.Queries;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
+using Microsoft.JSInterop;
 
 namespace GrayMoon.App.Components.Modals;
 
 public sealed partial class WorkspaceRepositoriesModal : IAsyncDisposable
 {
     private readonly DebouncedQueryLoader _queryLoader = new();
-    private readonly List<RepositoryListItemDto> _items = new();
+    private readonly VirtualTableScrollState<RepositoryListItemDto> _virtual = new();
+    private ElementReference _tbodyRef;
 
     private FilterSearchInput? filterSearchInput;
 
@@ -20,16 +22,14 @@ public sealed partial class WorkspaceRepositoriesModal : IAsyncDisposable
     private bool _showOnlySelected;
     private HashSet<int> _selectedOnlySnapshot = new();
     private bool isInitialLoading;
-    private bool isLoadingMore;
-    private bool hasMore;
     private bool hasLoadedOnce;
     private int? totalCount;
-    private RepositoryListCursor? _nextCursor;
-    private bool _loadingNextChunk;
     private bool _disposed;
     private int _lastRefreshGeneration = -1;
 
     private HashSet<int> _matchingFilterIds = new();
+
+    [Inject] private IJSRuntime JSRuntime { get; set; } = default!;
 
     [Parameter] public bool IsVisible { get; set; }
     [Parameter] public string Title { get; set; } = "Select repositories";
@@ -57,6 +57,12 @@ public sealed partial class WorkspaceRepositoriesModal : IAsyncDisposable
         }
         else if (!IsVisible)
         {
+            if (_wasVisible)
+            {
+                _ = _virtual.DetachAsync(JSRuntime);
+                _virtual.Clear();
+            }
+
             _wasVisible = false;
         }
         else if (IsVisible && RefreshGeneration != _lastRefreshGeneration)
@@ -75,6 +81,11 @@ public sealed partial class WorkspaceRepositoriesModal : IAsyncDisposable
             {
                 await filterSearchInput.FocusAsync();
             }
+        }
+
+        if (IsVisible && !isInitialLoading && _virtual.Count > 0 && !_virtual.IsAttached && !_disposed)
+        {
+            await _virtual.AttachAsync(JSRuntime, this, _tbodyRef);
         }
     }
 
@@ -164,13 +175,10 @@ public sealed partial class WorkspaceRepositoriesModal : IAsyncDisposable
         }
 
         var token = _queryLoader.BeginQueryCycle(out var generation);
-        _items.Clear();
-        _nextCursor = null;
-        hasMore = false;
+        await _virtual.DetachAsync(JSRuntime);
+        _virtual.Clear();
         totalCount = null;
         isInitialLoading = true;
-        isLoadingMore = false;
-        _loadingNextChunk = false;
 
         try
         {
@@ -183,16 +191,9 @@ public sealed partial class WorkspaceRepositoriesModal : IAsyncDisposable
             }
 
             _matchingFilterIds = matchingIds.ToHashSet();
-            var page = await RepositoryListQueryService.GetPageAsync(BuildRequest(null), token);
-            if (generation != _queryLoader.Generation || _disposed)
-            {
-                return;
-            }
-
-            _items.AddRange(page.Items);
-            _nextCursor = page.NextCursor;
-            hasMore = page.HasMore;
+            _virtual.SetIndex(matchingIds);
             hasLoadedOnce = true;
+            await EnsureVisibleHydratedAsync(token);
         }
         catch (OperationCanceledException)
         {
@@ -201,7 +202,7 @@ public sealed partial class WorkspaceRepositoriesModal : IAsyncDisposable
         {
             if (generation == _queryLoader.Generation && !_disposed)
             {
-                _items.Clear();
+                _virtual.Clear();
             }
         }
         finally
@@ -214,38 +215,42 @@ public sealed partial class WorkspaceRepositoriesModal : IAsyncDisposable
         }
     }
 
-    private async Task LoadNextChunkAsync()
+    private async Task EnsureVisibleHydratedAsync(CancellationToken cancellationToken)
     {
-        if (_loadingNextChunk || isInitialLoading || !hasMore || _nextCursor is null)
+        var missing = _virtual.GetMissingIds(_virtual.VisibleStart, _virtual.VisibleEnd);
+        if (missing.Count == 0)
         {
             return;
         }
 
-        _loadingNextChunk = true;
-        isLoadingMore = true;
+        var rows = await RepositoryListQueryService.GetByIdsAsync(missing, cancellationToken);
+        if (cancellationToken.IsCancellationRequested || _disposed)
+        {
+            return;
+        }
+
+        _virtual.CacheItems(rows.Select(r => (r.RepositoryId, r)));
+    }
+
+    [JSInvokable]
+    public async Task OnVirtualScroll(double scrollTop, double clientHeight)
+    {
+        if (_disposed || _virtual.Count == 0)
+        {
+            return;
+        }
+
         var generation = _queryLoader.Generation;
         var token = _queryLoader.GetQueryToken();
+        var (start, end) = _virtual.ComputeRange(scrollTop, clientHeight);
+        _virtual.UpdateVisibleRange(start, end);
+        await EnsureVisibleHydratedAsync(token);
+        if (generation != _queryLoader.Generation || _disposed)
+        {
+            return;
+        }
 
-        try
-        {
-            var page = await RepositoryListQueryService.GetPageAsync(BuildRequest(_nextCursor), token);
-            if (generation != _queryLoader.Generation || _disposed)
-            {
-                return;
-            }
-
-            _items.AddRange(page.Items);
-            _nextCursor = page.NextCursor;
-            hasMore = page.HasMore;
-        }
-        catch (OperationCanceledException)
-        {
-        }
-        finally
-        {
-            _loadingNextChunk = false;
-            isLoadingMore = false;
-        }
+        await InvokeAsync(StateHasChanged);
     }
 
     private RepositoryListFilter BuildFilter()
@@ -256,19 +261,11 @@ public sealed partial class WorkspaceRepositoriesModal : IAsyncDisposable
         return new RepositoryListFilter(_effectiveSearch, restrict);
     }
 
-    private RepositoryListRequest BuildRequest(RepositoryListCursor? cursor) =>
-        new(
-            _effectiveSearch,
-            _showOnlySelected ? _selectedOnlySnapshot.ToList() : null,
-            RepositorySortField.Name,
-            SortDescending: false,
-            IRepositoryListQueryService.DefaultChunkSize,
-            cursor);
-
     public async ValueTask DisposeAsync()
     {
         _disposed = true;
+        await _virtual.DetachAsync(JSRuntime);
+        await _virtual.DisposeAsync();
         _queryLoader.Dispose();
-        await Task.CompletedTask;
     }
 }

--- a/src/GrayMoon.App/Components/Modals/WorkspaceRepositoriesModal.razor.cs
+++ b/src/GrayMoon.App/Components/Modals/WorkspaceRepositoriesModal.razor.cs
@@ -1,0 +1,274 @@
+using GrayMoon.App.Components.Shared;
+using GrayMoon.App.Models;
+using GrayMoon.App.Services.Queries;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
+
+namespace GrayMoon.App.Components.Modals;
+
+public sealed partial class WorkspaceRepositoriesModal : IAsyncDisposable
+{
+    private readonly DebouncedQueryLoader _queryLoader = new();
+    private readonly List<RepositoryListItemDto> _items = new();
+
+    private FilterSearchInput? filterSearchInput;
+
+    private string repositorySearch = string.Empty;
+    private string _effectiveSearch = string.Empty;
+    private bool _wasVisible;
+    private bool _needsFocus;
+    private bool _showOnlySelected;
+    private HashSet<int> _selectedOnlySnapshot = new();
+    private bool isInitialLoading;
+    private bool isLoadingMore;
+    private bool hasMore;
+    private bool hasLoadedOnce;
+    private int? totalCount;
+    private RepositoryListCursor? _nextCursor;
+    private bool _loadingNextChunk;
+    private bool _disposed;
+    private int _lastRefreshGeneration = -1;
+
+    private HashSet<int> _matchingFilterIds = new();
+
+    [Parameter] public bool IsVisible { get; set; }
+    [Parameter] public string Title { get; set; } = "Select repositories";
+    [Parameter] public HashSet<int> SelectedRepositoryIds { get; set; } = new();
+    [Parameter] public bool HasConnectors { get; set; }
+    [Parameter] public bool IsSaving { get; set; }
+    [Parameter] public bool IsFetching { get; set; }
+    [Parameter] public string? ErrorMessage { get; set; }
+    [Parameter] public IReadOnlyList<RenamedRepositoryInfo>? RenameWarnings { get; set; }
+    [Parameter] public EventCallback OnSave { get; set; }
+    [Parameter] public EventCallback OnCancel { get; set; }
+    [Parameter] public EventCallback OnFetchRepositories { get; set; }
+    [Parameter] public bool DefaultSelectedOnly { get; set; }
+    [Parameter] public int RefreshGeneration { get; set; }
+
+    protected override void OnParametersSet()
+    {
+        if (IsVisible && !_wasVisible)
+        {
+            _wasVisible = true;
+            _needsFocus = true;
+            _showOnlySelected = DefaultSelectedOnly;
+            _selectedOnlySnapshot = new HashSet<int>(SelectedRepositoryIds);
+            _ = ResetAndLoadFromTopAsync();
+        }
+        else if (!IsVisible)
+        {
+            _wasVisible = false;
+        }
+        else if (IsVisible && RefreshGeneration != _lastRefreshGeneration)
+        {
+            _lastRefreshGeneration = RefreshGeneration;
+            _ = ResetAndLoadFromTopAsync();
+        }
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (_needsFocus)
+        {
+            _needsFocus = false;
+            if (filterSearchInput != null)
+            {
+                await filterSearchInput.FocusAsync();
+            }
+        }
+    }
+
+    private async Task OnRepositorySearchChangedAsync(string value)
+    {
+        repositorySearch = value;
+        await _queryLoader.DebounceSearchAsync(async () =>
+        {
+            _effectiveSearch = repositorySearch;
+            await ResetAndLoadFromTopAsync();
+            if (!_disposed)
+            {
+                await InvokeAsync(StateHasChanged);
+            }
+        });
+    }
+
+    private void ToggleSelectedOnly(bool value)
+    {
+        _showOnlySelected = value;
+        if (value)
+        {
+            _selectedOnlySnapshot = new HashSet<int>(SelectedRepositoryIds);
+        }
+
+        _ = ResetAndLoadFromTopAsync();
+    }
+
+    private async Task HandleKeyDown(KeyboardEventArgs e)
+    {
+        if (e.Key == "Escape")
+        {
+            await OnCancel.InvokeAsync();
+        }
+        else if (e.Key == "Enter")
+        {
+            await OnSave.InvokeAsync();
+        }
+    }
+
+    private async Task ToggleRepository(int repositoryId, bool isSelected)
+    {
+        if (isSelected)
+        {
+            SelectedRepositoryIds.Add(repositoryId);
+        }
+        else
+        {
+            SelectedRepositoryIds.Remove(repositoryId);
+        }
+
+        await InvokeAsync(StateHasChanged);
+    }
+
+    private bool AreAllFilteredSelected() =>
+        _matchingFilterIds.Count > 0 && _matchingFilterIds.All(SelectedRepositoryIds.Contains);
+
+    private async Task ToggleAllFiltered(bool isSelected)
+    {
+        var filter = BuildFilter();
+        var ids = await RepositoryListQueryService.GetMatchingIdsAsync(filter);
+        if (isSelected)
+        {
+            foreach (var id in ids)
+            {
+                SelectedRepositoryIds.Add(id);
+            }
+        }
+        else
+        {
+            foreach (var id in ids)
+            {
+                SelectedRepositoryIds.Remove(id);
+            }
+        }
+
+        await InvokeAsync(StateHasChanged);
+    }
+
+    private bool IsRowSelected(int repositoryId) => SelectedRepositoryIds.Contains(repositoryId);
+
+    private async Task ResetAndLoadFromTopAsync()
+    {
+        if (!IsVisible)
+        {
+            return;
+        }
+
+        var token = _queryLoader.BeginQueryCycle(out var generation);
+        _items.Clear();
+        _nextCursor = null;
+        hasMore = false;
+        totalCount = null;
+        isInitialLoading = true;
+        isLoadingMore = false;
+        _loadingNextChunk = false;
+
+        try
+        {
+            var filter = BuildFilter();
+            totalCount = await RepositoryListQueryService.CountAsync(filter, token);
+            var matchingIds = await RepositoryListQueryService.GetMatchingIdsAsync(filter, token);
+            if (generation != _queryLoader.Generation || _disposed)
+            {
+                return;
+            }
+
+            _matchingFilterIds = matchingIds.ToHashSet();
+            var page = await RepositoryListQueryService.GetPageAsync(BuildRequest(null), token);
+            if (generation != _queryLoader.Generation || _disposed)
+            {
+                return;
+            }
+
+            _items.AddRange(page.Items);
+            _nextCursor = page.NextCursor;
+            hasMore = page.HasMore;
+            hasLoadedOnce = true;
+        }
+        catch (OperationCanceledException)
+        {
+        }
+        catch (Exception)
+        {
+            if (generation == _queryLoader.Generation && !_disposed)
+            {
+                _items.Clear();
+            }
+        }
+        finally
+        {
+            if (generation == _queryLoader.Generation && !_disposed)
+            {
+                isInitialLoading = false;
+                await InvokeAsync(StateHasChanged);
+            }
+        }
+    }
+
+    private async Task LoadNextChunkAsync()
+    {
+        if (_loadingNextChunk || isInitialLoading || !hasMore || _nextCursor is null)
+        {
+            return;
+        }
+
+        _loadingNextChunk = true;
+        isLoadingMore = true;
+        var generation = _queryLoader.Generation;
+        var token = _queryLoader.GetQueryToken();
+
+        try
+        {
+            var page = await RepositoryListQueryService.GetPageAsync(BuildRequest(_nextCursor), token);
+            if (generation != _queryLoader.Generation || _disposed)
+            {
+                return;
+            }
+
+            _items.AddRange(page.Items);
+            _nextCursor = page.NextCursor;
+            hasMore = page.HasMore;
+        }
+        catch (OperationCanceledException)
+        {
+        }
+        finally
+        {
+            _loadingNextChunk = false;
+            isLoadingMore = false;
+        }
+    }
+
+    private RepositoryListFilter BuildFilter()
+    {
+        IReadOnlyList<int>? restrict = _showOnlySelected
+            ? _selectedOnlySnapshot.ToList()
+            : null;
+        return new RepositoryListFilter(_effectiveSearch, restrict);
+    }
+
+    private RepositoryListRequest BuildRequest(RepositoryListCursor? cursor) =>
+        new(
+            _effectiveSearch,
+            _showOnlySelected ? _selectedOnlySnapshot.ToList() : null,
+            RepositorySortField.Name,
+            SortDescending: false,
+            IRepositoryListQueryService.DefaultChunkSize,
+            cursor);
+
+    public async ValueTask DisposeAsync()
+    {
+        _disposed = true;
+        _queryLoader.Dispose();
+        await Task.CompletedTask;
+    }
+}

--- a/src/GrayMoon.App/Components/Pages/Repositories.razor
+++ b/src/GrayMoon.App/Components/Pages/Repositories.razor
@@ -4,6 +4,7 @@
 @using GrayMoon.App.Services
 @using GrayMoon.App.Services.Queries
 @using GrayMoon.App.Components.Shared
+@using static GrayMoon.App.Components.Shared.VirtualScrollUi
 @inject GitHubRepositoryService RepositoryService
 @inject IRepositoryListQueryService RepositoryListQueryService
 @inject ILogger<Repositories> Logger
@@ -98,7 +99,7 @@
                 }
                 <div class="card-body p-0">
                     <div class="table-responsive">
-                        <table class="table table-striped table-hover mb-0 repositories-table resizable-columns">
+                        <table class="table table-hover mb-0 repositories-table resizable-columns virtual-scroll-table">
                         <thead class="table-dark">
                             <tr>
                                 <th class="col-repo">Repository</th>
@@ -141,17 +142,17 @@
                                         <td colspan="5" style="height:@(_virtual.TopSpacerPx.ToString("0.###", System.Globalization.CultureInfo.InvariantCulture))px;padding:0;border:0;line-height:0;"></td>
                                     </tr>
                                 }
-                                @foreach (var (id, repository) in _virtual.VisibleRows)
+                                @foreach (var (index, id, repository) in _virtual.VisibleRows)
                                 {
                                     if (repository is null)
                                     {
-                                        <tr @key="@id" class="virtual-scroll-placeholder">
+                                        <tr @key="@id" class="virtual-scroll-placeholder @StripeClass(index)">
                                             <td colspan="5">&nbsp;</td>
                                         </tr>
                                     }
                                     else
                                     {
-                                        <tr @key="@id">
+                                        <tr @key="@id" class="@StripeClass(index)">
                                             <td class="col-repo"><strong>@repository.RepositoryName</strong></td>
                                             <td class="col-owner">@(string.IsNullOrWhiteSpace(repository.OrgName) ? "-" : repository.OrgName)</td>
                                             <td class="col-topics">

--- a/src/GrayMoon.App/Components/Pages/Repositories.razor
+++ b/src/GrayMoon.App/Components/Pages/Repositories.razor
@@ -145,7 +145,7 @@
                                 {
                                     if (repository is null)
                                     {
-                                        <tr @key="@($"ph-{id}")" class="virtual-scroll-placeholder">
+                                        <tr @key="@id" class="virtual-scroll-placeholder">
                                             <td colspan="5">&nbsp;</td>
                                         </tr>
                                     }

--- a/src/GrayMoon.App/Components/Pages/Repositories.razor
+++ b/src/GrayMoon.App/Components/Pages/Repositories.razor
@@ -20,7 +20,7 @@
                     @if (hasLoadedOnce && !isInitialLoading)
                     {
                         var repoSuffix = HasSearchFilter ? " found" : "";
-                        var repoCount = HasSearchFilter ? (totalCount ?? _items.Count) : (totalCount ?? _items.Count);
+                        var repoCount = totalCount ?? 0;
                         <span>@($"{repoCount} {(repoCount == 1 ? "repository" : "repositories")}{repoSuffix}")</span>
                     }
                     else if (hasLoadedOnce && catalogHasAny)
@@ -108,8 +108,8 @@
                                 <th class="col-visibility col-status-badge">Visibility</th>
                             </tr>
                         </thead>
-                        <tbody>
-                            @if (isInitialLoading && _items.Count == 0)
+                        <tbody @ref="_tbodyRef">
+                            @if (isInitialLoading && _virtual.Count == 0)
                             {
                                 <tr>
                                     <td colspan="5" class="text-center text-muted py-4">
@@ -117,7 +117,7 @@
                                     </td>
                                 </tr>
                             }
-                            else if (!catalogHasAny && _items.Count == 0)
+                            else if (!catalogHasAny && _virtual.Count == 0)
                             {
                                 <tr>
                                     <td colspan="5" class="text-center text-muted py-4">
@@ -125,7 +125,7 @@
                                     </td>
                                 </tr>
                             }
-                            else if (_items.Count == 0)
+                            else if (hasLoadedOnce && _virtual.Count == 0)
                             {
                                 <tr>
                                     <td colspan="5" class="text-center text-muted py-4">
@@ -135,49 +135,54 @@
                             }
                             else
                             {
-                                @foreach (var repository in _items)
+                                @if (_virtual.TopSpacerPx > 0)
                                 {
-                                    <tr>
-                                        <td class="col-repo"><strong>@repository.RepositoryName</strong></td>
-                                        <td class="col-owner">@(string.IsNullOrWhiteSpace(repository.OrgName) ? "-" : repository.OrgName)</td>
-                                        <td class="col-topics">
-                                            @if (!string.IsNullOrWhiteSpace(repository.Topics))
-                                            {
-                                                @foreach (var topic in repository.Topics.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+                                    <tr class="virtual-scroll-spacer" aria-hidden="true">
+                                        <td colspan="5" style="height:@(_virtual.TopSpacerPx.ToString("0.###", System.Globalization.CultureInfo.InvariantCulture))px;padding:0;border:0;line-height:0;"></td>
+                                    </tr>
+                                }
+                                @foreach (var (id, repository) in _virtual.VisibleRows)
+                                {
+                                    if (repository is null)
+                                    {
+                                        <tr @key="@($"ph-{id}")" class="virtual-scroll-placeholder">
+                                            <td colspan="5">&nbsp;</td>
+                                        </tr>
+                                    }
+                                    else
+                                    {
+                                        <tr @key="@id">
+                                            <td class="col-repo"><strong>@repository.RepositoryName</strong></td>
+                                            <td class="col-owner">@(string.IsNullOrWhiteSpace(repository.OrgName) ? "-" : repository.OrgName)</td>
+                                            <td class="col-topics">
+                                                @if (!string.IsNullOrWhiteSpace(repository.Topics))
                                                 {
-                                                    <span class="badge badge-topic">@topic</span>
+                                                    @foreach (var topic in repository.Topics.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+                                                    {
+                                                        <span class="badge badge-topic">@topic</span>
+                                                    }
                                                 }
-                                            }
-                                        </td>
-                                        <td class="col-connector">@repository.ConnectorName</td>
-                                        <td class="col-visibility col-status-badge">
-                                            @if (repository.Archived)
-                                            {
-                                                <span class="badge badge-archived">archived</span>
-                                            }
-                                            else
-                                            {
-                                                <span class="badge @(repository.Visibility == "Private" ? "badge-private" : "badge-public")">
-                                                    @repository.Visibility.ToLowerInvariant()
-                                                </span>
-                                            }
-                                        </td>
-                                    </tr>
+                                            </td>
+                                            <td class="col-connector">@repository.ConnectorName</td>
+                                            <td class="col-visibility col-status-badge">
+                                                @if (repository.Archived)
+                                                {
+                                                    <span class="badge badge-archived">archived</span>
+                                                }
+                                                else
+                                                {
+                                                    <span class="badge @(repository.Visibility == "Private" ? "badge-private" : "badge-public")">
+                                                        @repository.Visibility.ToLowerInvariant()
+                                                    </span>
+                                                }
+                                            </td>
+                                        </tr>
+                                    }
                                 }
-                                @if (isLoadingMore)
+                                @if (_virtual.BottomSpacerPx > 0)
                                 {
-                                    <tr>
-                                        <td colspan="5" class="text-center text-muted py-3">
-                                            Loading more...
-                                        </td>
-                                    </tr>
-                                }
-                                @if (hasMore && !isLoadingMore)
-                                {
-                                    <tr>
-                                        <td colspan="5" class="p-0">
-                                            <InfiniteScrollLoadTrigger IsEnabled="true" OnLoadMore="LoadNextChunkAsync" />
-                                        </td>
+                                    <tr class="virtual-scroll-spacer" aria-hidden="true">
+                                        <td colspan="5" style="height:@(_virtual.BottomSpacerPx.ToString("0.###", System.Globalization.CultureInfo.InvariantCulture))px;padding:0;border:0;line-height:0;"></td>
                                     </tr>
                                 }
                             }

--- a/src/GrayMoon.App/Components/Pages/Repositories.razor
+++ b/src/GrayMoon.App/Components/Pages/Repositories.razor
@@ -1,10 +1,11 @@
 @page "/repositories"
 @rendermode @(new InteractiveServerRenderMode(prerender: false))
-@implements IDisposable
 @using GrayMoon.App.Models
 @using GrayMoon.App.Services
+@using GrayMoon.App.Services.Queries
 @using GrayMoon.App.Components.Shared
 @inject GitHubRepositoryService RepositoryService
+@inject IRepositoryListQueryService RepositoryListQueryService
 @inject ILogger<Repositories> Logger
 @using Microsoft.AspNetCore.Components.Web
 
@@ -16,13 +17,17 @@
             <div class="workspace-repos-title-row">
                 <h2 class="workspace-repos-title">Repositories</h2>
                 <p class="text-muted mb-0 workspace-repos-subtitle repositories-page__subtitle">
-                    @if (repositories != null && repositories.Count > 0)
+                    @if (hasLoadedOnce && !isInitialLoading)
                     {
                         var repoSuffix = HasSearchFilter ? " found" : "";
-                        var repoCount = HasSearchFilter ? (GetFilteredRepositories()?.Count ?? 0) : repositories.Count;
+                        var repoCount = HasSearchFilter ? (totalCount ?? _items.Count) : (totalCount ?? _items.Count);
                         <span>@($"{repoCount} {(repoCount == 1 ? "repository" : "repositories")}{repoSuffix}")</span>
                     }
-                    else if (repositories != null)
+                    else if (hasLoadedOnce && catalogHasAny)
+                    {
+                        <span>&nbsp;</span>
+                    }
+                    else if (hasLoadedOnce)
                     {
                         <span>0 repositories</span>
                     }
@@ -35,11 +40,12 @@
             </div>
             <div class="d-flex gap-2 align-items-center workspace-repos-header-actions">
                 <div class="workspace-grid-search-wrapper">
-                    <FilterSearchInput @bind-Value="searchTerm"
+                    <FilterSearchInput Value="@searchTerm"
+                                       ValueChanged="OnSearchTermChangedAsync"
                                        InputId="repositories-search"
                                        InputAdditionalClass="workspace-grid-search"
                                        Placeholder="Search repositories…"
-                                       Disabled="@(repositories == null || repositories.Count == 0)"
+                                       Disabled="@(isInitialLoading && !hasLoadedOnce)"
                                        OnKeyDown="OnSearchKeyDown"
                                        OnClear="ClearSearchFilter" />
                 </div>
@@ -103,7 +109,7 @@
                             </tr>
                         </thead>
                         <tbody>
-                            @if (repositories == null)
+                            @if (isInitialLoading && _items.Count == 0)
                             {
                                 <tr>
                                     <td colspan="5" class="text-center text-muted py-4">
@@ -111,7 +117,7 @@
                                     </td>
                                 </tr>
                             }
-                            else if (repositories.Count == 0)
+                            else if (!catalogHasAny && _items.Count == 0)
                             {
                                 <tr>
                                     <td colspan="5" class="text-center text-muted py-4">
@@ -119,7 +125,7 @@
                                     </td>
                                 </tr>
                             }
-                            else if (GetFilteredRepositories()?.Count == 0)
+                            else if (_items.Count == 0)
                             {
                                 <tr>
                                     <td colspan="5" class="text-center text-muted py-4">
@@ -129,7 +135,7 @@
                             }
                             else
                             {
-                                @foreach (var repository in GetFilteredRepositories() ?? new List<GitHubRepositoryEntry>())
+                                @foreach (var repository in _items)
                                 {
                                     <tr>
                                         <td class="col-repo"><strong>@repository.RepositoryName</strong></td>
@@ -158,6 +164,22 @@
                                         </td>
                                     </tr>
                                 }
+                                @if (isLoadingMore)
+                                {
+                                    <tr>
+                                        <td colspan="5" class="text-center text-muted py-3">
+                                            Loading more...
+                                        </td>
+                                    </tr>
+                                }
+                                @if (hasMore && !isLoadingMore)
+                                {
+                                    <tr>
+                                        <td colspan="5" class="p-0">
+                                            <InfiniteScrollLoadTrigger IsEnabled="true" OnLoadMore="LoadNextChunkAsync" />
+                                        </td>
+                                    </tr>
+                                }
                             }
                         </tbody>
                     </table>
@@ -169,133 +191,3 @@
 </div>
 
 <LoadingOverlay IsVisible="@isPersisting" Message="@(fetchedRepositoryCount is null || fetchedRepositoryCount == 0 ? "Fetching repositories..." : $"Fetched {fetchedRepositoryCount} {(fetchedRepositoryCount == 1 ? "repository" : "repositories")}")" OnAbort="AbortFetchRepositories" />
-
-@code {
-    private List<GitHubRepositoryEntry>? repositories;
-    private IReadOnlyList<ConnectorFetchError>? connectorErrors;
-    private IReadOnlyList<RenamedRepositoryInfo>? renamedRepositories;
-    private string? errorMessage;
-    private string searchTerm = string.Empty;
-    private bool isPersisting;
-
-    private bool HasSearchFilter => !string.IsNullOrWhiteSpace(searchTerm);
-
-    private void ClearSearchFilter()
-    {
-        searchTerm = string.Empty;
-        StateHasChanged();
-    }
-
-    private void OnSearchKeyDown(KeyboardEventArgs e)
-    {
-        if (e.Key == "Escape")
-        {
-            searchTerm = string.Empty;
-            StateHasChanged();
-        }
-    }
-
-    private int? fetchedRepositoryCount;
-    private CancellationTokenSource? _fetchRepositoriesCts;
-
-    private void DismissConnectorErrors()
-    {
-        connectorErrors = null;
-    }
-
-    public void Dispose()
-    {
-        _fetchRepositoriesCts?.Cancel();
-        _fetchRepositoriesCts?.Dispose();
-    }
-
-    protected override async Task OnInitializedAsync()
-    {
-        await LoadRepositoriesAsync();
-    }
-
-    private async Task LoadRepositoriesAsync()
-    {
-        try
-        {
-            repositories = null;
-            connectorErrors = null;
-            errorMessage = null;
-            var persisted = await RepositoryService.GetPersistedRepositoriesAsync();
-            if (persisted.Count > 0)
-            {
-                repositories = persisted;
-                return;
-            }
-
-            await ReloadRepositoriesAsync();
-        }
-        catch (Exception ex)
-        {
-            Logger.LogError(ex, "Error loading repositories");
-            errorMessage = "Failed to load repositories. Please try again later.";
-            repositories = new List<GitHubRepositoryEntry>();
-        }
-    }
-
-    private void AbortFetchRepositories()
-    {
-        _fetchRepositoriesCts?.Cancel();
-    }
-
-    private async Task ReloadRepositoriesAsync()
-    {
-        _fetchRepositoriesCts?.Cancel();
-        _fetchRepositoriesCts = new CancellationTokenSource();
-
-        try
-        {
-            isPersisting = true;
-            fetchedRepositoryCount = null;
-            await InvokeAsync(StateHasChanged);
-            errorMessage = null;
-            connectorErrors = null;
-
-            var progress = new Progress<int>(count =>
-            {
-                fetchedRepositoryCount = count;
-                _ = InvokeAsync(StateHasChanged);
-            });
-            var result = await RepositoryService.RefreshRepositoriesAsync(progress, _fetchRepositoriesCts.Token);
-            repositories = result.Repositories.ToList();
-            connectorErrors = result.ConnectorErrors.Count > 0 ? result.ConnectorErrors : null;
-            renamedRepositories = result.RenamedRepositories.Count > 0 ? result.RenamedRepositories : null;
-        }
-        catch (OperationCanceledException)
-        {
-            repositories = (await RepositoryService.GetPersistedRepositoriesAsync()).ToList();
-        }
-        catch (Exception ex)
-        {
-            Logger.LogError(ex, "Error refreshing repositories");
-            errorMessage = "Failed to refresh repositories. Please try again later.";
-            repositories = new List<GitHubRepositoryEntry>();
-        }
-        finally
-        {
-            isPersisting = false;
-        }
-    }
-
-    private List<GitHubRepositoryEntry>? GetFilteredRepositories()
-    {
-        if (repositories == null)
-        {
-            return null;
-        }
-
-        if (string.IsNullOrWhiteSpace(searchTerm))
-        {
-            return repositories;
-        }
-
-        return repositories
-            .Where(r => GitHubRepositorySearchMatcher.Matches(r, searchTerm))
-            .ToList();
-    }
-}

--- a/src/GrayMoon.App/Components/Pages/Repositories.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/Repositories.razor.cs
@@ -2,14 +2,19 @@ using GrayMoon.App.Components.Shared;
 using GrayMoon.App.Models;
 using GrayMoon.App.Services;
 using GrayMoon.App.Services.Queries;
+using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
+using Microsoft.JSInterop;
 
 namespace GrayMoon.App.Components.Pages;
 
-public sealed partial class Repositories : IDisposable
+public sealed partial class Repositories : IAsyncDisposable, IDisposable
 {
     private readonly DebouncedQueryLoader _queryLoader = new();
-    private readonly List<RepositoryListItemDto> _items = new();
+    private readonly VirtualTableScrollState<RepositoryListItemDto> _virtual = new();
+    private ElementReference _tbodyRef;
+
+    [Inject] private IJSRuntime JSRuntime { get; set; } = default!;
 
     private IReadOnlyList<ConnectorFetchError>? connectorErrors;
     private IReadOnlyList<RenamedRepositoryInfo>? renamedRepositories;
@@ -18,15 +23,11 @@ public sealed partial class Repositories : IDisposable
     private string _effectiveSearch = string.Empty;
     private bool isPersisting;
     private bool isInitialLoading = true;
-    private bool isLoadingMore;
-    private bool hasMore;
     private bool catalogHasAny;
     private bool hasLoadedOnce;
     private int? totalCount;
-    private RepositoryListCursor? _nextCursor;
     private int? fetchedRepositoryCount;
     private CancellationTokenSource? _fetchRepositoriesCts;
-    private bool _loadingNextChunk;
     private bool _disposed;
 
     private bool HasSearchFilter => !string.IsNullOrWhiteSpace(_effectiveSearch);
@@ -67,10 +68,22 @@ public sealed partial class Repositories : IDisposable
 
     public void Dispose()
     {
+        if (_disposed)
+        {
+            return;
+        }
+
         _disposed = true;
         _fetchRepositoriesCts?.Cancel();
         _fetchRepositoriesCts?.Dispose();
         _queryLoader.Dispose();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _virtual.DetachAsync(JSRuntime);
+        await _virtual.DisposeAsync();
+        Dispose();
     }
 
     protected override async Task OnInitializedAsync()
@@ -94,32 +107,36 @@ public sealed partial class Repositories : IDisposable
         }
     }
 
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (!isInitialLoading && _virtual.Count > 0 && !_virtual.IsAttached && !_disposed)
+        {
+            await _virtual.AttachAsync(JSRuntime, this, _tbodyRef);
+        }
+    }
+
     private async Task ResetAndLoadFromTopAsync()
     {
         var token = _queryLoader.BeginQueryCycle(out var generation);
-        _items.Clear();
-        _nextCursor = null;
-        hasMore = false;
+        await _virtual.DetachAsync(JSRuntime);
+        _virtual.Clear();
         totalCount = null;
         isInitialLoading = true;
-        isLoadingMore = false;
-        _loadingNextChunk = false;
         errorMessage = null;
 
         try
         {
             var filter = BuildFilter();
             totalCount = await RepositoryListQueryService.CountAsync(filter, token);
-            var page = await RepositoryListQueryService.GetPageAsync(BuildRequest(null), token);
+            var ids = await RepositoryListQueryService.GetMatchingIdsAsync(filter, token);
             if (generation != _queryLoader.Generation || _disposed)
             {
                 return;
             }
 
-            _items.AddRange(page.Items);
-            _nextCursor = page.NextCursor;
-            hasMore = page.HasMore;
+            _virtual.SetIndex(ids);
             hasLoadedOnce = true;
+            await EnsureVisibleHydratedAsync(token);
         }
         catch (OperationCanceledException)
         {
@@ -130,7 +147,7 @@ public sealed partial class Repositories : IDisposable
             {
                 Logger.LogError(ex, "Error loading repository list");
                 errorMessage = "Failed to load repositories. Please try again later.";
-                _items.Clear();
+                _virtual.Clear();
             }
         }
         finally
@@ -142,59 +159,46 @@ public sealed partial class Repositories : IDisposable
         }
     }
 
-    private async Task LoadNextChunkAsync()
+    private async Task EnsureVisibleHydratedAsync(CancellationToken cancellationToken)
     {
-        if (_loadingNextChunk || isInitialLoading || !hasMore || _nextCursor is null)
+        var missing = _virtual.GetMissingIds(_virtual.VisibleStart, _virtual.VisibleEnd);
+        if (missing.Count == 0)
         {
             return;
         }
 
-        _loadingNextChunk = true;
-        isLoadingMore = true;
+        var rows = await RepositoryListQueryService.GetByIdsAsync(missing, cancellationToken);
+        if (cancellationToken.IsCancellationRequested || _disposed)
+        {
+            return;
+        }
+
+        _virtual.CacheItems(rows.Select(r => (r.RepositoryId, r)));
+    }
+
+    [JSInvokable]
+    public async Task OnVirtualScroll(double scrollTop, double clientHeight)
+    {
+        if (_disposed || _virtual.Count == 0)
+        {
+            return;
+        }
+
         var generation = _queryLoader.Generation;
         var token = _queryLoader.GetQueryToken();
+        var (start, end) = _virtual.ComputeRange(scrollTop, clientHeight);
+        _virtual.UpdateVisibleRange(start, end);
+        await EnsureVisibleHydratedAsync(token);
+        if (generation != _queryLoader.Generation || _disposed)
+        {
+            return;
+        }
 
-        try
-        {
-            var page = await RepositoryListQueryService.GetPageAsync(BuildRequest(_nextCursor), token);
-            if (generation != _queryLoader.Generation || _disposed)
-            {
-                return;
-            }
-
-            _items.AddRange(page.Items);
-            _nextCursor = page.NextCursor;
-            hasMore = page.HasMore;
-        }
-        catch (OperationCanceledException)
-        {
-        }
-        catch (Exception ex)
-        {
-            if (generation == _queryLoader.Generation && !_disposed)
-            {
-                Logger.LogError(ex, "Error loading more repositories");
-                errorMessage = "Failed to load more repositories. Please try again later.";
-            }
-        }
-        finally
-        {
-            _loadingNextChunk = false;
-            isLoadingMore = false;
-        }
+        await InvokeAsync(StateHasChanged);
     }
 
     private RepositoryListFilter BuildFilter() =>
         new(_effectiveSearch, null);
-
-    private RepositoryListRequest BuildRequest(RepositoryListCursor? cursor) =>
-        new(
-            _effectiveSearch,
-            null,
-            RepositorySortField.Name,
-            SortDescending: false,
-            IRepositoryListQueryService.DefaultChunkSize,
-            cursor);
 
     private void AbortFetchRepositories()
     {

--- a/src/GrayMoon.App/Components/Pages/Repositories.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/Repositories.razor.cs
@@ -190,6 +190,11 @@ public sealed partial class Repositories : IAsyncDisposable, IDisposable
         var token = _queryLoader.GetQueryToken();
         var (start, end) = _virtual.ComputeRange(scrollTop, clientHeight);
         var rangeChanged = _virtual.UpdateVisibleRange(start, end);
+        if (rangeChanged && _virtual.IsCurrentScroll(scrollGeneration) && !_disposed)
+        {
+            await InvokeAsync(StateHasChanged);
+        }
+
         var itemsHydrated = await EnsureVisibleHydratedAsync(token);
         if (!_virtual.IsCurrentScroll(scrollGeneration)
             || queryGeneration != _queryLoader.Generation
@@ -198,7 +203,7 @@ public sealed partial class Repositories : IAsyncDisposable, IDisposable
             return;
         }
 
-        if (rangeChanged || itemsHydrated)
+        if (itemsHydrated)
         {
             await InvokeAsync(StateHasChanged);
         }

--- a/src/GrayMoon.App/Components/Pages/Repositories.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/Repositories.razor.cs
@@ -159,21 +159,22 @@ public sealed partial class Repositories : IAsyncDisposable, IDisposable
         }
     }
 
-    private async Task EnsureVisibleHydratedAsync(CancellationToken cancellationToken)
+    private async Task<bool> EnsureVisibleHydratedAsync(CancellationToken cancellationToken)
     {
         var missing = _virtual.GetMissingIds(_virtual.VisibleStart, _virtual.VisibleEnd);
         if (missing.Count == 0)
         {
-            return;
+            return false;
         }
 
         var rows = await RepositoryListQueryService.GetByIdsAsync(missing, cancellationToken);
         if (cancellationToken.IsCancellationRequested || _disposed)
         {
-            return;
+            return false;
         }
 
         _virtual.CacheItems(rows.Select(r => (r.RepositoryId, r)));
+        return rows.Count > 0;
     }
 
     [JSInvokable]
@@ -184,17 +185,23 @@ public sealed partial class Repositories : IAsyncDisposable, IDisposable
             return;
         }
 
-        var generation = _queryLoader.Generation;
+        var scrollGeneration = _virtual.BeginScrollUpdate();
+        var queryGeneration = _queryLoader.Generation;
         var token = _queryLoader.GetQueryToken();
         var (start, end) = _virtual.ComputeRange(scrollTop, clientHeight);
-        _virtual.UpdateVisibleRange(start, end);
-        await EnsureVisibleHydratedAsync(token);
-        if (generation != _queryLoader.Generation || _disposed)
+        var rangeChanged = _virtual.UpdateVisibleRange(start, end);
+        var itemsHydrated = await EnsureVisibleHydratedAsync(token);
+        if (!_virtual.IsCurrentScroll(scrollGeneration)
+            || queryGeneration != _queryLoader.Generation
+            || _disposed)
         {
             return;
         }
 
-        await InvokeAsync(StateHasChanged);
+        if (rangeChanged || itemsHydrated)
+        {
+            await InvokeAsync(StateHasChanged);
+        }
     }
 
     private RepositoryListFilter BuildFilter() =>

--- a/src/GrayMoon.App/Components/Pages/Repositories.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/Repositories.razor.cs
@@ -1,0 +1,248 @@
+using GrayMoon.App.Components.Shared;
+using GrayMoon.App.Models;
+using GrayMoon.App.Services;
+using GrayMoon.App.Services.Queries;
+using Microsoft.AspNetCore.Components.Web;
+
+namespace GrayMoon.App.Components.Pages;
+
+public sealed partial class Repositories : IDisposable
+{
+    private readonly DebouncedQueryLoader _queryLoader = new();
+    private readonly List<RepositoryListItemDto> _items = new();
+
+    private IReadOnlyList<ConnectorFetchError>? connectorErrors;
+    private IReadOnlyList<RenamedRepositoryInfo>? renamedRepositories;
+    private string? errorMessage;
+    private string searchTerm = string.Empty;
+    private string _effectiveSearch = string.Empty;
+    private bool isPersisting;
+    private bool isInitialLoading = true;
+    private bool isLoadingMore;
+    private bool hasMore;
+    private bool catalogHasAny;
+    private bool hasLoadedOnce;
+    private int? totalCount;
+    private RepositoryListCursor? _nextCursor;
+    private int? fetchedRepositoryCount;
+    private CancellationTokenSource? _fetchRepositoriesCts;
+    private bool _loadingNextChunk;
+    private bool _disposed;
+
+    private bool HasSearchFilter => !string.IsNullOrWhiteSpace(_effectiveSearch);
+
+    private void ClearSearchFilter()
+    {
+        searchTerm = string.Empty;
+        _ = OnSearchTermChangedAsync(string.Empty);
+    }
+
+    private void OnSearchKeyDown(KeyboardEventArgs e)
+    {
+        if (e.Key == "Escape")
+        {
+            searchTerm = string.Empty;
+            _ = OnSearchTermChangedAsync(string.Empty);
+        }
+    }
+
+    private async Task OnSearchTermChangedAsync(string value)
+    {
+        searchTerm = value;
+        await _queryLoader.DebounceSearchAsync(async () =>
+        {
+            _effectiveSearch = searchTerm;
+            await ResetAndLoadFromTopAsync();
+            if (!_disposed)
+            {
+                await InvokeAsync(StateHasChanged);
+            }
+        });
+    }
+
+    private void DismissConnectorErrors()
+    {
+        connectorErrors = null;
+    }
+
+    public void Dispose()
+    {
+        _disposed = true;
+        _fetchRepositoriesCts?.Cancel();
+        _fetchRepositoriesCts?.Dispose();
+        _queryLoader.Dispose();
+    }
+
+    protected override async Task OnInitializedAsync()
+    {
+        try
+        {
+            catalogHasAny = await RepositoryListQueryService.AnyAsync();
+            if (!catalogHasAny)
+            {
+                await ReloadRepositoriesAsync();
+                catalogHasAny = await RepositoryListQueryService.AnyAsync();
+            }
+
+            await ResetAndLoadFromTopAsync();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error loading repositories");
+            errorMessage = "Failed to load repositories. Please try again later.";
+            isInitialLoading = false;
+        }
+    }
+
+    private async Task ResetAndLoadFromTopAsync()
+    {
+        var token = _queryLoader.BeginQueryCycle(out var generation);
+        _items.Clear();
+        _nextCursor = null;
+        hasMore = false;
+        totalCount = null;
+        isInitialLoading = true;
+        isLoadingMore = false;
+        _loadingNextChunk = false;
+        errorMessage = null;
+
+        try
+        {
+            var filter = BuildFilter();
+            totalCount = await RepositoryListQueryService.CountAsync(filter, token);
+            var page = await RepositoryListQueryService.GetPageAsync(BuildRequest(null), token);
+            if (generation != _queryLoader.Generation || _disposed)
+            {
+                return;
+            }
+
+            _items.AddRange(page.Items);
+            _nextCursor = page.NextCursor;
+            hasMore = page.HasMore;
+            hasLoadedOnce = true;
+        }
+        catch (OperationCanceledException)
+        {
+        }
+        catch (Exception ex)
+        {
+            if (generation == _queryLoader.Generation && !_disposed)
+            {
+                Logger.LogError(ex, "Error loading repository list");
+                errorMessage = "Failed to load repositories. Please try again later.";
+                _items.Clear();
+            }
+        }
+        finally
+        {
+            if (generation == _queryLoader.Generation && !_disposed)
+            {
+                isInitialLoading = false;
+            }
+        }
+    }
+
+    private async Task LoadNextChunkAsync()
+    {
+        if (_loadingNextChunk || isInitialLoading || !hasMore || _nextCursor is null)
+        {
+            return;
+        }
+
+        _loadingNextChunk = true;
+        isLoadingMore = true;
+        var generation = _queryLoader.Generation;
+        var token = _queryLoader.GetQueryToken();
+
+        try
+        {
+            var page = await RepositoryListQueryService.GetPageAsync(BuildRequest(_nextCursor), token);
+            if (generation != _queryLoader.Generation || _disposed)
+            {
+                return;
+            }
+
+            _items.AddRange(page.Items);
+            _nextCursor = page.NextCursor;
+            hasMore = page.HasMore;
+        }
+        catch (OperationCanceledException)
+        {
+        }
+        catch (Exception ex)
+        {
+            if (generation == _queryLoader.Generation && !_disposed)
+            {
+                Logger.LogError(ex, "Error loading more repositories");
+                errorMessage = "Failed to load more repositories. Please try again later.";
+            }
+        }
+        finally
+        {
+            _loadingNextChunk = false;
+            isLoadingMore = false;
+        }
+    }
+
+    private RepositoryListFilter BuildFilter() =>
+        new(_effectiveSearch, null);
+
+    private RepositoryListRequest BuildRequest(RepositoryListCursor? cursor) =>
+        new(
+            _effectiveSearch,
+            null,
+            RepositorySortField.Name,
+            SortDescending: false,
+            IRepositoryListQueryService.DefaultChunkSize,
+            cursor);
+
+    private void AbortFetchRepositories()
+    {
+        _fetchRepositoriesCts?.Cancel();
+    }
+
+    private async Task ReloadRepositoriesAsync()
+    {
+        _fetchRepositoriesCts?.Cancel();
+        _fetchRepositoriesCts?.Dispose();
+        _fetchRepositoriesCts = new CancellationTokenSource();
+
+        try
+        {
+            isPersisting = true;
+            fetchedRepositoryCount = null;
+            await InvokeAsync(StateHasChanged);
+            errorMessage = null;
+            connectorErrors = null;
+
+            var progress = new Progress<int>(count =>
+            {
+                fetchedRepositoryCount = count;
+                _ = InvokeAsync(StateHasChanged);
+            });
+            var result = await RepositoryService.RefreshRepositoriesAsync(progress, _fetchRepositoriesCts.Token);
+            connectorErrors = result.ConnectorErrors.Count > 0 ? result.ConnectorErrors : null;
+            renamedRepositories = result.RenamedRepositories.Count > 0 ? result.RenamedRepositories : null;
+            catalogHasAny = await RepositoryListQueryService.AnyAsync();
+            await ResetAndLoadFromTopAsync();
+        }
+        catch (OperationCanceledException)
+        {
+            catalogHasAny = await RepositoryListQueryService.AnyAsync();
+            await ResetAndLoadFromTopAsync();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error refreshing repositories");
+            errorMessage = "Failed to refresh repositories. Please try again later.";
+        }
+        finally
+        {
+            isPersisting = false;
+            if (!_disposed)
+            {
+                await InvokeAsync(StateHasChanged);
+            }
+        }
+    }
+}

--- a/src/GrayMoon.App/Components/Pages/WorkspaceProjects.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceProjects.razor
@@ -108,7 +108,7 @@
                                     {
                                         if (p is null)
                                         {
-                                            <tr @key="@($"ph-{id}")" class="virtual-scroll-placeholder">
+                                            <tr @key="@id" class="virtual-scroll-placeholder">
                                                 <td colspan="4">&nbsp;</td>
                                             </tr>
                                         }

--- a/src/GrayMoon.App/Components/Pages/WorkspaceProjects.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceProjects.razor
@@ -5,6 +5,7 @@
 @using GrayMoon.App.Services
 @using GrayMoon.App.Services.Queries
 @using GrayMoon.App.Components.Shared
+@using static GrayMoon.App.Components.Shared.VirtualScrollUi
 @using Microsoft.AspNetCore.Components.Web
 @inject WorkspaceRepository WorkspaceRepository
 @inject IWorkspaceProjectListQueryService WorkspaceProjectListQueryService
@@ -62,7 +63,7 @@
             <div class="card page-card mb-4">
                 <div class="card-body p-0">
                     <div class="table-responsive">
-                        <table class="table table-striped table-hover mb-0 projects-table resizable-columns">
+                        <table class="table table-hover mb-0 projects-table resizable-columns virtual-scroll-table">
                             <thead class="table-dark">
                                 <tr>
                                     <th class="col-name">Name</th>
@@ -104,17 +105,17 @@
                                             <td colspan="4" style="height:@(_virtual.TopSpacerPx.ToString("0.###", System.Globalization.CultureInfo.InvariantCulture))px;padding:0;border:0;line-height:0;"></td>
                                         </tr>
                                     }
-                                    @foreach (var (id, p) in _virtual.VisibleRows)
+                                    @foreach (var (index, id, p) in _virtual.VisibleRows)
                                     {
                                         if (p is null)
                                         {
-                                            <tr @key="@id" class="virtual-scroll-placeholder">
+                                            <tr @key="@id" class="virtual-scroll-placeholder @StripeClass(index)">
                                                 <td colspan="4">&nbsp;</td>
                                             </tr>
                                         }
                                         else
                                         {
-                                            <tr @key="@id">
+                                            <tr @key="@id" class="@StripeClass(index)">
                                                 <td class="col-name"><strong>@p.ProjectName</strong></td>
                                                 <td class="col-type text-muted">@p.ProjectType</td>
                                                 <td class="col-framework"><span class="badge bg-secondary">@(p.TargetFramework ?? "-")</span></td>

--- a/src/GrayMoon.App/Components/Pages/WorkspaceProjects.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceProjects.razor
@@ -3,10 +3,11 @@
 @using GrayMoon.App.Models
 @using GrayMoon.App.Repositories
 @using GrayMoon.App.Services
+@using GrayMoon.App.Services.Queries
 @using GrayMoon.App.Components.Shared
 @using Microsoft.AspNetCore.Components.Web
 @inject WorkspaceRepository WorkspaceRepository
-@inject WorkspaceProjectRepository WorkspaceProjectRepository
+@inject IWorkspaceProjectListQueryService WorkspaceProjectListQueryService
 @inject ILogger<WorkspaceProjects> Logger
 @using WorkspaceModel = GrayMoon.App.Models.Workspace
 
@@ -18,17 +19,17 @@
             <div class="workspace-repos-title-row">
                 <h2 class="workspace-repos-title">Projects</h2>
                 <p class="text-muted mb-0 workspace-repos-subtitle workspace-projects__subtitle">
-                    @if (!isLoading && projects.Count > 0)
+                    @if (hasLoadedOnce && !isInitialLoading)
                     {
                         var projSuffix = HasSearchFilter ? " found" : "";
-                        var projCount = HasSearchFilter ? FilteredProjectCount : projects.Count;
+                        var projCount = totalCount ?? _items.Count;
                         <span>@($"{projCount} {(projCount == 1 ? "project" : "projects")}{projSuffix}")</span>
                     }
-                    else if (!isLoading && workspace != null)
+                    else if (hasLoadedOnce && workspace != null && totalCount == 0 && !HasSearchFilter)
                     {
                         <span>0 projects</span>
                     }
-                    else if (isLoading)
+                    else if (isInitialLoading)
                     {
                         <span>&nbsp;</span>
                     }
@@ -37,11 +38,12 @@
             </div>
             <div class="d-flex gap-2 align-items-center workspace-repos-header-actions">
                 <div class="workspace-grid-search-wrapper">
-                    <FilterSearchInput @bind-Value="searchTerm"
+                    <FilterSearchInput Value="@searchTerm"
+                                       ValueChanged="OnSearchTermChangedAsync"
                                        InputId="workspace-projects-search"
                                        InputAdditionalClass="workspace-grid-search"
                                        Placeholder="Search project name or file..."
-                                       Disabled="@(isLoading || projects.Count == 0)"
+                                       Disabled="@(isInitialLoading && !hasLoadedOnce)"
                                        OnKeyDown="OnSearchKeyDown"
                                        OnClear="ClearSearchFilter" />
                 </div>
@@ -70,7 +72,7 @@
                                 </tr>
                             </thead>
                             <tbody>
-                                @if (isLoading)
+                                @if (isInitialLoading && _items.Count == 0)
                                 {
                                     <tr>
                                         <td colspan="4" class="text-center text-muted py-4">
@@ -78,7 +80,7 @@
                                         </td>
                                     </tr>
                                 }
-                                else if (projects.Count == 0)
+                                else if (hasLoadedOnce && totalCount == 0 && !HasSearchFilter)
                                 {
                                     <tr>
                                         <td colspan="4" class="text-center text-muted py-4">
@@ -96,13 +98,29 @@
                                 }
                                 else
                                 {
-                                    @foreach (var p in FilteredProjects)
+                                    @foreach (var p in _items)
                                     {
                                         <tr>
                                             <td class="col-name"><strong>@p.ProjectName</strong></td>
                                             <td class="col-type text-muted">@p.ProjectType</td>
                                             <td class="col-framework"><span class="badge bg-secondary">@(p.TargetFramework ?? "-")</span></td>
                                             <td class="col-file text-muted" title="@p.ProjectFilePath">@GetFileName(p.ProjectFilePath)</td>
+                                        </tr>
+                                    }
+                                    @if (isLoadingMore)
+                                    {
+                                        <tr>
+                                            <td colspan="4" class="text-center text-muted py-3">
+                                                Loading more...
+                                            </td>
+                                        </tr>
+                                    }
+                                    @if (hasMore && !isLoadingMore)
+                                    {
+                                        <tr>
+                                            <td colspan="4" class="p-0">
+                                                <InfiniteScrollLoadTrigger IsEnabled="true" OnLoadMore="LoadNextChunkAsync" />
+                                            </td>
                                         </tr>
                                     }
                                 }
@@ -115,88 +133,4 @@
     }
 </div>
 
-<LoadingOverlay IsVisible="@isLoading" Message="Loading projects..." />
-
-@code {
-    [Parameter] public int WorkspaceId { get; set; }
-
-    private WorkspaceModel? workspace;
-    private List<WorkspaceProject> projects = new();
-    private string? errorMessage;
-    private bool isLoading = true;
-    private string searchTerm = string.Empty;
-
-    private bool HasSearchFilter => !string.IsNullOrWhiteSpace(searchTerm);
-
-    private IReadOnlyList<WorkspaceProject> FilteredProjects => GetFilteredProjects();
-
-    private int FilteredProjectCount => FilteredProjects.Count;
-
-    private bool NoProjectsMatchSearch =>
-        !isLoading && projects.Count > 0 && FilteredProjects.Count == 0;
-
-    private IReadOnlyList<WorkspaceProject> GetFilteredProjects()
-    {
-        if (string.IsNullOrWhiteSpace(searchTerm))
-        {
-            return projects;
-        }
-
-        return projects.Where(p => WorkspaceProjectSearchMatcher.Matches(p, searchTerm)).ToList();
-    }
-
-    private void ClearSearchFilter()
-    {
-        searchTerm = string.Empty;
-        StateHasChanged();
-    }
-
-    private void OnSearchKeyDown(KeyboardEventArgs e)
-    {
-        if (e.Key == "Escape")
-        {
-            searchTerm = string.Empty;
-            StateHasChanged();
-        }
-    }
-
-    protected override async Task OnInitializedAsync()
-    {
-        await LoadAsync();
-    }
-
-    private async Task LoadAsync()
-    {
-        try
-        {
-            isLoading = true;
-            errorMessage = null;
-            workspace = await WorkspaceRepository.GetByIdAsync(WorkspaceId);
-            if (workspace == null)
-            {
-                errorMessage = "Workspace not found.";
-                projects = new List<WorkspaceProject>();
-                return;
-            }
-            projects = await WorkspaceProjectRepository.GetByWorkspaceIdAsync(WorkspaceId);
-        }
-        catch (Exception ex)
-        {
-            Logger.LogError(ex, "Error loading projects for workspace {WorkspaceId}", WorkspaceId);
-            errorMessage = "Failed to load projects. Please try again later.";
-            projects = new List<WorkspaceProject>();
-        }
-        finally
-        {
-            isLoading = false;
-        }
-    }
-
-    private static string GetFileName(string path)
-    {
-        if (string.IsNullOrWhiteSpace(path)) return "-";
-        var name = path.Replace('\\', '/');
-        var last = name.LastIndexOf('/');
-        return last >= 0 ? name[(last + 1)..] : name;
-    }
-}
+<LoadingOverlay IsVisible="@(isInitialLoading && !hasLoadedOnce)" Message="Loading projects..." />

--- a/src/GrayMoon.App/Components/Pages/WorkspaceProjects.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceProjects.razor
@@ -22,7 +22,7 @@
                     @if (hasLoadedOnce && !isInitialLoading)
                     {
                         var projSuffix = HasSearchFilter ? " found" : "";
-                        var projCount = totalCount ?? _items.Count;
+                        var projCount = totalCount ?? 0;
                         <span>@($"{projCount} {(projCount == 1 ? "project" : "projects")}{projSuffix}")</span>
                     }
                     else if (hasLoadedOnce && workspace != null && totalCount == 0 && !HasSearchFilter)
@@ -71,8 +71,8 @@
                                     <th class="col-file">File</th>
                                 </tr>
                             </thead>
-                            <tbody>
-                                @if (isInitialLoading && _items.Count == 0)
+                            <tbody @ref="_tbodyRef">
+                                @if (isInitialLoading && _virtual.Count == 0)
                                 {
                                     <tr>
                                         <td colspan="4" class="text-center text-muted py-4">
@@ -98,29 +98,34 @@
                                 }
                                 else
                                 {
-                                    @foreach (var p in _items)
+                                    @if (_virtual.TopSpacerPx > 0)
                                     {
-                                        <tr>
-                                            <td class="col-name"><strong>@p.ProjectName</strong></td>
-                                            <td class="col-type text-muted">@p.ProjectType</td>
-                                            <td class="col-framework"><span class="badge bg-secondary">@(p.TargetFramework ?? "-")</span></td>
-                                            <td class="col-file text-muted" title="@p.ProjectFilePath">@GetFileName(p.ProjectFilePath)</td>
+                                        <tr class="virtual-scroll-spacer" aria-hidden="true">
+                                            <td colspan="4" style="height:@(_virtual.TopSpacerPx.ToString("0.###", System.Globalization.CultureInfo.InvariantCulture))px;padding:0;border:0;line-height:0;"></td>
                                         </tr>
                                     }
-                                    @if (isLoadingMore)
+                                    @foreach (var (id, p) in _virtual.VisibleRows)
                                     {
-                                        <tr>
-                                            <td colspan="4" class="text-center text-muted py-3">
-                                                Loading more...
-                                            </td>
-                                        </tr>
+                                        if (p is null)
+                                        {
+                                            <tr @key="@($"ph-{id}")" class="virtual-scroll-placeholder">
+                                                <td colspan="4">&nbsp;</td>
+                                            </tr>
+                                        }
+                                        else
+                                        {
+                                            <tr @key="@id">
+                                                <td class="col-name"><strong>@p.ProjectName</strong></td>
+                                                <td class="col-type text-muted">@p.ProjectType</td>
+                                                <td class="col-framework"><span class="badge bg-secondary">@(p.TargetFramework ?? "-")</span></td>
+                                                <td class="col-file text-muted" title="@p.ProjectFilePath">@GetFileName(p.ProjectFilePath)</td>
+                                            </tr>
+                                        }
                                     }
-                                    @if (hasMore && !isLoadingMore)
+                                    @if (_virtual.BottomSpacerPx > 0)
                                     {
-                                        <tr>
-                                            <td colspan="4" class="p-0">
-                                                <InfiniteScrollLoadTrigger IsEnabled="true" OnLoadMore="LoadNextChunkAsync" />
-                                            </td>
+                                        <tr class="virtual-scroll-spacer" aria-hidden="true">
+                                            <td colspan="4" style="height:@(_virtual.BottomSpacerPx.ToString("0.###", System.Globalization.CultureInfo.InvariantCulture))px;padding:0;border:0;line-height:0;"></td>
                                         </tr>
                                     }
                                 }

--- a/src/GrayMoon.App/Components/Pages/WorkspaceProjects.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceProjects.razor.cs
@@ -1,0 +1,220 @@
+using GrayMoon.App.Components.Shared;
+using GrayMoon.App.Models;
+using GrayMoon.App.Repositories;
+using GrayMoon.App.Services.Queries;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
+using WorkspaceModel = GrayMoon.App.Models.Workspace;
+
+namespace GrayMoon.App.Components.Pages;
+
+public sealed partial class WorkspaceProjects : IDisposable
+{
+    [Parameter] public int WorkspaceId { get; set; }
+
+    private readonly DebouncedQueryLoader _queryLoader = new();
+    private readonly List<WorkspaceProjectListItemDto> _items = new();
+
+    private WorkspaceModel? workspace;
+    private string? errorMessage;
+    private bool isInitialLoading = true;
+    private bool isLoadingMore;
+    private bool hasMore;
+    private bool hasLoadedOnce;
+    private int? totalCount;
+    private string searchTerm = string.Empty;
+    private string _effectiveSearch = string.Empty;
+    private WorkspaceProjectListCursor? _nextCursor;
+    private bool _loadingNextChunk;
+    private bool _disposed;
+
+    private bool HasSearchFilter => !string.IsNullOrWhiteSpace(_effectiveSearch);
+
+    private bool NoProjectsMatchSearch =>
+        hasLoadedOnce && totalCount == 0 && !isInitialLoading && !string.IsNullOrWhiteSpace(_effectiveSearch);
+
+    private void ClearSearchFilter()
+    {
+        searchTerm = string.Empty;
+        _ = OnSearchTermChangedAsync(string.Empty);
+    }
+
+    private void OnSearchKeyDown(KeyboardEventArgs e)
+    {
+        if (e.Key == "Escape")
+        {
+            searchTerm = string.Empty;
+            _ = OnSearchTermChangedAsync(string.Empty);
+        }
+    }
+
+    private async Task OnSearchTermChangedAsync(string value)
+    {
+        searchTerm = value;
+        await _queryLoader.DebounceSearchAsync(async () =>
+        {
+            _effectiveSearch = searchTerm;
+            await ResetAndLoadFromTopAsync();
+            if (!_disposed)
+            {
+                await InvokeAsync(StateHasChanged);
+            }
+        });
+    }
+
+    public void Dispose()
+    {
+        _disposed = true;
+        _queryLoader.Dispose();
+    }
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (workspace?.WorkspaceId != WorkspaceId)
+        {
+            await LoadWorkspaceHeaderAsync();
+            await ResetAndLoadFromTopAsync();
+        }
+    }
+
+    private async Task LoadWorkspaceHeaderAsync()
+    {
+        try
+        {
+            isInitialLoading = true;
+            errorMessage = null;
+            workspace = await WorkspaceRepository.GetByIdAsync(WorkspaceId);
+            if (workspace == null)
+            {
+                errorMessage = "Workspace not found.";
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error loading workspace {WorkspaceId}", WorkspaceId);
+            errorMessage = "Failed to load projects. Please try again later.";
+        }
+    }
+
+    private async Task ResetAndLoadFromTopAsync()
+    {
+        if (workspace == null && errorMessage == null)
+        {
+            return;
+        }
+
+        if (errorMessage != null)
+        {
+            isInitialLoading = false;
+            return;
+        }
+
+        var token = _queryLoader.BeginQueryCycle(out var generation);
+        _items.Clear();
+        _nextCursor = null;
+        hasMore = false;
+        totalCount = null;
+        isInitialLoading = true;
+        isLoadingMore = false;
+        _loadingNextChunk = false;
+
+        try
+        {
+            var filter = new WorkspaceProjectListFilter(WorkspaceId, _effectiveSearch);
+            totalCount = await WorkspaceProjectListQueryService.CountAsync(filter, token);
+            var page = await WorkspaceProjectListQueryService.GetPageAsync(
+                new WorkspaceProjectListRequest(
+                    WorkspaceId,
+                    _effectiveSearch,
+                    IWorkspaceProjectListQueryService.DefaultChunkSize,
+                    null),
+                token);
+
+            if (generation != _queryLoader.Generation || _disposed)
+            {
+                return;
+            }
+
+            _items.AddRange(page.Items);
+            _nextCursor = page.NextCursor;
+            hasMore = page.HasMore;
+            hasLoadedOnce = true;
+        }
+        catch (OperationCanceledException)
+        {
+        }
+        catch (Exception ex)
+        {
+            if (generation == _queryLoader.Generation && !_disposed)
+            {
+                Logger.LogError(ex, "Error loading projects for workspace {WorkspaceId}", WorkspaceId);
+                errorMessage = "Failed to load projects. Please try again later.";
+                _items.Clear();
+            }
+        }
+        finally
+        {
+            if (generation == _queryLoader.Generation && !_disposed)
+            {
+                isInitialLoading = false;
+            }
+        }
+    }
+
+    private async Task LoadNextChunkAsync()
+    {
+        if (_loadingNextChunk || isInitialLoading || !hasMore || _nextCursor is null)
+        {
+            return;
+        }
+
+        _loadingNextChunk = true;
+        isLoadingMore = true;
+        var generation = _queryLoader.Generation;
+        var token = _queryLoader.GetQueryToken();
+
+        try
+        {
+            var page = await WorkspaceProjectListQueryService.GetPageAsync(
+                new WorkspaceProjectListRequest(
+                    WorkspaceId,
+                    _effectiveSearch,
+                    IWorkspaceProjectListQueryService.DefaultChunkSize,
+                    _nextCursor),
+                token);
+
+            if (generation != _queryLoader.Generation || _disposed)
+            {
+                return;
+            }
+
+            _items.AddRange(page.Items);
+            _nextCursor = page.NextCursor;
+            hasMore = page.HasMore;
+        }
+        catch (OperationCanceledException)
+        {
+        }
+        catch (Exception ex)
+        {
+            if (generation == _queryLoader.Generation && !_disposed)
+            {
+                Logger.LogError(ex, "Error loading more projects for workspace {WorkspaceId}", WorkspaceId);
+                errorMessage = "Failed to load more projects. Please try again later.";
+            }
+        }
+        finally
+        {
+            _loadingNextChunk = false;
+            isLoadingMore = false;
+        }
+    }
+
+    private static string GetFileName(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path)) return "-";
+        var name = path.Replace('\\', '/');
+        var last = name.LastIndexOf('/');
+        return last >= 0 ? name[(last + 1)..] : name;
+    }
+}

--- a/src/GrayMoon.App/Components/Pages/WorkspaceProjects.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceProjects.razor.cs
@@ -206,6 +206,11 @@ public sealed partial class WorkspaceProjects : IAsyncDisposable, IDisposable
         var token = _queryLoader.GetQueryToken();
         var (start, end) = _virtual.ComputeRange(scrollTop, clientHeight);
         var rangeChanged = _virtual.UpdateVisibleRange(start, end);
+        if (rangeChanged && _virtual.IsCurrentScroll(scrollGeneration) && !_disposed)
+        {
+            await InvokeAsync(StateHasChanged);
+        }
+
         var itemsHydrated = await EnsureVisibleHydratedAsync(token);
         if (!_virtual.IsCurrentScroll(scrollGeneration)
             || queryGeneration != _queryLoader.Generation
@@ -214,7 +219,7 @@ public sealed partial class WorkspaceProjects : IAsyncDisposable, IDisposable
             return;
         }
 
-        if (rangeChanged || itemsHydrated)
+        if (itemsHydrated)
         {
             await InvokeAsync(StateHasChanged);
         }

--- a/src/GrayMoon.App/Components/Pages/WorkspaceProjects.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceProjects.razor.cs
@@ -175,21 +175,22 @@ public sealed partial class WorkspaceProjects : IAsyncDisposable, IDisposable
         }
     }
 
-    private async Task EnsureVisibleHydratedAsync(CancellationToken cancellationToken)
+    private async Task<bool> EnsureVisibleHydratedAsync(CancellationToken cancellationToken)
     {
         var missing = _virtual.GetMissingIds(_virtual.VisibleStart, _virtual.VisibleEnd);
         if (missing.Count == 0)
         {
-            return;
+            return false;
         }
 
         var rows = await WorkspaceProjectListQueryService.GetByIdsAsync(missing, cancellationToken);
         if (cancellationToken.IsCancellationRequested || _disposed)
         {
-            return;
+            return false;
         }
 
         _virtual.CacheItems(rows.Select(r => (r.ProjectId, r)));
+        return rows.Count > 0;
     }
 
     [JSInvokable]
@@ -200,17 +201,23 @@ public sealed partial class WorkspaceProjects : IAsyncDisposable, IDisposable
             return;
         }
 
-        var generation = _queryLoader.Generation;
+        var scrollGeneration = _virtual.BeginScrollUpdate();
+        var queryGeneration = _queryLoader.Generation;
         var token = _queryLoader.GetQueryToken();
         var (start, end) = _virtual.ComputeRange(scrollTop, clientHeight);
-        _virtual.UpdateVisibleRange(start, end);
-        await EnsureVisibleHydratedAsync(token);
-        if (generation != _queryLoader.Generation || _disposed)
+        var rangeChanged = _virtual.UpdateVisibleRange(start, end);
+        var itemsHydrated = await EnsureVisibleHydratedAsync(token);
+        if (!_virtual.IsCurrentScroll(scrollGeneration)
+            || queryGeneration != _queryLoader.Generation
+            || _disposed)
         {
             return;
         }
 
-        await InvokeAsync(StateHasChanged);
+        if (rangeChanged || itemsHydrated)
+        {
+            await InvokeAsync(StateHasChanged);
+        }
     }
 
     private static string GetFileName(string path)

--- a/src/GrayMoon.App/Components/Pages/WorkspaceProjects.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceProjects.razor.cs
@@ -4,29 +4,30 @@ using GrayMoon.App.Repositories;
 using GrayMoon.App.Services.Queries;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
+using Microsoft.JSInterop;
 using WorkspaceModel = GrayMoon.App.Models.Workspace;
 
 namespace GrayMoon.App.Components.Pages;
 
-public sealed partial class WorkspaceProjects : IDisposable
+public sealed partial class WorkspaceProjects : IAsyncDisposable, IDisposable
 {
     [Parameter] public int WorkspaceId { get; set; }
 
+    [Inject] private IJSRuntime JSRuntime { get; set; } = default!;
+
     private readonly DebouncedQueryLoader _queryLoader = new();
-    private readonly List<WorkspaceProjectListItemDto> _items = new();
+    private readonly VirtualTableScrollState<WorkspaceProjectListItemDto> _virtual = new();
+    private ElementReference _tbodyRef;
 
     private WorkspaceModel? workspace;
     private string? errorMessage;
     private bool isInitialLoading = true;
-    private bool isLoadingMore;
-    private bool hasMore;
     private bool hasLoadedOnce;
     private int? totalCount;
     private string searchTerm = string.Empty;
     private string _effectiveSearch = string.Empty;
-    private WorkspaceProjectListCursor? _nextCursor;
-    private bool _loadingNextChunk;
     private bool _disposed;
+    private int _loadedWorkspaceId;
 
     private bool HasSearchFilter => !string.IsNullOrWhiteSpace(_effectiveSearch);
 
@@ -64,16 +65,39 @@ public sealed partial class WorkspaceProjects : IDisposable
 
     public void Dispose()
     {
+        if (_disposed)
+        {
+            return;
+        }
+
         _disposed = true;
         _queryLoader.Dispose();
     }
 
+    public async ValueTask DisposeAsync()
+    {
+        await _virtual.DetachAsync(JSRuntime);
+        await _virtual.DisposeAsync();
+        Dispose();
+    }
+
     protected override async Task OnParametersSetAsync()
     {
-        if (workspace?.WorkspaceId != WorkspaceId)
+        if (_loadedWorkspaceId == WorkspaceId && workspace != null)
         {
-            await LoadWorkspaceHeaderAsync();
-            await ResetAndLoadFromTopAsync();
+            return;
+        }
+
+        _loadedWorkspaceId = WorkspaceId;
+        await LoadWorkspaceHeaderAsync();
+        await ResetAndLoadFromTopAsync();
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (!isInitialLoading && _virtual.Count > 0 && !_virtual.IsAttached && !_disposed)
+        {
+            await _virtual.AttachAsync(JSRuntime, this, _tbodyRef);
         }
     }
 
@@ -83,7 +107,7 @@ public sealed partial class WorkspaceProjects : IDisposable
         {
             isInitialLoading = true;
             errorMessage = null;
-            workspace = await WorkspaceRepository.GetByIdAsync(WorkspaceId);
+            workspace = await WorkspaceRepository.GetHeaderAsync(WorkspaceId);
             if (workspace == null)
             {
                 errorMessage = "Workspace not found.";
@@ -110,35 +134,25 @@ public sealed partial class WorkspaceProjects : IDisposable
         }
 
         var token = _queryLoader.BeginQueryCycle(out var generation);
-        _items.Clear();
-        _nextCursor = null;
-        hasMore = false;
+        await _virtual.DetachAsync(JSRuntime);
+        _virtual.Clear();
         totalCount = null;
         isInitialLoading = true;
-        isLoadingMore = false;
-        _loadingNextChunk = false;
 
         try
         {
             var filter = new WorkspaceProjectListFilter(WorkspaceId, _effectiveSearch);
             totalCount = await WorkspaceProjectListQueryService.CountAsync(filter, token);
-            var page = await WorkspaceProjectListQueryService.GetPageAsync(
-                new WorkspaceProjectListRequest(
-                    WorkspaceId,
-                    _effectiveSearch,
-                    IWorkspaceProjectListQueryService.DefaultChunkSize,
-                    null),
-                token);
+            var ids = await WorkspaceProjectListQueryService.GetIndexAsync(filter, token);
 
             if (generation != _queryLoader.Generation || _disposed)
             {
                 return;
             }
 
-            _items.AddRange(page.Items);
-            _nextCursor = page.NextCursor;
-            hasMore = page.HasMore;
+            _virtual.SetIndex(ids);
             hasLoadedOnce = true;
+            await EnsureVisibleHydratedAsync(token);
         }
         catch (OperationCanceledException)
         {
@@ -149,7 +163,7 @@ public sealed partial class WorkspaceProjects : IDisposable
             {
                 Logger.LogError(ex, "Error loading projects for workspace {WorkspaceId}", WorkspaceId);
                 errorMessage = "Failed to load projects. Please try again later.";
-                _items.Clear();
+                _virtual.Clear();
             }
         }
         finally
@@ -161,53 +175,42 @@ public sealed partial class WorkspaceProjects : IDisposable
         }
     }
 
-    private async Task LoadNextChunkAsync()
+    private async Task EnsureVisibleHydratedAsync(CancellationToken cancellationToken)
     {
-        if (_loadingNextChunk || isInitialLoading || !hasMore || _nextCursor is null)
+        var missing = _virtual.GetMissingIds(_virtual.VisibleStart, _virtual.VisibleEnd);
+        if (missing.Count == 0)
         {
             return;
         }
 
-        _loadingNextChunk = true;
-        isLoadingMore = true;
+        var rows = await WorkspaceProjectListQueryService.GetByIdsAsync(missing, cancellationToken);
+        if (cancellationToken.IsCancellationRequested || _disposed)
+        {
+            return;
+        }
+
+        _virtual.CacheItems(rows.Select(r => (r.ProjectId, r)));
+    }
+
+    [JSInvokable]
+    public async Task OnVirtualScroll(double scrollTop, double clientHeight)
+    {
+        if (_disposed || _virtual.Count == 0)
+        {
+            return;
+        }
+
         var generation = _queryLoader.Generation;
         var token = _queryLoader.GetQueryToken();
+        var (start, end) = _virtual.ComputeRange(scrollTop, clientHeight);
+        _virtual.UpdateVisibleRange(start, end);
+        await EnsureVisibleHydratedAsync(token);
+        if (generation != _queryLoader.Generation || _disposed)
+        {
+            return;
+        }
 
-        try
-        {
-            var page = await WorkspaceProjectListQueryService.GetPageAsync(
-                new WorkspaceProjectListRequest(
-                    WorkspaceId,
-                    _effectiveSearch,
-                    IWorkspaceProjectListQueryService.DefaultChunkSize,
-                    _nextCursor),
-                token);
-
-            if (generation != _queryLoader.Generation || _disposed)
-            {
-                return;
-            }
-
-            _items.AddRange(page.Items);
-            _nextCursor = page.NextCursor;
-            hasMore = page.HasMore;
-        }
-        catch (OperationCanceledException)
-        {
-        }
-        catch (Exception ex)
-        {
-            if (generation == _queryLoader.Generation && !_disposed)
-            {
-                Logger.LogError(ex, "Error loading more projects for workspace {WorkspaceId}", WorkspaceId);
-                errorMessage = "Failed to load more projects. Please try again later.";
-            }
-        }
-        finally
-        {
-            _loadingNextChunk = false;
-            isLoadingMore = false;
-        }
+        await InvokeAsync(StateHasChanged);
     }
 
     private static string GetFileName(string path)

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.Branches.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.Branches.cs
@@ -173,7 +173,7 @@ public sealed partial class WorkspaceRepositories
             });
 
             if (failureCount > 0)
-                SafeInvoke(() => ToastService.Show($"Fetched branches for {successCount} repositories. {failureCount} failed."));
+                SafeInvoke(() => ToastService.ShowError($"Fetched branches for {successCount} repositories. {failureCount} failed."));
         }, new PageJobOptions
         {
             RefreshOnSuccess = false,
@@ -181,7 +181,7 @@ public sealed partial class WorkspaceRepositories
             OnError = ex =>
             {
                 Logger.LogError(ex, "Error fetching branches across workspace {WorkspaceId}", WorkspaceId);
-                SafeInvoke(() => ToastService.Show("Failed to fetch branches across workspace."));
+                SafeInvoke(() => ToastService.ShowError("Failed to fetch branches across workspace."));
             }
         });
 
@@ -230,14 +230,20 @@ public sealed partial class WorkspaceRepositories
             });
 
             if (result.FailureCount > 0)
-                SafeInvoke(() => ToastService.Show($"Checked out branch in {result.SuccessCount} repositories. {result.FailureCount} failed."));
+            {
+                var firstError = result.ErrorsByRepositoryId.Values.FirstOrDefault();
+                SafeInvoke(() => ToastService.ShowError(
+                    !string.IsNullOrWhiteSpace(firstError)
+                        ? firstError
+                        : $"Checked out branch in {result.SuccessCount} repositories. {result.FailureCount} failed."));
+            }
         }, new PageJobOptions
         {
             CancelToast = "Checkout cancelled.",
             OnError = ex =>
             {
                 Logger.LogError(ex, "Error checking out branch {BranchName} across workspace {WorkspaceId}", branchName, WorkspaceId);
-                SafeInvoke(() => ToastService.Show("Failed to check out branch across workspace."));
+                SafeInvoke(() => ToastService.ShowError("Failed to check out branch across workspace."));
             }
         });
 
@@ -344,9 +350,15 @@ public sealed partial class WorkspaceRepositories
             SafeInvoke(() =>
             {
                 if (success)
+                {
                     repositoryErrors.Remove(repositoryId);
+                }
                 else
-                    repositoryErrors[repositoryId] = errMsg ?? (isTag ? "Failed to checkout tag." : "Failed to checkout branch.");
+                {
+                    var message = errMsg ?? (isTag ? "Failed to checkout tag." : "Failed to checkout branch.");
+                    repositoryErrors[repositoryId] = message;
+                    ToastService.ShowError(message);
+                }
             });
         }, new PageJobOptions
         {
@@ -354,9 +366,14 @@ public sealed partial class WorkspaceRepositories
             OnError = ex =>
             {
                 Logger.LogError(ex, "Error checking out {Kind} for repository {RepositoryId}", isTag ? "tag" : "branch", repositoryId);
-                SafeInvoke(() => { repositoryErrors[repositoryId] = isTag
+                var message = isTag
                     ? "Failed to checkout tag. The GrayMoon Agent may be offline. Start the Agent and try again."
-                    : "Failed to checkout branch. The GrayMoon Agent may be offline. Start the Agent and try again."; });
+                    : "Failed to checkout branch. The GrayMoon Agent may be offline. Start the Agent and try again.";
+                SafeInvoke(() =>
+                {
+                    repositoryErrors[repositoryId] = message;
+                    ToastService.ShowError(message);
+                });
             }
         });
 

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.Branches.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.Branches.cs
@@ -10,7 +10,7 @@ public sealed partial class WorkspaceRepositories
 
     private void ShowSwitchBranchModal(int repositoryId, string? currentBranch, string? cloneUrl)
     {
-        var wr = workspaceRepositories.FirstOrDefault(wr => wr.RepositoryId == repositoryId);
+        var wr = TryGetLink(repositoryId);
         var repo = wr?.Repository;
 
         if (repo == null)
@@ -42,7 +42,7 @@ public sealed partial class WorkspaceRepositories
 
     private void ShowSwitchBranchModalOnTagsTab(WorkspaceRepositoryLink link)
     {
-        var wr = workspaceRepositories.FirstOrDefault(r => r.RepositoryId == link.RepositoryId);
+        var wr = TryGetLink(link.RepositoryId);
         var repo = wr?.Repository;
         if (repo == null)
             return;
@@ -79,7 +79,7 @@ public sealed partial class WorkspaceRepositories
 
     private async Task ShowBranchModalAsync(string initialTab = "newbranch")
     {
-        if (workspace == null || workspaceRepositories.Count == 0)
+        if (workspace == null || !HasRepositories)
             return;
         try
         {
@@ -89,10 +89,11 @@ public sealed partial class WorkspaceRepositories
         {
             Logger.LogWarning(ex, "Could not load common branches for branch modal");
         }
+        var allLinks = await GetAllLinksForOperationAsync();
         _branchModal = _branchModal with
         {
             IsVisible = true,
-            WorkspaceUnifiedCurrentBranch = GetUnifiedWorkspaceCurrentBranch(workspaceRepositories),
+            WorkspaceUnifiedCurrentBranch = GetUnifiedWorkspaceCurrentBranch(allLinks),
             InitialTab = string.Equals(initialTab, "switchbranch", StringComparison.OrdinalIgnoreCase) ? "switchbranch" : "newbranch"
         };
         StateHasChanged();
@@ -115,27 +116,29 @@ public sealed partial class WorkspaceRepositories
 
         var commonLocal = data.CommonLocalBranchNames ?? data.CommonBranchNames ?? new List<string>();
         var commonRemote = data.CommonRemoteBranchNames ?? new List<string>();
+        var allLinks = await GetAllLinksForOperationAsync();
         _branchModal = _branchModal with
         {
             CommonBranchNames = commonLocal,
             CommonLocalBranchNames = commonLocal,
             CommonRemoteBranchNames = commonRemote,
             DefaultDisplayText = data.DefaultDisplayText ?? "multiple",
-            WorkspaceUnifiedCurrentBranch = GetUnifiedWorkspaceCurrentBranch(workspaceRepositories)
+            WorkspaceUnifiedCurrentBranch = GetUnifiedWorkspaceCurrentBranch(allLinks)
         };
     }
 
-    private Task FetchCommonBranchesAcrossWorkspaceAsync()
+    private async Task FetchCommonBranchesAcrossWorkspaceAsync()
     {
         if (workspace == null || IsJobRunning)
-            return Task.CompletedTask;
+            return;
 
-        var repoIds = workspaceRepositories
+        var allLinks = await GetAllLinksForOperationAsync();
+        var repoIds = allLinks
             .Select(wr => wr.RepositoryId)
             .Distinct()
             .ToList();
         if (repoIds.Count == 0)
-            return Task.CompletedTask;
+            return;
 
         StartPageJob("Fetching branches...", async (job, ct) =>
         {
@@ -182,22 +185,22 @@ public sealed partial class WorkspaceRepositories
             }
         });
 
-        return Task.CompletedTask;
     }
 
-    private Task CheckoutCommonBranchAcrossWorkspaceAsync((string BranchName, bool SkipReposOnTags) args)
+    private async Task CheckoutCommonBranchAcrossWorkspaceAsync((string BranchName, bool SkipReposOnTags) args)
     {
         var (branchName, skipReposOnTags) = args;
         if (workspace == null || string.IsNullOrWhiteSpace(branchName) || IsJobRunning)
-            return Task.CompletedTask;
+            return;
 
-        var repoIds = workspaceRepositories
+        var allLinks = await GetAllLinksForOperationAsync();
+        var repoIds = allLinks
             .Where(wr => !skipReposOnTags || !wr.IsOnTag)
             .Select(wr => wr.RepositoryId)
             .Distinct()
             .ToList();
         if (repoIds.Count == 0)
-            return Task.CompletedTask;
+            return;
 
         StartPageJob("Checking out...", async (job, ct) =>
         {
@@ -238,20 +241,20 @@ public sealed partial class WorkspaceRepositories
             }
         });
 
-        return Task.CompletedTask;
     }
 
-    private Task CreateBranchesAsync((string NewBranchName, string BaseBranch, bool SkipReposOnTags) args)
+    private async Task CreateBranchesAsync((string NewBranchName, string BaseBranch, bool SkipReposOnTags) args)
     {
         var (newBranchName, baseBranch, skipReposOnTags) = args;
         if (workspace == null || string.IsNullOrWhiteSpace(newBranchName) || IsJobRunning)
-            return Task.CompletedTask;
+            return;
 
         CloseBranchModal();
         errorMessage = null;
 
+        var allLinks = await GetAllLinksForOperationAsync();
         var tagFilteredRepoIds = skipReposOnTags
-            ? workspaceRepositories.Where(wr => !wr.IsOnTag).Select(wr => wr.RepositoryId).ToHashSet()
+            ? allLinks.Where(wr => !wr.IsOnTag).Select(wr => wr.RepositoryId).ToHashSet()
             : (IReadOnlySet<int>?)null;
 
         StartPageJob("Creating branches...", async (job, ct) =>
@@ -275,7 +278,6 @@ public sealed partial class WorkspaceRepositories
             }
         });
 
-        return Task.CompletedTask;
     }
 
     private async Task OnBranchChangedAsync()

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.CommitSync.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.CommitSync.cs
@@ -5,12 +5,13 @@ namespace GrayMoon.App.Components.Pages;
 public sealed partial class WorkspaceRepositories
 {
     /// <summary>Pull button click (when any repo has incoming commits): run commit sync (Pull) only for repos with incoming commits. Uses same overlay and merge/error handling as CommitSyncAsync/CommitSyncLevelAsync.</summary>
-    private void OnPullClickAsync()
+    private async Task OnPullClickAsync()
     {
-        if (workspace == null || workspaceRepositories.Count == 0 || IsJobRunning)
+        if (workspace == null || !HasRepositories || IsJobRunning)
             return;
 
-        var repoIdsWithIncoming = workspaceRepositories
+        var allLinks = await GetAllLinksForOperationAsync();
+        var repoIdsWithIncoming = allLinks
             .Where(wr =>
                 !wr.IsOnTag
                 && (wr.IncomingCommits ?? 0) > 0
@@ -46,6 +47,24 @@ public sealed partial class WorkspaceRepositories
     private void ShowConfirmSyncCommits(int repositoryId)
     {
         ShowConfirm("Do you want to sync commits for this repository?", () => CommitSyncAsync(repositoryId));
+    }
+
+    private async Task SyncCommitsForLevelAsync(int? levelKey)
+    {
+        var ids = (await GetRepositoryIdsAtLevelAsync(levelKey)).ToList();
+        ShowConfirmSyncCommitsLevel(ids);
+    }
+
+    private async Task SyncToDefaultForLevelAsync(int? levelKey)
+    {
+        var ids = (await GetRepositoryIdsAtLevelAsync(levelKey)).ToList();
+        await ShowConfirmSyncToDefaultLevel(ids);
+    }
+
+    private async Task SyncLevelForLevelAsync(int? levelKey)
+    {
+        var ids = (await GetRepositoryIdsAtLevelAsync(levelKey)).ToList();
+        ShowConfirmSyncLevel(ids);
     }
 
     private void ShowConfirmSyncCommitsLevel(List<int> repositoryIds)

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.Dependencies.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.Dependencies.cs
@@ -12,7 +12,7 @@ public sealed partial class WorkspaceRepositories
     private CustomDependenciesModalState _customDependenciesModal = new();
 
     private bool HasOutOfDateFiles(int repositoryId) =>
-        (workspaceRepositories.FirstOrDefault(wr => wr.RepositoryId == repositoryId)?.OutOfDateFileRepos ?? 0) > 0;
+        (TryGetLink(repositoryId)?.OutOfDateFileRepos ?? 0) > 0;
 
     private IReadOnlyList<FileVersionMismatchLine> GetMismatchedFileVersionLines(int repositoryId) =>
         _mismatchedFileVersionLinesByRepo.TryGetValue(repositoryId, out var lines) ? lines : Array.Empty<FileVersionMismatchLine>();
@@ -88,9 +88,9 @@ public sealed partial class WorkspaceRepositories
                 return;
             }
             var repoPayload = payload[0];
-            var repoName = workspaceRepositories.FirstOrDefault(wr => wr.RepositoryId == repositoryId)?.Repository?.RepositoryName;
+            var repoName = TryGetLink(repositoryId)?.Repository?.RepositoryName;
 
-            var repo = workspaceRepositories.FirstOrDefault(wr => wr.RepositoryId == repositoryId);
+            var repo = TryGetLink(repositoryId);
             if (repo != null
                 && !string.IsNullOrWhiteSpace(repo.DefaultBranchName)
                 && string.Equals(repo.BranchName, repo.DefaultBranchName, StringComparison.Ordinal))
@@ -200,7 +200,7 @@ public sealed partial class WorkspaceRepositories
 
     private async Task ShowCustomDependenciesModalAsync(int repositoryId)
     {
-        if (workspaceRepositories.FirstOrDefault(wr => wr.RepositoryId == repositoryId) is not { } link)
+        if (TryGetLink(repositoryId) is not { } link)
             return;
 
         if (link.IsOnTag)
@@ -220,7 +220,8 @@ public sealed partial class WorkspaceRepositories
             var workspaceRepo = scope.ServiceProvider.GetRequiredService<WorkspaceRepository>();
 
             var workspaceData = await workspaceRepo.GetByIdAsync(WorkspaceId);
-            var allLinks = workspaceData?.Repositories ?? workspaceRepositories;
+            var allLinks = workspaceData?.Repositories
+                ?? (await GetAllLinksForOperationAsync()).ToList();
 
             var implicitBySource = await projectRepo.GetImplicitReferencedRepoIdsBySourceAsync(WorkspaceId, repositoryId);
             var lockedIds = new HashSet<int>(implicitBySource.FromProject);

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.Dependencies.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.Dependencies.cs
@@ -111,7 +111,7 @@ public sealed partial class WorkspaceRepositories
         catch (Exception ex)
         {
             Logger.LogError(ex, "Error getting update plan for repository {RepositoryId}", repositoryId);
-            ToastService.Show("Could not load dependency updates.");
+            ToastService.ShowError("Could not load dependency updates.");
         }
     }
 
@@ -156,7 +156,7 @@ public sealed partial class WorkspaceRepositories
             OnError = ex =>
             {
                 Logger.LogError(ex, "Update dependencies failed for repository {RepositoryId}", repositoryId);
-                SafeInvoke(() => ToastService.Show(ex.Message));
+                SafeInvoke(() => ToastService.ShowError(ex.Message));
             }
         });
 

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.FileVersions.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.FileVersions.cs
@@ -9,7 +9,7 @@ public sealed partial class WorkspaceRepositories
 
     private Task OnUpdateFilesClickAsync()
     {
-        if (workspace == null || workspaceRepositories.Count == 0 || IsJobRunning)
+        if (workspace == null || !HasRepositories || IsJobRunning)
             return Task.CompletedTask;
 
         errorMessage = null;
@@ -129,7 +129,7 @@ public sealed partial class WorkspaceRepositories
             return;
         }
 
-        var repo = workspaceRepositories.FirstOrDefault(wr => wr.RepositoryId == repositoryId);
+        var repo = TryGetLink(repositoryId);
         var repoName = repo?.Repository?.RepositoryName;
 
         if (repo != null

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.Loading.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.Loading.cs
@@ -97,11 +97,11 @@ public sealed partial class WorkspaceRepositories
             }
         }
     }
-    private async Task EnsureSlotsHydratedAsync(int start, int end, CancellationToken cancellationToken)
+    private async Task<bool> EnsureSlotsHydratedAsync(int start, int end, CancellationToken cancellationToken)
     {
         if (_slots.Count == 0 || end < start)
         {
-            return;
+            return false;
         }
         start = Math.Clamp(start, 0, _slots.Count - 1);
         end = Math.Clamp(end, start, _slots.Count - 1);
@@ -120,14 +120,15 @@ public sealed partial class WorkspaceRepositories
         }
         if (missingIds.Count == 0)
         {
-            return;
+            return false;
         }
         var dtos = await LinkListQueryService.GetByIdsAsync(WorkspaceId, missingIds, cancellationToken);
         if (cancellationToken.IsCancellationRequested || _disposed)
         {
-            return;
+            return false;
         }
         ApplyItemsFromDtos(dtos, replace: false);
+        return dtos.Count > 0;
     }
     [JSInvokable]
     public async Task OnVirtualScroll(double scrollTop, double clientHeight)
@@ -136,7 +137,9 @@ public sealed partial class WorkspaceRepositories
         {
             return;
         }
-        var generation = _queryLoader.Generation;
+
+        var scrollGeneration = Interlocked.Increment(ref _scrollGeneration);
+        var queryGeneration = _queryLoader.Generation;
         var token = _queryLoader.GetQueryToken();
         var rangeStart = scrollTop - (VirtualOverscanSlots * VirtualRowHeightPx);
         var rangeEnd = scrollTop + clientHeight + (VirtualOverscanSlots * VirtualRowHeightPx);
@@ -172,13 +175,20 @@ public sealed partial class WorkspaceRepositories
             start = 0;
             end = Math.Min(_slots.Count - 1, VirtualInitialViewportSlots - 1);
         }
-        UpdateVisibleRange(start, end);
-        await EnsureSlotsHydratedAsync(start, end, token);
-        if (generation != _queryLoader.Generation || _disposed)
+
+        var rangeChanged = UpdateVisibleRange(start, end);
+        var itemsHydrated = await EnsureSlotsHydratedAsync(start, end, token);
+        if (scrollGeneration != _scrollGeneration
+            || queryGeneration != _queryLoader.Generation
+            || _disposed)
         {
             return;
         }
-        await InvokeAsync(StateHasChanged);
+
+        if (rangeChanged || itemsHydrated)
+        {
+            await InvokeAsync(StateHasChanged);
+        }
     }
     private async Task AttachVirtualScrollAsync()
     {

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.Loading.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.Loading.cs
@@ -2,9 +2,8 @@ using GrayMoon.App.Models;
 using GrayMoon.App.Repositories;
 using GrayMoon.App.Services;
 using GrayMoon.App.Services.Queries;
-
+using Microsoft.JSInterop;
 namespace GrayMoon.App.Components.Pages;
-
 public sealed partial class WorkspaceRepositories
 {
     private async Task LoadWorkspaceAsync()
@@ -13,24 +12,22 @@ public sealed partial class WorkspaceRepositories
         {
             isInitialLoading = true;
             errorMessage = null;
+            CancelBackgroundWork();
+            _backgroundWorkCts = new CancellationTokenSource();
             await LoadWorkspaceHeaderAsync();
             await ResetAndLoadFromTopAsync();
-            _ = RefreshPullRequestsInBackgroundAndReloadAsync();
         }
         catch (Exception ex)
         {
             Logger.LogError(ex, "Error loading workspace {WorkspaceId}", WorkspaceId);
             errorMessage = "Failed to load workspace. Please try again later.";
-            _items.Clear();
-            _linkByRepoId.Clear();
-            _headerState = null;
+            ClearGridState();
         }
         finally
         {
             isInitialLoading = false;
         }
     }
-
     private async Task LoadWorkspaceHeaderAsync()
     {
         workspace = await WorkspacePageService.WorkspaceRepository.GetHeaderAsync(WorkspaceId);
@@ -39,59 +36,45 @@ public sealed partial class WorkspaceRepositories
             errorMessage = "Workspace not found.";
         }
     }
-
     private async Task LoadHeaderStateAsync(CancellationToken cancellationToken = default)
     {
         _headerState = await LinkListQueryService.GetHeaderStateAsync(WorkspaceId, cancellationToken);
     }
-
     private async Task ResetAndLoadFromTopAsync()
     {
         if (workspace == null && errorMessage == null)
         {
             return;
         }
-
         if (errorMessage != null)
         {
             isInitialLoading = false;
             return;
         }
-
         var token = _queryLoader.BeginQueryCycle(out var generation);
-        _items.Clear();
-        _linkByRepoId.Clear();
-        _nextCursor = null;
-        hasMore = false;
-        totalCount = null;
+        ClearGridState();
         isInitialLoading = true;
-        isLoadingMore = false;
-        _loadingNextChunk = false;
-        prByRepositoryId = new Dictionary<int, PullRequestInfo?>();
-
+        _virtualScrollAttached = false;
         try
         {
             var filter = new WorkspaceRepositoryLinkListFilter(WorkspaceId, _effectiveSearch);
             await LoadHeaderStateAsync(token);
             totalCount = await LinkListQueryService.CountAsync(filter, token);
-            var page = await LinkListQueryService.GetPageAsync(
-                new WorkspaceRepositoryLinkListRequest(
-                    WorkspaceId,
-                    _effectiveSearch,
-                    IWorkspaceRepositoryLinkListQueryService.DefaultChunkSize,
-                    null),
-                token);
-
+            var index = await LinkListQueryService.GetIndexAsync(filter, token);
             if (generation != _queryLoader.Generation || _disposed)
             {
                 return;
             }
-
-            ApplyItemsFromDtos(page.Items, replace: true);
-            _nextCursor = page.NextCursor;
-            hasMore = page.HasMore;
+            BuildSlots(index);
             hasLoadedOnce = true;
-            await LoadMismatchedDependencyLinesAsync();
+            _loadedWorkspaceId = WorkspaceId;
+            var initialEnd = Math.Min(_slots.Count - 1, VirtualInitialViewportSlots - 1);
+            UpdateVisibleRange(0, Math.Max(-1, initialEnd));
+            await EnsureSlotsHydratedAsync(0, initialEnd, token);
+            if (generation != _queryLoader.Generation || _disposed)
+            {
+                return;
+            }
             ApplySyncStateFromLoadedItems();
         }
         catch (OperationCanceledException)
@@ -103,8 +86,7 @@ public sealed partial class WorkspaceRepositories
             {
                 Logger.LogError(ex, "Error loading repositories for workspace {WorkspaceId}", WorkspaceId);
                 errorMessage = "Failed to load workspace. Please try again later.";
-                _items.Clear();
-                _linkByRepoId.Clear();
+                ClearGridState();
             }
         }
         finally
@@ -115,91 +97,130 @@ public sealed partial class WorkspaceRepositories
             }
         }
     }
-
-    private async Task LoadNextChunkAsync()
+    private async Task EnsureSlotsHydratedAsync(int start, int end, CancellationToken cancellationToken)
     {
-        if (_loadingNextChunk || isInitialLoading || !hasMore || _nextCursor is null)
+        if (_slots.Count == 0 || end < start)
         {
             return;
         }
-
-        _loadingNextChunk = true;
-        isLoadingMore = true;
+        start = Math.Clamp(start, 0, _slots.Count - 1);
+        end = Math.Clamp(end, start, _slots.Count - 1);
+        var missingIds = new List<int>();
+        for (var i = start; i <= end; i++)
+        {
+            var slot = _slots[i];
+            if (slot.Kind != VirtualSlotKind.Row)
+            {
+                continue;
+            }
+            if (!_linkByWrlId.ContainsKey(slot.WorkspaceRepositoryId))
+            {
+                missingIds.Add(slot.WorkspaceRepositoryId);
+            }
+        }
+        if (missingIds.Count == 0)
+        {
+            return;
+        }
+        var dtos = await LinkListQueryService.GetByIdsAsync(WorkspaceId, missingIds, cancellationToken);
+        if (cancellationToken.IsCancellationRequested || _disposed)
+        {
+            return;
+        }
+        ApplyItemsFromDtos(dtos, replace: false);
+    }
+    [JSInvokable]
+    public async Task OnVirtualScroll(double scrollTop, double clientHeight)
+    {
+        if (_disposed || _slots.Count == 0)
+        {
+            return;
+        }
         var generation = _queryLoader.Generation;
         var token = _queryLoader.GetQueryToken();
-
-        try
+        var rangeStart = scrollTop - (VirtualOverscanSlots * VirtualRowHeightPx);
+        var rangeEnd = scrollTop + clientHeight + (VirtualOverscanSlots * VirtualRowHeightPx);
+        if (rangeStart < 0)
         {
-            var page = await LinkListQueryService.GetPageAsync(
-                new WorkspaceRepositoryLinkListRequest(
-                    WorkspaceId,
-                    _effectiveSearch,
-                    IWorkspaceRepositoryLinkListQueryService.DefaultChunkSize,
-                    _nextCursor),
-                token);
-
-            if (generation != _queryLoader.Generation || _disposed)
+            rangeStart = 0;
+        }
+        var start = 0;
+        var end = _slots.Count - 1;
+        double cumulative = 0;
+        var foundStart = false;
+        for (var i = 0; i < _slots.Count; i++)
+        {
+            var height = SlotHeight(_slots[i]);
+            var slotBottom = cumulative + height;
+            if (!foundStart && slotBottom > rangeStart)
             {
-                return;
+                start = i;
+                foundStart = true;
             }
-
-            ApplyItemsFromDtos(page.Items, replace: false);
-            _nextCursor = page.NextCursor;
-            hasMore = page.HasMore;
-            ApplySyncStateFromLoadedItems();
-        }
-        catch (OperationCanceledException)
-        {
-        }
-        catch (Exception ex)
-        {
-            if (generation == _queryLoader.Generation && !_disposed)
+            if (cumulative < rangeEnd)
             {
-                Logger.LogError(ex, "Error loading more repositories for workspace {WorkspaceId}", WorkspaceId);
-                errorMessage = "Failed to load more repositories. Please try again later.";
+                end = i;
             }
+            else if (foundStart)
+            {
+                break;
+            }
+            cumulative = slotBottom;
         }
-        finally
+        if (!foundStart)
         {
-            _loadingNextChunk = false;
-            isLoadingMore = false;
+            start = 0;
+            end = Math.Min(_slots.Count - 1, VirtualInitialViewportSlots - 1);
         }
+        UpdateVisibleRange(start, end);
+        await EnsureSlotsHydratedAsync(start, end, token);
+        if (generation != _queryLoader.Generation || _disposed)
+        {
+            return;
+        }
+        await InvokeAsync(StateHasChanged);
     }
-
-    /// <summary>Optional: refresh PR from API then reload workspace data so grid shows updated badges. When a PR becomes merged, runs branch fetch for that repo (same as Switch Branch Fetch) so remote branch list is updated.</summary>
-    private async Task RefreshPullRequestsInBackgroundAndReloadAsync()
+    private async Task AttachVirtualScrollAsync()
     {
-        var previouslyMergedRepoIds = prByRepositoryId
-            .Where(kv => kv.Value?.IsMerged == true)
-            .Select(kv => kv.Key)
-            .ToHashSet();
-
+        if (_disposed || _virtualScrollAttached || _slots.Count == 0)
+        {
+            return;
+        }
         try
         {
-            await WorkspacePageService.WorkspacePullRequestService.RefreshPullRequestsForWorkspaceAsync(WorkspaceId);
-            await ReloadWorkspaceDataFromFreshScopeAsync();
-
-            var newlyMergedRepoIds = prByRepositoryId
-                .Where(kv => kv.Value?.IsMerged == true)
-                .Select(kv => kv.Key)
-                .Where(id => !previouslyMergedRepoIds.Contains(id))
-                .ToList();
-
-            foreach (var repositoryId in newlyMergedRepoIds)
-            {
-                await RefreshBranchesForRepositoryAsync(repositoryId);
-            }
-
-            await InvokeAsync(StateHasChanged);
+            _virtualScrollDotNetRef ??= DotNetObjectReference.Create(this);
+            await JSRuntime.InvokeVoidAsync(
+                "grayMoonVirtualScroll.attach",
+                _tbodyRef,
+                _virtualScrollDotNetRef,
+                TotalScrollHeightPx());
+            _virtualScrollAttached = true;
         }
-        catch (ObjectDisposedException) { }
-        catch (InvalidOperationException) { }
-        catch (Exception ex)
+        catch (JSDisconnectedException)
         {
-            Logger.LogDebug(ex, "Background PR refresh failed for workspace {WorkspaceId}", WorkspaceId);
+        }
+        catch (InvalidOperationException)
+        {
         }
     }
-
+    private async Task DetachVirtualScrollAsync()
+    {
+        if (!_virtualScrollAttached)
+        {
+            return;
+        }
+        try
+        {
+            await JSRuntime.InvokeVoidAsync("grayMoonVirtualScroll.detach", _tbodyRef);
+        }
+        catch (JSDisconnectedException)
+        {
+        }
+        catch (InvalidOperationException)
+        {
+        }
+        _virtualScrollAttached = false;
+    }
     /// <summary>Refreshes PR for one repository when user enters the PR badge. Only runs if PR is not merged and throttle allows.</summary>
     private async Task RefreshPrOnBadgeEnterAsync(int repositoryId)
     {
@@ -211,8 +232,7 @@ public sealed partial class WorkspaceRepositories
         {
             await WorkspacePageService.WorkspacePullRequestService.RefreshPullRequestsAsync(WorkspaceId, new[] { repositoryId });
             _lastPrRefreshByRepoId[repositoryId] = DateTime.UtcNow;
-            await ReloadWorkspaceDataFromFreshScopeAsync();
-            ApplySyncStateFromLoadedItems();
+            await PatchRepositoryRowAsync(repositoryId);
             await InvokeAsync(StateHasChanged);
         }
         catch (ObjectDisposedException) { }
@@ -222,7 +242,40 @@ public sealed partial class WorkspaceRepositories
             Logger.LogDebug(ex, "PR refresh on badge enter failed for RepositoryId={RepositoryId}", repositoryId);
         }
     }
-
+    private async Task PatchRepositoryRowAsync(int repositoryId)
+    {
+        var dto = await LinkListQueryService.GetSnapshotAsync(WorkspaceId, repositoryId);
+        if (dto is null)
+        {
+            return;
+        }
+        CacheLink(
+            WorkspaceRepositoryLinkListMapper.ToLink(dto),
+            WorkspaceRepositoryLinkListMapper.ToPullRequestInfo(dto));
+    }
+    private async Task RefreshVisibleRowsAsync(CancellationToken cancellationToken = default)
+    {
+        await LoadHeaderStateAsync(cancellationToken);
+        totalCount = await LinkListQueryService.CountAsync(
+            new WorkspaceRepositoryLinkListFilter(WorkspaceId, _effectiveSearch),
+            cancellationToken);
+        if (_visibleEnd >= _visibleStart && _slots.Count > 0)
+        {
+            var ids = new List<int>();
+            for (var i = _visibleStart; i <= _visibleEnd && i < _slots.Count; i++)
+            {
+                if (_slots[i].Kind == VirtualSlotKind.Row)
+                {
+                    ids.Add(_slots[i].WorkspaceRepositoryId);
+                }
+            }
+            if (ids.Count > 0)
+            {
+                var dtos = await LinkListQueryService.GetByIdsAsync(WorkspaceId, ids, cancellationToken);
+                ApplyItemsFromDtos(dtos, replace: false);
+            }
+        }
+    }
     private async Task RefreshBranchesForRepositoryAsync(int repositoryId)
     {
         try
@@ -235,7 +288,6 @@ public sealed partial class WorkspaceRepositories
             Logger.LogDebug(ex, "Branch refresh after PR merge failed for RepositoryId={RepositoryId}", repositoryId);
         }
     }
-
     /// <summary>Reload workspace after abort/cancel using a fresh scope. Safe to call from background job bodies. Swallows disposal exceptions so abort does not cascade errors when the circuit or context is already disposed.</summary>
     private async Task ReloadWorkspaceDataAfterCancelAsync()
     {
@@ -259,7 +311,6 @@ public sealed partial class WorkspaceRepositories
         catch (ObjectDisposedException) { }
         catch (InvalidOperationException) { }
     }
-
     /// <summary>Loads workspace using a new scope (fresh DbContext) so we get current DB values and avoid EF cache. Used by RefreshFromSync so the grid shows updated UnmatchedDeps after notify or Update.</summary>
     private async Task ReloadWorkspaceDataFromFreshScopeAsync()
     {
@@ -268,130 +319,146 @@ public sealed partial class WorkspaceRepositories
         if (w == null)
         {
             errorMessage = "Workspace not found.";
-            _items.Clear();
-            _linkByRepoId.Clear();
-            _headerState = null;
+            ClearGridState();
             return;
         }
-
         workspace = w;
-        await LoadHeaderStateAsync();
         await ResetAndLoadFromTopAsync();
     }
-
-    private async Task LoadMismatchedDependencyLinesAsync()
+    /// <summary>Called when WorkspaceSynced is received (or after an operation): refresh header + visible rows only.</summary>
+    private async Task RefreshFromSync()
     {
-        await _loadMismatchedDepsLock.WaitAsync();
+        if (_disposed) return;
+        try
+        {
+            var token = _queryLoader.GetQueryToken();
+            var w = await ScopedExecutor.ExecuteAsync<WorkspaceRepository, Workspace?>(
+                repo => repo.GetHeaderAsync(WorkspaceId));
+            if (w == null)
+            {
+                errorMessage = "Workspace not found.";
+                ClearGridState();
+                await InvokeAsync(StateHasChanged);
+                return;
+            }
+            workspace = w;
+            // Rebuild index when levels/order may have changed; keep scroll position via virtual scroll.
+            var filter = new WorkspaceRepositoryLinkListFilter(WorkspaceId, _effectiveSearch);
+            var index = await LinkListQueryService.GetIndexAsync(filter, token);
+            if (_disposed) return;
+            BuildSlots(index);
+            totalCount = index.Count;
+            await LoadHeaderStateAsync(token);
+            _linkByRepoId.Clear();
+            _linkByWrlId.Clear();
+            prByRepositoryId = new Dictionary<int, PullRequestInfo?>();
+            repoSyncStatus = new();
+            _tooltipLoadedRepoIds.Clear();
+            _tooltipLoadInFlight.Clear();
+            if (_visibleEnd < 0 || _visibleStart >= _slots.Count)
+            {
+                var initialEnd = Math.Min(_slots.Count - 1, VirtualInitialViewportSlots - 1);
+                UpdateVisibleRange(0, Math.Max(-1, initialEnd));
+            }
+            else
+            {
+                UpdateVisibleRange(_visibleStart, Math.Min(_visibleEnd, _slots.Count - 1));
+            }
+            await EnsureSlotsHydratedAsync(_visibleStart, _visibleEnd, token);
+            if (_virtualScrollAttached)
+            {
+                try
+                {
+                    await JSRuntime.InvokeVoidAsync("grayMoonVirtualScroll.setTotalHeight", _tbodyRef, TotalScrollHeightPx());
+                }
+                catch (JSDisconnectedException) { }
+                catch (InvalidOperationException) { }
+            }
+            ApplySyncStateFromLoadedItems();
+            await InvokeAsync(StateHasChanged);
+        }
+        catch (OperationCanceledException) { }
+        catch (ObjectDisposedException) { }
+        catch (InvalidOperationException) { }
+        catch (Exception ex)
+        {
+            Logger.LogDebug(ex, "RefreshFromSync failed for workspace {WorkspaceId}", WorkspaceId);
+        }
+    }
+    private void CancelBackgroundWork()
+    {
+        try
+        {
+            _backgroundWorkCts?.Cancel();
+            _backgroundWorkCts?.Dispose();
+        }
+        catch
+        {
+        }
+        _backgroundWorkCts = null;
+        _queryLoader.CancelQuery();
+    }
+    private async Task EnsureTooltipDataForRepoAsync(int repositoryId)
+    {
+        if (_tooltipLoadedRepoIds.Contains(repositoryId) || !_tooltipLoadInFlight.Add(repositoryId))
+        {
+            return;
+        }
         try
         {
             await using var scope = ServiceScopeFactory.CreateAsyncScope();
             var projectRepo = scope.ServiceProvider.GetRequiredService<WorkspaceProjectRepository>();
             var fileVersionService = scope.ServiceProvider.GetRequiredService<WorkspaceFileVersionService>();
-
-            if (!(_headerState?.HasUnmatchedDependencies ?? false))
-            {
-                _mismatchedDependencyLinesByRepo = new Dictionary<int, IReadOnlyList<DependencyMismatchLine>>();
-            }
-            else
-            {
-                try
-                {
-                    var payloads = await projectRepo.GetSyncDependenciesPayloadAsync(WorkspaceId);
-                    var dict = new Dictionary<int, IReadOnlyList<DependencyMismatchLine>>();
-                    foreach (var p in payloads.Where(p => p.ProjectUpdates.Count > 0))
-                    {
-                        var lines = p.ProjectUpdates
-                            .SelectMany(pu => pu.PackageUpdates)
-                            .GroupBy(x => (x.PackageId.Trim(), x.CurrentVersion.Trim(), x.NewVersion.Trim()))
-                            .Select(g => new DependencyMismatchLine(g.Key.Item1, g.Key.Item2, g.Key.Item3))
-                            .ToList();
-                        dict[p.RepoId] = lines;
-                    }
-                    _mismatchedDependencyLinesByRepo = dict;
-                }
-                catch (Exception ex)
-                {
-                    Logger.LogDebug(ex, "Could not load mismatched dependency lines for workspace {WorkspaceId}", WorkspaceId);
-                    _mismatchedDependencyLinesByRepo = new Dictionary<int, IReadOnlyList<DependencyMismatchLine>>();
-                }
-            }
-
-            try
-            {
-                var raw = await projectRepo.GetPackageDependencyLinesByRepoAsync(WorkspaceId);
-                _allDependencyLinesByRepo = raw.ToDictionary(
-                    kv => kv.Key,
-                    kv => (IReadOnlyList<DependencyLine>)kv.Value.Select(t => new DependencyLine(t.PackageId, t.Version)).ToList());
-            }
-            catch (Exception ex)
-            {
-                Logger.LogDebug(ex, "Could not load dependency listing for workspace {WorkspaceId}", WorkspaceId);
-                _allDependencyLinesByRepo = new Dictionary<int, IReadOnlyList<DependencyLine>>();
-            }
-
-            try
-            {
-                var raw = await fileVersionService.GetMismatchedFileVersionLinesByRepoAsync(WorkspaceId);
-                _mismatchedFileVersionLinesByRepo = raw.ToDictionary(
-                    kv => kv.Key,
-                    kv => (IReadOnlyList<FileVersionMismatchLine>)kv.Value
-                        .Select(t => new FileVersionMismatchLine(t.FileName, t.TokenName, t.CurrentValue, t.ExpectedValue))
-                        .ToList());
-            }
-            catch (Exception ex)
-            {
-                Logger.LogDebug(ex, "Could not load mismatched file version lines for workspace {WorkspaceId}", WorkspaceId);
-                _mismatchedFileVersionLinesByRepo = new Dictionary<int, IReadOnlyList<FileVersionMismatchLine>>();
-            }
-
-            try
-            {
-                _fileLineStatusByRepo = await fileVersionService.GetFileLineStatusByWorkspaceAsync(WorkspaceId);
-            }
-            catch (Exception ex)
-            {
-                Logger.LogDebug(ex, "Could not load file line status for workspace {WorkspaceId}", WorkspaceId);
-                _fileLineStatusByRepo = new Dictionary<int, IReadOnlyList<WorkspaceFileLineStatus>>();
-            }
-
-            try
-            {
-                var repoVersionMap = await LinkListQueryService.GetGitVersionNameMapAsync(WorkspaceId);
-                var raw = await fileVersionService.GetAllFileVersionLinesByRepoAsync(WorkspaceId, repoVersionMap);
-                _allFileVersionLinesByRepo = raw.ToDictionary(
-                    kv => kv.Key,
-                    kv => (IReadOnlyList<FileVersionDisplayLine>)kv.Value
-                        .Select(t => new FileVersionDisplayLine(t.FileName, t.TokenName, t.Version))
-                        .ToList());
-            }
-            catch (Exception ex)
-            {
-                Logger.LogDebug(ex, "Could not load file version lines for workspace {WorkspaceId}", WorkspaceId);
-                _allFileVersionLinesByRepo = new Dictionary<int, IReadOnlyList<FileVersionDisplayLine>>();
-            }
-
-            try
-            {
-                var customDepRepo = scope.ServiceProvider.GetRequiredService<WorkspaceRepositoryCustomDependencyRepository>();
-                _customDependencyLinesByRepo = await customDepRepo.GetCustomDependencyNamesByRepoAsync(WorkspaceId);
-            }
-            catch (Exception ex)
-            {
-                Logger.LogDebug(ex, "Could not load custom dependency lines for workspace {WorkspaceId}", WorkspaceId);
-                _customDependencyLinesByRepo = new Dictionary<int, IReadOnlyList<string>>();
-            }
+            var customDepRepo = scope.ServiceProvider.GetRequiredService<WorkspaceRepositoryCustomDependencyRepository>();
+            var mismatched = await projectRepo.GetMismatchedDependencyLinesForRepoAsync(WorkspaceId, repositoryId);
+            var allDeps = await projectRepo.GetPackageDependencyLinesForRepoAsync(WorkspaceId, repositoryId);
+            var mismatchedFiles = await fileVersionService.GetMismatchedFileVersionLinesForRepoAsync(WorkspaceId, repositoryId);
+            var fileStatuses = await fileVersionService.GetFileLineStatusForRepoAsync(WorkspaceId, repositoryId);
+            var repoVersionMap = await LinkListQueryService.GetGitVersionNameMapAsync(WorkspaceId);
+            var allFileLines = await fileVersionService.GetAllFileVersionLinesForRepoAsync(WorkspaceId, repositoryId, repoVersionMap);
+            var custom = await customDepRepo.GetCustomDependencyNamesForRepoAsync(WorkspaceId, repositoryId);
+            var mismatchDict = _mismatchedDependencyLinesByRepo as Dictionary<int, IReadOnlyList<DependencyMismatchLine>>
+                ?? _mismatchedDependencyLinesByRepo.ToDictionary(kv => kv.Key, kv => kv.Value);
+            mismatchDict[repositoryId] = mismatched
+                .Select(t => new DependencyMismatchLine(t.PackageId, t.CurrentVersion, t.NewVersion))
+                .ToList();
+            _mismatchedDependencyLinesByRepo = mismatchDict;
+            var allDepDict = _allDependencyLinesByRepo as Dictionary<int, IReadOnlyList<DependencyLine>>
+                ?? _allDependencyLinesByRepo.ToDictionary(kv => kv.Key, kv => kv.Value);
+            allDepDict[repositoryId] = allDeps.Select(t => new DependencyLine(t.PackageId, t.Version)).ToList();
+            _allDependencyLinesByRepo = allDepDict;
+            var mismatchFileDict = _mismatchedFileVersionLinesByRepo as Dictionary<int, IReadOnlyList<FileVersionMismatchLine>>
+                ?? _mismatchedFileVersionLinesByRepo.ToDictionary(kv => kv.Key, kv => kv.Value);
+            mismatchFileDict[repositoryId] = mismatchedFiles
+                .Select(t => new FileVersionMismatchLine(t.FileName, t.TokenName, t.CurrentValue, t.ExpectedValue))
+                .ToList();
+            _mismatchedFileVersionLinesByRepo = mismatchFileDict;
+            var fileStatusDict = _fileLineStatusByRepo as Dictionary<int, IReadOnlyList<WorkspaceFileLineStatus>>
+                ?? _fileLineStatusByRepo.ToDictionary(kv => kv.Key, kv => kv.Value);
+            fileStatusDict[repositoryId] = fileStatuses;
+            _fileLineStatusByRepo = fileStatusDict;
+            var allFileDict = _allFileVersionLinesByRepo as Dictionary<int, IReadOnlyList<FileVersionDisplayLine>>
+                ?? _allFileVersionLinesByRepo.ToDictionary(kv => kv.Key, kv => kv.Value);
+            allFileDict[repositoryId] = allFileLines
+                .Select(t => new FileVersionDisplayLine(t.FileName, t.TokenName, t.Version))
+                .ToList();
+            _allFileVersionLinesByRepo = allFileDict;
+            var customDict = _customDependencyLinesByRepo as Dictionary<int, IReadOnlyList<string>>
+                ?? _customDependencyLinesByRepo.ToDictionary(kv => kv.Key, kv => kv.Value);
+            customDict[repositoryId] = custom;
+            _customDependencyLinesByRepo = customDict;
+            _tooltipLoadedRepoIds.Add(repositoryId);
+            await InvokeAsync(StateHasChanged);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogDebug(ex, "Tooltip load failed for RepositoryId={RepositoryId}", repositoryId);
         }
         finally
         {
-            _loadMismatchedDepsLock.Release();
+            _tooltipLoadInFlight.Remove(repositoryId);
         }
     }
-
-    /// <summary>Called when WorkspaceSynced is received (or after an operation): reload from a fresh scope so the grid gets current DB values (no stale DbContext).</summary>
-    private async Task RefreshFromSync()
-    {
-        await ReloadWorkspaceDataFromFreshScopeAsync();
-        ApplySyncStateFromLoadedItems();
-        await InvokeAsync(StateHasChanged);
-    }
+    private void OnDependencyBadgeMouseEnter(int repositoryId) =>
+        _ = EnsureTooltipDataForRepoAsync(repositoryId);
 }

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.Loading.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.Loading.cs
@@ -177,6 +177,11 @@ public sealed partial class WorkspaceRepositories
         }
 
         var rangeChanged = UpdateVisibleRange(start, end);
+        if (rangeChanged && scrollGeneration == _scrollGeneration && !_disposed)
+        {
+            await InvokeAsync(StateHasChanged);
+        }
+
         var itemsHydrated = await EnsureSlotsHydratedAsync(start, end, token);
         if (scrollGeneration != _scrollGeneration
             || queryGeneration != _queryLoader.Generation
@@ -185,7 +190,7 @@ public sealed partial class WorkspaceRepositories
             return;
         }
 
-        if (rangeChanged || itemsHydrated)
+        if (itemsHydrated)
         {
             await InvokeAsync(StateHasChanged);
         }

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.Loading.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.Loading.cs
@@ -1,6 +1,7 @@
 using GrayMoon.App.Models;
 using GrayMoon.App.Repositories;
 using GrayMoon.App.Services;
+using GrayMoon.App.Services.Queries;
 
 namespace GrayMoon.App.Components.Pages;
 
@@ -10,60 +11,159 @@ public sealed partial class WorkspaceRepositories
     {
         try
         {
-            isLoading = true;
+            isInitialLoading = true;
             errorMessage = null;
-            await ReloadWorkspaceDataAsync();
+            await LoadWorkspaceHeaderAsync();
+            await ResetAndLoadFromTopAsync();
             _ = RefreshPullRequestsInBackgroundAndReloadAsync();
         }
         catch (Exception ex)
         {
             Logger.LogError(ex, "Error loading workspace {WorkspaceId}", WorkspaceId);
             errorMessage = "Failed to load workspace. Please try again later.";
-            workspaceRepositories = new List<WorkspaceRepositoryLink>();
+            _items.Clear();
+            _linkByRepoId.Clear();
+            _headerState = null;
         }
         finally
         {
-            isLoading = false;
+            isInitialLoading = false;
         }
     }
 
-    private async Task ReloadWorkspaceDataAsync()
+    private async Task LoadWorkspaceHeaderAsync()
     {
-        workspace = await WorkspacePageService.WorkspaceRepository.GetByIdAsync(WorkspaceId);
+        workspace = await WorkspacePageService.WorkspaceRepository.GetHeaderAsync(WorkspaceId);
         if (workspace == null)
         {
             errorMessage = "Workspace not found.";
-            workspaceRepositories = new List<WorkspaceRepositoryLink>();
-            UpdateFilteredRepositories();
+        }
+    }
+
+    private async Task LoadHeaderStateAsync(CancellationToken cancellationToken = default)
+    {
+        _headerState = await LinkListQueryService.GetHeaderStateAsync(WorkspaceId, cancellationToken);
+    }
+
+    private async Task ResetAndLoadFromTopAsync()
+    {
+        if (workspace == null && errorMessage == null)
+        {
             return;
         }
 
-        workspaceRepositories = workspace.Repositories
-            .OrderByDescending(wr => wr.DependencyLevel ?? int.MinValue)
-            .ThenBy(wr => GetRepositoryTypeSortOrder(wr.RepositoryType))
-            .ThenByDescending(wr => wr.Dependencies ?? int.MinValue)
-            .ToList();
-        prByRepositoryId = BuildPrByRepositoryIdFromLinks(workspaceRepositories);
-        await LoadMismatchedDependencyLinesAsync();
-        UpdateFilteredRepositories();
+        if (errorMessage != null)
+        {
+            isInitialLoading = false;
+            return;
+        }
+
+        var token = _queryLoader.BeginQueryCycle(out var generation);
+        _items.Clear();
+        _linkByRepoId.Clear();
+        _nextCursor = null;
+        hasMore = false;
+        totalCount = null;
+        isInitialLoading = true;
+        isLoadingMore = false;
+        _loadingNextChunk = false;
+        prByRepositoryId = new Dictionary<int, PullRequestInfo?>();
+
+        try
+        {
+            var filter = new WorkspaceRepositoryLinkListFilter(WorkspaceId, _effectiveSearch);
+            await LoadHeaderStateAsync(token);
+            totalCount = await LinkListQueryService.CountAsync(filter, token);
+            var page = await LinkListQueryService.GetPageAsync(
+                new WorkspaceRepositoryLinkListRequest(
+                    WorkspaceId,
+                    _effectiveSearch,
+                    IWorkspaceRepositoryLinkListQueryService.DefaultChunkSize,
+                    null),
+                token);
+
+            if (generation != _queryLoader.Generation || _disposed)
+            {
+                return;
+            }
+
+            ApplyItemsFromDtos(page.Items, replace: true);
+            _nextCursor = page.NextCursor;
+            hasMore = page.HasMore;
+            hasLoadedOnce = true;
+            await LoadMismatchedDependencyLinesAsync();
+            ApplySyncStateFromLoadedItems();
+        }
+        catch (OperationCanceledException)
+        {
+        }
+        catch (Exception ex)
+        {
+            if (generation == _queryLoader.Generation && !_disposed)
+            {
+                Logger.LogError(ex, "Error loading repositories for workspace {WorkspaceId}", WorkspaceId);
+                errorMessage = "Failed to load workspace. Please try again later.";
+                _items.Clear();
+                _linkByRepoId.Clear();
+            }
+        }
+        finally
+        {
+            if (generation == _queryLoader.Generation && !_disposed)
+            {
+                isInitialLoading = false;
+            }
+        }
     }
 
-    private static int GetRepositoryTypeSortOrder(ProjectType? type) => type switch
+    private async Task LoadNextChunkAsync()
     {
-        ProjectType.Service    => 0,
-        ProjectType.Package    => 1,
-        ProjectType.Executable => 2,
-        ProjectType.Library    => 3,
-        ProjectType.Test       => 4,
-        _                      => 5 // null - no projects yet
-    };
+        if (_loadingNextChunk || isInitialLoading || !hasMore || _nextCursor is null)
+        {
+            return;
+        }
 
-    private static IReadOnlyDictionary<int, PullRequestInfo?> BuildPrByRepositoryIdFromLinks(List<WorkspaceRepositoryLink> links)
-    {
-        var dict = new Dictionary<int, PullRequestInfo?>();
-        foreach (var wr in links.Where(wr => wr.PullRequest != null))
-            dict[wr.RepositoryId] = wr.PullRequest!.PullRequestNumber.HasValue ? wr.PullRequest.ToPullRequestInfo() : null;
-        return dict;
+        _loadingNextChunk = true;
+        isLoadingMore = true;
+        var generation = _queryLoader.Generation;
+        var token = _queryLoader.GetQueryToken();
+
+        try
+        {
+            var page = await LinkListQueryService.GetPageAsync(
+                new WorkspaceRepositoryLinkListRequest(
+                    WorkspaceId,
+                    _effectiveSearch,
+                    IWorkspaceRepositoryLinkListQueryService.DefaultChunkSize,
+                    _nextCursor),
+                token);
+
+            if (generation != _queryLoader.Generation || _disposed)
+            {
+                return;
+            }
+
+            ApplyItemsFromDtos(page.Items, replace: false);
+            _nextCursor = page.NextCursor;
+            hasMore = page.HasMore;
+            ApplySyncStateFromLoadedItems();
+        }
+        catch (OperationCanceledException)
+        {
+        }
+        catch (Exception ex)
+        {
+            if (generation == _queryLoader.Generation && !_disposed)
+            {
+                Logger.LogError(ex, "Error loading more repositories for workspace {WorkspaceId}", WorkspaceId);
+                errorMessage = "Failed to load more repositories. Please try again later.";
+            }
+        }
+        finally
+        {
+            _loadingNextChunk = false;
+            isLoadingMore = false;
+        }
     }
 
     /// <summary>Optional: refresh PR from API then reload workspace data so grid shows updated badges. When a PR becomes merged, runs branch fetch for that repo (same as Switch Branch Fetch) so remote branch list is updated.</summary>
@@ -77,7 +177,7 @@ public sealed partial class WorkspaceRepositories
         try
         {
             await WorkspacePageService.WorkspacePullRequestService.RefreshPullRequestsForWorkspaceAsync(WorkspaceId);
-            await ReloadWorkspaceDataAsync();
+            await ReloadWorkspaceDataFromFreshScopeAsync();
 
             var newlyMergedRepoIds = prByRepositoryId
                 .Where(kv => kv.Value?.IsMerged == true)
@@ -112,7 +212,7 @@ public sealed partial class WorkspaceRepositories
             await WorkspacePageService.WorkspacePullRequestService.RefreshPullRequestsAsync(WorkspaceId, new[] { repositoryId });
             _lastPrRefreshByRepoId[repositoryId] = DateTime.UtcNow;
             await ReloadWorkspaceDataFromFreshScopeAsync();
-            ApplySyncStateFromWorkspace();
+            ApplySyncStateFromLoadedItems();
             await InvokeAsync(StateHasChanged);
         }
         catch (ObjectDisposedException) { }
@@ -154,7 +254,7 @@ public sealed partial class WorkspaceRepositories
         }
         try
         {
-            await InvokeAsync(() => { if (!_disposed) { ApplySyncStateFromWorkspace(); StateHasChanged(); } });
+            await InvokeAsync(() => { if (!_disposed) { ApplySyncStateFromLoadedItems(); StateHasChanged(); } });
         }
         catch (ObjectDisposedException) { }
         catch (InvalidOperationException) { }
@@ -164,23 +264,19 @@ public sealed partial class WorkspaceRepositories
     private async Task ReloadWorkspaceDataFromFreshScopeAsync()
     {
         var w = await ScopedExecutor.ExecuteAsync<WorkspaceRepository, Workspace?>(
-            repo => repo.GetByIdAsync(WorkspaceId));
+            repo => repo.GetHeaderAsync(WorkspaceId));
         if (w == null)
         {
             errorMessage = "Workspace not found.";
-            workspaceRepositories = new List<WorkspaceRepositoryLink>();
-            UpdateFilteredRepositories();
+            _items.Clear();
+            _linkByRepoId.Clear();
+            _headerState = null;
             return;
         }
+
         workspace = w;
-        workspaceRepositories = workspace.Repositories
-            .OrderByDescending(wr => wr.DependencyLevel ?? int.MinValue)
-            .ThenBy(wr => GetRepositoryTypeSortOrder(wr.RepositoryType))
-            .ThenByDescending(wr => wr.Dependencies ?? int.MinValue)
-            .ToList();
-        prByRepositoryId = BuildPrByRepositoryIdFromLinks(workspaceRepositories);
-        await LoadMismatchedDependencyLinesAsync();
-        UpdateFilteredRepositories();
+        await LoadHeaderStateAsync();
+        await ResetAndLoadFromTopAsync();
     }
 
     private async Task LoadMismatchedDependencyLinesAsync()
@@ -188,12 +284,11 @@ public sealed partial class WorkspaceRepositories
         await _loadMismatchedDepsLock.WaitAsync();
         try
         {
-            // Fresh scope: circuit-scoped DbContext may be busy (e.g. CheckFileVersions during sync/update).
             await using var scope = ServiceScopeFactory.CreateAsyncScope();
             var projectRepo = scope.ServiceProvider.GetRequiredService<WorkspaceProjectRepository>();
             var fileVersionService = scope.ServiceProvider.GetRequiredService<WorkspaceFileVersionService>();
 
-            if (!workspaceRepositories.Any(wr => (wr.UnmatchedDeps ?? 0) > 0))
+            if (!(_headerState?.HasUnmatchedDependencies ?? false))
             {
                 _mismatchedDependencyLinesByRepo = new Dictionary<int, IReadOnlyList<DependencyMismatchLine>>();
             }
@@ -201,8 +296,6 @@ public sealed partial class WorkspaceRepositories
             {
                 try
                 {
-                    // Use raw sync payloads so tag-pinned repos still get mismatch lines for hover/copy in the badge tooltip.
-                    // GetUpdatePlanAsync excludes tag-pinned repos on purpose so Update does not target them.
                     var payloads = await projectRepo.GetSyncDependenciesPayloadAsync(WorkspaceId);
                     var dict = new Dictionary<int, IReadOnlyList<DependencyMismatchLine>>();
                     foreach (var p in payloads.Where(p => p.ProjectUpdates.Count > 0))
@@ -263,9 +356,7 @@ public sealed partial class WorkspaceRepositories
 
             try
             {
-                var repoVersionMap = workspaceRepositories
-                    .Where(r => r.Repository?.RepositoryName != null && !string.IsNullOrEmpty(r.GitVersion))
-                    .ToDictionary(r => r.Repository!.RepositoryName!, r => r.GitVersion!, StringComparer.OrdinalIgnoreCase);
+                var repoVersionMap = await LinkListQueryService.GetGitVersionNameMapAsync(WorkspaceId);
                 var raw = await fileVersionService.GetAllFileVersionLinesByRepoAsync(WorkspaceId, repoVersionMap);
                 _allFileVersionLinesByRepo = raw.ToDictionary(
                     kv => kv.Key,
@@ -300,7 +391,7 @@ public sealed partial class WorkspaceRepositories
     private async Task RefreshFromSync()
     {
         await ReloadWorkspaceDataFromFreshScopeAsync();
-        ApplySyncStateFromWorkspace();
+        ApplySyncStateFromLoadedItems();
         await InvokeAsync(StateHasChanged);
     }
 }

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.NewFeature.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.NewFeature.cs
@@ -10,7 +10,7 @@ public sealed partial class WorkspaceRepositories
 
     private async Task ShowNewFeatureModalAsync()
     {
-        if (workspace == null || workspaceRepositories.Count == 0)
+        if (workspace == null || !HasRepositories)
             return;
         try
         {
@@ -35,16 +35,17 @@ public sealed partial class WorkspaceRepositories
         _newFeatureModal = _newFeatureModal with { IsVisible = false };
     }
 
-    private Task HandleNewFeatureCreateAsync(NewFeatureRequest request)
+    private async Task HandleNewFeatureCreateAsync(NewFeatureRequest request)
     {
         if (workspace == null || IsJobRunning)
-            return Task.CompletedTask;
+            return;
 
         CloseNewFeatureModal();
         errorMessage = null;
 
+        var allLinks = await GetAllLinksForOperationAsync();
         var tagFilteredRepoIds = request.SkipReposOnTags
-            ? workspaceRepositories.Where(wr => !wr.IsOnTag).Select(wr => wr.RepositoryId).ToHashSet()
+            ? allLinks.Where(wr => !wr.IsOnTag).Select(wr => wr.RepositoryId).ToHashSet()
             : (IReadOnlySet<int>?)null;
 
         // Phases 1 + 2: branch creation (hooks suppressed, state persisted inline) then optional update.
@@ -73,7 +74,7 @@ public sealed partial class WorkspaceRepositories
 
                 // Unconditional reload so workspaceRepositories is current for Phase 3
                 await ReloadWorkspaceDataFromFreshScopeAsync();
-                _ = InvokeAsync(() => { if (!_disposed) { ApplySyncStateFromWorkspace(); StateHasChanged(); } });
+                _ = InvokeAsync(() => { if (!_disposed) { ApplySyncStateFromLoadedItems(); StateHasChanged(); } });
             }
             catch (OperationCanceledException)
             {
@@ -122,8 +123,6 @@ public sealed partial class WorkspaceRepositories
                 return;
             }
         }, new PageJobOptions { RefreshOnSuccess = false });
-
-        return Task.CompletedTask;
     }
 
     private sealed record NewFeatureModalState

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.PullRequests.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.PullRequests.cs
@@ -10,8 +10,18 @@ public sealed partial class WorkspaceRepositories
 {
     private NewPullRequestModalState _newPrModal = new();
 
-    private Task OpenPullRequestDialogForAllRepositoriesAsync()
-        => OpenPullRequestDialogCoreAsync(workspaceRepositories);
+    private async Task OpenPullRequestDialogForAllRepositoriesAsync()
+    {
+        var links = await GetAllLinksForOperationAsync();
+        await OpenPullRequestDialogCoreAsync(links);
+    }
+
+    private async Task OpenPullRequestDialogForLevelAsync(int? levelKey)
+    {
+        var ids = (await GetRepositoryIdsAtLevelAsync(levelKey)).ToHashSet();
+        var links = (await GetAllLinksForOperationAsync()).Where(wr => ids.Contains(wr.RepositoryId)).ToList();
+        await OpenPullRequestDialogCoreAsync(links);
+    }
 
     private Task OpenPullRequestDialogForRepositoryAsync(WorkspaceRepositoryLink link)
         => OpenPullRequestDialogCoreAsync(new[] { link });

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.Push.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.Push.cs
@@ -38,7 +38,7 @@ public sealed partial class WorkspaceRepositories
                 CancellationToken.None);
             if (depInfo == null)
             {
-                ToastService.Show("Could not load push plan. Try again.");
+                ToastService.ShowError("Could not load push plan. Try again.");
                 return;
             }
             _pushWithDependenciesModal = _pushWithDependenciesModal with
@@ -129,7 +129,7 @@ public sealed partial class WorkspaceRepositories
         catch (Exception ex)
         {
             Logger.LogError(ex, "Error getting push dependency info for repository {RepositoryId}", repositoryId);
-            ToastService.Show("Could not load dependency info. Try again.");
+            ToastService.ShowError("Could not load dependency info. Try again.");
         }
     }
 
@@ -217,7 +217,7 @@ public sealed partial class WorkspaceRepositories
                     synchronizedPush,
                     requiredPackageIds,
                     job.ReportProgress,
-                    ToastService.Show,
+                    ToastService.ShowError,
                     syncedRepoIds: syncedRepoIds,
                     cancellationToken: ct));
         }
@@ -250,7 +250,7 @@ public sealed partial class WorkspaceRepositories
             if (success)
                 await InvokeAsync(async () => { if (_disposed) return; await RefreshFromSync(); });
             else
-                SafeInvoke(() => ToastService.Show(pushError ?? "Push failed."));
+                SafeInvoke(() => ToastService.ShowError(pushError ?? "Push failed."));
         }, new PageJobOptions
         {
             RefreshOnSuccess = false,
@@ -258,7 +258,7 @@ public sealed partial class WorkspaceRepositories
             OnError = ex =>
             {
                 Logger.LogError(ex, "Push with upstream failed for repository {RepositoryId}", repositoryId);
-                SafeInvoke(() => ToastService.Show(ex.Message));
+                SafeInvoke(() => ToastService.ShowError(ex.Message));
             }
         });
 

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.Push.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.Push.cs
@@ -11,14 +11,15 @@ public sealed partial class WorkspaceRepositories
     /// <summary>Push button click: get push plan; filter to repos with unpushed commits or no upstream branch; show modal only if at least one dependency repo needs push; otherwise push immediately.</summary>
     private async Task OnPushClickAsync()
     {
-        if (workspace == null || workspaceRepositories.Count == 0 || IsJobRunning)
+        if (workspace == null || !HasRepositories || IsJobRunning)
             return;
 
         try
         {
+            var allLinks = await GetAllLinksForOperationAsync();
             var (_, pushRepoIds, hasUnpushed) = await WorkspacePushHandler.GetPushPlanAsync(
                 WorkspaceId,
-                workspaceRepositories,
+                allLinks,
                 CancellationToken.None);
             if (!hasUnpushed || pushRepoIds.Count == 0)
             {
@@ -27,7 +28,7 @@ public sealed partial class WorkspaceRepositories
             }
 
             var repoIdsWithUnpushed = pushRepoIds;
-            var repoIdsThatNeedPush = workspaceRepositories
+            var repoIdsThatNeedPush = allLinks
                 .Where(wr => !wr.IsOnTag && (wr.OutgoingCommits ?? 0) > 0)
                 .Select(wr => wr.RepositoryId)
                 .ToHashSet();
@@ -77,7 +78,7 @@ public sealed partial class WorkspaceRepositories
             return;
         }
 
-        var repo = workspaceRepositories.FirstOrDefault(r => r.RepositoryId == repositoryId);
+        var repo = TryGetLink(repositoryId);
         if (repo != null
             && !string.IsNullOrWhiteSpace(repo.DefaultBranchName)
             && string.Equals(repo.BranchName, repo.DefaultBranchName, StringComparison.Ordinal))
@@ -97,7 +98,8 @@ public sealed partial class WorkspaceRepositories
     {
         try
         {
-            var repoIdsThatNeedPush = workspaceRepositories
+            var allLinks = await GetAllLinksForOperationAsync();
+            var repoIdsThatNeedPush = allLinks
                 .Where(wr => !wr.IsOnTag && (wr.OutgoingCommits ?? 0) > 0)
                 .Select(wr => wr.RepositoryId)
                 .ToHashSet();
@@ -112,7 +114,7 @@ public sealed partial class WorkspaceRepositories
                 return;
             }
 
-            var repoName = workspaceRepositories.FirstOrDefault(wr => wr.RepositoryId == repositoryId)?.Repository?.RepositoryName;
+            var repoName = TryGetLink(repositoryId)?.Repository?.RepositoryName;
             _pushWithDependenciesModal = _pushWithDependenciesModal with
             {
                 IsVisible = true,
@@ -182,7 +184,8 @@ public sealed partial class WorkspaceRepositories
         await using var planScope = ServiceScopeFactory.CreateAsyncScope();
         var planPushHandler = planScope.ServiceProvider.GetRequiredService<WorkspacePushHandler>();
         var planDepService = planScope.ServiceProvider.GetRequiredService<WorkspaceDependencyService>();
-        var (_, pushRepoIds, hasUnpushed) = await planPushHandler.GetPushPlanAsync(WorkspaceId, workspaceRepositories, ct, maxLevel);
+        var allLinks = await GetAllLinksForOperationAsync();
+        var (_, pushRepoIds, hasUnpushed) = await planPushHandler.GetPushPlanAsync(WorkspaceId, allLinks, ct, maxLevel);
         if (!hasUnpushed || pushRepoIds.Count == 0)
         {
             SafeInvoke(() => ToastService.Show(emptyMessage));

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.Realtime.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.Realtime.cs
@@ -8,13 +8,13 @@ public sealed partial class WorkspaceRepositories
     private HubConnection? _hubConnection;
     private CancellationTokenSource? _fetchRepositoriesCts;
 
-    protected override async Task OnAfterRenderAsync(bool firstRender)
+    private async Task OnAfterRenderRealtimeAsync(bool firstRender)
     {
         if (firstRender)
         {
             try { await JSRuntime.InvokeVoidAsync("focusElement", "workspace-repos-search"); } catch { /* ignore */ }
         }
-        if (firstRender && workspace != null && errorMessage == null)
+        if (firstRender && workspace != null && errorMessage == null && _hubConnection == null)
         {
             _hubConnection = new HubConnectionBuilder()
                 .WithUrl(NavigationManager.ToAbsoluteUri("/hubs/workspace-sync"))

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.RepositoriesModal.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.RepositoriesModal.cs
@@ -14,29 +14,21 @@ public sealed partial class WorkspaceRepositories
             IsVisible = true,
             SelectedRepositoryIds = ids,
             ErrorMessage = null,
+            RefreshGeneration = _repositoriesModal.RefreshGeneration + 1,
         };
         StateHasChanged();
-        await EnsureRepositoriesForModalAsync();
-    }
-
-    private async Task EnsureRepositoriesForModalAsync()
-    {
-        if (_repositoriesModal.RepositoriesLoaded)
-            return;
 
         try
         {
             var connectors = await WorkspacePageService.ConnectorRepository.GetAllAsync();
             _repositoriesModal.HasConnectors = connectors.Count > 0;
-            _repositoriesModal.Repositories = await WorkspacePageService.RepositoryService.GetPersistedRepositoriesAsync();
-            _repositoriesModal.RepositoriesLoaded = true;
         }
         catch (Exception ex)
         {
-            Logger.LogError(ex, "Failed to load repositories for Repositories modal.");
+            Logger.LogError(ex, "Failed to load connectors for Repositories modal.");
             _repositoriesModal.ErrorMessage = "Failed to load repositories. Please try again.";
+            await InvokeAsync(StateHasChanged);
         }
-        await InvokeAsync(StateHasChanged);
     }
 
     private void CloseRepositoriesModal()
@@ -112,12 +104,12 @@ public sealed partial class WorkspaceRepositories
             });
 
             var result = await WorkspacePageService.RepositoryService.RefreshRepositoriesAsync(progress, cts.Token);
-            _repositoriesModal.Repositories = result.Repositories.ToList();
             _repositoriesModal.RenameWarnings = result.RenamedRepositories.Count > 0 ? result.RenamedRepositories : null;
+            _repositoriesModal.RefreshGeneration++;
         }
         catch (OperationCanceledException)
         {
-            _repositoriesModal.Repositories = await WorkspacePageService.RepositoryService.GetPersistedRepositoriesAsync();
+            _repositoriesModal.RefreshGeneration++;
         }
         catch (Exception ex)
         {
@@ -136,14 +128,13 @@ public sealed partial class WorkspaceRepositories
     {
         public bool IsVisible { get; set; }
         public HashSet<int> SelectedRepositoryIds { get; set; } = new();
-        public List<GitHubRepositoryEntry>? Repositories { get; set; }
         public bool HasConnectors { get; set; }
-        public bool RepositoriesLoaded { get; set; }
         public bool IsSaving { get; set; }
         public string? ErrorMessage { get; set; }
         public bool IsFetching { get; set; }
         public int? FetchedRepositoryCount { get; set; }
         public string? FetchError { get; set; }
         public IReadOnlyList<RenamedRepositoryInfo>? RenameWarnings { get; set; }
+        public int RefreshGeneration { get; set; }
     }
 }

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.RepositoriesModal.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.RepositoriesModal.cs
@@ -8,7 +8,8 @@ public sealed partial class WorkspaceRepositories
 
     private async Task ShowRepositoriesModalAsync()
     {
-        var ids = workspace?.Repositories.Select(r => r.RepositoryId).ToHashSet() ?? new HashSet<int>();
+        var snapshots = await LinkListQueryService.GetAllSnapshotsAsync(WorkspaceId);
+        var ids = snapshots.Select(r => r.RepositoryId).ToHashSet();
         _repositoriesModal = new RepositoriesModalState
         {
             IsVisible = true,
@@ -61,7 +62,7 @@ public sealed partial class WorkspaceRepositories
                 workspace?.Name ?? string.Empty,
                 ids,
                 workspace?.RootPath);
-            await ReloadWorkspaceDataAsync();
+            await ReloadWorkspaceDataFromFreshScopeAsync();
             CloseRepositoriesModal();
             ToastService.Show("Workspace repositories updated.");
         }

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.Search.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.Search.cs
@@ -1,5 +1,3 @@
-using GrayMoon.App.Models;
-using GrayMoon.App.Services;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 
@@ -7,11 +5,23 @@ namespace GrayMoon.App.Components.Pages;
 
 public sealed partial class WorkspaceRepositories
 {
+    private async Task OnSearchTermChangedAsync(string value)
+    {
+        searchTerm = value;
+        await _queryLoader.DebounceSearchAsync(async () =>
+        {
+            _effectiveSearch = searchTerm;
+            await ResetAndLoadFromTopAsync();
+            if (!_disposed)
+            {
+                await InvokeAsync(StateHasChanged);
+            }
+        });
+    }
+
     private void OnSearchChanged(ChangeEventArgs e)
     {
-        searchTerm = e.Value?.ToString() ?? string.Empty;
-        UpdateFilteredRepositories();
-        StateHasChanged();
+        _ = OnSearchTermChangedAsync(e.Value?.ToString() ?? string.Empty);
     }
 
     private void OnSearchKeyDown(KeyboardEventArgs e)
@@ -19,27 +29,13 @@ public sealed partial class WorkspaceRepositories
         if (e.Key == "Escape")
         {
             searchTerm = string.Empty;
-            UpdateFilteredRepositories();
-            StateHasChanged();
+            _ = OnSearchTermChangedAsync(string.Empty);
         }
     }
 
     private void ClearSearchFilter()
     {
         searchTerm = string.Empty;
-        UpdateFilteredRepositories();
-        StateHasChanged();
-    }
-
-    private List<WorkspaceRepositoryLink> GetFilteredWorkspaceRepositories()
-    {
-        if (string.IsNullOrWhiteSpace(searchTerm))
-        {
-            return workspaceRepositories;
-        }
-
-        return workspaceRepositories
-            .Where(wr => WorkspaceRepositoryLinkSearchMatcher.Matches(wr, searchTerm, repoSyncStatus))
-            .ToList();
+        _ = OnSearchTermChangedAsync(string.Empty);
     }
 }

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.State.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.State.cs
@@ -1,49 +1,51 @@
+using GrayMoon.App.Components.Shared;
 using GrayMoon.App.Models;
 using GrayMoon.App.Services;
+using GrayMoon.App.Services.Queries;
 
 namespace GrayMoon.App.Components.Pages;
 
 public sealed partial class WorkspaceRepositories
 {
+    private readonly DebouncedQueryLoader _queryLoader = new();
+    private readonly List<WorkspaceRepositoryLink> _items = new();
+    private readonly Dictionary<int, WorkspaceRepositoryLink> _linkByRepoId = new();
+
     private Workspace? workspace;
-    private List<WorkspaceRepositoryLink> workspaceRepositories = new();
+    private WorkspaceRepositoryHeaderStateDto? _headerState;
     private IReadOnlyDictionary<int, PullRequestInfo?> prByRepositoryId = new Dictionary<int, PullRequestInfo?>();
     private readonly Dictionary<int, DateTime> _lastPrRefreshByRepoId = new();
     private static readonly TimeSpan PrRefreshThrottle = TimeSpan.FromSeconds(10);
     private string? errorMessage;
-    private bool isLoading = true;
-    private bool? isOutOfSync = null;
-    private bool hasUnmatchedDependencies => workspaceRepositories.Any(wr => !wr.IsOnTag &&
-        ((wr.UnmatchedDeps ?? 0) > 0 || (wr.OutOfDateFileRepos ?? 0) > 0));
-    private bool isPushRecommended => workspaceRepositories.Any(wr => !wr.IsOnTag && ((wr.OutgoingCommits ?? 0) > 0 || wr.BranchHasUpstream == false));
-    private int? lowestLevelNeedingWork =>
-        workspaceRepositories
-            .Where(wr => !wr.IsOnTag && ((wr.UnmatchedDeps ?? 0) > 0 || (wr.OutOfDateFileRepos ?? 0) > 0))
-            .Min(wr => (int?)wr.DependencyLevel);
-    private bool hasTaggedRepos => workspaceRepositories.Any(wr => wr.IsOnTag);
-    /// <summary>When true, any repository on its default branch has incoming commits; header shows red Pull button and executes only Pull (commit sync) for those repos. Repos pinned to a tag are excluded.</summary>
-    private bool hasIncomingCommits => workspaceRepositories.Any(wr =>
-        !wr.IsOnTag
-        && (wr.IncomingCommits ?? 0) > 0
-        && !string.IsNullOrWhiteSpace(wr.BranchName)
-        && !string.IsNullOrWhiteSpace(wr.DefaultBranchName)
-        && string.Equals(wr.BranchName, wr.DefaultBranchName, StringComparison.Ordinal));
-    private IEnumerable<IGrouping<int?, WorkspaceRepositoryLink>> LevelGroups =>
-        workspaceRepositories
+    private bool isInitialLoading = true;
+    private bool isLoadingMore;
+    private bool hasMore;
+    private bool hasLoadedOnce;
+    private int? totalCount;
+    private string _effectiveSearch = string.Empty;
+    private WorkspaceRepositoryLinkListCursor? _nextCursor;
+    private bool _loadingNextChunk;
+
+    private bool HasRepositories => (_headerState?.TotalCount ?? 0) > 0;
+    private bool hasUnmatchedDependencies => _headerState?.HasUnmatchedDependencies ?? false;
+    private bool isPushRecommended => _headerState?.IsPushRecommended ?? false;
+    private int? lowestLevelNeedingWork => _headerState?.LowestLevelNeedingWork;
+    private bool hasTaggedRepos => _headerState?.HasTaggedRepos ?? false;
+    private bool hasIncomingCommits => _headerState?.HasIncomingCommits ?? false;
+    private bool? isOutOfSync => _headerState?.IsOutOfSync;
+
+    private IEnumerable<IGrouping<int?, WorkspaceRepositoryLink>> LoadedLevelGroups =>
+        _items
             .GroupBy(wr => wr.DependencyLevel)
             .OrderByDescending(g => g.Key ?? int.MinValue);
 
-    private List<WorkspaceRepositoryLink> _filteredWorkspaceRepositories = new();
-    private List<WorkspaceRepositoryLink> FilteredWorkspaceRepositories => _filteredWorkspaceRepositories;
-    private void UpdateFilteredRepositories() => _filteredWorkspaceRepositories = GetFilteredWorkspaceRepositories();
+    private bool HasSearchFilter => !string.IsNullOrWhiteSpace(_effectiveSearch);
+
+    private bool NoRepositoriesMatchSearch =>
+        hasLoadedOnce && totalCount == 0 && !isInitialLoading && !string.IsNullOrWhiteSpace(_effectiveSearch);
 
     private string ApiBaseUrl => NavigationManager.BaseUri.TrimEnd('/');
 
-    private IEnumerable<IGrouping<int?, WorkspaceRepositoryLink>> FilteredLevelGroups =>
-        FilteredWorkspaceRepositories
-            .GroupBy(wr => wr.DependencyLevel)
-            .OrderByDescending(g => g.Key ?? int.MinValue);
-    private bool HasSearchFilter => !string.IsNullOrWhiteSpace(searchTerm);
     private string RepositoriesModalTitle => $"Repositories for {workspace?.Name ?? "Workspace"}";
     private bool ShowRepositoriesFetchOverlay => _repositoriesModal.IsVisible && _repositoriesModal.IsFetching;
     private string RepositoriesFetchOverlayMessage => _repositoriesModal.FetchedRepositoryCount is null || _repositoriesModal.FetchedRepositoryCount == 0
@@ -60,9 +62,9 @@ public sealed partial class WorkspaceRepositories
     private IReadOnlyDictionary<int, IReadOnlyList<FileVersionDisplayLine>> _allFileVersionLinesByRepo = new Dictionary<int, IReadOnlyList<FileVersionDisplayLine>>();
     /// <summary>User-declared custom dependency repo names per dependent repository (ordering only).</summary>
     private IReadOnlyDictionary<int, IReadOnlyList<string>> _customDependencyLinesByRepo = new Dictionary<int, IReadOnlyList<string>>();
-    private Dictionary<int, string> repositoryErrors = new(); // repositoryId -> error message
-    private HashSet<string> clickedVersions = new(); // Track clicked versions to hide hover until mouse leaves
-    private HashSet<int> clickedDependencyBadges = new(); // Track clicked dependency badges to hide tooltip immediately
+    private Dictionary<int, string> repositoryErrors = new();
+    private HashSet<string> clickedVersions = new();
+    private HashSet<int> clickedDependencyBadges = new();
 
     private string searchTerm = string.Empty;
 
@@ -78,25 +80,79 @@ public sealed partial class WorkspaceRepositories
     private readonly object _refreshDebounceLock = new();
     private readonly SemaphoreSlim _loadMismatchedDepsLock = new(1, 1);
 
-    /// <summary>Toast shown when the user attempts a write action against a repository that is pinned to a tag.</summary>
     private const string TagBlockedActionMessage = "Repository is on a tag; checkout a branch first.";
 
     private const int TableColSpan = 4;
 
-    /// <summary>True when the workspace repository link for <paramref name="repositoryId"/> is currently checked out at a tag.</summary>
     private bool IsRepoOnTag(int repositoryId) =>
-        workspaceRepositories.FirstOrDefault(wr => wr.RepositoryId == repositoryId)?.IsOnTag == true;
+        TryGetLink(repositoryId)?.IsOnTag == true;
 
-    private void ApplySyncStateFromWorkspace()
+    private WorkspaceRepositoryLink? TryGetLink(int repositoryId) =>
+        _linkByRepoId.TryGetValue(repositoryId, out var link) ? link : null;
+
+    private async Task<WorkspaceRepositoryLink?> TryGetLinkAsync(int repositoryId)
     {
-        if (workspace == null || workspaceRepositories.Count == 0)
+        if (_linkByRepoId.TryGetValue(repositoryId, out var link))
+        {
+            return link;
+        }
+
+        var dto = await LinkListQueryService.GetSnapshotAsync(WorkspaceId, repositoryId);
+        if (dto is null)
+        {
+            return null;
+        }
+
+        link = WorkspaceRepositoryLinkListMapper.ToLink(dto);
+        _linkByRepoId[repositoryId] = link;
+        return link;
+    }
+
+    private async Task<IReadOnlyList<WorkspaceRepositoryLink>> GetAllLinksForOperationAsync()
+    {
+        var snapshots = await LinkListQueryService.GetAllSnapshotsAsync(WorkspaceId);
+        return snapshots.Select(WorkspaceRepositoryLinkListMapper.ToLink).ToList();
+    }
+
+    private Task<IReadOnlyList<int>> GetRepositoryIdsAtLevelAsync(int? levelKey) =>
+        LinkListQueryService.GetRepositoryIdsAtLevelAsync(WorkspaceId, levelKey, _effectiveSearch);
+
+    private WorkspaceRepositoryLink? FindLink(IReadOnlyList<WorkspaceRepositoryLink> links, int repositoryId) =>
+        links.FirstOrDefault(w => w.RepositoryId == repositoryId);
+
+    private void ApplyItemsFromDtos(IReadOnlyList<WorkspaceRepositoryLinkListItemDto> dtos, bool replace)
+    {
+        if (replace)
+        {
+            _items.Clear();
+            _linkByRepoId.Clear();
+        }
+
+        var prDict = replace
+            ? new Dictionary<int, PullRequestInfo?>()
+            : prByRepositoryId.ToDictionary(kv => kv.Key, kv => kv.Value);
+
+        foreach (var dto in dtos)
+        {
+            var link = WorkspaceRepositoryLinkListMapper.ToLink(dto);
+            _items.Add(link);
+            _linkByRepoId[link.RepositoryId] = link;
+            prDict[link.RepositoryId] = WorkspaceRepositoryLinkListMapper.ToPullRequestInfo(dto);
+        }
+
+        prByRepositoryId = prDict;
+    }
+
+    private void ApplySyncStateFromLoadedItems()
+    {
+        if (_items.Count == 0)
         {
             return;
         }
-        repoSyncStatus = workspaceRepositories
+
+        repoSyncStatus = _items
             .Where(wr => wr.Repository != null)
             .ToDictionary(wr => wr.RepositoryId, wr => wr.SyncStatus);
-        isOutOfSync = repoSyncStatus.Values.Any(s => s != RepoSyncStatus.InSync);
         StateHasChanged();
     }
 }

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.State.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.State.cs
@@ -9,8 +9,9 @@ public sealed partial class WorkspaceRepositories
 {
     private const double VirtualRowHeightPx = 48;
     private const double VirtualHeaderHeightPx = 40;
-    private const int VirtualOverscanSlots = 8;
-    private const int VirtualInitialViewportSlots = 40;
+    private const int VirtualOverscanSlots = 24;
+    private const int VirtualInitialViewportSlots = 48;
+    private int _scrollGeneration;
     private readonly DebouncedQueryLoader _queryLoader = new();
     private readonly Dictionary<int, WorkspaceRepositoryLink> _linkByRepoId = new();
     private readonly Dictionary<int, WorkspaceRepositoryLink> _linkByWrlId = new();
@@ -229,18 +230,26 @@ public sealed partial class WorkspaceRepositories
         }
         return hydrated.All(wr => wr.IsOnTag);
     }
-    private void UpdateVisibleRange(int start, int end)
+    /// <summary>Returns true when the visible window actually changed.</summary>
+    private bool UpdateVisibleRange(int start, int end)
     {
-        start = Math.Clamp(start, 0, Math.Max(0, _slots.Count - 1));
-        end = Math.Clamp(end, start, Math.Max(-1, _slots.Count - 1));
         if (_slots.Count == 0)
         {
+            var wasEmpty = _visibleEnd < 0 && _visibleStart == 0 && _topSpacerPx == 0 && _bottomSpacerPx == 0;
             _visibleStart = 0;
             _visibleEnd = -1;
             _topSpacerPx = 0;
             _bottomSpacerPx = 0;
-            return;
+            return !wasEmpty;
         }
+
+        start = Math.Clamp(start, 0, _slots.Count - 1);
+        end = Math.Clamp(end, start, _slots.Count - 1);
+        if (start == _visibleStart && end == _visibleEnd)
+        {
+            return false;
+        }
+
         _visibleStart = start;
         _visibleEnd = end;
         double top = 0;
@@ -255,6 +264,7 @@ public sealed partial class WorkspaceRepositories
         }
         _topSpacerPx = top;
         _bottomSpacerPx = bottom;
+        return true;
     }
     private IReadOnlyList<VirtualSlot> VisibleSlots
     {

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.State.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.State.cs
@@ -2,15 +2,20 @@ using GrayMoon.App.Components.Shared;
 using GrayMoon.App.Models;
 using GrayMoon.App.Services;
 using GrayMoon.App.Services.Queries;
-
+using Microsoft.AspNetCore.Components;
+using Microsoft.JSInterop;
 namespace GrayMoon.App.Components.Pages;
-
 public sealed partial class WorkspaceRepositories
 {
+    private const double VirtualRowHeightPx = 48;
+    private const double VirtualHeaderHeightPx = 40;
+    private const int VirtualOverscanSlots = 8;
+    private const int VirtualInitialViewportSlots = 40;
     private readonly DebouncedQueryLoader _queryLoader = new();
-    private readonly List<WorkspaceRepositoryLink> _items = new();
     private readonly Dictionary<int, WorkspaceRepositoryLink> _linkByRepoId = new();
-
+    private readonly Dictionary<int, WorkspaceRepositoryLink> _linkByWrlId = new();
+    private readonly List<VirtualSlot> _slots = new();
+    private readonly HashSet<int> _tooltipLoadInFlight = new();
     private Workspace? workspace;
     private WorkspaceRepositoryHeaderStateDto? _headerState;
     private IReadOnlyDictionary<int, PullRequestInfo?> prByRepositoryId = new Dictionary<int, PullRequestInfo?>();
@@ -18,14 +23,17 @@ public sealed partial class WorkspaceRepositories
     private static readonly TimeSpan PrRefreshThrottle = TimeSpan.FromSeconds(10);
     private string? errorMessage;
     private bool isInitialLoading = true;
-    private bool isLoadingMore;
-    private bool hasMore;
     private bool hasLoadedOnce;
     private int? totalCount;
     private string _effectiveSearch = string.Empty;
-    private WorkspaceRepositoryLinkListCursor? _nextCursor;
-    private bool _loadingNextChunk;
-
+    private int _visibleStart;
+    private int _visibleEnd = -1;
+    private double _topSpacerPx;
+    private double _bottomSpacerPx;
+    private ElementReference _tbodyRef;
+    private DotNetObjectReference<WorkspaceRepositories>? _virtualScrollDotNetRef;
+    private bool _virtualScrollAttached;
+    private int _loadedWorkspaceId;
     private bool HasRepositories => (_headerState?.TotalCount ?? 0) > 0;
     private bool hasUnmatchedDependencies => _headerState?.HasUnmatchedDependencies ?? false;
     private bool isPushRecommended => _headerState?.IsPushRecommended ?? false;
@@ -33,19 +41,10 @@ public sealed partial class WorkspaceRepositories
     private bool hasTaggedRepos => _headerState?.HasTaggedRepos ?? false;
     private bool hasIncomingCommits => _headerState?.HasIncomingCommits ?? false;
     private bool? isOutOfSync => _headerState?.IsOutOfSync;
-
-    private IEnumerable<IGrouping<int?, WorkspaceRepositoryLink>> LoadedLevelGroups =>
-        _items
-            .GroupBy(wr => wr.DependencyLevel)
-            .OrderByDescending(g => g.Key ?? int.MinValue);
-
     private bool HasSearchFilter => !string.IsNullOrWhiteSpace(_effectiveSearch);
-
     private bool NoRepositoriesMatchSearch =>
         hasLoadedOnce && totalCount == 0 && !isInitialLoading && !string.IsNullOrWhiteSpace(_effectiveSearch);
-
     private string ApiBaseUrl => NavigationManager.BaseUri.TrimEnd('/');
-
     private string RepositoriesModalTitle => $"Repositories for {workspace?.Name ?? "Workspace"}";
     private bool ShowRepositoriesFetchOverlay => _repositoriesModal.IsVisible && _repositoriesModal.IsFetching;
     private string RepositoriesFetchOverlayMessage => _repositoriesModal.FetchedRepositoryCount is null || _repositoriesModal.FetchedRepositoryCount == 0
@@ -55,104 +54,222 @@ public sealed partial class WorkspaceRepositories
     private IReadOnlyDictionary<int, IReadOnlyList<DependencyMismatchLine>> _mismatchedDependencyLinesByRepo = new Dictionary<int, IReadOnlyList<DependencyMismatchLine>>();
     private IReadOnlyDictionary<int, IReadOnlyList<WorkspaceFileLineStatus>> _fileLineStatusByRepo = new Dictionary<int, IReadOnlyList<WorkspaceFileLineStatus>>();
     private IReadOnlyDictionary<int, IReadOnlyList<FileVersionMismatchLine>> _mismatchedFileVersionLinesByRepo = new Dictionary<int, IReadOnlyList<FileVersionMismatchLine>>();
-
     /// <summary>All workspace-internal package dependencies of each repository (PackageId + version as written in the .csproj). Used to populate the dependency-badge tooltip for repositories whose dependencies are up to date.</summary>
     private IReadOnlyDictionary<int, IReadOnlyList<DependencyLine>> _allDependencyLinesByRepo = new Dictionary<int, IReadOnlyList<DependencyLine>>();
     /// <summary>Per-repo (FileName, TokenName, Version) triples derived from version-file configs and current GitVersions. Drives the OK badge file-dependency tooltip.</summary>
     private IReadOnlyDictionary<int, IReadOnlyList<FileVersionDisplayLine>> _allFileVersionLinesByRepo = new Dictionary<int, IReadOnlyList<FileVersionDisplayLine>>();
     /// <summary>User-declared custom dependency repo names per dependent repository (ordering only).</summary>
     private IReadOnlyDictionary<int, IReadOnlyList<string>> _customDependencyLinesByRepo = new Dictionary<int, IReadOnlyList<string>>();
+    private readonly HashSet<int> _tooltipLoadedRepoIds = new();
     private Dictionary<int, string> repositoryErrors = new();
     private HashSet<string> clickedVersions = new();
     private HashSet<int> clickedDependencyBadges = new();
-
     private string searchTerm = string.Empty;
-
     private bool _disposed;
     private bool _wasJobRunning;
     private string PageJobKey => new Uri(NavigationManager.Uri).AbsolutePath.ToLowerInvariant();
     private bool IsJobRunning => JobService.IsRunning(PageJobKey);
-
     private int AgentTasksPendingCount => AgentQueueStateService.GetPendingCountForWorkspace(WorkspaceId);
-
     private const int RefreshDebounceMs = 200;
     private CancellationTokenSource? _refreshDebounceCts;
     private readonly object _refreshDebounceLock = new();
-    private readonly SemaphoreSlim _loadMismatchedDepsLock = new(1, 1);
-
+    private CancellationTokenSource? _backgroundWorkCts;
     private const string TagBlockedActionMessage = "Repository is on a tag; checkout a branch first.";
-
     private const int TableColSpan = 4;
-
+    private enum VirtualSlotKind
+    {
+        LevelHeader,
+        Row,
+    }
+    private sealed record VirtualSlot(
+        VirtualSlotKind Kind,
+        int? LevelKey,
+        int WorkspaceRepositoryId,
+        int RepositoryId,
+        int LevelRepoCount);
     private bool IsRepoOnTag(int repositoryId) =>
         TryGetLink(repositoryId)?.IsOnTag == true;
-
     private WorkspaceRepositoryLink? TryGetLink(int repositoryId) =>
         _linkByRepoId.TryGetValue(repositoryId, out var link) ? link : null;
-
     private async Task<WorkspaceRepositoryLink?> TryGetLinkAsync(int repositoryId)
     {
         if (_linkByRepoId.TryGetValue(repositoryId, out var link))
         {
             return link;
         }
-
         var dto = await LinkListQueryService.GetSnapshotAsync(WorkspaceId, repositoryId);
         if (dto is null)
         {
             return null;
         }
-
         link = WorkspaceRepositoryLinkListMapper.ToLink(dto);
-        _linkByRepoId[repositoryId] = link;
+        CacheLink(link, WorkspaceRepositoryLinkListMapper.ToPullRequestInfo(dto));
         return link;
     }
-
     private async Task<IReadOnlyList<WorkspaceRepositoryLink>> GetAllLinksForOperationAsync()
     {
         var snapshots = await LinkListQueryService.GetAllSnapshotsAsync(WorkspaceId);
         return snapshots.Select(WorkspaceRepositoryLinkListMapper.ToLink).ToList();
     }
-
     private Task<IReadOnlyList<int>> GetRepositoryIdsAtLevelAsync(int? levelKey) =>
         LinkListQueryService.GetRepositoryIdsAtLevelAsync(WorkspaceId, levelKey, _effectiveSearch);
-
     private WorkspaceRepositoryLink? FindLink(IReadOnlyList<WorkspaceRepositoryLink> links, int repositoryId) =>
         links.FirstOrDefault(w => w.RepositoryId == repositoryId);
-
+    private void ClearGridState()
+    {
+        _slots.Clear();
+        _linkByRepoId.Clear();
+        _linkByWrlId.Clear();
+        prByRepositoryId = new Dictionary<int, PullRequestInfo?>();
+        repoSyncStatus = new();
+        _visibleStart = 0;
+        _visibleEnd = -1;
+        _topSpacerPx = 0;
+        _bottomSpacerPx = 0;
+        totalCount = null;
+        _headerState = null;
+        _tooltipLoadedRepoIds.Clear();
+        _tooltipLoadInFlight.Clear();
+        _mismatchedDependencyLinesByRepo = new Dictionary<int, IReadOnlyList<DependencyMismatchLine>>();
+        _allDependencyLinesByRepo = new Dictionary<int, IReadOnlyList<DependencyLine>>();
+        _mismatchedFileVersionLinesByRepo = new Dictionary<int, IReadOnlyList<FileVersionMismatchLine>>();
+        _fileLineStatusByRepo = new Dictionary<int, IReadOnlyList<WorkspaceFileLineStatus>>();
+        _allFileVersionLinesByRepo = new Dictionary<int, IReadOnlyList<FileVersionDisplayLine>>();
+        _customDependencyLinesByRepo = new Dictionary<int, IReadOnlyList<string>>();
+    }
+    private void BuildSlots(IReadOnlyList<WorkspaceRepositoryLinkIndexEntry> index)
+    {
+        _slots.Clear();
+        if (index.Count == 0)
+        {
+            return;
+        }
+        var levelCounts = new Dictionary<int, int>();
+        foreach (var entry in index)
+        {
+            var levelKey = entry.DependencyLevel ?? int.MinValue;
+            levelCounts[levelKey] = levelCounts.GetValueOrDefault(levelKey) + 1;
+        }
+        var previousLevel = int.MinValue;
+        var hasPrevious = false;
+        foreach (var entry in index)
+        {
+            var levelKey = entry.DependencyLevel ?? int.MinValue;
+            if (!hasPrevious || levelKey != previousLevel)
+            {
+                _slots.Add(new VirtualSlot(
+                    VirtualSlotKind.LevelHeader,
+                    entry.DependencyLevel,
+                    0,
+                    0,
+                    levelCounts[levelKey]));
+                previousLevel = levelKey;
+                hasPrevious = true;
+            }
+            _slots.Add(new VirtualSlot(
+                VirtualSlotKind.Row,
+                entry.DependencyLevel,
+                entry.WorkspaceRepositoryId,
+                entry.RepositoryId,
+                0));
+        }
+    }
+    private static double SlotHeight(VirtualSlot slot) =>
+        slot.Kind == VirtualSlotKind.LevelHeader ? VirtualHeaderHeightPx : VirtualRowHeightPx;
+    private double TotalScrollHeightPx()
+    {
+        double total = 0;
+        foreach (var slot in _slots)
+        {
+            total += SlotHeight(slot);
+        }
+        return total;
+    }
+    private void CacheLink(WorkspaceRepositoryLink link, PullRequestInfo? prInfo)
+    {
+        _linkByRepoId[link.RepositoryId] = link;
+        _linkByWrlId[link.WorkspaceRepositoryId] = link;
+        var prDict = prByRepositoryId as Dictionary<int, PullRequestInfo?>
+            ?? prByRepositoryId.ToDictionary(kv => kv.Key, kv => kv.Value);
+        prDict[link.RepositoryId] = prInfo;
+        prByRepositoryId = prDict;
+        repoSyncStatus[link.RepositoryId] = link.SyncStatus;
+    }
     private void ApplyItemsFromDtos(IReadOnlyList<WorkspaceRepositoryLinkListItemDto> dtos, bool replace)
     {
         if (replace)
         {
-            _items.Clear();
             _linkByRepoId.Clear();
+            _linkByWrlId.Clear();
+            prByRepositoryId = new Dictionary<int, PullRequestInfo?>();
+            repoSyncStatus = new();
         }
-
-        var prDict = replace
-            ? new Dictionary<int, PullRequestInfo?>()
-            : prByRepositoryId.ToDictionary(kv => kv.Key, kv => kv.Value);
-
         foreach (var dto in dtos)
         {
             var link = WorkspaceRepositoryLinkListMapper.ToLink(dto);
-            _items.Add(link);
-            _linkByRepoId[link.RepositoryId] = link;
-            prDict[link.RepositoryId] = WorkspaceRepositoryLinkListMapper.ToPullRequestInfo(dto);
+            CacheLink(link, WorkspaceRepositoryLinkListMapper.ToPullRequestInfo(dto));
         }
-
-        prByRepositoryId = prDict;
     }
-
     private void ApplySyncStateFromLoadedItems()
     {
-        if (_items.Count == 0)
+        if (_linkByRepoId.Count == 0)
         {
             return;
         }
-
-        repoSyncStatus = _items
-            .Where(wr => wr.Repository != null)
-            .ToDictionary(wr => wr.RepositoryId, wr => wr.SyncStatus);
         StateHasChanged();
+    }
+    private IEnumerable<WorkspaceRepositoryLink> GetHydratedLinksAtLevel(int? levelKey) =>
+        _linkByRepoId.Values.Where(wr => wr.DependencyLevel == levelKey);
+    private bool IsLevelActionsDisabled(int? levelKey)
+    {
+        var hydrated = GetHydratedLinksAtLevel(levelKey).ToList();
+        if (hydrated.Count == 0)
+        {
+            return false;
+        }
+        return hydrated.All(wr => wr.IsOnTag);
+    }
+    private void UpdateVisibleRange(int start, int end)
+    {
+        start = Math.Clamp(start, 0, Math.Max(0, _slots.Count - 1));
+        end = Math.Clamp(end, start, Math.Max(-1, _slots.Count - 1));
+        if (_slots.Count == 0)
+        {
+            _visibleStart = 0;
+            _visibleEnd = -1;
+            _topSpacerPx = 0;
+            _bottomSpacerPx = 0;
+            return;
+        }
+        _visibleStart = start;
+        _visibleEnd = end;
+        double top = 0;
+        for (var i = 0; i < start; i++)
+        {
+            top += SlotHeight(_slots[i]);
+        }
+        double bottom = 0;
+        for (var i = end + 1; i < _slots.Count; i++)
+        {
+            bottom += SlotHeight(_slots[i]);
+        }
+        _topSpacerPx = top;
+        _bottomSpacerPx = bottom;
+    }
+    private IReadOnlyList<VirtualSlot> VisibleSlots
+    {
+        get
+        {
+            if (_slots.Count == 0 || _visibleEnd < _visibleStart)
+            {
+                return Array.Empty<VirtualSlot>();
+            }
+            var list = new List<VirtualSlot>(_visibleEnd - _visibleStart + 1);
+            for (var i = _visibleStart; i <= _visibleEnd && i < _slots.Count; i++)
+            {
+                list.Add(_slots[i]);
+            }
+            return list;
+        }
     }
 }

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.State.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.State.cs
@@ -87,7 +87,8 @@ public sealed partial class WorkspaceRepositories
         int? LevelKey,
         int WorkspaceRepositoryId,
         int RepositoryId,
-        int LevelRepoCount);
+        int LevelRepoCount,
+        int StripeIndex);
     private bool IsRepoOnTag(int repositoryId) =>
         TryGetLink(repositoryId)?.IsOnTag == true;
     private WorkspaceRepositoryLink? TryGetLink(int repositoryId) =>
@@ -153,6 +154,7 @@ public sealed partial class WorkspaceRepositories
         }
         var previousLevel = int.MinValue;
         var hasPrevious = false;
+        var stripeIndex = 0;
         foreach (var entry in index)
         {
             var levelKey = entry.DependencyLevel ?? int.MinValue;
@@ -163,7 +165,8 @@ public sealed partial class WorkspaceRepositories
                     entry.DependencyLevel,
                     0,
                     0,
-                    levelCounts[levelKey]));
+                    levelCounts[levelKey],
+                    -1));
                 previousLevel = levelKey;
                 hasPrevious = true;
             }
@@ -172,9 +175,12 @@ public sealed partial class WorkspaceRepositories
                 entry.DependencyLevel,
                 entry.WorkspaceRepositoryId,
                 entry.RepositoryId,
-                0));
+                0,
+                stripeIndex++));
         }
     }
+
+    private static string StripeClass(int stripeIndex) => VirtualScrollUi.StripeClass(stripeIndex);
     private static double SlotHeight(VirtualSlot slot) =>
         slot.Kind == VirtualSlotKind.LevelHeader ? VirtualHeaderHeightPx : VirtualRowHeightPx;
     private double TotalScrollHeightPx()

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.Sync.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.Sync.cs
@@ -8,7 +8,7 @@ public sealed partial class WorkspaceRepositories
 {
     private Task SyncAsync()
     {
-        if (workspace == null || workspaceRepositories.Count == 0 || IsJobRunning) return Task.CompletedTask;
+        if (workspace == null || !HasRepositories || IsJobRunning) return Task.CompletedTask;
         var skipDependencyLevelPersistence = !string.IsNullOrEmpty(errorMessage);
         errorMessage = null;
         return RunSyncJobAsync(null, "Synchronizing...", skipDependencyLevelPersistence);
@@ -24,7 +24,7 @@ public sealed partial class WorkspaceRepositories
 
     private Task SyncSingleRepoAsync(int repositoryId)
     {
-        if (workspace == null || workspaceRepositories.Count == 0 || IsJobRunning) return Task.CompletedTask;
+        if (workspace == null || !HasRepositories || IsJobRunning) return Task.CompletedTask;
         errorMessage = null;
         return RunSyncJobAsync(new[] { repositoryId }, "Synchronizing repository...", skipDependencyLevelPersistence: true);
     }
@@ -59,8 +59,7 @@ public sealed partial class WorkspaceRepositories
                         setProgress: job.ReportProgress,
                         updateRepoGitInfo: (repoId, info) => SafeInvoke(() =>
                         {
-                            var wr = workspaceRepositories.FirstOrDefault(w => w.RepositoryId == repoId);
-                            if (wr != null)
+                            if (_linkByRepoId.TryGetValue(repoId, out var wr))
                             {
                                 wr.GitVersion = info.Version == "-" ? null : info.Version;
                                 wr.BranchName = info.Branch == "-" ? null : info.Branch;
@@ -74,9 +73,8 @@ public sealed partial class WorkspaceRepositories
                 await InvokeAsync(async () =>
                 {
                     if (_disposed) return;
-                    await ReloadWorkspaceDataAsync();
-                    ApplySyncStateFromWorkspace();
-                    isOutOfSync = repoSyncStatus.Values.Any(v => v != RepoSyncStatus.InSync);
+                    await ReloadWorkspaceDataFromFreshScopeAsync();
+                    ApplySyncStateFromLoadedItems();
                     foreach (var (repoId, info) in repoGitInfos)
                     {
                         if (!string.IsNullOrWhiteSpace(info.ErrorMessage))

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.SyncToDefault.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.SyncToDefault.cs
@@ -148,7 +148,7 @@ public sealed partial class WorkspaceRepositories
                 catch (Exception ex)
                 {
                     Logger.LogError(ex, "Error checking branches for sync to default");
-                    SafeInvoke(() => ToastService.Show("Failed to prepare sync to default."));
+                    SafeInvoke(() => ToastService.ShowError("Failed to prepare sync to default."));
                     throw;
                 }
             });
@@ -231,7 +231,7 @@ public sealed partial class WorkspaceRepositories
         catch (Exception ex)
         {
             Logger.LogError(ex, "Error preparing sync to default (repository {RepositoryId})", repositoryId);
-            ToastService.Show("Failed to prepare sync to default.");
+            ToastService.ShowError("Failed to prepare sync to default.");
         }
     }
 
@@ -256,7 +256,11 @@ public sealed partial class WorkspaceRepositories
             }
             else if (errMsg != null)
             {
-                SafeInvoke(() => { repositoryErrors[repositoryId] = errMsg; });
+                SafeInvoke(() =>
+                {
+                    repositoryErrors[repositoryId] = errMsg;
+                    ToastService.ShowError(errMsg);
+                });
             }
         }, new PageJobOptions
         {
@@ -264,7 +268,12 @@ public sealed partial class WorkspaceRepositories
             OnError = ex =>
             {
                 Logger.LogError(ex, "Error syncing to default branch for repository {RepositoryId}", repositoryId);
-                SafeInvoke(() => { repositoryErrors[repositoryId] = "An error occurred while syncing to default branch. The GrayMoon Agent may be offline."; });
+                var message = "An error occurred while syncing to default branch. The GrayMoon Agent may be offline.";
+                SafeInvoke(() =>
+                {
+                    repositoryErrors[repositoryId] = message;
+                    ToastService.ShowError(message);
+                });
             }
         });
 
@@ -341,7 +350,7 @@ public sealed partial class WorkspaceRepositories
                     {
                         repositoryErrors[repoId] = errMsg;
                         var repoName = TryGetLink(repoId)?.Repository?.RepositoryName ?? repoId.ToString();
-                        ToastService.Show($"{repoName}: {errMsg}");
+                        ToastService.ShowError($"{repoName}: {errMsg}");
                     }
                 }
             });
@@ -451,7 +460,7 @@ public sealed partial class WorkspaceRepositories
                 catch (Exception ex)
                 {
                     Logger.LogError(ex, "Error fetching branch state before sync all to default");
-                    SafeInvoke(() => ToastService.Show("Failed to prepare sync to default."));
+                    SafeInvoke(() => ToastService.ShowError("Failed to prepare sync to default."));
                     throw;
                 }
             });
@@ -552,7 +561,7 @@ public sealed partial class WorkspaceRepositories
                     {
                         repositoryErrors[repoId] = errMsg;
                         var repoName = TryGetLink(repoId)?.Repository?.RepositoryName ?? repoId.ToString();
-                        ToastService.Show($"{repoName}: {errMsg}");
+                        ToastService.ShowError($"{repoName}: {errMsg}");
                     }
                 }
 
@@ -561,7 +570,7 @@ public sealed partial class WorkspaceRepositories
                     if (failureCount == 0)
                         ToastService.Show($"Synced {successCount} of {total} repositories to default branch.");
                     else
-                        ToastService.Show($"Synced {successCount} of {total} repositories to default branch ({failureCount} failed).");
+                        ToastService.ShowError($"Synced {successCount} of {total} repositories to default branch ({failureCount} failed).");
                 }
             });
         }, new PageJobOptions

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.SyncToDefault.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.SyncToDefault.cs
@@ -15,7 +15,7 @@ public sealed partial class WorkspaceRepositories
             return;
 
         var nonDefaultRepoIds = repositoryIds
-            .Select(id => workspaceRepositories.FirstOrDefault(w => w.RepositoryId == id))
+            .Select(id => TryGetLink(id))
             .Where(wr =>
             {
                 if (wr == null || wr.IsOnTag || string.IsNullOrWhiteSpace(wr.BranchName))
@@ -48,7 +48,7 @@ public sealed partial class WorkspaceRepositories
         {
             await WorkspacePageService.WorkspacePullRequestService.RefreshPullRequestsAsync(WorkspaceId, repositoryIds, force: true);
             await ReloadWorkspaceDataFromFreshScopeAsync();
-            ApplySyncStateFromWorkspace();
+            ApplySyncStateFromLoadedItems();
             await InvokeAsync(StateHasChanged);
         }
         catch (Exception ex)
@@ -60,7 +60,7 @@ public sealed partial class WorkspaceRepositories
         var checkResults = repositoryIds
             .Select(repoId =>
             {
-                var wr = workspaceRepositories.FirstOrDefault(w => w.RepositoryId == repoId);
+                var wr = TryGetLink(repoId);
                 return new SyncToDefaultCheckResult(repoId, wr?.DefaultBranchAheadCommits, wr?.BranchHasUpstream);
             })
             .ToList();
@@ -74,7 +74,7 @@ public sealed partial class WorkspaceRepositories
 
         foreach (var r in blocked)
         {
-            var name = workspaceRepositories.FirstOrDefault(w => w.RepositoryId == r.RepoId)?.Repository?.RepositoryName ?? r.RepoId.ToString();
+            var name = TryGetLink(r.RepoId)?.Repository?.RepositoryName ?? r.RepoId.ToString();
             ToastService.Show($"{name}: skipped sync to default (commits ahead of default, PR not merged).");
         }
 
@@ -124,7 +124,7 @@ public sealed partial class WorkspaceRepositories
                         _syncToDefaultCheckResults = _syncToDefaultCheckResults?
                             .Select(r =>
                             {
-                                var wr2 = workspaceRepositories.FirstOrDefault(w => w.RepositoryId == r.RepoId);
+                                var wr2 = TryGetLink(r.RepoId);
                                 return new SyncToDefaultCheckResult(r.RepoId, r.DefaultAhead, wr2?.BranchHasUpstream);
                             })
                             .ToList();
@@ -132,7 +132,7 @@ public sealed partial class WorkspaceRepositories
                         var repoItems = _syncToDefaultCheckResults?
                             .Select(r =>
                             {
-                                var wr2 = workspaceRepositories.FirstOrDefault(w => w.RepositoryId == r.RepoId);
+                                var wr2 = TryGetLink(r.RepoId);
                                 return new SyncToDefaultRepoItem(wr2?.Repository?.RepositoryName ?? r.RepoId.ToString(), wr2?.BranchName ?? "", r.HasUpstream == true, PrState: null, CommitsAhead: 0);
                             })
                             .ToList() ?? new List<SyncToDefaultRepoItem>();
@@ -188,7 +188,7 @@ public sealed partial class WorkspaceRepositories
         try
         {
             // Use persisted workspace link state (updated by hooks); no agent GetCommitCounts call.
-            var wr = workspaceRepositories.FirstOrDefault(w => w.RepositoryId == repositoryId);
+            var wr = await TryGetLinkAsync(repositoryId);
             var defaultAhead = wr?.DefaultBranchAheadCommits ?? 0;
             var hasUpstream = wr?.BranchHasUpstream == true;
 
@@ -198,7 +198,7 @@ public sealed partial class WorkspaceRepositories
                 {
                     await WorkspacePageService.WorkspacePullRequestService.RefreshPullRequestsAsync(WorkspaceId, new[] { repositoryId }, force: true);
                     await ReloadWorkspaceDataFromFreshScopeAsync();
-                    ApplySyncStateFromWorkspace();
+                    ApplySyncStateFromLoadedItems();
                     await InvokeAsync(StateHasChanged);
                 }
                 catch (Exception ex)
@@ -298,7 +298,7 @@ public sealed partial class WorkspaceRepositories
 
             var tasks = repositoryIds.Select(async repositoryId =>
             {
-                var wr = workspaceRepositories.FirstOrDefault(w => w.RepositoryId == repositoryId);
+                var wr = await TryGetLinkAsync(repositoryId);
                 var currentBranchName = wr?.BranchName;
                 if (string.IsNullOrWhiteSpace(currentBranchName))
                 {
@@ -340,7 +340,7 @@ public sealed partial class WorkspaceRepositories
                     else if (errMsg != null)
                     {
                         repositoryErrors[repoId] = errMsg;
-                        var repoName = workspaceRepositories.FirstOrDefault(w => w.RepositoryId == repoId)?.Repository?.RepositoryName ?? repoId.ToString();
+                        var repoName = TryGetLink(repoId)?.Repository?.RepositoryName ?? repoId.ToString();
                         ToastService.Show($"{repoName}: {errMsg}");
                     }
                 }
@@ -362,7 +362,8 @@ public sealed partial class WorkspaceRepositories
         if (workspace == null || IsJobRunning)
             return;
 
-        var eligibleRepos = workspaceRepositories
+        var allLinks = await GetAllLinksForOperationAsync();
+        var eligibleRepos = allLinks
             .Where(wr =>
                 !wr.IsOnTag &&
                 !string.IsNullOrWhiteSpace(wr.BranchName) &&
@@ -425,7 +426,7 @@ public sealed partial class WorkspaceRepositories
                         var repoItems = eligibleIds
                             .Select(repoId =>
                             {
-                                var wr2 = workspaceRepositories.FirstOrDefault(w => w.RepositoryId == repoId);
+                                var wr2 = TryGetLink(repoId);
                                 prByRepositoryId.TryGetValue(repoId, out var pr);
                                 var prState = pr == null ? null : pr.IsMerged ? "merged" : pr.IsClosed ? "closed" : "open";
                                 var commitsAhead = wr2?.DefaultBranchAheadCommits ?? 0;
@@ -456,14 +457,15 @@ public sealed partial class WorkspaceRepositories
             });
     }
 
-    private Task ExecuteSyncAllToDefaultAsync(
+    private async Task ExecuteSyncAllToDefaultAsync(
         IReadOnlyList<SyncToDefaultRepoItem> repoItems,
         bool deleteRemoteBranch)
     {
         if (workspace == null || repoItems.Count == 0 || IsJobRunning)
-            return Task.CompletedTask;
+            return;
 
-        var repoIdByName = workspaceRepositories.ToDictionary(
+        var allLinks = await GetAllLinksForOperationAsync();
+        var repoIdByName = allLinks.ToDictionary(
             wr => wr.Repository?.RepositoryName ?? string.Empty,
             wr => wr.RepositoryId);
         var prNumberByRepoName = new Dictionary<string, int>();
@@ -492,7 +494,7 @@ public sealed partial class WorkspaceRepositories
                     return (RepoId: 0, Success: false, ErrorMsg: (string?)"Repository not found");
                 }
 
-                var wr = workspaceRepositories.FirstOrDefault(w => w.RepositoryId == repoId);
+                var wr = TryGetLink(repoId);
                 var currentBranch = wr?.BranchName ?? item.BranchName;
                 if (string.IsNullOrWhiteSpace(currentBranch))
                 {
@@ -549,7 +551,7 @@ public sealed partial class WorkspaceRepositories
                     else if (errMsg != null)
                     {
                         repositoryErrors[repoId] = errMsg;
-                        var repoName = workspaceRepositories.FirstOrDefault(w => w.RepositoryId == repoId)?.Repository?.RepositoryName ?? repoId.ToString();
+                        var repoName = TryGetLink(repoId)?.Repository?.RepositoryName ?? repoId.ToString();
                         ToastService.Show($"{repoName}: {errMsg}");
                     }
                 }
@@ -571,6 +573,5 @@ public sealed partial class WorkspaceRepositories
             }
         });
 
-        return Task.CompletedTask;
     }
 }

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.UndoPush.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.UndoPush.cs
@@ -8,19 +8,20 @@ public sealed partial class WorkspaceRepositories
     private UndoPushModalState _undoPushModal = new();
 
     /// <summary>Opens the Undo Push modal showing all repositories that have outgoing commits.</summary>
-    private Task OnUndoPushClickAsync()
+    private async Task OnUndoPushClickAsync()
     {
         if (workspace == null || IsJobRunning)
-            return Task.CompletedTask;
+            return;
 
-        var reposWithOutgoing = workspaceRepositories
+        var allLinks = await GetAllLinksForOperationAsync();
+        var reposWithOutgoing = allLinks
             .Where(wr => !wr.IsOnTag && (wr.OutgoingCommits ?? 0) > 0)
             .ToList();
 
         if (reposWithOutgoing.Count == 0)
         {
             ToastService.Show("No outgoing commits to undo.");
-            return Task.CompletedTask;
+            return;
         }
 
         _undoPushModal = _undoPushModal with
@@ -32,7 +33,6 @@ public sealed partial class WorkspaceRepositories
                 .ToList()
         };
         StateHasChanged();
-        return Task.CompletedTask;
     }
 
     private Task OnUndoPushProceedAsync(bool keepChanges)

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.Update.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.Update.cs
@@ -13,10 +13,11 @@ public sealed partial class WorkspaceRepositories
     /// <summary>Update button click: get update plan; if no updates, toast; else show modal (single vs multi-level).</summary>
     private async Task OnUpdateClickAsync()
     {
-        if (workspace == null || workspaceRepositories.Count == 0 || IsJobRunning)
+        if (workspace == null || !HasRepositories || IsJobRunning)
             return;
 
-        if (workspaceRepositories.All(wr => wr.IsOnTag))
+        var allLinks = await GetAllLinksForOperationAsync();
+        if (allLinks.All(wr => wr.IsOnTag))
         {
             ToastService.Show("All repositories are on tags; checkout a branch first.");
             return;
@@ -26,7 +27,7 @@ public sealed partial class WorkspaceRepositories
             svc => svc.GetUpdatePlanAsync(WorkspaceId));
         var repoIdsWithUpdates = updatePlan.Select(p => p.RepoId).ToHashSet();
 
-        var reposOnDefault = workspaceRepositories
+        var reposOnDefault = allLinks
             .Where(wr => !wr.IsOnTag
                 && !string.IsNullOrWhiteSpace(wr.DefaultBranchName)
                 && string.Equals(wr.BranchName, wr.DefaultBranchName, StringComparison.Ordinal)
@@ -85,7 +86,7 @@ public sealed partial class WorkspaceRepositories
     /// <summary>Runs update (refresh, sync deps, commit per level, refresh version). Overlay shows progress.</summary>
     private Task RunUpdateCoreAsync(string? commitMessage = null, bool includeDepsInCommitMessage = true)
     {
-        if (workspace == null || workspaceRepositories.Count == 0 || IsJobRunning)
+        if (workspace == null || !HasRepositories || IsJobRunning)
             return Task.CompletedTask;
 
         errorMessage = null;
@@ -116,10 +117,11 @@ public sealed partial class WorkspaceRepositories
 
     private async Task OnUpdateAndPushClickAsync()
     {
-        if (workspace == null || workspaceRepositories.Count == 0 || IsJobRunning)
+        if (workspace == null || !HasRepositories || IsJobRunning)
             return;
 
-        if (workspaceRepositories.All(wr => wr.IsOnTag))
+        var allLinks = await GetAllLinksForOperationAsync();
+        if (allLinks.All(wr => wr.IsOnTag))
         {
             ToastService.Show("All repositories are on tags; checkout a branch first.");
             return;
@@ -129,7 +131,7 @@ public sealed partial class WorkspaceRepositories
             svc => svc.GetUpdatePlanAsync(WorkspaceId));
         var repoIdsWithUpdates = updatePlan.Select(p => p.RepoId).ToHashSet();
 
-        var reposOnDefault = workspaceRepositories
+        var reposOnDefault = allLinks
             .Where(wr => !wr.IsOnTag
                 && !string.IsNullOrWhiteSpace(wr.DefaultBranchName)
                 && string.Equals(wr.BranchName, wr.DefaultBranchName, StringComparison.Ordinal)
@@ -176,7 +178,7 @@ public sealed partial class WorkspaceRepositories
 
     private async Task OnLevelOnlyUpdateAndPushClickAsync()
     {
-        if (workspace == null || workspaceRepositories.Count == 0 || IsJobRunning)
+        if (workspace == null || !HasRepositories || IsJobRunning)
             return;
 
         var level = lowestLevelNeedingWork;
@@ -186,7 +188,8 @@ public sealed partial class WorkspaceRepositories
             return;
         }
 
-        if (workspaceRepositories.Where(wr => !wr.IsOnTag && (wr.DependencyLevel ?? 0) <= level).All(wr => wr.IsOnTag))
+        var allLinks = await GetAllLinksForOperationAsync();
+        if (allLinks.Where(wr => !wr.IsOnTag && (wr.DependencyLevel ?? 0) <= level).All(wr => wr.IsOnTag))
         {
             ToastService.Show("All repositories at this level are on tags; checkout a branch first.");
             return;
@@ -196,7 +199,7 @@ public sealed partial class WorkspaceRepositories
             svc => svc.GetUpdatePlanAsync(WorkspaceId));
         var repoIdsWithUpdates = updatePlan.Select(p => p.RepoId).ToHashSet();
 
-        var reposOnDefault = workspaceRepositories
+        var reposOnDefault = allLinks
             .Where(wr => !wr.IsOnTag
                 && (wr.DependencyLevel ?? 0) <= level
                 && !string.IsNullOrWhiteSpace(wr.DefaultBranchName)
@@ -245,7 +248,7 @@ public sealed partial class WorkspaceRepositories
 
     private Task RunLevelOnlyUpdateAndPushCoreAsync(int level, string? commitMessage = null, bool includeDepsInCommitMessage = true)
     {
-        if (workspace == null || workspaceRepositories.Count == 0 || IsJobRunning)
+        if (workspace == null || !HasRepositories || IsJobRunning)
             return Task.CompletedTask;
 
         errorMessage = null;
@@ -256,7 +259,8 @@ public sealed partial class WorkspaceRepositories
             IReadOnlySet<int> syncedRepoIds = new HashSet<int>();
             try
             {
-                var reposNeedingWork = workspaceRepositories
+                var allLinks = await GetAllLinksForOperationAsync();
+                var reposNeedingWork = allLinks
                     .Where(wr => !wr.IsOnTag && (wr.DependencyLevel ?? 0) <= level)
                     .Where(wr => (wr.UnmatchedDeps ?? 0) > 0 || (wr.OutOfDateFileRepos ?? 0) > 0)
                     .Select(wr => wr.RepositoryId)
@@ -274,7 +278,7 @@ public sealed partial class WorkspaceRepositories
                         maxLevel: level));
 
                 await ReloadWorkspaceDataFromFreshScopeAsync();
-                _ = InvokeAsync(() => { if (!_disposed) { ApplySyncStateFromWorkspace(); StateHasChanged(); } });
+                _ = InvokeAsync(() => { if (!_disposed) { ApplySyncStateFromLoadedItems(); StateHasChanged(); } });
             }
             catch (OperationCanceledException)
             {
@@ -339,7 +343,7 @@ public sealed partial class WorkspaceRepositories
 
     private Task RunUpdateAndPushCoreAsync(string? commitMessage = null, bool includeDepsInCommitMessage = true)
     {
-        if (workspace == null || workspaceRepositories.Count == 0 || IsJobRunning)
+        if (workspace == null || !HasRepositories || IsJobRunning)
             return Task.CompletedTask;
 
         errorMessage = null;
@@ -350,7 +354,8 @@ public sealed partial class WorkspaceRepositories
             IReadOnlySet<int> syncedRepoIds = new HashSet<int>();
             try
             {
-                var reposNeedingWork = workspaceRepositories
+                var allLinks = await GetAllLinksForOperationAsync();
+                var reposNeedingWork = allLinks
                     .Where(wr => !wr.IsOnTag)
                     .Where(wr => (wr.UnmatchedDeps ?? 0) > 0 || (wr.OutOfDateFileRepos ?? 0) > 0)
                     .Select(wr => wr.RepositoryId)
@@ -366,9 +371,8 @@ public sealed partial class WorkspaceRepositories
                         commitMessage: commitMessage,
                         includeDepsInCommitMessage: includeDepsInCommitMessage));
 
-                // Unconditional reload so workspaceRepositories is current for Phase 2
                 await ReloadWorkspaceDataFromFreshScopeAsync();
-                _ = InvokeAsync(() => { if (!_disposed) { ApplySyncStateFromWorkspace(); StateHasChanged(); } });
+                _ = InvokeAsync(() => { if (!_disposed) { ApplySyncStateFromLoadedItems(); StateHasChanged(); } });
             }
             catch (OperationCanceledException)
             {

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor
@@ -180,13 +180,13 @@
 
 <WorkspaceRepositoriesModal IsVisible="@_repositoriesModal.IsVisible"
                             Title="@RepositoriesModalTitle"
-                            Repositories="@_repositoriesModal.Repositories"
                             SelectedRepositoryIds="@_repositoriesModal.SelectedRepositoryIds"
                             HasConnectors="@_repositoriesModal.HasConnectors"
                             IsSaving="@_repositoriesModal.IsSaving"
                             IsFetching="@_repositoriesModal.IsFetching"
                             ErrorMessage="@_repositoriesModal.ErrorMessage"
                             RenameWarnings="@_repositoriesModal.RenameWarnings"
+                            RefreshGeneration="@_repositoriesModal.RefreshGeneration"
                             OnSave="@SaveRepositoriesAsync"
                             OnCancel="@CloseRepositoriesModal"
                             OnFetchRepositories="@FetchRepositoriesAsync" />

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor
@@ -3,7 +3,7 @@
 @using GrayMoon.App.Models
 @using GrayMoon.App.Models.Api
 @using GrayMoon.App.Repositories
-@using GrayMoon.App.Services
+@using GrayMoon.App.Services.Queries
 @using GrayMoon.App.Components.Shared
 @using GrayMoon.App.Components.Modals
 @using Microsoft.AspNetCore.Components.Web
@@ -16,9 +16,9 @@
 <div class="container-fluid page-container grid-page">
     <div class="grid-page-header">
         <WorkspaceRepositoriesHeader WorkspaceName="@(workspace?.Name)"
-                                    RepositoriesCount="@(workspaceRepositories.Count)"
+                                    RepositoriesCount="@(_headerState?.TotalCount ?? 0)"
                                     HasFilter="@HasSearchFilter"
-                                    FilteredCount="@(FilteredWorkspaceRepositories.Count)"
+                                    FilteredCount="@(totalCount ?? _items.Count)"
                                     SearchTerm="@searchTerm"
                                     HasUnmatchedDependencies="@hasUnmatchedDependencies"
                                     IsPushRecommended="@isPushRecommended"
@@ -30,7 +30,7 @@
                                     IsCommitSyncing="@IsJobRunning"
                                     AgentTasksPendingCount="@AgentTasksPendingCount"
                                     IsRestoringPackages="@IsJobRunning"
-                                    IsOverlayVisible="@(isLoading || IsJobRunning || ShowRepositoriesFetchOverlay)"
+                                    IsOverlayVisible="@(isInitialLoading && !hasLoadedOnce || IsJobRunning || ShowRepositoriesFetchOverlay)"
                                     OnShowRepositories="ShowRepositoriesModalAsync"
                                     OnNewFeature="ShowNewFeatureModalAsync"
                                     OnShowBranch="() => ShowBranchModalAsync()"
@@ -91,7 +91,7 @@
                             </tr>
                         </thead>
                         <tbody>
-                            @if (isLoading)
+                            @if (isInitialLoading && _items.Count == 0)
                             {
                                 <tr>
                                     <td colspan="@TableColSpan" class="text-center text-muted py-4">
@@ -99,7 +99,7 @@
                                     </td>
                                 </tr>
                             }
-                            else if (workspaceRepositories.Count == 0)
+                            else if (hasLoadedOnce && (_headerState?.TotalCount ?? 0) == 0 && !HasSearchFilter)
                             {
                                 <tr>
                                     <td colspan="@TableColSpan" class="text-center text-muted py-4">
@@ -107,7 +107,7 @@
                                     </td>
                                 </tr>
                             }
-                            else if (FilteredWorkspaceRepositories.Count == 0)
+                            else if (NoRepositoriesMatchSearch)
                             {
                                 <tr>
                                     <td colspan="@TableColSpan" class="text-center text-muted py-4">
@@ -117,17 +117,17 @@
                             }
                             else
                             {
-                                @foreach (var group in FilteredLevelGroups)
+                                @foreach (var group in LoadedLevelGroups)
                                 {
                                     <WorkspaceRepositoriesLevelHeader WorkspaceId="@WorkspaceId"
                                                                        LevelKey="@group.Key"
                                                                        ColSpan="@TableColSpan"
                                                                        Group="@group"
                                                                        ActionsDisabled="@group.All(wr => wr.IsOnTag)"
-                                                                       OnSyncToDefault="async () => await ShowConfirmSyncToDefaultLevel(group.Select(wr => wr.RepositoryId).ToList())"
-                                                                       OnSyncCommits="() => ShowConfirmSyncCommitsLevel(group.Select(wr => wr.RepositoryId).ToList())"
-                                                                       OnOpenPr="() => OpenPullRequestDialogForRepositoriesAsync(group.ToList())"
-                                                                       OnSyncLevel="() => ShowConfirmSyncLevel(group.Select(wr => wr.RepositoryId).ToList())"
+                                                                       OnSyncToDefault="async () => await SyncToDefaultForLevelAsync(group.Key)"
+                                                                       OnSyncCommits="async () => await SyncCommitsForLevelAsync(group.Key)"
+                                                                       OnOpenPr="async () => await OpenPullRequestDialogForLevelAsync(group.Key)"
+                                                                       OnSyncLevel="async () => await SyncLevelForLevelAsync(group.Key)"
                                                                        OpenPrUrls="@GetOpenPrUrlsForGroup(group)"
                                                                        OpenPrPullMap="@GetOpenPrPullMapForGroup(group)"
                                                                        />
@@ -167,6 +167,22 @@
                                                                   OnUpgradeClick="ShowSwitchBranchModalOnTagsTab"
                                                                   OnDismissError="() => DismissRepositoryError(wr.RepositoryId)" />
                                     }
+                                }
+                                @if (isLoadingMore)
+                                {
+                                    <tr>
+                                        <td colspan="@TableColSpan" class="text-center text-muted py-3">
+                                            Loading more...
+                                        </td>
+                                    </tr>
+                                }
+                                @if (hasMore && !isLoadingMore)
+                                {
+                                    <tr>
+                                        <td colspan="@TableColSpan" class="p-0">
+                                            <InfiniteScrollLoadTrigger IsEnabled="true" OnLoadMore="LoadNextChunkAsync" />
+                                        </td>
+                                    </tr>
                                 }
                             }
                         </tbody>
@@ -320,7 +336,7 @@
                OnProceed="@OnUndoPushProceedAsync"
                OnCancel="@CloseUndoPushModal" />
 
-@if (isLoading)
+@if (isInitialLoading && !hasLoadedOnce)
 {
     <LoadingOverlay IsVisible="true" PageScoped="true" Message="Loading workspace..." ShowCommandTerminal="false" />
 }

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor
@@ -18,7 +18,7 @@
         <WorkspaceRepositoriesHeader WorkspaceName="@(workspace?.Name)"
                                     RepositoriesCount="@(_headerState?.TotalCount ?? 0)"
                                     HasFilter="@HasSearchFilter"
-                                    FilteredCount="@(totalCount ?? _items.Count)"
+                                    FilteredCount="@(totalCount ?? 0)"
                                     SearchTerm="@searchTerm"
                                     HasUnmatchedDependencies="@hasUnmatchedDependencies"
                                     IsPushRecommended="@isPushRecommended"
@@ -90,8 +90,8 @@
                                 </th>
                             </tr>
                         </thead>
-                        <tbody>
-                            @if (isInitialLoading && _items.Count == 0)
+                        <tbody @ref="_tbodyRef" class="repositories-virtual-tbody">
+                            @if (isInitialLoading && _slots.Count == 0)
                             {
                                 <tr>
                                     <td colspan="@TableColSpan" class="text-center text-muted py-4">
@@ -117,23 +117,36 @@
                             }
                             else
                             {
-                                @foreach (var group in LoadedLevelGroups)
+                                @if (_topSpacerPx > 0)
                                 {
-                                    <WorkspaceRepositoriesLevelHeader WorkspaceId="@WorkspaceId"
-                                                                       LevelKey="@group.Key"
-                                                                       ColSpan="@TableColSpan"
-                                                                       Group="@group"
-                                                                       ActionsDisabled="@group.All(wr => wr.IsOnTag)"
-                                                                       OnSyncToDefault="async () => await SyncToDefaultForLevelAsync(group.Key)"
-                                                                       OnSyncCommits="async () => await SyncCommitsForLevelAsync(group.Key)"
-                                                                       OnOpenPr="async () => await OpenPullRequestDialogForLevelAsync(group.Key)"
-                                                                       OnSyncLevel="async () => await SyncLevelForLevelAsync(group.Key)"
-                                                                       OpenPrUrls="@GetOpenPrUrlsForGroup(group)"
-                                                                       OpenPrPullMap="@GetOpenPrPullMapForGroup(group)"
-                                                                       />
-                                    @foreach (var wr in group)
+                                    <tr class="virtual-scroll-spacer" aria-hidden="true">
+                                        <td colspan="@TableColSpan" style="height:@(_topSpacerPx.ToString("0.###", System.Globalization.CultureInfo.InvariantCulture))px;padding:0;border:0;line-height:0;"></td>
+                                    </tr>
+                                }
+                                @foreach (var slot in VisibleSlots)
+                                {
+                                    if (slot.Kind == VirtualSlotKind.LevelHeader)
                                     {
-                                        <WorkspaceRepositoriesRow WorkspaceId="@WorkspaceId"
+                                        var levelGroup = GetHydratedLinksAtLevel(slot.LevelKey);
+                                        <WorkspaceRepositoriesLevelHeader @key="@($"lvl-{slot.LevelKey?.ToString() ?? "none"}")"
+                                                                           WorkspaceId="@WorkspaceId"
+                                                                           LevelKey="@slot.LevelKey"
+                                                                           ColSpan="@TableColSpan"
+                                                                           Group="@levelGroup"
+                                                                           RepositoryCount="@slot.LevelRepoCount"
+                                                                           ActionsDisabled="@IsLevelActionsDisabled(slot.LevelKey)"
+                                                                           OnSyncToDefault="async () => await SyncToDefaultForLevelAsync(slot.LevelKey)"
+                                                                           OnSyncCommits="async () => await SyncCommitsForLevelAsync(slot.LevelKey)"
+                                                                           OnOpenPr="async () => await OpenPullRequestDialogForLevelAsync(slot.LevelKey)"
+                                                                           OnSyncLevel="async () => await SyncLevelForLevelAsync(slot.LevelKey)"
+                                                                           OpenPrUrls="@GetOpenPrUrlsForGroup(levelGroup)"
+                                                                           OpenPrPullMap="@GetOpenPrPullMapForGroup(levelGroup)"
+                                                                           />
+                                    }
+                                    else if (_linkByWrlId.TryGetValue(slot.WorkspaceRepositoryId, out var wr))
+                                    {
+                                        <WorkspaceRepositoriesRow @key="@($"row-{slot.WorkspaceRepositoryId}")"
+                                                                  WorkspaceId="@WorkspaceId"
                                                                   Link="@wr"
                                                                   PrInfo="@GetPrInfoForRepository(wr.RepositoryId)"
                                                                   IsPrVerified="@prByRepositoryId.ContainsKey(wr.RepositoryId)"
@@ -151,12 +164,13 @@
                                                                   IsUpdating="@IsJobRunning"
                                                                   ColSpan="@TableColSpan"
                                                                   OnVersionClick="() => CopyVersionToClipboard(wr.GitVersion!)"
-                                                                  OnVersionMouseLeave="() => OnVersionMouseLeave(wr.GitVersion)"
+                                                                  OnVersionMouseLeave="() => OnVersionMouseLeave(wr.GitVersion!)"
                                                                   OnBranchClick="() => ShowSwitchBranchModal(wr.RepositoryId, wr.BranchName, wr.Repository?.CloneUrl)"
                                                                   OnDependencyBadgeClick="() => OnDependencyBadgeClick(wr.RepositoryId, wr.UnmatchedDeps ?? 0)"
                                                                   OnCustomDependenciesClick="() => ShowCustomDependenciesModalAsync(wr.RepositoryId)"
                                                                   OnFileDependencyBadgeClick="() => OnFileDependencyBadgeClick(wr.RepositoryId)"
                                                                   OnDependencyBadgeKeydown="(e) => HandleDependencyBadgeKeydown(e, wr.RepositoryId, wr.UnmatchedDeps ?? 0)"
+                                                                  OnDependencyBadgeMouseEnter="() => OnDependencyBadgeMouseEnter(wr.RepositoryId)"
                                                                   OnDependencyBadgeMouseLeave="() => OnDependencyBadgeMouseLeave(wr.RepositoryId)"
                                                                   OnPushBadgeClick="() => OnPushBadgeClickAsync(wr.RepositoryId, wr.BranchName)"
                                                                   OnPullBadgeClick="() => OnPullBadgeClickAsync(wr.RepositoryId)"
@@ -167,21 +181,17 @@
                                                                   OnUpgradeClick="ShowSwitchBranchModalOnTagsTab"
                                                                   OnDismissError="() => DismissRepositoryError(wr.RepositoryId)" />
                                     }
+                                    else
+                                    {
+                                        <tr @key="@($"ph-{slot.WorkspaceRepositoryId}")" class="virtual-scroll-placeholder">
+                                            <td colspan="@TableColSpan" class="text-muted py-2">&nbsp;</td>
+                                        </tr>
+                                    }
                                 }
-                                @if (isLoadingMore)
+                                @if (_bottomSpacerPx > 0)
                                 {
-                                    <tr>
-                                        <td colspan="@TableColSpan" class="text-center text-muted py-3">
-                                            Loading more...
-                                        </td>
-                                    </tr>
-                                }
-                                @if (hasMore && !isLoadingMore)
-                                {
-                                    <tr>
-                                        <td colspan="@TableColSpan" class="p-0">
-                                            <InfiniteScrollLoadTrigger IsEnabled="true" OnLoadMore="LoadNextChunkAsync" />
-                                        </td>
+                                    <tr class="virtual-scroll-spacer" aria-hidden="true">
+                                        <td colspan="@TableColSpan" style="height:@(_bottomSpacerPx.ToString("0.###", System.Globalization.CultureInfo.InvariantCulture))px;padding:0;border:0;line-height:0;"></td>
                                     </tr>
                                 }
                             }

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor
@@ -183,8 +183,8 @@
                                     }
                                     else
                                     {
-                                        <tr @key="@($"ph-{slot.WorkspaceRepositoryId}")" class="virtual-scroll-placeholder">
-                                            <td colspan="@TableColSpan" class="text-muted py-2">&nbsp;</td>
+                                        <tr @key="@($"row-{slot.WorkspaceRepositoryId}")" class="virtual-scroll-placeholder">
+                                            <td colspan="@TableColSpan">&nbsp;</td>
                                         </tr>
                                     }
                                 }

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor
@@ -63,7 +63,7 @@
             <div class="card page-card mb-4">
                     <div class="card-body p-0">
                         <div class="table-responsive">
-                            <table class="table table-striped table-hover mb-0 repositories-table resizable-columns">
+                            <table class="table table-hover mb-0 repositories-table resizable-columns virtual-scroll-table">
                         <thead class="table-dark">
                             <tr>
                                 <th class="col-repo">Repository</th>
@@ -147,6 +147,7 @@
                                     {
                                         <WorkspaceRepositoriesRow @key="@($"row-{slot.WorkspaceRepositoryId}")"
                                                                   WorkspaceId="@WorkspaceId"
+                                                                  RowCssClass="@StripeClass(slot.StripeIndex)"
                                                                   Link="@wr"
                                                                   PrInfo="@GetPrInfoForRepository(wr.RepositoryId)"
                                                                   IsPrVerified="@prByRepositoryId.ContainsKey(wr.RepositoryId)"
@@ -183,7 +184,7 @@
                                     }
                                     else
                                     {
-                                        <tr @key="@($"row-{slot.WorkspaceRepositoryId}")" class="virtual-scroll-placeholder">
+                                        <tr @key="@($"row-{slot.WorkspaceRepositoryId}")" class="virtual-scroll-placeholder @StripeClass(slot.StripeIndex)">
                                             <td colspan="@TableColSpan">&nbsp;</td>
                                         </tr>
                                     }

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
@@ -3,13 +3,10 @@ using GrayMoon.App.Services.Queries;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Options;
 using Microsoft.JSInterop;
-
 namespace GrayMoon.App.Components.Pages;
-
-public sealed partial class WorkspaceRepositories : IDisposable
+public sealed partial class WorkspaceRepositories : IAsyncDisposable, IDisposable
 {
     [Parameter] public int WorkspaceId { get; set; }
-
     [Inject] private IWorkspacePageService WorkspacePageService { get; set; } = default!;
     [Inject] private IServiceScopeFactory ServiceScopeFactory { get; set; } = default!;
     [Inject] private NavigationManager NavigationManager { get; set; } = default!;
@@ -31,19 +28,47 @@ public sealed partial class WorkspaceRepositories : IDisposable
     [Inject] private IBackgroundJobService JobService { get; set; } = default!;
     [Inject] private IScopedServiceExecutor ScopedExecutor { get; set; } = default!;
     [Inject] private IWorkspaceRepositoryLinkListQueryService LinkListQueryService { get; set; } = default!;
-
     protected override async Task OnInitializedAsync()
     {
         AgentQueueStateService.OnQueueStateChanged(OnQueueStateChanged);
         JobService.Changed += OnJobServiceChanged;
         _wasJobRunning = IsJobRunning;
+        _loadedWorkspaceId = WorkspaceId;
         await LoadWorkspaceAsync();
         ApplySyncStateFromLoadedItems();
     }
-
+    protected override async Task OnParametersSetAsync()
+    {
+        if (_loadedWorkspaceId == WorkspaceId || _disposed)
+        {
+            return;
+        }
+        CancelBackgroundWork();
+        await DetachVirtualScrollAsync();
+        _loadedWorkspaceId = WorkspaceId;
+        errorMessage = null;
+        hasLoadedOnce = false;
+        ClearGridState();
+        await LoadWorkspaceAsync();
+        ApplySyncStateFromLoadedItems();
+    }
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        await OnAfterRenderRealtimeAsync(firstRender);
+        if (!isInitialLoading && _slots.Count > 0 && !_virtualScrollAttached && !_disposed)
+        {
+            await AttachVirtualScrollAsync();
+        }
+    }
     public void Dispose()
     {
+        if (_disposed)
+        {
+            return;
+        }
+
         _disposed = true;
+        CancelBackgroundWork();
         AgentQueueStateService.RemoveQueueStateChanged(OnQueueStateChanged);
         JobService.Changed -= OnJobServiceChanged;
         lock (_refreshDebounceLock)
@@ -56,7 +81,13 @@ public sealed partial class WorkspaceRepositories : IDisposable
         _ = _hubConnection?.DisposeAsync().AsTask();
         _fetchRepositoriesCts?.Cancel();
         _fetchRepositoriesCts?.Dispose();
-        _loadMismatchedDepsLock.Dispose();
         _queryLoader.Dispose();
+        _virtualScrollDotNetRef?.Dispose();
+        _virtualScrollDotNetRef = null;
+    }
+    public async ValueTask DisposeAsync()
+    {
+        await DetachVirtualScrollAsync();
+        Dispose();
     }
 }

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
@@ -1,4 +1,5 @@
 using GrayMoon.App.Services;
+using GrayMoon.App.Services.Queries;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Options;
 using Microsoft.JSInterop;
@@ -29,6 +30,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
     [Inject] private IPullRequestService PullRequestService { get; set; } = default!;
     [Inject] private IBackgroundJobService JobService { get; set; } = default!;
     [Inject] private IScopedServiceExecutor ScopedExecutor { get; set; } = default!;
+    [Inject] private IWorkspaceRepositoryLinkListQueryService LinkListQueryService { get; set; } = default!;
 
     protected override async Task OnInitializedAsync()
     {
@@ -36,7 +38,7 @@ public sealed partial class WorkspaceRepositories : IDisposable
         JobService.Changed += OnJobServiceChanged;
         _wasJobRunning = IsJobRunning;
         await LoadWorkspaceAsync();
-        ApplySyncStateFromWorkspace();
+        ApplySyncStateFromLoadedItems();
     }
 
     public void Dispose()
@@ -55,5 +57,6 @@ public sealed partial class WorkspaceRepositories : IDisposable
         _fetchRepositoriesCts?.Cancel();
         _fetchRepositoriesCts?.Dispose();
         _loadMismatchedDepsLock.Dispose();
+        _queryLoader.Dispose();
     }
 }

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.css
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.css
@@ -23,7 +23,12 @@
 }
 .repositories-virtual-tbody tr.virtual-scroll-placeholder td {
     height: 48px;
+    max-height: 48px;
+    padding: 0;
+    border-bottom-color: transparent;
     box-sizing: border-box;
+    line-height: 48px;
+    overflow: hidden;
 }
 
 .workspace-repos-title-spacer {

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.css
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.css
@@ -21,6 +21,11 @@
     text-overflow: ellipsis;
     min-width: 0;
 }
+.repositories-virtual-tbody tr.virtual-scroll-placeholder td {
+    height: 48px;
+    box-sizing: border-box;
+}
+
 .workspace-repos-title-spacer {
     flex: 1 1 auto;
     min-width: 0;

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositoriesLevelHeader.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositoriesLevelHeader.razor
@@ -73,7 +73,7 @@
                   data-pr-pull-map="@OpenPrPullMapJson"
                   tabindex="0"
                   aria-haspopup="true">
-                <span class="dependency-level-count-num">@RepositoryCount</span> @(RepositoryCount == 1 ? "repository" : "repositories")
+                <span class="dependency-level-count-num">@DisplayRepositoryCount</span> @(DisplayRepositoryCount == 1 ? "repository" : "repositories")
             </span>
         </div>
     </td>
@@ -84,6 +84,8 @@
     [Parameter] public int? LevelKey { get; set; }
     [Parameter] public int ColSpan { get; set; } = 8;
     [Parameter] public IEnumerable<WorkspaceRepositoryLink>? Group { get; set; }
+    /// <summary>Total repositories at this level (may exceed hydrated <see cref="Group"/> count under virtual scroll).</summary>
+    [Parameter] public int RepositoryCount { get; set; }
     [Parameter] public bool ActionsDisabled { get; set; }
     [Parameter] public EventCallback OnSyncToDefault { get; set; }
     [Parameter] public EventCallback OnSyncCommits { get; set; }
@@ -92,7 +94,7 @@
     [Parameter] public IReadOnlyList<string>? OpenPrUrls { get; set; }
     [Parameter] public IReadOnlyDictionary<string, string>? OpenPrPullMap { get; set; }
 
-    private int RepositoryCount => Group?.Count() ?? 0;
+    private int DisplayRepositoryCount => RepositoryCount > 0 ? RepositoryCount : (Group?.Count() ?? 0);
 
     private string OpenPrUrlsJson => System.Text.Json.JsonSerializer.Serialize(OpenPrUrls ?? (IReadOnlyList<string>)[]);
 

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositoriesRow.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositoriesRow.razor
@@ -112,6 +112,7 @@
                     else if (unmatchedWithFiles == 0)
                     {
                         <span class="dependency-badge-tooltip-wrap dependency-badge-link @(depOkBadgeInactive ? "dependency-badge-link--disabled dependency-badge-link--readonly" : "") @(IsDependencyBadgeClicked ? "dependency-badge-tooltip-wrap--clicked" : "")"
+                              @onmouseenter="OnDependencyBadgeMouseEnter"
                               @onmouseleave="OnDependencyBadgeMouseLeave">
                             <span class="badge build-dep-badge build-dep-badge-ok dependency-badge-graph-link"
                                   role="button"
@@ -232,6 +233,7 @@
                               @onclick="HandleDependencyBadgeClick"
                               @onclick:preventDefault
                               @onkeydown="OnDependencyBadgeKeydown"
+                              @onmouseenter="OnDependencyBadgeMouseEnter"
                               @onmouseleave="OnDependencyBadgeMouseLeave">
                             <span class="badge build-dep-badge @(depBadgeOnTag ? "build-dep-badge-none" : "build-dep-badge-mismatch")">@unmatchedWithFiles of @totalWithFiles</span>
                             @if (MismatchedDependencyLines.Count > 0 || MismatchedFileVersionLines.Count > 0 || CustomDependencyLines.Count > 0)
@@ -424,6 +426,7 @@
     [Parameter] public EventCallback OnCustomDependenciesClick { get; set; }
     [Parameter] public EventCallback OnFileDependencyBadgeClick { get; set; }
     [Parameter] public EventCallback<KeyboardEventArgs> OnDependencyBadgeKeydown { get; set; }
+    [Parameter] public EventCallback OnDependencyBadgeMouseEnter { get; set; }
     [Parameter] public EventCallback OnDependencyBadgeMouseLeave { get; set; }
     [Parameter] public EventCallback OnPushBadgeClick { get; set; }
     [Parameter] public EventCallback OnPullBadgeClick { get; set; }

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositoriesRow.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositoriesRow.razor
@@ -23,7 +23,7 @@
         || CustomDependencyLines.Count > 0;
     var depOkBadgeInactive = ActionsDisabled || Link.IsOnTag;
 
-    <tr>
+    <tr class="@RowCssClass">
         <td class="col-repo">
             @if (!string.IsNullOrEmpty(repoUrl))
             {
@@ -398,6 +398,8 @@
 
 @code {
     [Parameter] public int WorkspaceId { get; set; }
+    /// <summary>Absolute-index stripe class (virtual-row-odd / virtual-row-even) so striping stays stable while scrolling.</summary>
+    [Parameter] public string? RowCssClass { get; set; }
     [Parameter] public WorkspaceRepositoryLink? Link { get; set; }
     [Parameter] public PullRequestInfo? PrInfo { get; set; }
     [Parameter] public bool IsPrVerified { get; set; }

--- a/src/GrayMoon.App/Components/Pages/Workspaces.razor
+++ b/src/GrayMoon.App/Components/Pages/Workspaces.razor
@@ -4,14 +4,15 @@
 @using GrayMoon.App.Models
 @using WorkspaceModel = GrayMoon.App.Models.Workspace
 @using GrayMoon.App.Repositories
-@using GrayMoon.App.Services
+@using GrayMoon.App.Services.Queries
 @using GrayMoon.App.Components.Shared
 @using GrayMoon.App.Components.Modals
 @using Microsoft.AspNetCore.Components.Web
+@using GrayMoon.App.Services
 @inject WorkspaceRepository WorkspaceRepository
 @inject ConnectorRepository ConnectorRepository
+@inject IRepositoryListQueryService RepositoryListQueryService
 @inject GitHubRepositoryService RepositoryService
-@inject GitHubRepositoryRepository GitHubRepositoryRepository
 @inject WorkspaceService WorkspaceService
 @inject IAgentBridge AgentBridge
 @inject AgentConnectionTracker AgentConnectionTracker
@@ -186,13 +187,13 @@
 
 <WorkspaceRepositoriesModal IsVisible="@showRepositoriesModal"
                             Title="@($"Select repositories for {repositoriesModalWorkspaceName}")"
-                            Repositories="@repositories"
                             SelectedRepositoryIds="@selectedRepositoryIds"
                             HasConnectors="@hasConnectors"
                             IsSaving="@isSavingRepositories"
                             IsFetching="@isPersisting"
                             ErrorMessage="@repositoriesModalErrorMessage"
                             RenameWarnings="@repositoriesModalRenameWarnings"
+                            RefreshGeneration="@repositoriesModalRefreshGeneration"
                             OnSave="@SaveRepositoriesAsync"
                             OnCancel="@CloseRepositoriesModal"
                             OnFetchRepositories="@FetchRepositoriesAsync" />
@@ -230,7 +231,7 @@
 @code {
     private List<WorkspaceModel>? workspaces;
     private string searchTerm = string.Empty;
-    private List<GitHubRepositoryEntry>? repositories;
+    private int repositoriesModalRefreshGeneration;
     private string? errorMessage;
 
     private bool HasSearchFilter => !string.IsNullOrWhiteSpace(searchTerm);
@@ -358,23 +359,6 @@
         }
     }
 
-    private async Task EnsureRepositoriesAsync()
-    {
-        if (repositories != null)
-        {
-            return;
-        }
-
-        var connectors = await ConnectorRepository.GetAllAsync();
-        hasConnectors = connectors.Count > 0;
-        repositories = await RepositoryService.GetPersistedRepositoriesAsync();
-
-        if (hasConnectors && repositories.Count == 0)
-        {
-            await FetchRepositoriesAsync();
-        }
-    }
-
     private async Task ShowCreateModalAsync()
     {
         editingWorkspaceId = null;
@@ -434,8 +418,19 @@
         selectedRepositoryIds = workspace.Repositories
             .Select(link => link.RepositoryId)
             .ToHashSet();
-        await EnsureRepositoriesAsync();
-        PruneInvalidSelectedRepositoryIds();
+
+        try
+        {
+            var connectors = await ConnectorRepository.GetAllAsync();
+            hasConnectors = connectors.Count > 0;
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to load connectors for repositories modal.");
+            repositoriesModalErrorMessage = "Failed to load repositories. Please try again.";
+        }
+
+        repositoriesModalRefreshGeneration++;
         showRepositoriesModal = true;
     }
 
@@ -538,7 +533,7 @@
         if (editingWorkspaceId == null) return;
         if (isSavingRepositories) return;
 
-        var removedInvalidSelections = PruneInvalidSelectedRepositoryIds();
+        var removedInvalidSelections = await PruneInvalidSelectedRepositoryIdsAsync();
         if (removedInvalidSelections > 0)
         {
             Logger.LogWarning("Removed {Count} stale repository selections before saving workspace {WorkspaceId}",
@@ -653,23 +648,21 @@
                 _ = InvokeAsync(StateHasChanged);
             });
             var result = await RepositoryService.RefreshRepositoriesAsync(progress, _fetchRepositoriesCts.Token);
-            repositories = result.Repositories.ToList();
             repositoriesModalRenameWarnings = result.RenamedRepositories.Count > 0 ? result.RenamedRepositories : null;
-            // Translate any stale selectedRepositoryIds (caused by rename-merge) to canonical IDs.
             if (result.MergedRepositoryIdMap.Count > 0)
                 TranslateStaleRepositoryIds(result.MergedRepositoryIdMap);
-            PruneInvalidSelectedRepositoryIds();
+            await PruneInvalidSelectedRepositoryIdsAsync();
+            repositoriesModalRefreshGeneration++;
         }
         catch (OperationCanceledException)
         {
-            repositories = await RepositoryService.GetPersistedRepositoriesAsync();
-            PruneInvalidSelectedRepositoryIds();
+            await PruneInvalidSelectedRepositoryIdsAsync();
+            repositoriesModalRefreshGeneration++;
         }
         catch (Exception ex)
         {
             Logger.LogError(ex, "Error fetching repositories");
             repositoriesModalErrorMessage = "Failed to fetch repositories. Please try again later.";
-            repositories = new List<GitHubRepositoryEntry>();
         }
         finally
         {
@@ -677,19 +670,17 @@
         }
     }
 
-    private int PruneInvalidSelectedRepositoryIds()
+    private async Task<int> PruneInvalidSelectedRepositoryIdsAsync()
     {
-        if (repositories == null || selectedRepositoryIds.Count == 0)
+        if (selectedRepositoryIds.Count == 0)
         {
             return 0;
         }
 
-        var validRepositoryIds = repositories
-            .Select(repository => repository.RepositoryId)
-            .ToHashSet();
-
+        var valid = await RepositoryListQueryService.FilterExistingIdsAsync(selectedRepositoryIds);
+        var validSet = valid.ToHashSet();
         var before = selectedRepositoryIds.Count;
-        selectedRepositoryIds.RemoveWhere(repositoryId => !validRepositoryIds.Contains(repositoryId));
+        selectedRepositoryIds.RemoveWhere(repositoryId => !validSet.Contains(repositoryId));
         return before - selectedRepositoryIds.Count;
     }
 
@@ -812,10 +803,7 @@
             if (urls.Count == 0)
                 return;
 
-            var allRepos = await GitHubRepositoryRepository.GetAllEntriesAsync();
-            var byUrl = allRepos
-                .Where(r => !string.IsNullOrWhiteSpace(r.CloneUrl))
-                .ToDictionary(r => r.CloneUrl.Trim(), r => r.RepositoryId, StringComparer.OrdinalIgnoreCase);
+            var byUrl = await RepositoryListQueryService.GetIdsByCloneUrlsAsync(urls);
 
             var matchedIds = new HashSet<int>();
             foreach (var url in urls)

--- a/src/GrayMoon.App/Components/Shared/DebouncedQueryLoader.cs
+++ b/src/GrayMoon.App/Components/Shared/DebouncedQueryLoader.cs
@@ -1,0 +1,78 @@
+namespace GrayMoon.App.Components.Shared;
+
+/// <summary>Debounced search and cancellable query cycles for incremental list loading.</summary>
+public sealed class DebouncedQueryLoader : IDisposable
+{
+    public const int DefaultDebounceMs = 400;
+
+    private CancellationTokenSource? _debounceCts;
+    private CancellationTokenSource? _queryCts;
+    private int _generation;
+    private bool _disposed;
+
+    public int Generation => _generation;
+
+    public CancellationToken BeginQueryCycle(out int generation)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        _queryCts?.Cancel();
+        _queryCts?.Dispose();
+        _queryCts = new CancellationTokenSource();
+        _generation++;
+        generation = _generation;
+        return _queryCts.Token;
+    }
+
+    public CancellationToken GetQueryToken()
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        _queryCts ??= new CancellationTokenSource();
+        return _queryCts.Token;
+    }
+
+    public void CancelQuery()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _queryCts?.Cancel();
+    }
+
+    public async Task DebounceSearchAsync(Func<Task> action, int delayMs = DefaultDebounceMs)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        _debounceCts?.Cancel();
+        _debounceCts?.Dispose();
+        _debounceCts = new CancellationTokenSource();
+        var cts = _debounceCts;
+        try
+        {
+            await Task.Delay(delayMs, cts.Token);
+        }
+        catch (OperationCanceledException)
+        {
+            return;
+        }
+
+        if (!cts.IsCancellationRequested && !_disposed)
+        {
+            await action();
+        }
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        _debounceCts?.Cancel();
+        _debounceCts?.Dispose();
+        _queryCts?.Cancel();
+        _queryCts?.Dispose();
+    }
+}

--- a/src/GrayMoon.App/Components/Shared/InfiniteScrollLoadTrigger.razor
+++ b/src/GrayMoon.App/Components/Shared/InfiniteScrollLoadTrigger.razor
@@ -1,0 +1,53 @@
+@implements IAsyncDisposable
+@inject IJSRuntime Js
+
+<div @ref="_sentinel" class="infinite-scroll-sentinel" aria-hidden="true"></div>
+
+@code {
+    private ElementReference _sentinel;
+    private DotNetObjectReference<InfiniteScrollLoadTrigger>? _dotNetRef;
+    private bool _observing;
+
+    [Parameter] public EventCallback OnLoadMore { get; set; }
+    [Parameter] public bool IsEnabled { get; set; } = true;
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (IsEnabled && !_observing)
+        {
+            _dotNetRef ??= DotNetObjectReference.Create(this);
+            await Js.InvokeVoidAsync("grayMoonInfiniteScroll.observe", _sentinel, _dotNetRef);
+            _observing = true;
+        }
+        else if (!IsEnabled && _observing)
+        {
+            await Js.InvokeVoidAsync("grayMoonInfiniteScroll.disconnect", _sentinel);
+            _observing = false;
+        }
+    }
+
+    [JSInvokable]
+    public async Task OnIntersect()
+    {
+        if (IsEnabled && OnLoadMore.HasDelegate)
+        {
+            await OnLoadMore.InvokeAsync();
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        try
+        {
+            await Js.InvokeVoidAsync("grayMoonInfiniteScroll.disconnect", _sentinel);
+        }
+        catch (JSDisconnectedException)
+        {
+        }
+        catch (InvalidOperationException)
+        {
+        }
+
+        _dotNetRef?.Dispose();
+    }
+}

--- a/src/GrayMoon.App/Components/Shared/Toast.razor.css
+++ b/src/GrayMoon.App/Components/Shared/Toast.razor.css
@@ -5,7 +5,8 @@
     left: 50%;
     transform: translateX(-50%);
     z-index: 9999;
-    max-width: min(90vw, 420px);
+    width: max-content;
+    max-width: min(90vw, 48rem);
     padding: 0.5rem 1rem;
     background-color: var(--bg-card, #252526);
     color: var(--text-primary, #cccccc);
@@ -15,6 +16,7 @@
     font-size: 0.875rem;
     animation: toast-in 0.2s ease;
     pointer-events: none;
+    box-sizing: border-box;
 }
 
 .toast-bubble--error {
@@ -25,7 +27,10 @@
 
 .toast-bubble-text {
     display: block;
-    text-align: center;
+    text-align: left;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+    word-break: break-word;
 }
 
 @keyframes toast-in {

--- a/src/GrayMoon.App/Components/Shared/VirtualScrollUi.cs
+++ b/src/GrayMoon.App/Components/Shared/VirtualScrollUi.cs
@@ -1,0 +1,9 @@
+namespace GrayMoon.App.Components.Shared;
+
+/// <summary>Shared virtual-scroll UI helpers (stable striping independent of DOM position).</summary>
+public static class VirtualScrollUi
+{
+    /// <summary>Matches Bootstrap table-striped: first data row (index 0) is odd/striped.</summary>
+    public static string StripeClass(int absoluteIndex) =>
+        (absoluteIndex & 1) == 0 ? "virtual-row-odd" : "virtual-row-even";
+}

--- a/src/GrayMoon.App/Components/Shared/VirtualTableScrollState.cs
+++ b/src/GrayMoon.App/Components/Shared/VirtualTableScrollState.cs
@@ -133,7 +133,8 @@ public sealed class VirtualTableScrollState<TItem> : IAsyncDisposable
         return (start, end);
     }
 
-    public IEnumerable<(int Id, TItem? Item)> VisibleRows
+    /// <summary>Visible rows with absolute list index (for stable striping, independent of DOM position).</summary>
+    public IEnumerable<(int Index, int Id, TItem? Item)> VisibleRows
     {
         get
         {
@@ -146,10 +147,11 @@ public sealed class VirtualTableScrollState<TItem> : IAsyncDisposable
             {
                 var id = _ids[i];
                 _itemsById.TryGetValue(id, out var item);
-                yield return (id, item);
+                yield return (i, id, item);
             }
         }
     }
+
 
     public async Task AttachAsync<THost>(IJSRuntime js, THost host, ElementReference scrollElement)
         where THost : class

--- a/src/GrayMoon.App/Components/Shared/VirtualTableScrollState.cs
+++ b/src/GrayMoon.App/Components/Shared/VirtualTableScrollState.cs
@@ -7,13 +7,15 @@ namespace GrayMoon.App.Components.Shared;
 public sealed class VirtualTableScrollState<TItem> : IAsyncDisposable
 {
     public const double DefaultRowHeightPx = 48;
-    public const int DefaultOverscanSlots = 8;
-    public const int DefaultInitialViewportSlots = 40;
+    public const int DefaultOverscanSlots = 24;
+    public const int DefaultInitialViewportSlots = 48;
 
     private readonly List<int> _ids = new();
     private readonly Dictionary<int, TItem> _itemsById = new();
     private IDisposable? _dotNetRef;
     private bool _attached;
+    private int _scrollGeneration;
+    private ElementReference _scrollElement;
 
     public double RowHeightPx { get; init; } = DefaultRowHeightPx;
     public int OverscanSlots { get; init; } = DefaultOverscanSlots;
@@ -24,10 +26,15 @@ public sealed class VirtualTableScrollState<TItem> : IAsyncDisposable
     public double TopSpacerPx { get; private set; }
     public double BottomSpacerPx { get; private set; }
     public bool IsAttached => _attached;
+    public int ScrollGeneration => _scrollGeneration;
 
     public int Count => _ids.Count;
     public double TotalHeightPx => _ids.Count * RowHeightPx;
     public IReadOnlyList<int> Ids => _ids;
+
+    public int BeginScrollUpdate() => Interlocked.Increment(ref _scrollGeneration);
+
+    public bool IsCurrentScroll(int generation) => generation == _scrollGeneration;
 
     public void SetIndex(IReadOnlyList<int> ids)
     {
@@ -82,23 +89,31 @@ public sealed class VirtualTableScrollState<TItem> : IAsyncDisposable
         return missing;
     }
 
-    public void UpdateVisibleRange(int start, int end)
+    /// <summary>Returns true when the visible window actually changed.</summary>
+    public bool UpdateVisibleRange(int start, int end)
     {
         if (_ids.Count == 0)
         {
+            var wasEmpty = VisibleEnd < 0 && VisibleStart == 0 && TopSpacerPx == 0 && BottomSpacerPx == 0;
             VisibleStart = 0;
             VisibleEnd = -1;
             TopSpacerPx = 0;
             BottomSpacerPx = 0;
-            return;
+            return !wasEmpty;
         }
 
         start = Math.Clamp(start, 0, _ids.Count - 1);
         end = Math.Clamp(end, start, _ids.Count - 1);
+        if (start == VisibleStart && end == VisibleEnd)
+        {
+            return false;
+        }
+
         VisibleStart = start;
         VisibleEnd = end;
         TopSpacerPx = start * RowHeightPx;
         BottomSpacerPx = (_ids.Count - end - 1) * RowHeightPx;
+        return true;
     }
 
     public (int Start, int End) ComputeRange(double scrollTop, double clientHeight)
@@ -135,8 +150,6 @@ public sealed class VirtualTableScrollState<TItem> : IAsyncDisposable
             }
         }
     }
-
-    private ElementReference _scrollElement;
 
     public async Task AttachAsync<THost>(IJSRuntime js, THost host, ElementReference scrollElement)
         where THost : class

--- a/src/GrayMoon.App/Components/Shared/VirtualTableScrollState.cs
+++ b/src/GrayMoon.App/Components/Shared/VirtualTableScrollState.cs
@@ -1,0 +1,212 @@
+using Microsoft.AspNetCore.Components;
+using Microsoft.JSInterop;
+
+namespace GrayMoon.App.Components.Shared;
+
+/// <summary>Flat virtual-table state: full scrollbar height from index count, hydrate only the visible window.</summary>
+public sealed class VirtualTableScrollState<TItem> : IAsyncDisposable
+{
+    public const double DefaultRowHeightPx = 48;
+    public const int DefaultOverscanSlots = 8;
+    public const int DefaultInitialViewportSlots = 40;
+
+    private readonly List<int> _ids = new();
+    private readonly Dictionary<int, TItem> _itemsById = new();
+    private IDisposable? _dotNetRef;
+    private bool _attached;
+
+    public double RowHeightPx { get; init; } = DefaultRowHeightPx;
+    public int OverscanSlots { get; init; } = DefaultOverscanSlots;
+    public int InitialViewportSlots { get; init; } = DefaultInitialViewportSlots;
+
+    public int VisibleStart { get; private set; }
+    public int VisibleEnd { get; private set; } = -1;
+    public double TopSpacerPx { get; private set; }
+    public double BottomSpacerPx { get; private set; }
+    public bool IsAttached => _attached;
+
+    public int Count => _ids.Count;
+    public double TotalHeightPx => _ids.Count * RowHeightPx;
+    public IReadOnlyList<int> Ids => _ids;
+
+    public void SetIndex(IReadOnlyList<int> ids)
+    {
+        _ids.Clear();
+        _ids.AddRange(ids);
+        _itemsById.Clear();
+        var end = Math.Min(_ids.Count - 1, InitialViewportSlots - 1);
+        UpdateVisibleRange(0, Math.Max(-1, end));
+        _attached = false;
+    }
+
+    public void Clear()
+    {
+        _ids.Clear();
+        _itemsById.Clear();
+        VisibleStart = 0;
+        VisibleEnd = -1;
+        TopSpacerPx = 0;
+        BottomSpacerPx = 0;
+        _attached = false;
+    }
+
+    public void CacheItems(IEnumerable<(int Id, TItem Item)> items)
+    {
+        foreach (var (id, item) in items)
+        {
+            _itemsById[id] = item;
+        }
+    }
+
+    public bool TryGetItem(int id, out TItem item) => _itemsById.TryGetValue(id, out item!);
+
+    public IReadOnlyList<int> GetMissingIds(int start, int end)
+    {
+        if (_ids.Count == 0 || end < start)
+        {
+            return Array.Empty<int>();
+        }
+
+        start = Math.Clamp(start, 0, _ids.Count - 1);
+        end = Math.Clamp(end, start, _ids.Count - 1);
+        var missing = new List<int>();
+        for (var i = start; i <= end; i++)
+        {
+            var id = _ids[i];
+            if (!_itemsById.ContainsKey(id))
+            {
+                missing.Add(id);
+            }
+        }
+
+        return missing;
+    }
+
+    public void UpdateVisibleRange(int start, int end)
+    {
+        if (_ids.Count == 0)
+        {
+            VisibleStart = 0;
+            VisibleEnd = -1;
+            TopSpacerPx = 0;
+            BottomSpacerPx = 0;
+            return;
+        }
+
+        start = Math.Clamp(start, 0, _ids.Count - 1);
+        end = Math.Clamp(end, start, _ids.Count - 1);
+        VisibleStart = start;
+        VisibleEnd = end;
+        TopSpacerPx = start * RowHeightPx;
+        BottomSpacerPx = (_ids.Count - end - 1) * RowHeightPx;
+    }
+
+    public (int Start, int End) ComputeRange(double scrollTop, double clientHeight)
+    {
+        if (_ids.Count == 0)
+        {
+            return (0, -1);
+        }
+
+        var overscanPx = OverscanSlots * RowHeightPx;
+        var rangeStart = Math.Max(0, scrollTop - overscanPx);
+        var rangeEnd = scrollTop + clientHeight + overscanPx;
+        var start = (int)(rangeStart / RowHeightPx);
+        var end = (int)(rangeEnd / RowHeightPx);
+        start = Math.Clamp(start, 0, _ids.Count - 1);
+        end = Math.Clamp(end, start, _ids.Count - 1);
+        return (start, end);
+    }
+
+    public IEnumerable<(int Id, TItem? Item)> VisibleRows
+    {
+        get
+        {
+            if (_ids.Count == 0 || VisibleEnd < VisibleStart)
+            {
+                yield break;
+            }
+
+            for (var i = VisibleStart; i <= VisibleEnd && i < _ids.Count; i++)
+            {
+                var id = _ids[i];
+                _itemsById.TryGetValue(id, out var item);
+                yield return (id, item);
+            }
+        }
+    }
+
+    private ElementReference _scrollElement;
+
+    public async Task AttachAsync<THost>(IJSRuntime js, THost host, ElementReference scrollElement)
+        where THost : class
+    {
+        if (_attached || _ids.Count == 0)
+        {
+            return;
+        }
+
+        try
+        {
+            _scrollElement = scrollElement;
+            _dotNetRef?.Dispose();
+            var typedRef = DotNetObjectReference.Create(host);
+            _dotNetRef = typedRef;
+            await js.InvokeVoidAsync("grayMoonVirtualScroll.attach", _scrollElement, typedRef, TotalHeightPx);
+            _attached = true;
+        }
+        catch (JSDisconnectedException)
+        {
+        }
+        catch (InvalidOperationException)
+        {
+        }
+    }
+
+    public async Task DetachAsync(IJSRuntime js)
+    {
+        if (!_attached)
+        {
+            return;
+        }
+
+        try
+        {
+            await js.InvokeVoidAsync("grayMoonVirtualScroll.detach", _scrollElement);
+        }
+        catch (JSDisconnectedException)
+        {
+        }
+        catch (InvalidOperationException)
+        {
+        }
+
+        _attached = false;
+    }
+
+    public async Task SetTotalHeightAsync(IJSRuntime js)
+    {
+        if (!_attached)
+        {
+            return;
+        }
+
+        try
+        {
+            await js.InvokeVoidAsync("grayMoonVirtualScroll.setTotalHeight", _scrollElement, TotalHeightPx);
+        }
+        catch (JSDisconnectedException)
+        {
+        }
+        catch (InvalidOperationException)
+        {
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _dotNetRef?.Dispose();
+        _dotNetRef = null;
+        _attached = false;
+    }
+}

--- a/src/GrayMoon.App/Components/Shared/WorkspaceActionNotificationPanel.razor
+++ b/src/GrayMoon.App/Components/Shared/WorkspaceActionNotificationPanel.razor
@@ -804,7 +804,7 @@
                     await InvokeAsync(() =>
                     {
                         if (error != null) ToastService.ShowError(error);
-                        else if (failed > 0) ToastService.Show($"Updated {updated} line(s). {failed} file(s) could not be updated - check logs.");
+                        else if (failed > 0) ToastService.ShowError($"Updated {updated} line(s). {failed} file(s) could not be updated - check logs.");
                         else ToastService.Show("Versions updated in configured files.");
                     });
             }
@@ -903,7 +903,7 @@
             synchronizedPush,
             requiredPackageIds,
             job.ReportProgress,
-            ToastService.Show,
+            ToastService.ShowError,
             onAppSideComplete: () => { },
             cancellationToken: ct);
     }
@@ -1022,7 +1022,7 @@
                     synchronizedPush,
                     requiredPackageIds,
                     job.ReportProgress,
-                    ToastService.Show,
+                    ToastService.ShowError,
                     onAppSideComplete: () => { },
                     cancellationToken: ct);
             }

--- a/src/GrayMoon.App/Components/Shared/WorkspaceActionNotificationPanel.razor
+++ b/src/GrayMoon.App/Components/Shared/WorkspaceActionNotificationPanel.razor
@@ -67,6 +67,12 @@
                                 }
                             </div>
                         }
+                        @if (n.TotalActionRepoCount > n.Repos.Count)
+                        {
+                            <div class="notif-repo-row notif-repo-row--more">
+                                <a class="notif-repo-more-link" href="/workspaces/@n.WorkspaceId">... and more</a>
+                            </div>
+                        }
                     </div>
                 }
                 @if (GetHoveredRepo(n) is { MismatchedDeps.Count: > 0 } hoveredRepo)
@@ -936,10 +942,23 @@
         {
             await using var scope = ServiceScopeFactory.CreateAsyncScope();
             var depService = scope.ServiceProvider.GetRequiredService<WorkspaceDependencyService>();
-            var repoIdsThatNeedPush = n.Repos
-                .Where(r => r.OutgoingCommits > 0 || r.NewBranchNoPush)
-                .Select(r => r.RepositoryId)
-                .ToHashSet();
+            HashSet<int> repoIdsThatNeedPush;
+            if (n.TotalActionRepoCount > n.Repos.Count)
+            {
+                var workspaceRepo = scope.ServiceProvider.GetRequiredService<WorkspaceRepository>();
+                var ws = await workspaceRepo.GetByIdAsync(workspaceId);
+                repoIdsThatNeedPush = (ws?.Repositories ?? [])
+                    .Where(wr => !wr.IsOnTag && ((wr.OutgoingCommits ?? 0) > 0 || wr.BranchHasUpstream == false))
+                    .Select(wr => wr.RepositoryId)
+                    .ToHashSet();
+            }
+            else
+            {
+                repoIdsThatNeedPush = n.Repos
+                    .Where(r => r.OutgoingCommits > 0 || r.NewBranchNoPush)
+                    .Select(r => r.RepositoryId)
+                    .ToHashSet();
+            }
             var depInfo = await depService.GetPushDependencyInfoForRepoAsync(
                 workspaceId,
                 repo.RepositoryId,

--- a/src/GrayMoon.App/Components/Shared/WorkspaceActionNotificationPanel.razor.css
+++ b/src/GrayMoon.App/Components/Shared/WorkspaceActionNotificationPanel.razor.css
@@ -84,6 +84,20 @@
     font-size: 0.75rem;
 }
 
+.notif-repo-row--more {
+    justify-content: flex-start;
+}
+
+.notif-repo-more-link {
+    color: var(--link-color, #6cb6ff);
+    font-size: 0.75rem;
+    text-decoration: none;
+}
+
+.notif-repo-more-link:hover {
+    text-decoration: underline;
+}
+
 .notif-dep-badge {
     background-color: #dc3545;
     color: #fff;

--- a/src/GrayMoon.App/Data/AppDbContext.cs
+++ b/src/GrayMoon.App/Data/AppDbContext.cs
@@ -78,6 +78,9 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
             entity.HasIndex(repository => repository.CloneUrl)
                 .HasDatabaseName("IX_Repositories_CloneUrl");
 
+            entity.HasIndex(repository => new { repository.RepositoryName, repository.RepositoryId })
+                .HasDatabaseName("IX_Repositories_RepositoryName_RepositoryId");
+
             entity.Property(repository => repository.RepositoryName)
                 .IsRequired()
                 .HasMaxLength(200);
@@ -190,6 +193,9 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
             entity.HasKey(p => p.ProjectId);
             entity.HasIndex(p => new { p.WorkspaceId, p.RepositoryId, p.ProjectName })
                 .IsUnique();
+
+            entity.HasIndex(p => new { p.WorkspaceId, p.ProjectName, p.ProjectId })
+                .HasDatabaseName("IX_WorkspaceProjects_WorkspaceId_ProjectName_ProjectId");
 
             entity.Property(p => p.ProjectName)
                 .IsRequired()

--- a/src/GrayMoon.App/Data/AppDbContext.cs
+++ b/src/GrayMoon.App/Data/AppDbContext.cs
@@ -136,6 +136,15 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
             entity.HasIndex(wr => new { wr.WorkspaceId, wr.RepositoryId })
                 .IsUnique();
 
+            entity.HasIndex(wr => new
+            {
+                wr.WorkspaceId,
+                wr.DependencyLevel,
+                wr.RepositoryType,
+                wr.Dependencies,
+                wr.WorkspaceRepositoryId,
+            });
+
             entity.Property(wr => wr.GitVersion)
                 .HasMaxLength(100);
 

--- a/src/GrayMoon.App/Data/AppDbContext.cs
+++ b/src/GrayMoon.App/Data/AppDbContext.cs
@@ -243,6 +243,9 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
             entity.HasIndex(d => new { d.DependentProjectId, d.ReferencedProjectId })
                 .IsUnique();
 
+            entity.HasIndex(d => d.DependentProjectId)
+                .HasDatabaseName("IX_ProjectDependencies_DependentProjectId");
+
             entity.Property(d => d.Version)
                 .HasMaxLength(100);
 

--- a/src/GrayMoon.App/GrayMoon.App.csproj
+++ b/src/GrayMoon.App/GrayMoon.App.csproj
@@ -31,6 +31,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.*" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.*" />
+	<PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
     <PackageReference Include="Polly" Version="8.4.2" />
     <PackageReference Include="Serilog.AspNetCore" Version="8.0.2" />
   </ItemGroup>

--- a/src/GrayMoon.App/Migrations.cs
+++ b/src/GrayMoon.App/Migrations.cs
@@ -1482,6 +1482,13 @@ public static class Migrations
                 cmd.CommandText = "CREATE INDEX IX_WorkspaceProjects_WorkspaceId_ProjectName_ProjectId ON WorkspaceProjects(WorkspaceId, ProjectName, ProjectId)";
                 await cmd.ExecuteNonQueryAsync();
             }
+
+            cmd.CommandText = "SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name='IX_WorkspaceRepositories_WorkspaceId_Level_Type_Deps_Id'";
+            if (Convert.ToInt32(await cmd.ExecuteScalarAsync()) == 0)
+            {
+                cmd.CommandText = "CREATE INDEX IX_WorkspaceRepositories_WorkspaceId_Level_Type_Deps_Id ON WorkspaceRepositories(WorkspaceId, DependencyLevel, RepositoryType, Dependencies, WorkspaceRepositoryId)";
+                await cmd.ExecuteNonQueryAsync();
+            }
         }
         catch
         {

--- a/src/GrayMoon.App/Migrations.cs
+++ b/src/GrayMoon.App/Migrations.cs
@@ -51,6 +51,7 @@ public static class Migrations
         await MigrateWorkspaceFileLineStatusTokenColumnsAsync(dbContext);
         await MigrateWorkspaceFileLineStatusUniqueIndexFixAsync(dbContext);
         await MigrateListQueryIndexesAsync(dbContext);
+        await MigrateProjectDependenciesDependentIndexAsync(dbContext);
     }
 
     public static async Task MigrateRepositoriesTopicsAsync(AppDbContext dbContext)
@@ -1487,6 +1488,28 @@ public static class Migrations
             if (Convert.ToInt32(await cmd.ExecuteScalarAsync()) == 0)
             {
                 cmd.CommandText = "CREATE INDEX IX_WorkspaceRepositories_WorkspaceId_Level_Type_Deps_Id ON WorkspaceRepositories(WorkspaceId, DependencyLevel, RepositoryType, Dependencies, WorkspaceRepositoryId)";
+                await cmd.ExecuteNonQueryAsync();
+            }
+        }
+        catch
+        {
+            // Migration may already be applied
+        }
+    }
+
+    public static async Task MigrateProjectDependenciesDependentIndexAsync(AppDbContext dbContext)
+    {
+        try
+        {
+            var conn = dbContext.Database.GetDbConnection();
+            if (conn.State != System.Data.ConnectionState.Open)
+                await conn.OpenAsync();
+
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = "SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name='IX_ProjectDependencies_DependentProjectId'";
+            if (Convert.ToInt32(await cmd.ExecuteScalarAsync()) == 0)
+            {
+                cmd.CommandText = "CREATE INDEX IX_ProjectDependencies_DependentProjectId ON ProjectDependencies(DependentProjectId)";
                 await cmd.ExecuteNonQueryAsync();
             }
         }

--- a/src/GrayMoon.App/Migrations.cs
+++ b/src/GrayMoon.App/Migrations.cs
@@ -50,6 +50,7 @@ public static class Migrations
         await MigrateTotalFileConfigReposColumnAsync(dbContext);
         await MigrateWorkspaceFileLineStatusTokenColumnsAsync(dbContext);
         await MigrateWorkspaceFileLineStatusUniqueIndexFixAsync(dbContext);
+        await MigrateListQueryIndexesAsync(dbContext);
     }
 
     public static async Task MigrateRepositoriesTopicsAsync(AppDbContext dbContext)
@@ -1455,6 +1456,36 @@ public static class Migrations
         catch
         {
             // Migration may already be applied or table doesn't exist yet
+        }
+    }
+
+    /// <summary>Indexes for keyset-ordered repository and workspace-project list queries.</summary>
+    public static async Task MigrateListQueryIndexesAsync(AppDbContext dbContext)
+    {
+        try
+        {
+            var conn = dbContext.Database.GetDbConnection();
+            if (conn.State != System.Data.ConnectionState.Open)
+                await conn.OpenAsync();
+
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = "SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name='IX_Repositories_RepositoryName_RepositoryId'";
+            if (Convert.ToInt32(await cmd.ExecuteScalarAsync()) == 0)
+            {
+                cmd.CommandText = "CREATE INDEX IX_Repositories_RepositoryName_RepositoryId ON Repositories(RepositoryName, RepositoryId)";
+                await cmd.ExecuteNonQueryAsync();
+            }
+
+            cmd.CommandText = "SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name='IX_WorkspaceProjects_WorkspaceId_ProjectName_ProjectId'";
+            if (Convert.ToInt32(await cmd.ExecuteScalarAsync()) == 0)
+            {
+                cmd.CommandText = "CREATE INDEX IX_WorkspaceProjects_WorkspaceId_ProjectName_ProjectId ON WorkspaceProjects(WorkspaceId, ProjectName, ProjectId)";
+                await cmd.ExecuteNonQueryAsync();
+            }
+        }
+        catch
+        {
+            // Migration may already be applied
         }
     }
 }

--- a/src/GrayMoon.App/Models/RefreshRepositoriesResult.cs
+++ b/src/GrayMoon.App/Models/RefreshRepositoriesResult.cs
@@ -3,7 +3,6 @@ namespace GrayMoon.App.Models;
 /// <summary>Result of refreshing repositories from GitHub; may include per-connector fetch errors and detected renames.</summary>
 public sealed class RefreshRepositoriesResult
 {
-    public IReadOnlyList<GitHubRepositoryEntry> Repositories { get; init; } = [];
     public IReadOnlyList<ConnectorFetchError> ConnectorErrors { get; init; } = [];
     public IReadOnlyList<RenamedRepositoryInfo> RenamedRepositories { get; init; } = [];
     /// <summary>Maps old (deleted) RepositoryId to the surviving canonical RepositoryId for any repository that was merged during rename reconciliation. Empty when no merges occurred.</summary>

--- a/src/GrayMoon.App/Program.cs
+++ b/src/GrayMoon.App/Program.cs
@@ -73,6 +73,7 @@ try
     builder.Services.AddScoped<GitHubRepositoryService>();
     builder.Services.AddScoped<IRepositoryListQueryService, RepositoryListQueryService>();
     builder.Services.AddScoped<IWorkspaceProjectListQueryService, WorkspaceProjectListQueryService>();
+    builder.Services.AddScoped<IWorkspaceRepositoryLinkListQueryService, WorkspaceRepositoryLinkListQueryService>();
     builder.Services.AddScoped<GitHubActionsService>();
     builder.Services.AddScoped<GhaWorkflowLiveFeedService>();
     builder.Services.AddScoped<GitHubPullRequestService>();

--- a/src/GrayMoon.App/Program.cs
+++ b/src/GrayMoon.App/Program.cs
@@ -7,6 +7,7 @@ using GrayMoon.App.Hubs;
 using GrayMoon.App.Models;
 using GrayMoon.App.Repositories;
 using GrayMoon.App.Services;
+using GrayMoon.App.Services.Queries;
 using GrayMoon.App.Services.Security;
 using GrayMoon.Common;
 using Microsoft.AspNetCore.DataProtection;
@@ -70,6 +71,8 @@ try
     builder.Services.AddScoped<WorkspaceGitService>();
     builder.Services.AddScoped<ConnectorHealthService>();
     builder.Services.AddScoped<GitHubRepositoryService>();
+    builder.Services.AddScoped<IRepositoryListQueryService, RepositoryListQueryService>();
+    builder.Services.AddScoped<IWorkspaceProjectListQueryService, WorkspaceProjectListQueryService>();
     builder.Services.AddScoped<GitHubActionsService>();
     builder.Services.AddScoped<GhaWorkflowLiveFeedService>();
     builder.Services.AddScoped<GitHubPullRequestService>();

--- a/src/GrayMoon.App/Program.cs
+++ b/src/GrayMoon.App/Program.cs
@@ -46,8 +46,11 @@ try
         options.MaximumReceiveMessageSize = 10 * 1024 * 1024;
     });
 
-    // Database (SQLite) for persisted data - stored in db/ for easy container volume mounting
+    // Database (SQLite) for persisted data - stored in db/ for easy container volume mounting.
+    // WAL + busy_timeout so a large workspace's reads/writes do not block other circuits as hard.
     var connectionString = builder.Configuration.GetConnectionString("DefaultConnection") ?? "Data Source=db/graymoon.db";
+    if (!connectionString.Contains("Cache=", StringComparison.OrdinalIgnoreCase))
+        connectionString += connectionString.EndsWith(';') ? "Cache=Shared;" : ";Cache=Shared;";
     builder.Services.AddDbContext<AppDbContext>(options => options.UseSqlite(connectionString));
     builder.Services.AddScoped<ConnectorRepository>();
     builder.Services.AddScoped<GitHubRepositoryRepository>();
@@ -162,6 +165,10 @@ try
 
         dbContext.Database.EnsureCreated();
         await Migrations.RunAllAsync(dbContext);
+
+        await dbContext.Database.ExecuteSqlRawAsync("PRAGMA journal_mode=WAL;");
+        await dbContext.Database.ExecuteSqlRawAsync("PRAGMA busy_timeout=5000;");
+        await dbContext.Database.ExecuteSqlRawAsync("PRAGMA synchronous=NORMAL;");
     }
 
     static string? GetDatabasePath(string connectionString)

--- a/src/GrayMoon.App/Repositories/WorkspaceProjectRepository.cs
+++ b/src/GrayMoon.App/Repositories/WorkspaceProjectRepository.cs
@@ -741,6 +741,89 @@ public sealed class WorkspaceProjectRepository(
                 .ToList());
     }
 
+    /// <summary>Package dependency lines for a single repository (badge tooltip).</summary>
+    public async Task<IReadOnlyList<(string PackageId, string Version)>> GetPackageDependencyLinesForRepoAsync(
+        int workspaceId,
+        int repositoryId,
+        CancellationToken cancellationToken = default)
+    {
+        var depProjects = await dbContext.WorkspaceProjects
+            .AsNoTracking()
+            .Where(p => p.WorkspaceId == workspaceId && p.RepositoryId == repositoryId)
+            .Select(p => p.ProjectId)
+            .ToListAsync(cancellationToken);
+        if (depProjects.Count == 0)
+            return Array.Empty<(string, string)>();
+
+        var depProjectIds = depProjects.ToHashSet();
+        var edges = await (
+            from d in dbContext.ProjectDependencies.AsNoTracking()
+            join refProj in dbContext.WorkspaceProjects.AsNoTracking() on d.ReferencedProjectId equals refProj.ProjectId
+            where depProjectIds.Contains(d.DependentProjectId)
+                && refProj.WorkspaceId == workspaceId
+                && refProj.PackageId != null
+                && refProj.PackageId != string.Empty
+            select new { PackageId = refProj.PackageId!, Version = d.Version ?? string.Empty })
+            .ToListAsync(cancellationToken);
+
+        return edges
+            .Select(e => (e.PackageId, e.Version))
+            .Distinct()
+            .OrderBy(t => t.PackageId, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(t => t.Version, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    /// <summary>Mismatched package dependency lines for a single repository (badge tooltip).</summary>
+    public async Task<IReadOnlyList<(string PackageId, string CurrentVersion, string NewVersion)>> GetMismatchedDependencyLinesForRepoAsync(
+        int workspaceId,
+        int repositoryId,
+        CancellationToken cancellationToken = default)
+    {
+        var versionByRepo = await dbContext.WorkspaceRepositories
+            .AsNoTracking()
+            .Where(wr => wr.WorkspaceId == workspaceId)
+            .Select(wr => new { wr.RepositoryId, wr.GitVersion })
+            .ToDictionaryAsync(x => x.RepositoryId, x => x.GitVersion, cancellationToken);
+
+        var depProjects = await dbContext.WorkspaceProjects
+            .AsNoTracking()
+            .Where(p => p.WorkspaceId == workspaceId && p.RepositoryId == repositoryId)
+            .Select(p => p.ProjectId)
+            .ToListAsync(cancellationToken);
+        if (depProjects.Count == 0)
+            return Array.Empty<(string, string, string)>();
+
+        var depProjectIds = depProjects.ToHashSet();
+        var edges = await (
+            from d in dbContext.ProjectDependencies.AsNoTracking()
+            join refProj in dbContext.WorkspaceProjects.AsNoTracking() on d.ReferencedProjectId equals refProj.ProjectId
+            where depProjectIds.Contains(d.DependentProjectId) && refProj.WorkspaceId == workspaceId
+            select new
+            {
+                RefRepoId = refProj.RepositoryId,
+                PackageId = !string.IsNullOrWhiteSpace(refProj.PackageId) ? refProj.PackageId! : refProj.ProjectName,
+                Version = d.Version,
+            })
+            .ToListAsync(cancellationToken);
+
+        var lines = new HashSet<(string PackageId, string CurrentVersion, string NewVersion)>();
+        foreach (var e in edges)
+        {
+            if (string.IsNullOrWhiteSpace(e.PackageId))
+                continue;
+            var refVersion = versionByRepo.GetValueOrDefault(e.RefRepoId)?.Trim() ?? "";
+            var depVersion = e.Version?.Trim() ?? "";
+            if (string.IsNullOrEmpty(refVersion) || depVersion == refVersion)
+                continue;
+            lines.Add((e.PackageId.Trim(), depVersion, refVersion));
+        }
+
+        return lines
+            .OrderBy(t => t.PackageId, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
     /// <summary>Returns the dependency graph for the workspace: nodes (projects with labels) and edges. Suitable for Cytoscape (nodes + edges).</summary>
     public async Task<ProjectDependencyGraph> GetDependencyGraphAsync(int workspaceId, CancellationToken cancellationToken = default)
     {

--- a/src/GrayMoon.App/Repositories/WorkspaceRepository.cs
+++ b/src/GrayMoon.App/Repositories/WorkspaceRepository.cs
@@ -32,6 +32,14 @@ public class WorkspaceRepository(AppDbContext dbContext, WorkspaceService worksp
             .FirstOrDefaultAsync(workspace => workspace.WorkspaceId == workspaceId);
     }
 
+    /// <summary>Loads workspace metadata without repository links (for incremental list pages).</summary>
+    public async Task<Workspace?> GetHeaderAsync(int workspaceId)
+    {
+        return await _dbContext.Workspaces
+            .AsNoTracking()
+            .FirstOrDefaultAsync(workspace => workspace.WorkspaceId == workspaceId);
+    }
+
     public async Task<Workspace> AddAsync(string name, IReadOnlyCollection<int> repositoryIds)
     {
         var normalized = NormalizeName(name);

--- a/src/GrayMoon.App/Repositories/WorkspaceRepositoryCustomDependencyRepository.cs
+++ b/src/GrayMoon.App/Repositories/WorkspaceRepositoryCustomDependencyRepository.cs
@@ -57,6 +57,28 @@ public sealed class WorkspaceRepositoryCustomDependencyRepository(
         return referencedRepoIds.ToHashSet();
     }
 
+    /// <summary>Custom dependency repo names for a single dependent repository (badge tooltip).</summary>
+    public async Task<IReadOnlyList<string>> GetCustomDependencyNamesForRepoAsync(
+        int workspaceId,
+        int repositoryId,
+        CancellationToken cancellationToken = default)
+    {
+        var names = await dbContext.WorkspaceRepositoryCustomDependencies
+            .AsNoTracking()
+            .Where(d => d.DependentWorkspaceRepository!.WorkspaceId == workspaceId
+                && d.DependentWorkspaceRepository.RepositoryId == repositoryId
+                && d.ReferencedWorkspaceRepository!.Repository != null)
+            .Select(d => d.ReferencedWorkspaceRepository!.Repository!.RepositoryName)
+            .Where(n => n != null && n != string.Empty)
+            .ToListAsync(cancellationToken);
+
+        return names
+            .Where(n => !string.IsNullOrWhiteSpace(n))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(n => n, StringComparer.OrdinalIgnoreCase)
+            .ToList()!;
+    }
+
     /// <summary>Returns custom dependency repo names keyed by dependent repository ID (for badge tooltips).</summary>
     public async Task<IReadOnlyDictionary<int, IReadOnlyList<string>>> GetCustomDependencyNamesByRepoAsync(
         int workspaceId,

--- a/src/GrayMoon.App/Services/GitHubRepositoryService.cs
+++ b/src/GrayMoon.App/Services/GitHubRepositoryService.cs
@@ -17,8 +17,8 @@ public class GitHubRepositoryService(
             return persisted;
         }
 
-        var result = await RefreshRepositoriesAsync();
-        return result.Repositories.ToList();
+        await RefreshRepositoriesAsync();
+        return await repositoryRepository.GetAllEntriesAsync();
     }
 
     public async Task<List<GitHubRepositoryEntry>> GetPersistedRepositoriesAsync()
@@ -98,10 +98,8 @@ public class GitHubRepositoryService(
             mergedIdMap = mergeResult.MergedRepositoryIdMap;
         }
 
-        var repositoriesList = await repositoryRepository.GetAllEntriesAsync();
         return new RefreshRepositoriesResult
         {
-            Repositories = repositoriesList,
             ConnectorErrors = connectorErrors,
             RenamedRepositories = renamedRepositories,
             MergedRepositoryIdMap = mergedIdMap

--- a/src/GrayMoon.App/Services/Queries/IRepositoryListQueryService.cs
+++ b/src/GrayMoon.App/Services/Queries/IRepositoryListQueryService.cs
@@ -12,6 +12,10 @@ public interface IRepositoryListQueryService
 
     Task<IReadOnlyList<int>> GetMatchingIdsAsync(RepositoryListFilter filter, CancellationToken cancellationToken = default);
 
+    Task<IReadOnlyList<RepositoryListItemDto>> GetByIdsAsync(
+        IReadOnlyList<int> repositoryIds,
+        CancellationToken cancellationToken = default);
+
     Task<IReadOnlyList<int>> FilterExistingIdsAsync(IReadOnlyCollection<int> repositoryIds, CancellationToken cancellationToken = default);
 
     Task<IReadOnlyDictionary<string, int>> GetIdsByCloneUrlsAsync(IReadOnlyList<string> cloneUrls, CancellationToken cancellationToken = default);

--- a/src/GrayMoon.App/Services/Queries/IRepositoryListQueryService.cs
+++ b/src/GrayMoon.App/Services/Queries/IRepositoryListQueryService.cs
@@ -1,0 +1,18 @@
+namespace GrayMoon.App.Services.Queries;
+
+public interface IRepositoryListQueryService
+{
+    const int DefaultChunkSize = 50;
+
+    Task<bool> AnyAsync(CancellationToken cancellationToken = default);
+
+    Task<int> CountAsync(RepositoryListFilter filter, CancellationToken cancellationToken = default);
+
+    Task<RepositoryListPageResult> GetPageAsync(RepositoryListRequest request, CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<int>> GetMatchingIdsAsync(RepositoryListFilter filter, CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<int>> FilterExistingIdsAsync(IReadOnlyCollection<int> repositoryIds, CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyDictionary<string, int>> GetIdsByCloneUrlsAsync(IReadOnlyList<string> cloneUrls, CancellationToken cancellationToken = default);
+}

--- a/src/GrayMoon.App/Services/Queries/IWorkspaceProjectListQueryService.cs
+++ b/src/GrayMoon.App/Services/Queries/IWorkspaceProjectListQueryService.cs
@@ -1,0 +1,10 @@
+namespace GrayMoon.App.Services.Queries;
+
+public interface IWorkspaceProjectListQueryService
+{
+    const int DefaultChunkSize = 50;
+
+    Task<int> CountAsync(WorkspaceProjectListFilter filter, CancellationToken cancellationToken = default);
+
+    Task<WorkspaceProjectListPageResult> GetPageAsync(WorkspaceProjectListRequest request, CancellationToken cancellationToken = default);
+}

--- a/src/GrayMoon.App/Services/Queries/IWorkspaceProjectListQueryService.cs
+++ b/src/GrayMoon.App/Services/Queries/IWorkspaceProjectListQueryService.cs
@@ -7,4 +7,10 @@ public interface IWorkspaceProjectListQueryService
     Task<int> CountAsync(WorkspaceProjectListFilter filter, CancellationToken cancellationToken = default);
 
     Task<WorkspaceProjectListPageResult> GetPageAsync(WorkspaceProjectListRequest request, CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<int>> GetIndexAsync(WorkspaceProjectListFilter filter, CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<WorkspaceProjectListItemDto>> GetByIdsAsync(
+        IReadOnlyList<int> projectIds,
+        CancellationToken cancellationToken = default);
 }

--- a/src/GrayMoon.App/Services/Queries/IWorkspaceRepositoryLinkListQueryService.cs
+++ b/src/GrayMoon.App/Services/Queries/IWorkspaceRepositoryLinkListQueryService.cs
@@ -1,0 +1,33 @@
+namespace GrayMoon.App.Services.Queries;
+
+public interface IWorkspaceRepositoryLinkListQueryService
+{
+    const int DefaultChunkSize = 50;
+
+    Task<int> CountAsync(WorkspaceRepositoryLinkListFilter filter, CancellationToken cancellationToken = default);
+
+    Task<WorkspaceRepositoryLinkListPageResult> GetPageAsync(
+        WorkspaceRepositoryLinkListRequest request,
+        CancellationToken cancellationToken = default);
+
+    Task<WorkspaceRepositoryHeaderStateDto> GetHeaderStateAsync(int workspaceId, CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<int>> GetRepositoryIdsAtLevelAsync(
+        int workspaceId,
+        int? levelKey,
+        string? search,
+        CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<WorkspaceRepositoryLinkListItemDto>> GetAllSnapshotsAsync(
+        int workspaceId,
+        CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyDictionary<string, string>> GetGitVersionNameMapAsync(
+        int workspaceId,
+        CancellationToken cancellationToken = default);
+
+    Task<WorkspaceRepositoryLinkListItemDto?> GetSnapshotAsync(
+        int workspaceId,
+        int repositoryId,
+        CancellationToken cancellationToken = default);
+}

--- a/src/GrayMoon.App/Services/Queries/IWorkspaceRepositoryLinkListQueryService.cs
+++ b/src/GrayMoon.App/Services/Queries/IWorkspaceRepositoryLinkListQueryService.cs
@@ -12,6 +12,17 @@ public interface IWorkspaceRepositoryLinkListQueryService
 
     Task<WorkspaceRepositoryHeaderStateDto> GetHeaderStateAsync(int workspaceId, CancellationToken cancellationToken = default);
 
+    /// <summary>Ordered lightweight index for virtual scroll (same sort as the grid).</summary>
+    Task<IReadOnlyList<WorkspaceRepositoryLinkIndexEntry>> GetIndexAsync(
+        WorkspaceRepositoryLinkListFilter filter,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Hydrates full list DTOs for the given workspace-repository link PKs.</summary>
+    Task<IReadOnlyList<WorkspaceRepositoryLinkListItemDto>> GetByIdsAsync(
+        int workspaceId,
+        IReadOnlyList<int> workspaceRepositoryIds,
+        CancellationToken cancellationToken = default);
+
     Task<IReadOnlyList<int>> GetRepositoryIdsAtLevelAsync(
         int workspaceId,
         int? levelKey,

--- a/src/GrayMoon.App/Services/Queries/RepositoryListModels.cs
+++ b/src/GrayMoon.App/Services/Queries/RepositoryListModels.cs
@@ -1,0 +1,36 @@
+namespace GrayMoon.App.Services.Queries;
+
+public enum RepositorySortField
+{
+    Name,
+}
+
+public sealed record RepositoryListCursor(string RepositoryName, int RepositoryId);
+
+public sealed record RepositoryListRequest(
+    string? Search,
+    IReadOnlyList<int>? RestrictToRepositoryIds,
+    RepositorySortField SortField,
+    bool SortDescending,
+    int PageSize,
+    RepositoryListCursor? Cursor);
+
+public sealed record RepositoryListItemDto(
+    int RepositoryId,
+    string RepositoryName,
+    string? OrgName,
+    string ConnectorName,
+    string Visibility,
+    bool Archived,
+    string? Topics);
+
+public sealed record RepositoryListPageResult(
+    IReadOnlyList<RepositoryListItemDto> Items,
+    RepositoryListCursor? NextCursor,
+    bool HasMore);
+
+public sealed record RepositoryListFilter(
+    string? Search,
+    IReadOnlyList<int>? RestrictToRepositoryIds,
+    RepositorySortField SortField = RepositorySortField.Name,
+    bool SortDescending = false);

--- a/src/GrayMoon.App/Services/Queries/RepositoryListQueryService.cs
+++ b/src/GrayMoon.App/Services/Queries/RepositoryListQueryService.cs
@@ -1,0 +1,162 @@
+using GrayMoon.App.Data;
+using GrayMoon.App.Models;
+using GrayMoon.Common.Search;
+using Microsoft.EntityFrameworkCore;
+
+namespace GrayMoon.App.Services.Queries;
+
+public sealed class RepositoryListQueryService(AppDbContext dbContext) : IRepositoryListQueryService
+{
+    private readonly AppDbContext _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+
+    public Task<bool> AnyAsync(CancellationToken cancellationToken = default) =>
+        _dbContext.Repositories.AsNoTracking().AnyAsync(cancellationToken);
+
+    public Task<int> CountAsync(RepositoryListFilter filter, CancellationToken cancellationToken = default) =>
+        ApplyFilters(_dbContext.Repositories.AsNoTracking(), filter).CountAsync(cancellationToken);
+
+    public async Task<RepositoryListPageResult> GetPageAsync(RepositoryListRequest request, CancellationToken cancellationToken = default)
+    {
+        var filter = new RepositoryListFilter(
+            request.Search,
+            request.RestrictToRepositoryIds,
+            request.SortField,
+            request.SortDescending);
+
+        var query = ApplyFilters(_dbContext.Repositories.AsNoTracking(), filter);
+        query = ApplySort(query, request.SortField, request.SortDescending);
+        query = ApplyKeyset(query, request.Cursor, request.SortDescending);
+
+        var take = Math.Max(1, request.PageSize) + 1;
+        var rows = await query
+            .Select(r => new RepositoryListItemDto(
+                r.RepositoryId,
+                r.RepositoryName,
+                r.OrgName,
+                r.Connector != null ? r.Connector.ConnectorName : "Unknown",
+                r.Visibility,
+                r.Archived,
+                r.Topics))
+            .Take(take)
+            .ToListAsync(cancellationToken);
+
+        var hasMore = rows.Count > request.PageSize;
+        if (hasMore)
+        {
+            rows.RemoveAt(rows.Count - 1);
+        }
+
+        RepositoryListCursor? nextCursor = null;
+        if (hasMore && rows.Count > 0)
+        {
+            var last = rows[^1];
+            nextCursor = new RepositoryListCursor(last.RepositoryName, last.RepositoryId);
+        }
+
+        return new RepositoryListPageResult(rows, nextCursor, hasMore);
+    }
+
+    public async Task<IReadOnlyList<int>> GetMatchingIdsAsync(RepositoryListFilter filter, CancellationToken cancellationToken = default)
+    {
+        return await ApplyFilters(_dbContext.Repositories.AsNoTracking(), filter)
+            .OrderBy(r => r.RepositoryName)
+            .ThenBy(r => r.RepositoryId)
+            .Select(r => r.RepositoryId)
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<int>> FilterExistingIdsAsync(IReadOnlyCollection<int> repositoryIds, CancellationToken cancellationToken = default)
+    {
+        if (repositoryIds.Count == 0)
+        {
+            return [];
+        }
+
+        return await _dbContext.Repositories.AsNoTracking()
+            .Where(r => repositoryIds.Contains(r.RepositoryId))
+            .Select(r => r.RepositoryId)
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task<IReadOnlyDictionary<string, int>> GetIdsByCloneUrlsAsync(IReadOnlyList<string> cloneUrls, CancellationToken cancellationToken = default)
+    {
+        if (cloneUrls.Count == 0)
+        {
+            return new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        var normalized = cloneUrls
+            .Where(u => !string.IsNullOrWhiteSpace(u))
+            .Select(u => u.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        if (normalized.Count == 0)
+        {
+            return new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        var rows = await _dbContext.Repositories.AsNoTracking()
+            .Where(r => normalized.Contains(r.CloneUrl))
+            .Select(r => new { r.CloneUrl, r.RepositoryId })
+            .ToListAsync(cancellationToken);
+
+        var dict = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        foreach (var row in rows)
+        {
+            var url = row.CloneUrl.Trim();
+            if (!dict.ContainsKey(url))
+            {
+                dict[url] = row.RepositoryId;
+            }
+        }
+
+        return dict;
+    }
+
+    private static IQueryable<Repository> ApplyFilters(IQueryable<Repository> query, RepositoryListFilter filter)
+    {
+        query = query.ApplySearch(filter.Search, RepositorySearchExpressions.BuildTermPredicate);
+
+        if (filter.RestrictToRepositoryIds is { Count: > 0 } ids)
+        {
+            query = query.Where(r => ids.Contains(r.RepositoryId));
+        }
+
+        return query;
+    }
+
+    private static IQueryable<Repository> ApplySort(IQueryable<Repository> query, RepositorySortField sortField, bool descending) =>
+        sortField switch
+        {
+            RepositorySortField.Name when descending => query
+                .OrderByDescending(r => r.RepositoryName)
+                .ThenByDescending(r => r.RepositoryId),
+            RepositorySortField.Name => query
+                .OrderBy(r => r.RepositoryName)
+                .ThenBy(r => r.RepositoryId),
+            _ => query.OrderBy(r => r.RepositoryName).ThenBy(r => r.RepositoryId),
+        };
+
+    private static IQueryable<Repository> ApplyKeyset(
+        IQueryable<Repository> query,
+        RepositoryListCursor? cursor,
+        bool descending)
+    {
+        if (cursor is null)
+        {
+            return query;
+        }
+
+        if (descending)
+        {
+            return query.Where(r =>
+                r.RepositoryName.CompareTo(cursor.RepositoryName) < 0
+                || (r.RepositoryName == cursor.RepositoryName && r.RepositoryId < cursor.RepositoryId));
+        }
+
+        return query.Where(r =>
+            r.RepositoryName.CompareTo(cursor.RepositoryName) > 0
+            || (r.RepositoryName == cursor.RepositoryName && r.RepositoryId > cursor.RepositoryId));
+    }
+}

--- a/src/GrayMoon.App/Services/Queries/RepositoryListQueryService.cs
+++ b/src/GrayMoon.App/Services/Queries/RepositoryListQueryService.cs
@@ -58,11 +58,41 @@ public sealed class RepositoryListQueryService(AppDbContext dbContext) : IReposi
 
     public async Task<IReadOnlyList<int>> GetMatchingIdsAsync(RepositoryListFilter filter, CancellationToken cancellationToken = default)
     {
-        return await ApplyFilters(_dbContext.Repositories.AsNoTracking(), filter)
-            .OrderBy(r => r.RepositoryName)
-            .ThenBy(r => r.RepositoryId)
+        var query = ApplyFilters(_dbContext.Repositories.AsNoTracking(), filter);
+        query = ApplySort(query, filter.SortField, filter.SortDescending);
+        return await query
             .Select(r => r.RepositoryId)
             .ToListAsync(cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<RepositoryListItemDto>> GetByIdsAsync(
+        IReadOnlyList<int> repositoryIds,
+        CancellationToken cancellationToken = default)
+    {
+        if (repositoryIds.Count == 0)
+        {
+            return Array.Empty<RepositoryListItemDto>();
+        }
+
+        var idSet = repositoryIds.ToHashSet();
+        var rows = await _dbContext.Repositories.AsNoTracking()
+            .Where(r => idSet.Contains(r.RepositoryId))
+            .Select(r => new RepositoryListItemDto(
+                r.RepositoryId,
+                r.RepositoryName,
+                r.OrgName,
+                r.Connector != null ? r.Connector.ConnectorName : "Unknown",
+                r.Visibility,
+                r.Archived,
+                r.Topics))
+            .ToListAsync(cancellationToken);
+
+        var order = repositoryIds
+            .Select((id, index) => (id, index))
+            .ToDictionary(x => x.id, x => x.index);
+        return rows
+            .OrderBy(r => order.GetValueOrDefault(r.RepositoryId, int.MaxValue))
+            .ToList();
     }
 
     public async Task<IReadOnlyList<int>> FilterExistingIdsAsync(IReadOnlyCollection<int> repositoryIds, CancellationToken cancellationToken = default)

--- a/src/GrayMoon.App/Services/Queries/RepositorySearchExpressions.cs
+++ b/src/GrayMoon.App/Services/Queries/RepositorySearchExpressions.cs
@@ -1,0 +1,28 @@
+using System.Linq.Expressions;
+using GrayMoon.App.Models;
+using GrayMoon.Common.Search;
+
+namespace GrayMoon.App.Services.Queries;
+
+internal static class RepositorySearchExpressions
+{
+    public static Expression<Func<Repository, bool>> BuildTermPredicate(FilterSearchTerm term)
+    {
+        if (!string.IsNullOrEmpty(term.Field))
+        {
+            if (term.Field == "topic")
+            {
+                var value = term.Value.ToLowerInvariant();
+                return r => (r.Topics ?? string.Empty).ToLower().Contains(value);
+            }
+
+            return _ => true;
+        }
+
+        var termValue = term.Value.ToLowerInvariant();
+        return r => r.RepositoryName.ToLower().Contains(termValue)
+                    || (r.OrgName ?? string.Empty).ToLower().Contains(termValue)
+                    || (r.Topics ?? string.Empty).ToLower().Contains(termValue)
+                    || (r.Connector != null ? r.Connector.ConnectorName : "Unknown").ToLower().Contains(termValue);
+    }
+}

--- a/src/GrayMoon.App/Services/Queries/WorkspaceProjectListModels.cs
+++ b/src/GrayMoon.App/Services/Queries/WorkspaceProjectListModels.cs
@@ -1,0 +1,25 @@
+using GrayMoon.App.Models;
+
+namespace GrayMoon.App.Services.Queries;
+
+public sealed record WorkspaceProjectListCursor(int ProjectTypeSortKey, string ProjectName, int ProjectId);
+
+public sealed record WorkspaceProjectListRequest(
+    int WorkspaceId,
+    string? Search,
+    int PageSize,
+    WorkspaceProjectListCursor? Cursor);
+
+public sealed record WorkspaceProjectListItemDto(
+    int ProjectId,
+    string ProjectName,
+    ProjectType ProjectType,
+    string TargetFramework,
+    string ProjectFilePath);
+
+public sealed record WorkspaceProjectListPageResult(
+    IReadOnlyList<WorkspaceProjectListItemDto> Items,
+    WorkspaceProjectListCursor? NextCursor,
+    bool HasMore);
+
+public sealed record WorkspaceProjectListFilter(int WorkspaceId, string? Search);

--- a/src/GrayMoon.App/Services/Queries/WorkspaceProjectListQueryService.cs
+++ b/src/GrayMoon.App/Services/Queries/WorkspaceProjectListQueryService.cs
@@ -51,6 +51,45 @@ public sealed class WorkspaceProjectListQueryService(AppDbContext dbContext) : I
         return new WorkspaceProjectListPageResult(rows, nextCursor, hasMore);
     }
 
+    public async Task<IReadOnlyList<int>> GetIndexAsync(
+        WorkspaceProjectListFilter filter,
+        CancellationToken cancellationToken = default)
+    {
+        var query = ApplyFilters(_dbContext.WorkspaceProjects.AsNoTracking(), filter);
+        query = ApplySort(query);
+        return await query
+            .Select(p => p.ProjectId)
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<WorkspaceProjectListItemDto>> GetByIdsAsync(
+        IReadOnlyList<int> projectIds,
+        CancellationToken cancellationToken = default)
+    {
+        if (projectIds.Count == 0)
+        {
+            return Array.Empty<WorkspaceProjectListItemDto>();
+        }
+
+        var idSet = projectIds.ToHashSet();
+        var rows = await _dbContext.WorkspaceProjects.AsNoTracking()
+            .Where(p => idSet.Contains(p.ProjectId))
+            .Select(p => new WorkspaceProjectListItemDto(
+                p.ProjectId,
+                p.ProjectName,
+                p.ProjectType,
+                p.TargetFramework,
+                p.ProjectFilePath))
+            .ToListAsync(cancellationToken);
+
+        var order = projectIds
+            .Select((id, index) => (id, index))
+            .ToDictionary(x => x.id, x => x.index);
+        return rows
+            .OrderBy(r => order.GetValueOrDefault(r.ProjectId, int.MaxValue))
+            .ToList();
+    }
+
     private static IQueryable<WorkspaceProject> ApplyFilters(IQueryable<WorkspaceProject> query, WorkspaceProjectListFilter filter)
     {
         query = query.Where(p => p.WorkspaceId == filter.WorkspaceId);

--- a/src/GrayMoon.App/Services/Queries/WorkspaceProjectListQueryService.cs
+++ b/src/GrayMoon.App/Services/Queries/WorkspaceProjectListQueryService.cs
@@ -1,0 +1,97 @@
+using GrayMoon.App.Data;
+using GrayMoon.App.Models;
+using GrayMoon.Common.Search;
+using Microsoft.EntityFrameworkCore;
+
+namespace GrayMoon.App.Services.Queries;
+
+public sealed class WorkspaceProjectListQueryService(AppDbContext dbContext) : IWorkspaceProjectListQueryService
+{
+    private readonly AppDbContext _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+
+    public Task<int> CountAsync(WorkspaceProjectListFilter filter, CancellationToken cancellationToken = default) =>
+        ApplyFilters(_dbContext.WorkspaceProjects.AsNoTracking(), filter).CountAsync(cancellationToken);
+
+    public async Task<WorkspaceProjectListPageResult> GetPageAsync(
+        WorkspaceProjectListRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        var filter = new WorkspaceProjectListFilter(request.WorkspaceId, request.Search);
+        var query = ApplyFilters(_dbContext.WorkspaceProjects.AsNoTracking(), filter);
+        query = ApplySort(query);
+        query = ApplyKeyset(query, request.Cursor);
+
+        var take = Math.Max(1, request.PageSize) + 1;
+        var rows = await query
+            .Select(p => new WorkspaceProjectListItemDto(
+                p.ProjectId,
+                p.ProjectName,
+                p.ProjectType,
+                p.TargetFramework,
+                p.ProjectFilePath))
+            .Take(take)
+            .ToListAsync(cancellationToken);
+
+        var hasMore = rows.Count > request.PageSize;
+        if (hasMore)
+        {
+            rows.RemoveAt(rows.Count - 1);
+        }
+
+        WorkspaceProjectListCursor? nextCursor = null;
+        if (hasMore && rows.Count > 0)
+        {
+            var last = rows[^1];
+            nextCursor = new WorkspaceProjectListCursor(
+                WorkspaceProjectSearchExpressions.GetProjectTypeSortKey(last.ProjectType),
+                last.ProjectName,
+                last.ProjectId);
+        }
+
+        return new WorkspaceProjectListPageResult(rows, nextCursor, hasMore);
+    }
+
+    private static IQueryable<WorkspaceProject> ApplyFilters(IQueryable<WorkspaceProject> query, WorkspaceProjectListFilter filter)
+    {
+        query = query.Where(p => p.WorkspaceId == filter.WorkspaceId);
+        return query.ApplySearch(filter.Search, WorkspaceProjectSearchExpressions.BuildTermPredicate);
+    }
+
+    private static IQueryable<WorkspaceProject> ApplySort(IQueryable<WorkspaceProject> query) =>
+        query
+            .OrderBy(p => p.ProjectType == ProjectType.Service ? 0
+                : p.ProjectType == ProjectType.Library ? 1
+                : p.ProjectType == ProjectType.Package ? 2
+                : p.ProjectType == ProjectType.Test ? 3
+                : 4)
+            .ThenBy(p => p.ProjectName)
+            .ThenBy(p => p.ProjectId);
+
+    private static IQueryable<WorkspaceProject> ApplyKeyset(IQueryable<WorkspaceProject> query, WorkspaceProjectListCursor? cursor)
+    {
+        if (cursor is null)
+        {
+            return query;
+        }
+
+        return query.Where(p =>
+            (p.ProjectType == ProjectType.Service ? 0
+                : p.ProjectType == ProjectType.Library ? 1
+                : p.ProjectType == ProjectType.Package ? 2
+                : p.ProjectType == ProjectType.Test ? 3
+                : 4) > cursor.ProjectTypeSortKey
+            || ((p.ProjectType == ProjectType.Service ? 0
+                    : p.ProjectType == ProjectType.Library ? 1
+                    : p.ProjectType == ProjectType.Package ? 2
+                    : p.ProjectType == ProjectType.Test ? 3
+                    : 4) == cursor.ProjectTypeSortKey
+                && p.ProjectName.CompareTo(cursor.ProjectName) > 0)
+            || ((p.ProjectType == ProjectType.Service ? 0
+                    : p.ProjectType == ProjectType.Library ? 1
+                    : p.ProjectType == ProjectType.Package ? 2
+                    : p.ProjectType == ProjectType.Test ? 3
+                    : 4) == cursor.ProjectTypeSortKey
+                && p.ProjectName == cursor.ProjectName
+                && p.ProjectId > cursor.ProjectId));
+    }
+}

--- a/src/GrayMoon.App/Services/Queries/WorkspaceProjectSearchExpressions.cs
+++ b/src/GrayMoon.App/Services/Queries/WorkspaceProjectSearchExpressions.cs
@@ -1,0 +1,37 @@
+using System.Linq.Expressions;
+using GrayMoon.App.Models;
+using GrayMoon.Common.Search;
+
+namespace GrayMoon.App.Services.Queries;
+
+internal static class WorkspaceProjectSearchExpressions
+{
+    public static Expression<Func<WorkspaceProject, bool>> BuildTermPredicate(FilterSearchTerm term)
+    {
+        if (!string.IsNullOrEmpty(term.Field))
+        {
+            var value = term.Value.ToLowerInvariant();
+            return term.Field switch
+            {
+                "type" => p => p.ProjectType.ToString().ToLower().Contains(value),
+                "framework" => p => p.TargetFramework.ToLower().Contains(value),
+                _ => _ => false,
+            };
+        }
+
+        var termValue = term.Value.ToLowerInvariant();
+        return p => p.ProjectName.ToLower().Contains(termValue)
+                    || p.ProjectFilePath.ToLower().Contains(termValue)
+                    || p.ProjectType.ToString().ToLower().Contains(termValue)
+                    || p.TargetFramework.ToLower().Contains(termValue);
+    }
+
+    internal static int GetProjectTypeSortKey(ProjectType type) => type switch
+    {
+        ProjectType.Service => 0,
+        ProjectType.Library => 1,
+        ProjectType.Package => 2,
+        ProjectType.Test => 3,
+        _ => 4,
+    };
+}

--- a/src/GrayMoon.App/Services/Queries/WorkspaceRepositoryLinkListMapper.cs
+++ b/src/GrayMoon.App/Services/Queries/WorkspaceRepositoryLinkListMapper.cs
@@ -1,0 +1,74 @@
+using GrayMoon.App.Models;
+
+namespace GrayMoon.App.Services.Queries;
+
+internal static class WorkspaceRepositoryLinkListMapper
+{
+    public static WorkspaceRepositoryLink ToLink(WorkspaceRepositoryLinkListItemDto dto)
+    {
+        var link = new WorkspaceRepositoryLink
+        {
+            WorkspaceRepositoryId = dto.WorkspaceRepositoryId,
+            WorkspaceId = dto.WorkspaceId,
+            RepositoryId = dto.RepositoryId,
+            GitVersion = dto.GitVersion,
+            BranchName = dto.BranchName,
+            CheckedOutTag = dto.CheckedOutTag,
+            DefaultBranchName = dto.DefaultBranchName,
+            OutgoingCommits = dto.OutgoingCommits,
+            IncomingCommits = dto.IncomingCommits,
+            DefaultBranchBehindCommits = dto.DefaultBranchBehindCommits,
+            DefaultBranchAheadCommits = dto.DefaultBranchAheadCommits,
+            BranchHasUpstream = dto.BranchHasUpstream,
+            SyncStatus = dto.SyncStatus,
+            DependencyLevel = dto.DependencyLevel,
+            Dependencies = dto.Dependencies,
+            UnmatchedDeps = dto.UnmatchedDeps,
+            OutOfDateFileRepos = dto.OutOfDateFileRepos,
+            RepositoryType = dto.RepositoryType,
+            HasNewerTag = dto.HasNewerTag,
+            Repository = new Repository
+            {
+                RepositoryId = dto.RepositoryId,
+                RepositoryName = dto.RepositoryName,
+                CloneUrl = dto.CloneUrl,
+            },
+        };
+
+        if (dto.PullRequestNumber.HasValue || !string.IsNullOrEmpty(dto.PullRequestState))
+        {
+            link.PullRequest = new WorkspaceRepositoryPullRequest
+            {
+                WorkspaceRepositoryId = dto.WorkspaceRepositoryId,
+                PullRequestNumber = dto.PullRequestNumber,
+                State = dto.PullRequestState,
+                HtmlUrl = dto.PullRequestHtmlUrl,
+                MergedAt = dto.PullRequestMergedAt,
+                Mergeable = dto.PullRequestMergeable,
+                MergeableState = dto.PullRequestMergeableState,
+                ChangedFiles = dto.PullRequestChangedFiles,
+            };
+        }
+
+        return link;
+    }
+
+    public static PullRequestInfo? ToPullRequestInfo(WorkspaceRepositoryLinkListItemDto dto)
+    {
+        if (!dto.PullRequestNumber.HasValue && string.IsNullOrEmpty(dto.PullRequestState))
+        {
+            return null;
+        }
+
+        return new PullRequestInfo
+        {
+            Number = dto.PullRequestNumber ?? 0,
+            State = dto.PullRequestState ?? string.Empty,
+            HtmlUrl = dto.PullRequestHtmlUrl ?? string.Empty,
+            MergedAt = dto.PullRequestMergedAt,
+            Mergeable = dto.PullRequestMergeable,
+            MergeableState = dto.PullRequestMergeableState,
+            ChangedFiles = dto.PullRequestChangedFiles,
+        };
+    }
+}

--- a/src/GrayMoon.App/Services/Queries/WorkspaceRepositoryLinkListModels.cs
+++ b/src/GrayMoon.App/Services/Queries/WorkspaceRepositoryLinkListModels.cs
@@ -59,3 +59,9 @@ public sealed record WorkspaceRepositoryHeaderStateDto(
     bool HasTaggedRepos,
     bool IsOutOfSync,
     int? LowestLevelNeedingWork);
+
+/// <summary>Lightweight row for virtual-scroll index (no PR/join payload).</summary>
+public sealed record WorkspaceRepositoryLinkIndexEntry(
+    int WorkspaceRepositoryId,
+    int RepositoryId,
+    int? DependencyLevel);

--- a/src/GrayMoon.App/Services/Queries/WorkspaceRepositoryLinkListModels.cs
+++ b/src/GrayMoon.App/Services/Queries/WorkspaceRepositoryLinkListModels.cs
@@ -1,0 +1,61 @@
+using GrayMoon.App.Models;
+
+namespace GrayMoon.App.Services.Queries;
+
+public sealed record WorkspaceRepositoryLinkListCursor(
+    int DependencyLevelSortKey,
+    int RepositoryTypeSortKey,
+    int DependenciesSortKey,
+    int WorkspaceRepositoryId);
+
+public sealed record WorkspaceRepositoryLinkListRequest(
+    int WorkspaceId,
+    string? Search,
+    int PageSize,
+    WorkspaceRepositoryLinkListCursor? Cursor);
+
+public sealed record WorkspaceRepositoryLinkListItemDto(
+    int WorkspaceRepositoryId,
+    int WorkspaceId,
+    int RepositoryId,
+    string RepositoryName,
+    string CloneUrl,
+    string? GitVersion,
+    string? BranchName,
+    string? CheckedOutTag,
+    string? DefaultBranchName,
+    int? OutgoingCommits,
+    int? IncomingCommits,
+    int? DefaultBranchBehindCommits,
+    int? DefaultBranchAheadCommits,
+    bool? BranchHasUpstream,
+    RepoSyncStatus SyncStatus,
+    int? DependencyLevel,
+    int? Dependencies,
+    int? UnmatchedDeps,
+    int? OutOfDateFileRepos,
+    ProjectType? RepositoryType,
+    bool? HasNewerTag,
+    string? PullRequestState,
+    int? PullRequestNumber,
+    string? PullRequestHtmlUrl,
+    DateTimeOffset? PullRequestMergedAt,
+    bool? PullRequestMergeable,
+    string? PullRequestMergeableState,
+    int? PullRequestChangedFiles);
+
+public sealed record WorkspaceRepositoryLinkListPageResult(
+    IReadOnlyList<WorkspaceRepositoryLinkListItemDto> Items,
+    WorkspaceRepositoryLinkListCursor? NextCursor,
+    bool HasMore);
+
+public sealed record WorkspaceRepositoryLinkListFilter(int WorkspaceId, string? Search);
+
+public sealed record WorkspaceRepositoryHeaderStateDto(
+    int TotalCount,
+    bool HasUnmatchedDependencies,
+    bool IsPushRecommended,
+    bool HasIncomingCommits,
+    bool HasTaggedRepos,
+    bool IsOutOfSync,
+    int? LowestLevelNeedingWork);

--- a/src/GrayMoon.App/Services/Queries/WorkspaceRepositoryLinkListQueryService.cs
+++ b/src/GrayMoon.App/Services/Queries/WorkspaceRepositoryLinkListQueryService.cs
@@ -1,0 +1,238 @@
+using GrayMoon.App.Data;
+using GrayMoon.App.Models;
+using GrayMoon.Common.Search;
+using Microsoft.EntityFrameworkCore;
+
+namespace GrayMoon.App.Services.Queries;
+
+public sealed class WorkspaceRepositoryLinkListQueryService(AppDbContext dbContext) : IWorkspaceRepositoryLinkListQueryService
+{
+    private readonly AppDbContext _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+
+    public Task<int> CountAsync(WorkspaceRepositoryLinkListFilter filter, CancellationToken cancellationToken = default) =>
+        ApplyFilters(_dbContext.WorkspaceRepositories.AsNoTracking(), filter).CountAsync(cancellationToken);
+
+    public async Task<WorkspaceRepositoryLinkListPageResult> GetPageAsync(
+        WorkspaceRepositoryLinkListRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        var filter = new WorkspaceRepositoryLinkListFilter(request.WorkspaceId, request.Search);
+        var query = ApplyFilters(_dbContext.WorkspaceRepositories.AsNoTracking(), filter);
+        query = ApplySort(query);
+        query = ApplyKeyset(query, request.Cursor);
+
+        var take = Math.Max(1, request.PageSize) + 1;
+        var rows = await Project(query).Take(take).ToListAsync(cancellationToken);
+
+        var hasMore = rows.Count > request.PageSize;
+        if (hasMore)
+        {
+            rows.RemoveAt(rows.Count - 1);
+        }
+
+        WorkspaceRepositoryLinkListCursor? nextCursor = null;
+        if (hasMore && rows.Count > 0)
+        {
+            var last = rows[^1];
+            nextCursor = ToCursor(last);
+        }
+
+        return new WorkspaceRepositoryLinkListPageResult(rows, nextCursor, hasMore);
+    }
+
+    public async Task<WorkspaceRepositoryHeaderStateDto> GetHeaderStateAsync(
+        int workspaceId,
+        CancellationToken cancellationToken = default)
+    {
+        var links = await _dbContext.WorkspaceRepositories.AsNoTracking()
+            .Where(wr => wr.WorkspaceId == workspaceId)
+            .Select(wr => new
+            {
+                wr.DependencyLevel,
+                IsOnTag = wr.CheckedOutTag != null && wr.CheckedOutTag != string.Empty,
+                wr.UnmatchedDeps,
+                wr.OutOfDateFileRepos,
+                wr.OutgoingCommits,
+                wr.BranchHasUpstream,
+                wr.IncomingCommits,
+                wr.BranchName,
+                wr.DefaultBranchName,
+                wr.SyncStatus,
+            })
+            .ToListAsync(cancellationToken);
+
+        var totalCount = links.Count;
+        var hasUnmatchedDependencies = links.Any(wr => !wr.IsOnTag
+            && ((wr.UnmatchedDeps ?? 0) > 0 || (wr.OutOfDateFileRepos ?? 0) > 0));
+        var isPushRecommended = links.Any(wr => !wr.IsOnTag
+            && ((wr.OutgoingCommits ?? 0) > 0 || wr.BranchHasUpstream == false));
+        var hasIncomingCommits = links.Any(wr => !wr.IsOnTag
+            && (wr.IncomingCommits ?? 0) > 0
+            && !string.IsNullOrWhiteSpace(wr.BranchName)
+            && !string.IsNullOrWhiteSpace(wr.DefaultBranchName)
+            && wr.BranchName == wr.DefaultBranchName);
+        var hasTaggedRepos = links.Any(wr => wr.IsOnTag);
+        var isOutOfSync = links.Any(wr => wr.SyncStatus != RepoSyncStatus.InSync);
+        var lowestLevelNeedingWork = links
+            .Where(wr => !wr.IsOnTag && ((wr.UnmatchedDeps ?? 0) > 0 || (wr.OutOfDateFileRepos ?? 0) > 0))
+            .Select(wr => wr.DependencyLevel)
+            .Min();
+
+        return new WorkspaceRepositoryHeaderStateDto(
+            totalCount,
+            hasUnmatchedDependencies,
+            isPushRecommended,
+            hasIncomingCommits,
+            hasTaggedRepos,
+            isOutOfSync,
+            lowestLevelNeedingWork);
+    }
+
+    public async Task<IReadOnlyList<int>> GetRepositoryIdsAtLevelAsync(
+        int workspaceId,
+        int? levelKey,
+        string? search,
+        CancellationToken cancellationToken = default)
+    {
+        var filter = new WorkspaceRepositoryLinkListFilter(workspaceId, search);
+        var query = ApplyFilters(_dbContext.WorkspaceRepositories.AsNoTracking(), filter)
+            .Where(wr => wr.DependencyLevel == levelKey);
+
+        return await query
+            .OrderBy(wr => wr.WorkspaceRepositoryId)
+            .Select(wr => wr.RepositoryId)
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<WorkspaceRepositoryLinkListItemDto>> GetAllSnapshotsAsync(
+        int workspaceId,
+        CancellationToken cancellationToken = default)
+    {
+        var query = _dbContext.WorkspaceRepositories.AsNoTracking()
+            .Where(wr => wr.WorkspaceId == workspaceId);
+        query = ApplySort(query);
+        return await Project(query).ToListAsync(cancellationToken);
+    }
+
+    public async Task<IReadOnlyDictionary<string, string>> GetGitVersionNameMapAsync(
+        int workspaceId,
+        CancellationToken cancellationToken = default)
+    {
+        var rows = await _dbContext.WorkspaceRepositories.AsNoTracking()
+            .Where(wr => wr.WorkspaceId == workspaceId
+                && wr.Repository != null
+                && wr.GitVersion != null
+                && wr.GitVersion != string.Empty)
+            .Select(wr => new { wr.Repository!.RepositoryName, wr.GitVersion })
+            .ToListAsync(cancellationToken);
+
+        return rows
+            .Where(r => !string.IsNullOrWhiteSpace(r.RepositoryName) && !string.IsNullOrEmpty(r.GitVersion))
+            .ToDictionary(r => r.RepositoryName!, r => r.GitVersion!, StringComparer.OrdinalIgnoreCase);
+    }
+
+    public async Task<WorkspaceRepositoryLinkListItemDto?> GetSnapshotAsync(
+        int workspaceId,
+        int repositoryId,
+        CancellationToken cancellationToken = default)
+    {
+        return await Project(_dbContext.WorkspaceRepositories.AsNoTracking()
+                .Where(wr => wr.WorkspaceId == workspaceId && wr.RepositoryId == repositoryId))
+            .FirstOrDefaultAsync(cancellationToken);
+    }
+
+    private static IQueryable<WorkspaceRepositoryLink> ApplyFilters(
+        IQueryable<WorkspaceRepositoryLink> query,
+        WorkspaceRepositoryLinkListFilter filter)
+    {
+        query = query.Where(wr => wr.WorkspaceId == filter.WorkspaceId);
+        return query.ApplySearch(filter.Search, WorkspaceRepositoryLinkSearchExpressions.BuildTermPredicate);
+    }
+
+    private static IQueryable<WorkspaceRepositoryLink> ApplySort(IQueryable<WorkspaceRepositoryLink> query) =>
+        query
+            .OrderByDescending(wr => wr.DependencyLevel ?? int.MinValue)
+            .ThenBy(wr => wr.RepositoryType == ProjectType.Service ? 0
+                : wr.RepositoryType == ProjectType.Package ? 1
+                : wr.RepositoryType == ProjectType.Executable ? 2
+                : wr.RepositoryType == ProjectType.Library ? 3
+                : wr.RepositoryType == ProjectType.Test ? 4
+                : 5)
+            .ThenByDescending(wr => wr.Dependencies ?? int.MinValue)
+            .ThenBy(wr => wr.WorkspaceRepositoryId);
+
+    private static IQueryable<WorkspaceRepositoryLink> ApplyKeyset(
+        IQueryable<WorkspaceRepositoryLink> query,
+        WorkspaceRepositoryLinkListCursor? cursor)
+    {
+        if (cursor is null)
+        {
+            return query;
+        }
+
+        return query.Where(wr =>
+            (wr.DependencyLevel ?? int.MinValue) < cursor.DependencyLevelSortKey
+            || ((wr.DependencyLevel ?? int.MinValue) == cursor.DependencyLevelSortKey
+                && (wr.RepositoryType == ProjectType.Service ? 0
+                    : wr.RepositoryType == ProjectType.Package ? 1
+                    : wr.RepositoryType == ProjectType.Executable ? 2
+                    : wr.RepositoryType == ProjectType.Library ? 3
+                    : wr.RepositoryType == ProjectType.Test ? 4
+                    : 5) > cursor.RepositoryTypeSortKey)
+            || ((wr.DependencyLevel ?? int.MinValue) == cursor.DependencyLevelSortKey
+                && (wr.RepositoryType == ProjectType.Service ? 0
+                    : wr.RepositoryType == ProjectType.Package ? 1
+                    : wr.RepositoryType == ProjectType.Executable ? 2
+                    : wr.RepositoryType == ProjectType.Library ? 3
+                    : wr.RepositoryType == ProjectType.Test ? 4
+                    : 5) == cursor.RepositoryTypeSortKey
+                && (wr.Dependencies ?? int.MinValue) < cursor.DependenciesSortKey)
+            || ((wr.DependencyLevel ?? int.MinValue) == cursor.DependencyLevelSortKey
+                && (wr.RepositoryType == ProjectType.Service ? 0
+                    : wr.RepositoryType == ProjectType.Package ? 1
+                    : wr.RepositoryType == ProjectType.Executable ? 2
+                    : wr.RepositoryType == ProjectType.Library ? 3
+                    : wr.RepositoryType == ProjectType.Test ? 4
+                    : 5) == cursor.RepositoryTypeSortKey
+                && (wr.Dependencies ?? int.MinValue) == cursor.DependenciesSortKey
+                && wr.WorkspaceRepositoryId > cursor.WorkspaceRepositoryId));
+    }
+
+    private static IQueryable<WorkspaceRepositoryLinkListItemDto> Project(IQueryable<WorkspaceRepositoryLink> query) =>
+        query.Select(wr => new WorkspaceRepositoryLinkListItemDto(
+            wr.WorkspaceRepositoryId,
+            wr.WorkspaceId,
+            wr.RepositoryId,
+            wr.Repository != null ? wr.Repository.RepositoryName : string.Empty,
+            wr.Repository != null ? wr.Repository.CloneUrl : string.Empty,
+            wr.GitVersion,
+            wr.BranchName,
+            wr.CheckedOutTag,
+            wr.DefaultBranchName,
+            wr.OutgoingCommits,
+            wr.IncomingCommits,
+            wr.DefaultBranchBehindCommits,
+            wr.DefaultBranchAheadCommits,
+            wr.BranchHasUpstream,
+            wr.SyncStatus,
+            wr.DependencyLevel,
+            wr.Dependencies,
+            wr.UnmatchedDeps,
+            wr.OutOfDateFileRepos,
+            wr.RepositoryType,
+            wr.HasNewerTag,
+            wr.PullRequest != null ? wr.PullRequest.State : null,
+            wr.PullRequest != null ? wr.PullRequest.PullRequestNumber : null,
+            wr.PullRequest != null ? wr.PullRequest.HtmlUrl : null,
+            wr.PullRequest != null ? wr.PullRequest.MergedAt : null,
+            wr.PullRequest != null ? wr.PullRequest.Mergeable : null,
+            wr.PullRequest != null ? wr.PullRequest.MergeableState : null,
+            wr.PullRequest != null ? wr.PullRequest.ChangedFiles : null));
+
+    private static WorkspaceRepositoryLinkListCursor ToCursor(WorkspaceRepositoryLinkListItemDto dto) =>
+        new(
+            dto.DependencyLevel ?? int.MinValue,
+            WorkspaceRepositoryLinkSearchExpressions.GetRepositoryTypeSortKey(dto.RepositoryType),
+            dto.Dependencies ?? int.MinValue,
+            dto.WorkspaceRepositoryId);
+}

--- a/src/GrayMoon.App/Services/Queries/WorkspaceRepositoryLinkListQueryService.cs
+++ b/src/GrayMoon.App/Services/Queries/WorkspaceRepositoryLinkListQueryService.cs
@@ -44,39 +44,46 @@ public sealed class WorkspaceRepositoryLinkListQueryService(AppDbContext dbConte
         int workspaceId,
         CancellationToken cancellationToken = default)
     {
-        var links = await _dbContext.WorkspaceRepositories.AsNoTracking()
-            .Where(wr => wr.WorkspaceId == workspaceId)
-            .Select(wr => new
-            {
-                wr.DependencyLevel,
-                IsOnTag = wr.CheckedOutTag != null && wr.CheckedOutTag != string.Empty,
-                wr.UnmatchedDeps,
-                wr.OutOfDateFileRepos,
-                wr.OutgoingCommits,
-                wr.BranchHasUpstream,
-                wr.IncomingCommits,
-                wr.BranchName,
-                wr.DefaultBranchName,
-                wr.SyncStatus,
-            })
-            .ToListAsync(cancellationToken);
+        var baseQuery = _dbContext.WorkspaceRepositories.AsNoTracking()
+            .Where(wr => wr.WorkspaceId == workspaceId);
 
-        var totalCount = links.Count;
-        var hasUnmatchedDependencies = links.Any(wr => !wr.IsOnTag
-            && ((wr.UnmatchedDeps ?? 0) > 0 || (wr.OutOfDateFileRepos ?? 0) > 0));
-        var isPushRecommended = links.Any(wr => !wr.IsOnTag
-            && ((wr.OutgoingCommits ?? 0) > 0 || wr.BranchHasUpstream == false));
-        var hasIncomingCommits = links.Any(wr => !wr.IsOnTag
-            && (wr.IncomingCommits ?? 0) > 0
-            && !string.IsNullOrWhiteSpace(wr.BranchName)
-            && !string.IsNullOrWhiteSpace(wr.DefaultBranchName)
-            && wr.BranchName == wr.DefaultBranchName);
-        var hasTaggedRepos = links.Any(wr => wr.IsOnTag);
-        var isOutOfSync = links.Any(wr => wr.SyncStatus != RepoSyncStatus.InSync);
-        var lowestLevelNeedingWork = links
-            .Where(wr => !wr.IsOnTag && ((wr.UnmatchedDeps ?? 0) > 0 || (wr.OutOfDateFileRepos ?? 0) > 0))
-            .Select(wr => wr.DependencyLevel)
-            .Min();
+        var totalCount = await baseQuery.CountAsync(cancellationToken);
+
+        var hasUnmatchedDependencies = await baseQuery.AnyAsync(
+            wr => (wr.CheckedOutTag == null || wr.CheckedOutTag == string.Empty)
+                && ((wr.UnmatchedDeps ?? 0) > 0 || (wr.OutOfDateFileRepos ?? 0) > 0),
+            cancellationToken);
+
+        var isPushRecommended = await baseQuery.AnyAsync(
+            wr => (wr.CheckedOutTag == null || wr.CheckedOutTag == string.Empty)
+                && ((wr.OutgoingCommits ?? 0) > 0 || wr.BranchHasUpstream == false),
+            cancellationToken);
+
+        var hasIncomingCommits = await baseQuery.AnyAsync(
+            wr => (wr.CheckedOutTag == null || wr.CheckedOutTag == string.Empty)
+                && (wr.IncomingCommits ?? 0) > 0
+                && wr.BranchName != null && wr.BranchName != string.Empty
+                && wr.DefaultBranchName != null && wr.DefaultBranchName != string.Empty
+                && wr.BranchName == wr.DefaultBranchName,
+            cancellationToken);
+
+        var hasTaggedRepos = await baseQuery.AnyAsync(
+            wr => wr.CheckedOutTag != null && wr.CheckedOutTag != string.Empty,
+            cancellationToken);
+
+        var isOutOfSync = await baseQuery.AnyAsync(
+            wr => wr.SyncStatus != RepoSyncStatus.InSync,
+            cancellationToken);
+
+        var lowestLevels = await baseQuery
+            .Where(wr => (wr.CheckedOutTag == null || wr.CheckedOutTag == string.Empty)
+                && ((wr.UnmatchedDeps ?? 0) > 0 || (wr.OutOfDateFileRepos ?? 0) > 0)
+                && wr.DependencyLevel != null)
+            .Select(wr => wr.DependencyLevel!.Value)
+            .OrderBy(level => level)
+            .Take(1)
+            .ToListAsync(cancellationToken);
+        int? lowestLevelNeedingWork = lowestLevels.Count > 0 ? lowestLevels[0] : null;
 
         return new WorkspaceRepositoryHeaderStateDto(
             totalCount,
@@ -86,6 +93,43 @@ public sealed class WorkspaceRepositoryLinkListQueryService(AppDbContext dbConte
             hasTaggedRepos,
             isOutOfSync,
             lowestLevelNeedingWork);
+    }
+
+    public async Task<IReadOnlyList<WorkspaceRepositoryLinkIndexEntry>> GetIndexAsync(
+        WorkspaceRepositoryLinkListFilter filter,
+        CancellationToken cancellationToken = default)
+    {
+        var query = ApplyFilters(_dbContext.WorkspaceRepositories.AsNoTracking(), filter);
+        query = ApplySort(query);
+        return await query
+            .Select(wr => new WorkspaceRepositoryLinkIndexEntry(
+                wr.WorkspaceRepositoryId,
+                wr.RepositoryId,
+                wr.DependencyLevel))
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<WorkspaceRepositoryLinkListItemDto>> GetByIdsAsync(
+        int workspaceId,
+        IReadOnlyList<int> workspaceRepositoryIds,
+        CancellationToken cancellationToken = default)
+    {
+        if (workspaceRepositoryIds.Count == 0)
+        {
+            return Array.Empty<WorkspaceRepositoryLinkListItemDto>();
+        }
+
+        var idSet = workspaceRepositoryIds.ToHashSet();
+        var rows = await Project(_dbContext.WorkspaceRepositories.AsNoTracking()
+                .Where(wr => wr.WorkspaceId == workspaceId && idSet.Contains(wr.WorkspaceRepositoryId)))
+            .ToListAsync(cancellationToken);
+
+        var order = workspaceRepositoryIds
+            .Select((id, index) => (id, index))
+            .ToDictionary(x => x.id, x => x.index);
+        return rows
+            .OrderBy(r => order.GetValueOrDefault(r.WorkspaceRepositoryId, int.MaxValue))
+            .ToList();
     }
 
     public async Task<IReadOnlyList<int>> GetRepositoryIdsAtLevelAsync(

--- a/src/GrayMoon.App/Services/Queries/WorkspaceRepositoryLinkSearchExpressions.cs
+++ b/src/GrayMoon.App/Services/Queries/WorkspaceRepositoryLinkSearchExpressions.cs
@@ -1,0 +1,45 @@
+using System.Linq.Expressions;
+using GrayMoon.App.Models;
+using GrayMoon.Common.Search;
+
+namespace GrayMoon.App.Services.Queries;
+
+internal static class WorkspaceRepositoryLinkSearchExpressions
+{
+    internal static int GetRepositoryTypeSortKey(ProjectType? type) => type switch
+    {
+        ProjectType.Service => 0,
+        ProjectType.Package => 1,
+        ProjectType.Executable => 2,
+        ProjectType.Library => 3,
+        ProjectType.Test => 4,
+        _ => 5,
+    };
+
+    public static Expression<Func<WorkspaceRepositoryLink, bool>> BuildTermPredicate(FilterSearchTerm term)
+    {
+        if (!string.IsNullOrEmpty(term.Field))
+        {
+            return term.Field switch
+            {
+                "topic" => _ => false,
+                _ => _ => true,
+            };
+        }
+
+        var termValue = term.Value.ToLowerInvariant();
+        return wr =>
+            (wr.Repository != null ? wr.Repository.RepositoryName : string.Empty).ToLower().Contains(termValue)
+            || (wr.BranchName ?? string.Empty).ToLower().Contains(termValue)
+            || (wr.GitVersion ?? string.Empty).ToLower().Contains(termValue)
+            || (wr.DependencyLevel == null
+                ? "no dependencies"
+                : ("level " + wr.DependencyLevel.ToString())).Contains(termValue)
+            || (wr.SyncStatus == RepoSyncStatus.InSync ? "in sync"
+                : wr.SyncStatus == RepoSyncStatus.NeedsSync ? "sync"
+                : wr.SyncStatus == RepoSyncStatus.NotCloned ? "not cloned"
+                : wr.SyncStatus == RepoSyncStatus.VersionMismatch ? "version"
+                : wr.SyncStatus == RepoSyncStatus.Error ? "error"
+                : "sync").Contains(termValue);
+    }
+}

--- a/src/GrayMoon.App/Services/WorkspaceFileVersionService.cs
+++ b/src/GrayMoon.App/Services/WorkspaceFileVersionService.cs
@@ -522,6 +522,21 @@ public sealed class WorkspaceFileVersionService(
                     .ToList());
     }
 
+    /// <summary>Out-of-date file-config token rows for a single repository (badge tooltip).</summary>
+    public async Task<IReadOnlyList<(string FileName, string TokenName, string CurrentValue, string ExpectedValue)>> GetMismatchedFileVersionLinesForRepoAsync(
+        int workspaceId,
+        int repositoryId,
+        CancellationToken cancellationToken = default)
+    {
+        var rows = await dbContext.WorkspaceFileLineStatuses
+            .AsNoTracking()
+            .Where(s => s.WorkspaceId == workspaceId && s.RepositoryId == repositoryId && s.TokenName != "")
+            .ToListAsync(cancellationToken);
+        return rows
+            .Select(s => (s.FileName, s.TokenName, s.CurrentValue ?? "", s.ExpectedValue ?? ""))
+            .ToList();
+    }
+
     /// <summary>Returns out-of-date file line statuses for the workspace, grouped by RepositoryId.</summary>
     public async Task<IReadOnlyDictionary<int, IReadOnlyList<WorkspaceFileLineStatus>>> GetFileLineStatusByWorkspaceAsync(
         int workspaceId, CancellationToken cancellationToken = default)
@@ -533,6 +548,18 @@ public sealed class WorkspaceFileVersionService(
         return rows
             .GroupBy(s => s.RepositoryId)
             .ToDictionary(g => g.Key, g => (IReadOnlyList<WorkspaceFileLineStatus>)g.ToList());
+    }
+
+    /// <summary>Out-of-date file line statuses for a single repository.</summary>
+    public async Task<IReadOnlyList<WorkspaceFileLineStatus>> GetFileLineStatusForRepoAsync(
+        int workspaceId,
+        int repositoryId,
+        CancellationToken cancellationToken = default)
+    {
+        return await dbContext.WorkspaceFileLineStatuses
+            .AsNoTracking()
+            .Where(s => s.WorkspaceId == workspaceId && s.RepositoryId == repositoryId)
+            .ToListAsync(cancellationToken);
     }
 
     /// <summary>
@@ -567,6 +594,35 @@ public sealed class WorkspaceFileVersionService(
         }
 
         return result.ToDictionary(kvp => kvp.Key, kvp => (IReadOnlyList<(string, string, string)>)kvp.Value);
+    }
+
+    /// <summary>OK-badge file version lines for a single repository.</summary>
+    public async Task<IReadOnlyList<(string FileName, string TokenName, string Version)>> GetAllFileVersionLinesForRepoAsync(
+        int workspaceId,
+        int repositoryId,
+        IReadOnlyDictionary<string, string> repoVersionMap,
+        CancellationToken cancellationToken = default)
+    {
+        var configs = await versionConfigRepository.GetByWorkspaceIdAsync(workspaceId, cancellationToken);
+        var list = new List<(string FileName, string TokenName, string Version)>();
+
+        foreach (var cfg in configs)
+        {
+            if (cfg.File?.Repository == null || cfg.File.IsMissingOnDisk == true) continue;
+            if (cfg.File.RepositoryId != repositoryId) continue;
+            var fileName = cfg.File.FileName;
+            var tokens = ExtractTokens(cfg.VersionPattern);
+
+            foreach (var token in tokens)
+            {
+                if (!repoVersionMap.TryGetValue(token, out var ver) || string.IsNullOrEmpty(ver)) continue;
+                if (!list.Any(e => string.Equals(e.FileName, fileName, StringComparison.OrdinalIgnoreCase)
+                                   && string.Equals(e.TokenName, token, StringComparison.OrdinalIgnoreCase)))
+                    list.Add((fileName, token, ver));
+            }
+        }
+
+        return list;
     }
 
     /// <summary>

--- a/src/GrayMoon.App/Services/WorkspacePendingActionsService.cs
+++ b/src/GrayMoon.App/Services/WorkspacePendingActionsService.cs
@@ -1,7 +1,5 @@
 using GrayMoon.App.Models;
-
 namespace GrayMoon.App.Services;
-
 public sealed record NotificationRepo(
     int RepositoryId,
     string RepositoryName,
@@ -13,7 +11,6 @@ public sealed record NotificationRepo(
     IReadOnlyList<(string PackageId, string CurrentVersion, string NewVersion)> MismatchedDeps,
     string? BranchName,
     string? DefaultBranchName);
-
 public sealed record WorkspaceNotification(
     int WorkspaceId,
     string WorkspaceName,
@@ -21,16 +18,14 @@ public sealed record WorkspaceNotification(
     bool IsPushRecommended,
     bool HasIncomingCommits,
     IReadOnlyList<NotificationRepo> Repos,
-    int? LowestLevelNeedingWork);
-
+    int? LowestLevelNeedingWork,
+    int TotalActionRepoCount);
 public sealed class WorkspacePendingActionsService
 {
+    public const int MaxListedActionRepos = 100;
     private readonly List<WorkspaceNotification> _notifications = new();
-
     public IReadOnlyList<WorkspaceNotification> Notifications => _notifications;
-
     public event Action? Changed;
-
     public void OnWorkspaceSynced(WorkspaceNotification? notification, int workspaceId)
     {
         _notifications.RemoveAll(n => n.WorkspaceId == workspaceId);
@@ -42,13 +37,11 @@ public sealed class WorkspacePendingActionsService
         }
         Changed?.Invoke();
     }
-
     public void Dismiss(int workspaceId)
     {
         _notifications.RemoveAll(n => n.WorkspaceId == workspaceId);
         Changed?.Invoke();
     }
-
     public static WorkspaceNotification? ComputeNotification(
         int workspaceId,
         string workspaceName,
@@ -65,14 +58,17 @@ public sealed class WorkspacePendingActionsService
             && string.Equals(wr.BranchName, wr.DefaultBranchName, StringComparison.Ordinal));
         if (!hasUnmatched && !isPushRecommended && !hasIncoming)
             return null;
-
-        var repos = links
+        var actionLinks = links
             .Where(wr => !wr.IsOnTag && (
                 (wr.UnmatchedDeps ?? 0) > 0 ||
                 (wr.OutgoingCommits ?? 0) > 0 ||
                 wr.BranchHasUpstream == false))
             .OrderBy(wr => wr.DependencyLevel ?? 0)
             .ThenBy(wr => wr.Repository?.RepositoryName ?? string.Empty)
+            .ToList();
+        var totalActionRepoCount = actionLinks.Count;
+        var repos = actionLinks
+            .Take(MaxListedActionRepos)
             .Select(wr =>
             {
                 var depLines = mismatchedDeps != null && mismatchedDeps.TryGetValue(wr.RepositoryId, out var lines)
@@ -91,11 +87,17 @@ public sealed class WorkspacePendingActionsService
                     wr.DefaultBranchName);
             })
             .ToList();
-
         var lowestLevel = links
             .Where(wr => !wr.IsOnTag && (wr.UnmatchedDeps ?? 0) > 0)
             .Min(wr => (int?)wr.DependencyLevel);
-
-        return new WorkspaceNotification(workspaceId, workspaceName, hasUnmatched, isPushRecommended, hasIncoming, repos, lowestLevel);
+        return new WorkspaceNotification(
+            workspaceId,
+            workspaceName,
+            hasUnmatched,
+            isPushRecommended,
+            hasIncoming,
+            repos,
+            lowestLevel,
+            totalActionRepoCount);
     }
 }

--- a/src/GrayMoon.App/wwwroot/app.css
+++ b/src/GrayMoon.App/wwwroot/app.css
@@ -611,6 +611,12 @@ h1:focus {
     table-layout: fixed;
 }
 
+.grid-page-body .table tbody tr.virtual-scroll-placeholder td,
+.repository-grid tbody tr.virtual-scroll-placeholder td {
+    height: 48px;
+    box-sizing: border-box;
+}
+
 /* First column in grid data rows: normal weight (not bold) like other columns */
 .grid-page-body .table tbody td:first-child,
 .grid-page-body .table tbody td:first-child strong {

--- a/src/GrayMoon.App/wwwroot/app.css
+++ b/src/GrayMoon.App/wwwroot/app.css
@@ -622,6 +622,24 @@ h1:focus {
     overflow: hidden;
 }
 
+/* Absolute-index striping for virtual scroll (table-striped nth-child flips when the window moves). */
+.virtual-scroll-table > tbody > tr.virtual-row-odd > td {
+    background-color: var(--bg-table-stripe);
+    color: var(--text-primary) !important;
+}
+
+.virtual-scroll-table > tbody > tr.virtual-row-even > td {
+    background-color: var(--bg-card);
+    color: var(--text-primary) !important;
+}
+
+.virtual-scroll-table > tbody > tr.virtual-scroll-spacer > td {
+    background-color: transparent !important;
+    padding: 0 !important;
+    border: 0 !important;
+    line-height: 0 !important;
+}
+
 /* First column in grid data rows: normal weight (not bold) like other columns */
 .grid-page-body .table tbody td:first-child,
 .grid-page-body .table tbody td:first-child strong {

--- a/src/GrayMoon.App/wwwroot/app.css
+++ b/src/GrayMoon.App/wwwroot/app.css
@@ -614,7 +614,12 @@ h1:focus {
 .grid-page-body .table tbody tr.virtual-scroll-placeholder td,
 .repository-grid tbody tr.virtual-scroll-placeholder td {
     height: 48px;
+    max-height: 48px;
+    padding: 0;
+    border-bottom-color: transparent;
     box-sizing: border-box;
+    line-height: 48px;
+    overflow: hidden;
 }
 
 /* First column in grid data rows: normal weight (not bold) like other columns */

--- a/src/GrayMoon.App/wwwroot/js/infinite-scroll.js
+++ b/src/GrayMoon.App/wwwroot/js/infinite-scroll.js
@@ -1,0 +1,38 @@
+window.grayMoonInfiniteScroll = (function () {
+    const observers = new WeakMap();
+
+    function getScrollRoot(sentinel) {
+        return sentinel.closest('tbody')
+            || sentinel.closest('.repository-list')
+            || null;
+    }
+
+    return {
+        observe: function (sentinel, dotNetRef) {
+            if (!sentinel) {
+                return;
+            }
+            grayMoonInfiniteScroll.disconnect(sentinel);
+            var scrollRoot = getScrollRoot(sentinel);
+            var observer = new IntersectionObserver(function (entries) {
+                entries.forEach(function (entry) {
+                    if (entry.isIntersecting) {
+                        dotNetRef.invokeMethodAsync('OnIntersect').catch(function () { });
+                    }
+                });
+            }, { root: scrollRoot, rootMargin: '80px', threshold: 0 });
+            observer.observe(sentinel);
+            observers.set(sentinel, observer);
+        },
+        disconnect: function (sentinel) {
+            if (!sentinel) {
+                return;
+            }
+            var observer = observers.get(sentinel);
+            if (observer) {
+                observer.disconnect();
+                observers.delete(sentinel);
+            }
+        }
+    };
+})();

--- a/src/GrayMoon.App/wwwroot/js/virtual-scroll.js
+++ b/src/GrayMoon.App/wwwroot/js/virtual-scroll.js
@@ -1,0 +1,50 @@
+window.grayMoonVirtualScroll = (function () {
+    const stateByEl = new WeakMap();
+    function onScroll(ev) {
+        var el = ev.currentTarget;
+        var state = stateByEl.get(el);
+        if (!state || !state.dotNetRef) {
+            return;
+        }
+        if (state.raf) {
+            cancelAnimationFrame(state.raf);
+        }
+        state.raf = requestAnimationFrame(function () {
+            state.raf = 0;
+            state.dotNetRef.invokeMethodAsync('OnVirtualScroll', el.scrollTop, el.clientHeight).catch(function () { });
+        });
+    }
+    return {
+        attach: function (tbody, dotNetRef, totalHeight) {
+            if (!tbody) {
+                return;
+            }
+            grayMoonVirtualScroll.detach(tbody);
+            var state = { dotNetRef: dotNetRef, raf: 0, totalHeight: totalHeight || 0 };
+            stateByEl.set(tbody, state);
+            tbody.addEventListener('scroll', onScroll, { passive: true });
+            tbody.scrollTop = 0;
+            dotNetRef.invokeMethodAsync('OnVirtualScroll', 0, tbody.clientHeight).catch(function () { });
+        },
+        setTotalHeight: function (tbody, totalHeight) {
+            var state = tbody ? stateByEl.get(tbody) : null;
+            if (state) {
+                state.totalHeight = totalHeight || 0;
+            }
+        },
+        detach: function (tbody) {
+            if (!tbody) {
+                return;
+            }
+            var state = stateByEl.get(tbody);
+            if (!state) {
+                return;
+            }
+            tbody.removeEventListener('scroll', onScroll);
+            if (state.raf) {
+                cancelAnimationFrame(state.raf);
+            }
+            stateByEl.delete(tbody);
+        }
+    };
+})();

--- a/src/GrayMoon.App/wwwroot/js/virtual-scroll.js
+++ b/src/GrayMoon.App/wwwroot/js/virtual-scroll.js
@@ -1,5 +1,20 @@
 window.grayMoonVirtualScroll = (function () {
     const stateByEl = new WeakMap();
+
+    function invokeScroll(el, state, scrollTop, clientHeight) {
+        state.inflight = true;
+        state.dotNetRef.invokeMethodAsync('OnVirtualScroll', scrollTop, clientHeight)
+            .catch(function () { })
+            .finally(function () {
+                state.inflight = false;
+                if (state.pending) {
+                    var pending = state.pending;
+                    state.pending = null;
+                    invokeScroll(el, state, pending.scrollTop, pending.clientHeight);
+                }
+            });
+    }
+
     function onScroll(ev) {
         var el = ev.currentTarget;
         var state = stateByEl.get(el);
@@ -11,20 +26,33 @@ window.grayMoonVirtualScroll = (function () {
         }
         state.raf = requestAnimationFrame(function () {
             state.raf = 0;
-            state.dotNetRef.invokeMethodAsync('OnVirtualScroll', el.scrollTop, el.clientHeight).catch(function () { });
+            var scrollTop = el.scrollTop;
+            var clientHeight = el.clientHeight;
+            if (state.inflight) {
+                state.pending = { scrollTop: scrollTop, clientHeight: clientHeight };
+                return;
+            }
+            invokeScroll(el, state, scrollTop, clientHeight);
         });
     }
+
     return {
         attach: function (tbody, dotNetRef, totalHeight) {
             if (!tbody) {
                 return;
             }
             grayMoonVirtualScroll.detach(tbody);
-            var state = { dotNetRef: dotNetRef, raf: 0, totalHeight: totalHeight || 0 };
+            var state = {
+                dotNetRef: dotNetRef,
+                raf: 0,
+                totalHeight: totalHeight || 0,
+                inflight: false,
+                pending: null
+            };
             stateByEl.set(tbody, state);
             tbody.addEventListener('scroll', onScroll, { passive: true });
             tbody.scrollTop = 0;
-            dotNetRef.invokeMethodAsync('OnVirtualScroll', 0, tbody.clientHeight).catch(function () { });
+            invokeScroll(tbody, state, 0, tbody.clientHeight);
         },
         setTotalHeight: function (tbody, totalHeight) {
             var state = tbody ? stateByEl.get(tbody) : null;
@@ -44,6 +72,7 @@ window.grayMoonVirtualScroll = (function () {
             if (state.raf) {
                 cancelAnimationFrame(state.raf);
             }
+            state.pending = null;
             stateByEl.delete(tbody);
         }
     };

--- a/src/GrayMoon.Common.Tests/FilterSearchEfQueryableTests.cs
+++ b/src/GrayMoon.Common.Tests/FilterSearchEfQueryableTests.cs
@@ -1,0 +1,166 @@
+using System.Linq.Expressions;
+using GrayMoon.Common.Search;
+
+namespace GrayMoon.Common.Tests;
+
+public class FilterSearchEfQueryableTests
+{
+    private readonly TestRepository _repo = new(
+        Name: "graymoon-api",
+        Owner: "acme",
+        Topics: "blazor,angular",
+        Connector: "github-prod");
+
+    private readonly TestProject _project = new(
+        Name: "GrayMoon.App",
+        File: "src/GrayMoon.App/GrayMoon.App.csproj",
+        Type: "Service",
+        Framework: "net10.0");
+
+    [Fact]
+    public void Repository_filter_parity_empty_query()
+    {
+        AssertRepositoryParity(null);
+        AssertRepositoryParity("   ");
+    }
+
+    [Fact]
+    public void Repository_filter_parity_implicit_and()
+    {
+        AssertRepositoryParity("gray api");
+        AssertRepositoryParity("gray zz");
+    }
+
+    [Fact]
+    public void Repository_filter_parity_or_and_parens()
+    {
+        AssertRepositoryParity("zz or api");
+        AssertRepositoryParity("(zz or api) and gray");
+    }
+
+    [Fact]
+    public void Repository_filter_parity_topic_and_unknown_field()
+    {
+        AssertRepositoryParity("topic:blazor");
+        AssertRepositoryParity("topic:zz");
+        AssertRepositoryParity("status:open");
+    }
+
+    [Fact]
+    public void Repository_filter_parity_legacy_invalid_syntax()
+    {
+        AssertRepositoryParity("(api");
+        AssertRepositoryParity("  gray   api  ");
+    }
+
+    [Fact]
+    public void Project_filter_parity_type_and_framework()
+    {
+        AssertProjectParity("type:service");
+        AssertProjectParity("framework:net10");
+        AssertProjectParity("status:open");
+    }
+
+    [Fact]
+    public void Project_filter_parity_unqualified_haystack()
+    {
+        AssertProjectParity("GrayMoon.App");
+        AssertProjectParity("csproj");
+        AssertProjectParity("missing");
+    }
+
+    private void AssertRepositoryParity(string? query)
+    {
+        var expected = FilterSearchExpression.Matches(query, _repo.Matches);
+        var filter = FilterSearchEfQueryable.BuildFilter(query, BuildRepositoryTermPredicate);
+        var actual = filter is null || filter.Compile()(_repo);
+        Assert.Equal(expected, actual);
+    }
+
+    private void AssertProjectParity(string? query)
+    {
+        var expected = FilterSearchExpression.Matches(query, _project.Matches);
+        var filter = FilterSearchEfQueryable.BuildFilter(query, BuildProjectTermPredicate);
+        var actual = filter is null || filter.Compile()(_project);
+        Assert.Equal(expected, actual);
+    }
+
+    private static Expression<Func<TestRepository, bool>> BuildRepositoryTermPredicate(FilterSearchTerm term)
+    {
+        if (!string.IsNullOrEmpty(term.Field))
+        {
+            if (term.Field == "topic")
+            {
+                var value = term.Value;
+                return r => r.Topics.Contains(value, StringComparison.OrdinalIgnoreCase);
+            }
+
+            return _ => true;
+        }
+
+        var termValue = term.Value;
+        return r => r.Name.Contains(termValue, StringComparison.OrdinalIgnoreCase)
+                    || r.Owner.Contains(termValue, StringComparison.OrdinalIgnoreCase)
+                    || r.Topics.Contains(termValue, StringComparison.OrdinalIgnoreCase)
+                    || r.Connector.Contains(termValue, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static Expression<Func<TestProject, bool>> BuildProjectTermPredicate(FilterSearchTerm term)
+    {
+        if (!string.IsNullOrEmpty(term.Field))
+        {
+            var value = term.Value;
+            return term.Field switch
+            {
+                "type" => p => p.Type.Contains(value, StringComparison.OrdinalIgnoreCase),
+                "framework" => p => p.Framework.Contains(value, StringComparison.OrdinalIgnoreCase),
+                _ => _ => false,
+            };
+        }
+
+        var termValue = term.Value;
+        return p => p.Name.Contains(termValue, StringComparison.OrdinalIgnoreCase)
+                    || p.File.Contains(termValue, StringComparison.OrdinalIgnoreCase)
+                    || p.Type.Contains(termValue, StringComparison.OrdinalIgnoreCase)
+                    || p.Framework.Contains(termValue, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private sealed record TestRepository(string Name, string Owner, string Topics, string Connector)
+    {
+        public bool Matches(FilterSearchTerm term)
+        {
+            if (!string.IsNullOrEmpty(term.Field))
+            {
+                return term.Field switch
+                {
+                    "topic" => Topics.Contains(term.Value, StringComparison.OrdinalIgnoreCase),
+                    _ => true,
+                };
+            }
+
+            return Name.Contains(term.Value, StringComparison.OrdinalIgnoreCase)
+                   || Owner.Contains(term.Value, StringComparison.OrdinalIgnoreCase)
+                   || Topics.Contains(term.Value, StringComparison.OrdinalIgnoreCase)
+                   || Connector.Contains(term.Value, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    private sealed record TestProject(string Name, string File, string Type, string Framework)
+    {
+        public bool Matches(FilterSearchTerm term)
+        {
+            if (!string.IsNullOrEmpty(term.Field))
+            {
+                return term.Field switch
+                {
+                    "type" => Type.Contains(term.Value, StringComparison.OrdinalIgnoreCase),
+                    "framework" => Framework.Contains(term.Value, StringComparison.OrdinalIgnoreCase),
+                    _ => false,
+                };
+            }
+
+            var haystack = $"{Name} {File} {Type} {Framework}";
+            return haystack.Contains(term.Value, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/src/GrayMoon.Common.Tests/FilterSearchEfQueryableTests.cs
+++ b/src/GrayMoon.Common.Tests/FilterSearchEfQueryableTests.cs
@@ -17,6 +17,13 @@ public class FilterSearchEfQueryableTests
         Type: "Service",
         Framework: "net10.0");
 
+    private readonly TestWorkspaceLink _workspaceLink = new(
+        RepositoryName: "graymoon-api",
+        BranchName: "main",
+        GitVersion: "1.2.3",
+        DependencyLevel: 2,
+        SyncStatus: "in sync");
+
     [Fact]
     public void Repository_filter_parity_empty_query()
     {
@@ -67,6 +74,57 @@ public class FilterSearchEfQueryableTests
         AssertProjectParity("GrayMoon.App");
         AssertProjectParity("csproj");
         AssertProjectParity("missing");
+    }
+
+    [Fact]
+    public void Workspace_link_filter_parity_empty_query()
+    {
+        AssertWorkspaceLinkParity(null);
+        AssertWorkspaceLinkParity("   ");
+    }
+
+    [Fact]
+    public void Workspace_link_filter_parity_implicit_and()
+    {
+        AssertWorkspaceLinkParity("graymoon main");
+        AssertWorkspaceLinkParity("graymoon zz");
+    }
+
+    [Fact]
+    public void Workspace_link_filter_parity_or_and_parens()
+    {
+        AssertWorkspaceLinkParity("zz or main");
+        AssertWorkspaceLinkParity("(zz or main) and graymoon");
+    }
+
+    [Fact]
+    public void Workspace_link_filter_parity_topic_and_unknown_field()
+    {
+        AssertWorkspaceLinkParity("topic:blazor");
+        AssertWorkspaceLinkParity("status:open");
+    }
+
+    [Fact]
+    public void Workspace_link_filter_parity_sync_and_level_text()
+    {
+        AssertWorkspaceLinkParity("in sync");
+        AssertWorkspaceLinkParity("level 2");
+        AssertWorkspaceLinkParity("no dependencies");
+    }
+
+    [Fact]
+    public void Workspace_link_filter_parity_legacy_invalid_syntax()
+    {
+        AssertWorkspaceLinkParity("(main");
+        AssertWorkspaceLinkParity("  graymoon   main  ");
+    }
+
+    private void AssertWorkspaceLinkParity(string? query)
+    {
+        var expected = FilterSearchExpression.Matches(query, _workspaceLink.Matches);
+        var filter = FilterSearchEfQueryable.BuildFilter(query, BuildWorkspaceLinkTermPredicate);
+        var actual = filter is null || filter.Compile()(_workspaceLink);
+        Assert.Equal(expected, actual);
     }
 
     private void AssertRepositoryParity(string? query)
@@ -125,6 +183,25 @@ public class FilterSearchEfQueryableTests
                     || p.Framework.Contains(termValue, StringComparison.OrdinalIgnoreCase);
     }
 
+    private static Expression<Func<TestWorkspaceLink, bool>> BuildWorkspaceLinkTermPredicate(FilterSearchTerm term)
+    {
+        if (!string.IsNullOrEmpty(term.Field))
+        {
+            return term.Field switch
+            {
+                "topic" => _ => false,
+                _ => _ => true,
+            };
+        }
+
+        var termValue = term.Value;
+        return link => link.RepositoryName.Contains(termValue, StringComparison.OrdinalIgnoreCase)
+                       || link.BranchName.Contains(termValue, StringComparison.OrdinalIgnoreCase)
+                       || link.GitVersion.Contains(termValue, StringComparison.OrdinalIgnoreCase)
+                       || link.LevelTitle.Contains(termValue, StringComparison.OrdinalIgnoreCase)
+                       || link.SyncStatus.Contains(termValue, StringComparison.OrdinalIgnoreCase);
+    }
+
     private sealed record TestRepository(string Name, string Owner, string Topics, string Connector)
     {
         public bool Matches(FilterSearchTerm term)
@@ -161,6 +238,31 @@ public class FilterSearchEfQueryableTests
 
             var haystack = $"{Name} {File} {Type} {Framework}";
             return haystack.Contains(term.Value, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    private sealed record TestWorkspaceLink(
+        string RepositoryName,
+        string BranchName,
+        string GitVersion,
+        int? DependencyLevel,
+        string SyncStatus)
+    {
+        public string LevelTitle => DependencyLevel == null ? "No dependencies" : $"Level {DependencyLevel}";
+
+        public bool Matches(FilterSearchTerm term)
+        {
+            if (!string.IsNullOrEmpty(term.Field))
+            {
+                return term.Field switch
+                {
+                    "topic" => false,
+                    _ => true,
+                };
+            }
+
+            var searchable = $"{RepositoryName} {BranchName} {GitVersion} {LevelTitle} {SyncStatus}";
+            return searchable.Contains(term.Value, StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/src/GrayMoon.Common/Search/FilterSearchEfQueryable.cs
+++ b/src/GrayMoon.Common/Search/FilterSearchEfQueryable.cs
@@ -1,0 +1,109 @@
+using System.Linq.Expressions;
+
+namespace GrayMoon.Common.Search;
+
+/// <summary>Builds EF-translatable <see cref="Expression"/> filters from <see cref="FilterSearchExpression"/> queries.</summary>
+public static class FilterSearchEfQueryable
+{
+    public static IQueryable<T> ApplySearch<T>(
+        this IQueryable<T> query,
+        string? searchQuery,
+        Func<FilterSearchTerm, Expression<Func<T, bool>>> buildTermPredicate)
+    {
+        var filter = BuildFilter(searchQuery, buildTermPredicate);
+        return filter is null ? query : query.Where(filter);
+    }
+
+    public static Expression<Func<T, bool>>? BuildFilter<T>(
+        string? searchQuery,
+        Func<FilterSearchTerm, Expression<Func<T, bool>>> buildTermPredicate)
+    {
+        if (string.IsNullOrWhiteSpace(searchQuery))
+        {
+            return null;
+        }
+
+        var parsed = FilterSearchExpression.Parse(searchQuery);
+        if (parsed.IsValid)
+        {
+            if (parsed.Expression is null)
+            {
+                return null;
+            }
+
+            return BuildNodeExpression(parsed.Expression, buildTermPredicate);
+        }
+
+        Expression<Func<T, bool>>? combined = null;
+        foreach (var token in searchQuery.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            var term = ParseTermToken(token);
+            var termExpr = buildTermPredicate(term);
+            combined = combined is null ? termExpr : CombineAnd(combined, termExpr);
+        }
+
+        return combined;
+    }
+
+    private static Expression<Func<T, bool>> BuildNodeExpression<T>(
+        FilterSearchNode node,
+        Func<FilterSearchTerm, Expression<Func<T, bool>>> buildTermPredicate) =>
+        node switch
+        {
+            FilterSearchTermNode termNode => buildTermPredicate(termNode.Term),
+            FilterSearchAndNode andNode => CombineAnd(
+                BuildNodeExpression(andNode.Left, buildTermPredicate),
+                BuildNodeExpression(andNode.Right, buildTermPredicate)),
+            FilterSearchOrNode orNode => CombineOr(
+                BuildNodeExpression(orNode.Left, buildTermPredicate),
+                BuildNodeExpression(orNode.Right, buildTermPredicate)),
+            _ => throw new InvalidOperationException("Unknown filter search node."),
+        };
+
+    private static Expression<Func<T, bool>> CombineAnd<T>(
+        Expression<Func<T, bool>> left,
+        Expression<Func<T, bool>> right)
+    {
+        var param = Expression.Parameter(typeof(T), "x");
+        var body = Expression.AndAlso(
+            ReplaceParameter(left.Body, left.Parameters[0], param),
+            ReplaceParameter(right.Body, right.Parameters[0], param));
+        return Expression.Lambda<Func<T, bool>>(body, param);
+    }
+
+    private static Expression<Func<T, bool>> CombineOr<T>(
+        Expression<Func<T, bool>> left,
+        Expression<Func<T, bool>> right)
+    {
+        var param = Expression.Parameter(typeof(T), "x");
+        var body = Expression.OrElse(
+            ReplaceParameter(left.Body, left.Parameters[0], param),
+            ReplaceParameter(right.Body, right.Parameters[0], param));
+        return Expression.Lambda<Func<T, bool>>(body, param);
+    }
+
+    private static Expression ReplaceParameter(Expression expression, ParameterExpression source, ParameterExpression target) =>
+        new ParameterReplacer(source, target).Visit(expression);
+
+    private static FilterSearchTerm ParseTermToken(string token)
+    {
+        var colon = token.IndexOf(':');
+        if (colon > 0)
+        {
+            var field = token[..colon];
+            var value = token[(colon + 1)..];
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                return new FilterSearchTerm(field.ToLowerInvariant(), value);
+            }
+        }
+
+        return new FilterSearchTerm(null, token);
+    }
+
+    private sealed class ParameterReplacer(ParameterExpression source, ParameterExpression target) : ExpressionVisitor
+    {
+        protected override Expression VisitParameter(ParameterExpression node) =>
+            node == source ? target : base.VisitParameter(node);
+    }
+}


### PR DESCRIPTION
## Summary

- Move repository, workspace project, and workspace repository grids to cursor-paged server queries so large catalogs no longer load fully into the Blazor circuit
- Translate filter-search expressions into EF Core predicates (`FilterSearchEfQueryable`) and debounce search reloads for responsive filtering without stale results
- Add infinite-scroll and virtual-table rendering (plus virtual counts) across GitHub repos, projects, and workspace repositories for smoother scrolling at scale
- Improve toast and workspace action notification UX alongside the list performance work
- Add `GrayMoon.App.Tests` coverage for list query services and debounced loading; include DB migrations for supporting indexes
- Working tree has uncommitted changes that may not be included in the branch diff - commit and push before opening the PR

## Test plan

- [ ] Open Repositories, Workspace Projects, and Workspace Repositories with large datasets and confirm pages load in chunks as you scroll
- [ ] Search with field prefixes (e.g. `topic:`, branch/name text) and confirm counts and rows stay consistent across pages with no duplicates or gaps
- [ ] Toggle-all / select-by-filter on repository lists and confirm only matching IDs are selected
- [ ] Verify workspace header badges (unmatched deps, push recommended) still reflect full-workspace aggregates without loading every row
- [ ] Run `dotnet test src/GrayMoon.App.Tests/GrayMoon.App.Tests.csproj` and `dotnet test src/GrayMoon.Common.Tests/GrayMoon.Common.Tests.csproj`
- [ ] Smoke-test toast and workspace action notification panel behavior after list interactions