### PR TITLE
Fix page scrollbar visibility and modal UX polish

### DIFF
--- a/src/GrayMoon.App/Components/Modals/GhaLogsModal.razor.css
+++ b/src/GrayMoon.App/Components/Modals/GhaLogsModal.razor.css
@@ -1,22 +1,3 @@
-/* Outer modal overlay — styled scrollbar for when min-height forces overflow */
-.modal {
-    scrollbar-color: #5a5a5a transparent;
-    scrollbar-width: thin;
-}
-
-.modal::-webkit-scrollbar {
-    width: 8px;
-}
-
-.modal::-webkit-scrollbar-track {
-    background: transparent;
-}
-
-.modal::-webkit-scrollbar-thumb {
-    background: #5a5a5a;
-    border-radius: 4px;
-}
-
 .gha-logs-dialog {
     width: calc(100vw - 1rem);
     max-width: calc(100vw - 1rem);

--- a/src/GrayMoon.App/Components/Modals/NewPullRequestModal.razor
+++ b/src/GrayMoon.App/Components/Modals/NewPullRequestModal.razor
@@ -7,7 +7,7 @@
     <div class="modal show d-block" tabindex="-1" style="background-color: rgba(0,0,0,0.5);"
          @onkeydown="HandleKeyDown"
          @ref="modalElement">
-        <div class="modal-dialog modal-lg">
+        <div class="modal-dialog modal-lg modal-dialog-centered">
             <div class="modal-content">
                 <div class="modal-header">
                     <h5 class="modal-title">

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.State.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.State.cs
@@ -223,7 +223,7 @@ public sealed partial class WorkspaceRepositories
         {
             return;
         }
-        StateHasChanged();
+        _ = InvokeAsync(StateHasChanged);
     }
     private IEnumerable<WorkspaceRepositoryLink> GetHydratedLinksAtLevel(int? levelKey) =>
         _linkByRepoId.Values.Where(wr => wr.DependencyLevel == levelKey);

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.css
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.css
@@ -396,8 +396,8 @@
 ::deep .repositories-table .dependency-badge-tooltip {
     display: block;
     position: fixed;
-    top: 0;
-    left: 0;
+    top: -9999px;
+    left: -9999px;
     right: auto;
     /* No margin-top here: a transparent gap between badge and popup would break the :hover chain when the cursor
        crosses it. Use padding-top inside the popup instead so the popup is contiguous with the badge. */

--- a/src/GrayMoon.App/wwwroot/app.css
+++ b/src/GrayMoon.App/wwwroot/app.css
@@ -744,6 +744,39 @@ h1:focus {
     background-color: rgba(0, 0, 0, 0.6);
 }
 
+/* Gray scrollbar on the Bootstrap modal overlay (visible on Windows when the
+   dialog is taller than the viewport). */
+.modal {
+    scrollbar-color: #5a5a5a transparent;
+    scrollbar-width: thin;
+}
+
+.modal::-webkit-scrollbar {
+    width: 8px;
+}
+
+.modal::-webkit-scrollbar-track {
+    background: transparent;
+}
+
+.modal::-webkit-scrollbar-thumb {
+    background: #5a5a5a;
+    border-radius: 4px;
+}
+
+/* Prevent modal dialogs from slightly exceeding the viewport height, which on
+   Windows causes a barely-scrollable scrollbar on the .modal overlay.
+   3.5rem = 2 x Bootstrap's default 1.75rem top/bottom margin.
+   Scoped modal CSS with higher specificity overrides these where needed. */
+.modal-dialog {
+    max-height: calc(100vh - 3.5rem);
+}
+
+.modal-dialog > .modal-content {
+    max-height: 100%;
+    overflow: hidden;
+}
+
 .modal-content {
     background-color: var(--bg-card);
     border-color: var(--border-color);

--- a/src/GrayMoon.App/wwwroot/app.css
+++ b/src/GrayMoon.App/wwwroot/app.css
@@ -73,6 +73,11 @@ html, body {
     font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
     background-color: var(--bg-primary);
     color: var(--text-primary);
+    /* Prevent a page-level vertical scrollbar. This is a full-page app: all
+       scrolling is handled internally by grid-page-body tbody and other
+       explicit scroll containers. DPI scaling on VDI machines can cause
+       subpixel rounding that pushes layout a few pixels over 100vh. */
+    overflow: hidden;
 }
 
 /* Links */

--- a/src/GrayMoon.App/wwwroot/js/dependency-badge-tooltip.js
+++ b/src/GrayMoon.App/wwwroot/js/dependency-badge-tooltip.js
@@ -22,6 +22,12 @@
 
         const anchor = wrap.getBoundingClientRect();
 
+        // Skip positioning when the element has not been laid out yet (e.g. during
+        // initial render or right after a Blazor re-render replaces the DOM node).
+        // Without this guard the tooltip would land at top:0 left:0 because
+        // getBoundingClientRect returns all-zeros for off-screen / unrendered nodes.
+        if (anchor.width === 0 && anchor.height === 0) return;
+
         const tipWidth = tip.offsetWidth || 480;
 
         const margin = 8;
@@ -63,6 +69,8 @@
 
 
     document.addEventListener('mouseover', onWrapActivated, true);
+
+    document.addEventListener('mouseenter', onWrapActivated, true);
 
     document.addEventListener('focusin', onWrapActivated, true);
 

--- a/src/GrayMoon.App/wwwroot/js/dependency-badge-tooltip.js
+++ b/src/GrayMoon.App/wwwroot/js/dependency-badge-tooltip.js
@@ -22,12 +22,6 @@
 
         const anchor = wrap.getBoundingClientRect();
 
-        // Skip positioning when the element has not been laid out yet (e.g. during
-        // initial render or right after a Blazor re-render replaces the DOM node).
-        // Without this guard the tooltip would land at top:0 left:0 because
-        // getBoundingClientRect returns all-zeros for off-screen / unrendered nodes.
-        if (anchor.width === 0 && anchor.height === 0) return;
-
         const tipWidth = tip.offsetWidth || 480;
 
         const margin = 8;


### PR DESCRIPTION
## Summary

- Suppress the page-level vertical scrollbar by setting `overflow: hidden` on `html, body`; all scrolling is handled by internal scroll containers, and subpixel rounding on VDI machines was pushing layout past 100vh
- Move modal scrollbar styles (`scrollbar-color`, `-webkit-scrollbar`) from `GhaLogsModal.razor.css` into global `app.css` so the gray thin scrollbar applies to all Bootstrap modals on Windows
- Cap modal dialog height to `calc(100vh - 3.5rem)` and set `overflow: hidden` on `.modal-content` to prevent dialogs from barely exceeding the viewport and triggering a near-invisible scrollbar on the overlay
- Center the `NewPullRequestModal` vertically with `modal-dialog-centered`
- Fix `WorkspaceRepositories` state reload by calling `StateHasChanged` via `InvokeAsync` to avoid cross-thread Blazor dispatcher issues
- Move the dependency-badge tooltip to `-9999px` (off-screen) instead of `0,0` so it does not flash at the top-left corner before positioning; add `mouseenter` capture listener for activation
- Some changes are uncommitted only - commit and push before opening the PR