### PR TITLE
Add Update Branch flow to merge default into the current branch

### DIFF
--- a/src/GrayMoon.Agent/Abstractions/IGitService.cs
+++ b/src/GrayMoon.Agent/Abstractions/IGitService.cs
@@ -34,6 +34,13 @@ public interface IGitService
     Task<(bool Success, string? ErrorMessage)> PushAsync(string repoPath, string branchName, string? bearerToken, bool setTracking = false, CancellationToken ct = default);
     /// <summary>Aborts a merge in progress.</summary>
     Task AbortMergeAsync(string repoPath, CancellationToken ct);
+    /// <summary>
+    /// Merges <paramref name="remoteBranch"/> (e.g. "origin/main") into the current branch using
+    /// <c>git merge --no-edit</c>. Returns (Success, HasConflicts, ConflictFiles, ErrorMessage).
+    /// When <see cref="HasConflicts"/> is true the repo is left in MERGE_HEAD state for the user to
+    /// resolve; the caller must NOT abort - the user resolves in their IDE then commits.
+    /// </summary>
+    Task<(bool Success, bool HasConflicts, IReadOnlyList<string> ConflictFiles, string? ErrorMessage)> MergeFromRemoteAsync(string repoPath, string remoteBranch, CancellationToken ct);
     /// <summary>Gets all local branch names (without 'origin/' prefix).</summary>
     Task<IReadOnlyList<string>> GetLocalBranchesAsync(string repoPath, CancellationToken ct);
     /// <summary>Gets all remote branch names from local refs (refs/remotes/origin). Use after fetch to avoid ls-remote network call.</summary>

--- a/src/GrayMoon.Agent/Cli/Handlers/RunCommandHandler.cs
+++ b/src/GrayMoon.Agent/Cli/Handlers/RunCommandHandler.cs
@@ -130,6 +130,7 @@ internal static class RunCommandHandler
         builder.Services.AddSingleton<ICommandHandler<DotnetRestoreRequest, DotnetRestoreResponse>, DotnetRestoreCommand>();
         builder.Services.AddSingleton<ICommandHandler<UndoPushRequest, UndoPushResponse>, UndoPushCommand>();
         builder.Services.AddSingleton<ICommandHandler<SelfUpdateRequest, SelfUpdateResponse>, SelfUpdateCommand>();
+        builder.Services.AddSingleton<ICommandHandler<UpdateBranchFromDefaultRequest, UpdateBranchFromDefaultResponse>, UpdateBranchFromDefaultCommand>();
         builder.Services.AddSingleton<CheckoutHookSyncCommand>();
         builder.Services.AddSingleton<CommitHookSyncCommand>();
         builder.Services.AddSingleton<MergeHookSyncCommand>();

--- a/src/GrayMoon.Agent/Commands/UpdateBranchFromDefaultCommand.cs
+++ b/src/GrayMoon.Agent/Commands/UpdateBranchFromDefaultCommand.cs
@@ -1,0 +1,94 @@
+using GrayMoon.Agent.Abstractions;
+using GrayMoon.Agent.Jobs.Requests;
+using GrayMoon.Agent.Jobs.Response;
+using Microsoft.Extensions.Logging;
+
+namespace GrayMoon.Agent.Commands;
+
+public sealed class UpdateBranchFromDefaultCommand(IGitService git, ILogger<UpdateBranchFromDefaultCommand> logger) : ICommandHandler<UpdateBranchFromDefaultRequest, UpdateBranchFromDefaultResponse>
+{
+    public async Task<UpdateBranchFromDefaultResponse> ExecuteAsync(UpdateBranchFromDefaultRequest request, CancellationToken cancellationToken = default)
+    {
+        var workspaceName = request.WorkspaceName ?? throw new ArgumentException("workspaceName required");
+        var repositoryName = request.RepositoryName ?? throw new ArgumentException("repositoryName required");
+        var currentBranchName = request.CurrentBranchName ?? throw new ArgumentException("currentBranchName required");
+        var defaultBranchName = request.DefaultBranchName ?? throw new ArgumentException("defaultBranchName required");
+
+        var workspacePath = git.GetWorkspacePath(request.WorkspaceRoot!, workspaceName);
+        var repoPath = Path.Combine(workspacePath, repositoryName);
+
+        if (!git.DirectoryExists(repoPath))
+        {
+            return new UpdateBranchFromDefaultResponse
+            {
+                Success = false,
+                ErrorMessage = "Repository not found"
+            };
+        }
+
+        // Guard: refuse to start if a merge is already in progress (MERGE_HEAD exists).
+        var mergeHeadPath = Path.Combine(repoPath, ".git", "MERGE_HEAD");
+        if (File.Exists(mergeHeadPath))
+        {
+            logger.LogWarning("UpdateBranchFromDefault refused for {RepoPath}: MERGE_HEAD already present", repoPath);
+            return new UpdateBranchFromDefaultResponse
+            {
+                Success = false,
+                ErrorMessage = "A merge is already in progress. Resolve the conflicts in your IDE first, then commit."
+            };
+        }
+
+        // Step 1: Fetch only the default branch from origin (no tags needed, targeted for speed).
+        var remoteBranchRef = $"refs/heads/{defaultBranchName}:refs/remotes/origin/{defaultBranchName}";
+        var (fetchSuccess, fetchError) = await git.FetchAsync(repoPath, includeTags: false, request.BearerToken, cancellationToken);
+        if (!fetchSuccess)
+        {
+            return new UpdateBranchFromDefaultResponse
+            {
+                Success = false,
+                ErrorMessage = fetchError ?? "Failed to fetch from origin"
+            };
+        }
+
+        // Step 2: Merge origin/<defaultBranch> into the current branch.
+        var remoteBranch = $"origin/{defaultBranchName}";
+        var (mergeSuccess, hasConflicts, conflictFiles, mergeError) = await git.MergeFromRemoteAsync(repoPath, remoteBranch, cancellationToken);
+
+        if (hasConflicts)
+        {
+            logger.LogWarning("Merge conflicts in {RepoPath}: {Files}", repoPath, string.Join(", ", conflictFiles));
+            return new UpdateBranchFromDefaultResponse
+            {
+                Success = false,
+                HasConflicts = true,
+                ConflictFiles = conflictFiles
+            };
+        }
+
+        if (!mergeSuccess)
+        {
+            return new UpdateBranchFromDefaultResponse
+            {
+                Success = false,
+                ErrorMessage = mergeError ?? "Merge failed"
+            };
+        }
+
+        // Refresh commit counts so the UI can update divergence badges immediately.
+        // post-commit hook fires automatically for the merge commit and will send a full sync,
+        // but we return fresh counts here so the App can persist them without waiting.
+        var defaultRef = await git.GetDefaultBranchOriginRefAsync(repoPath, cancellationToken);
+        var (outgoing, incoming, _) = await git.GetCommitCountsAsync(repoPath, currentBranchName, defaultRef, cancellationToken);
+        var (defaultBehind, defaultAhead, _) = await git.GetCommitCountsVsDefaultAsync(repoPath, defaultRef, cancellationToken);
+
+        return new UpdateBranchFromDefaultResponse
+        {
+            Success = true,
+            HasConflicts = false,
+            OutgoingCommits = outgoing,
+            IncomingCommits = incoming,
+            DefaultBranchBehind = defaultBehind,
+            DefaultBranchAhead = defaultAhead
+        };
+    }
+}

--- a/src/GrayMoon.Agent/Jobs/Requests/UpdateBranchFromDefaultRequest.cs
+++ b/src/GrayMoon.Agent/Jobs/Requests/UpdateBranchFromDefaultRequest.cs
@@ -1,0 +1,21 @@
+using System.Text.Json.Serialization;
+
+namespace GrayMoon.Agent.Jobs.Requests;
+
+public sealed class UpdateBranchFromDefaultRequest : WorkspaceCommandRequest
+{
+    [JsonPropertyName("workspaceName")]
+    public string? WorkspaceName { get; set; }
+
+    [JsonPropertyName("repositoryName")]
+    public string? RepositoryName { get; set; }
+
+    [JsonPropertyName("currentBranchName")]
+    public string? CurrentBranchName { get; set; }
+
+    [JsonPropertyName("defaultBranchName")]
+    public string? DefaultBranchName { get; set; }
+
+    [JsonPropertyName("bearerToken")]
+    public string? BearerToken { get; set; }
+}

--- a/src/GrayMoon.Agent/Jobs/Response/UpdateBranchFromDefaultResponse.cs
+++ b/src/GrayMoon.Agent/Jobs/Response/UpdateBranchFromDefaultResponse.cs
@@ -1,0 +1,30 @@
+using System.Text.Json.Serialization;
+
+namespace GrayMoon.Agent.Jobs.Response;
+
+public sealed class UpdateBranchFromDefaultResponse
+{
+    [JsonPropertyName("success")]
+    public bool Success { get; set; }
+
+    [JsonPropertyName("hasConflicts")]
+    public bool HasConflicts { get; set; }
+
+    [JsonPropertyName("conflictFiles")]
+    public IReadOnlyList<string>? ConflictFiles { get; set; }
+
+    [JsonPropertyName("errorMessage")]
+    public string? ErrorMessage { get; set; }
+
+    [JsonPropertyName("outgoingCommits")]
+    public int? OutgoingCommits { get; set; }
+
+    [JsonPropertyName("incomingCommits")]
+    public int? IncomingCommits { get; set; }
+
+    [JsonPropertyName("defaultBranchBehind")]
+    public int? DefaultBranchBehind { get; set; }
+
+    [JsonPropertyName("defaultBranchAhead")]
+    public int? DefaultBranchAhead { get; set; }
+}

--- a/src/GrayMoon.Agent/Services/CommandDispatcher.cs
+++ b/src/GrayMoon.Agent/Services/CommandDispatcher.cs
@@ -34,7 +34,8 @@ public sealed class CommandDispatcher(
     ICommandHandler<DotnetRestoreRequest, DotnetRestoreResponse> dotnetRestoreCommand,
     ICommandHandler<UndoPushRequest, UndoPushResponse> undoPushCommand,
     ICommandHandler<SelfUpdateRequest, SelfUpdateResponse> selfUpdateCommand,
-    ICommandHandler<CheckFileVersionsRequest, CheckFileVersionsResponse> checkFileVersionsCommand) : ICommandDispatcher
+    ICommandHandler<CheckFileVersionsRequest, CheckFileVersionsResponse> checkFileVersionsCommand,
+    ICommandHandler<UpdateBranchFromDefaultRequest, UpdateBranchFromDefaultResponse> updateBranchFromDefaultCommand) : ICommandDispatcher
 {
     private readonly IReadOnlyDictionary<string, Func<object, CancellationToken, Task<object?>>> _executors = new Dictionary<string, Func<object, CancellationToken, Task<object?>>>(StringComparer.Ordinal)
     {
@@ -67,6 +68,7 @@ public sealed class CommandDispatcher(
         ["UndoPush"] = async (req, ct) => await undoPushCommand.ExecuteAsync((UndoPushRequest)req, ct),
         [AgentHubMethods.SelfUpdate] = async (req, ct) => await selfUpdateCommand.ExecuteAsync((SelfUpdateRequest)req, ct),
         [AgentHubMethods.CheckFileVersions] = async (req, ct) => await checkFileVersionsCommand.ExecuteAsync((CheckFileVersionsRequest)req, ct),
+        ["UpdateBranchFromDefault"] = async (req, ct) => await updateBranchFromDefaultCommand.ExecuteAsync((UpdateBranchFromDefaultRequest)req, ct),
     };
 
     public Task<object?> ExecuteAsync(string commandName, object request, CancellationToken cancellationToken = default)

--- a/src/GrayMoon.Agent/Services/CommandJobFactory.cs
+++ b/src/GrayMoon.Agent/Services/CommandJobFactory.cs
@@ -90,6 +90,8 @@ public sealed class CommandJobFactory
                 ?? throw new ArgumentException("Invalid SelfUpdate args"),
             AgentHubMethods.CheckFileVersions => JsonSerializer.Deserialize<CheckFileVersionsRequest>(json, options)
                 ?? throw new ArgumentException("Invalid CheckFileVersions args"),
+            "UpdateBranchFromDefault" => JsonSerializer.Deserialize<UpdateBranchFromDefaultRequest>(json, options)
+                ?? throw new ArgumentException("Invalid UpdateBranchFromDefault args"),
             _ => throw new NotSupportedException($"Unknown command: {command}")
         };
     }

--- a/src/GrayMoon.Agent/Services/GitService.cs
+++ b/src/GrayMoon.Agent/Services/GitService.cs
@@ -496,6 +496,50 @@ public sealed class GitService(IOptions<AgentOptions> options, ILogger<GitServic
             logger.LogInformation("Git merge aborted for {RepoPath}", repoPath);
     }
 
+    public async Task<(bool Success, bool HasConflicts, IReadOnlyList<string> ConflictFiles, string? ErrorMessage)> MergeFromRemoteAsync(string repoPath, string remoteBranch, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(repoPath) || !Directory.Exists(repoPath))
+            return (false, false, Array.Empty<string>(), "Invalid repository path");
+
+        var sw = Stopwatch.StartNew();
+        var (exitCode, stdout, stderr) = await runner.RunAsync("git", $"merge --no-edit {remoteBranch}", repoPath, ct);
+        sw.Stop();
+
+        if (exitCode == 0)
+        {
+            logger.LogInformation("Git merge completed in {ElapsedMs}ms for {RepoPath}. Branch={Branch}", sw.ElapsedMilliseconds, repoPath, remoteBranch);
+            return (true, false, Array.Empty<string>(), null);
+        }
+
+        // Exit code 1 with conflict markers = merge conflict; repo is left in MERGE_HEAD state.
+        if (GitResiliencePipelines.IsMergeConflict(stdout, stderr))
+        {
+            logger.LogWarning("Git merge conflict detected in {ElapsedMs}ms for {RepoPath}. Branch={Branch}", sw.ElapsedMilliseconds, repoPath, remoteBranch);
+            var conflictFiles = await GetConflictFilesAsync(repoPath, ct);
+            return (false, true, conflictFiles, null);
+        }
+
+        var combined = CombineOutput(stdout, stderr) ?? "Merge failed";
+        logger.LogError("Git merge failed in {ElapsedMs}ms for {RepoPath}. Branch={Branch}, ExitCode={ExitCode}, Stdout={Stdout}, Stderr={Stderr}", sw.ElapsedMilliseconds, repoPath, remoteBranch, exitCode, stdout, stderr);
+        return (false, false, Array.Empty<string>(), combined);
+    }
+
+    private async Task<IReadOnlyList<string>> GetConflictFilesAsync(string repoPath, CancellationToken ct)
+    {
+        var (exitCode, stdout, _) = await runner.RunAsync("git", "status --porcelain", repoPath, ct);
+        if (exitCode != 0 || string.IsNullOrWhiteSpace(stdout))
+            return Array.Empty<string>();
+
+        return stdout
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Where(line => line.Length >= 2 && (line[0] == 'U' || line[1] == 'U'
+                || (line[0] == 'A' && line[1] == 'A')
+                || (line[0] == 'D' && line[1] == 'D')))
+            .Select(line => line.Substring(3).Trim())
+            .Where(f => !string.IsNullOrWhiteSpace(f))
+            .ToList();
+    }
+
     public async Task<IReadOnlyList<string>> GetLocalBranchesAsync(string repoPath, CancellationToken ct)
     {
         if (string.IsNullOrWhiteSpace(repoPath) || !Directory.Exists(repoPath))

--- a/src/GrayMoon.App/Api/Endpoints/BranchEndpoints.cs
+++ b/src/GrayMoon.App/Api/Endpoints/BranchEndpoints.cs
@@ -23,6 +23,7 @@ public static class BranchEndpoints
         routes.MapPost("/api/branches/create", CreateBranch);
         routes.MapPost("/api/branches/set-upstream", SetUpstreamBranch);
         routes.MapPost("/api/branches/delete", DeleteBranch);
+        routes.MapPost("/api/branches/update-from-default", UpdateBranchFromDefault);
         return routes;
     }
 
@@ -749,6 +750,102 @@ public static class BranchEndpoints
             return Results.Problem("An error occurred while deleting branch", statusCode: 500);
         }
     }
+    private static async Task<IResult> UpdateBranchFromDefault(
+        UpdateBranchFromDefaultApiRequest? body,
+        IAgentBridge agentBridge,
+        WorkspaceService workspaceService,
+        WorkspaceRepository workspaceRepository,
+        GitHubRepositoryRepository repoRepository,
+        AppDbContext dbContext,
+        IHubContext<WorkspaceSyncHub> hubContext,
+        ConnectorHealthService connectorHealthService,
+        ILoggerFactory loggerFactory)
+    {
+        var logger = loggerFactory.CreateLogger("GrayMoon.App.Api.Branches");
+        if (body == null)
+            return Results.BadRequest("Request body is required.");
+
+        var workspaceId = body.WorkspaceId;
+        var repositoryId = body.RepositoryId;
+
+        if (workspaceId <= 0 || repositoryId <= 0)
+            return Results.BadRequest("workspaceId and repositoryId are required.");
+
+        var workspace = await workspaceRepository.GetByIdAsync(workspaceId);
+        if (workspace == null)
+            return Results.NotFound("Workspace not found.");
+
+        var repo = await repoRepository.GetByIdAsync(repositoryId);
+        if (repo == null)
+            return Results.NotFound("Repository not found.");
+
+        var wr = await dbContext.WorkspaceRepositories
+            .FirstOrDefaultAsync(wr => wr.WorkspaceId == workspaceId && wr.RepositoryId == repositoryId);
+        if (wr == null)
+            return Results.NotFound("Repository is not in the given workspace.");
+
+        if (!agentBridge.IsAgentConnected)
+            return Results.Problem("Agent not connected.", statusCode: 503);
+
+        try
+        {
+            await connectorHealthService.EnsureConnectorHealthyForRepositoryAsync(repo.RepositoryId, CancellationToken.None);
+
+            var workspaceRoot = await workspaceService.GetRootPathForWorkspaceAsync(workspace, CancellationToken.None);
+            var defaultBranchName = await dbContext.RepositoryBranches
+                .Where(rb => rb.WorkspaceRepositoryId == wr.WorkspaceRepositoryId && rb.IsDefault && !rb.IsTag)
+                .Select(rb => rb.BranchName)
+                .FirstOrDefaultAsync(CancellationToken.None) ?? "main";
+
+            var args = new
+            {
+                workspaceName = workspace.Name,
+                repositoryName = repo.RepositoryName,
+                currentBranchName = wr.BranchName,
+                defaultBranchName,
+                bearerToken = ConnectorHelpers.UnprotectToken(repo.Connector?.UserToken),
+                workspaceRoot
+            };
+            var response = await agentBridge.SendCommandAsync("UpdateBranchFromDefault", args, CancellationToken.None);
+
+            var updateResponse = AgentResponseJson.DeserializeAgentResponse<UpdateBranchFromDefaultResponse>(response.Data);
+            var commandSuccess = updateResponse?.Success ?? response.Success;
+
+            if (!commandSuccess && updateResponse?.HasConflicts != true)
+            {
+                var errorMessage = updateResponse?.ErrorMessage ?? response.Error ?? "Failed to update branch";
+                return Results.Problem(errorMessage, statusCode: 500);
+            }
+
+            // On clean merge: persist updated commit counts returned by the agent.
+            if (commandSuccess && updateResponse != null)
+            {
+                if (updateResponse.OutgoingCommits.HasValue)
+                    wr.OutgoingCommits = updateResponse.OutgoingCommits.Value;
+                if (updateResponse.IncomingCommits.HasValue)
+                    wr.IncomingCommits = updateResponse.IncomingCommits.Value;
+                if (updateResponse.DefaultBranchBehind.HasValue)
+                    wr.DefaultBranchBehindCommits = updateResponse.DefaultBranchBehind.Value;
+                if (updateResponse.DefaultBranchAhead.HasValue)
+                    wr.DefaultBranchAheadCommits = updateResponse.DefaultBranchAhead.Value;
+                await dbContext.SaveChangesAsync(CancellationToken.None);
+                await hubContext.Clients.All.SendAsync("WorkspaceSynced", workspaceId);
+            }
+
+            return Results.Ok(new
+            {
+                success = commandSuccess,
+                hasConflicts = updateResponse?.HasConflicts ?? false,
+                conflictFiles = updateResponse?.ConflictFiles ?? Array.Empty<string>()
+            });
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error updating branch from default for repository {RepositoryId}", repositoryId);
+            return Results.Problem("An error occurred while updating branch from default", statusCode: 500);
+        }
+    }
+
     private static async Task<IResult> GetCommonBranches(
         CommonBranchesApiRequest? body,
         WorkspaceRepository workspaceRepository,
@@ -937,5 +1034,39 @@ public sealed class DeleteBranchApiRequest
     public bool IsRemote { get; set; }
     /// <summary>When true, local delete uses git branch -D (after user confirmed not-fully-merged warning).</summary>
     public bool Force { get; set; }
+}
+
+public sealed class UpdateBranchFromDefaultApiRequest
+{
+    public int WorkspaceId { get; set; }
+    public int RepositoryId { get; set; }
+}
+
+/// <summary>Mirrors UpdateBranchFromDefaultResponse from the Agent for JSON deserialization on the App side.</summary>
+public sealed class UpdateBranchFromDefaultResponse
+{
+    [System.Text.Json.Serialization.JsonPropertyName("success")]
+    public bool Success { get; set; }
+
+    [System.Text.Json.Serialization.JsonPropertyName("hasConflicts")]
+    public bool HasConflicts { get; set; }
+
+    [System.Text.Json.Serialization.JsonPropertyName("conflictFiles")]
+    public IReadOnlyList<string>? ConflictFiles { get; set; }
+
+    [System.Text.Json.Serialization.JsonPropertyName("errorMessage")]
+    public string? ErrorMessage { get; set; }
+
+    [System.Text.Json.Serialization.JsonPropertyName("outgoingCommits")]
+    public int? OutgoingCommits { get; set; }
+
+    [System.Text.Json.Serialization.JsonPropertyName("incomingCommits")]
+    public int? IncomingCommits { get; set; }
+
+    [System.Text.Json.Serialization.JsonPropertyName("defaultBranchBehind")]
+    public int? DefaultBranchBehind { get; set; }
+
+    [System.Text.Json.Serialization.JsonPropertyName("defaultBranchAhead")]
+    public int? DefaultBranchAhead { get; set; }
 }
 

--- a/src/GrayMoon.App/Components/Modals/UpdateBranchModal.razor
+++ b/src/GrayMoon.App/Components/Modals/UpdateBranchModal.razor
@@ -1,0 +1,78 @@
+@using Microsoft.AspNetCore.Components.Web
+
+@if (IsVisible)
+{
+    <div class="modal show d-block" tabindex="-1" style="background-color: rgba(0,0,0,0.5); z-index: 1075;"
+         @onkeydown="HandleKeyDown"
+         @ref="_modalElement">
+        <div class="modal-dialog modal-dialog-centered">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Update Branch</h5>
+                    <button type="button" class="btn-close" aria-label="Close" @onclick="OnCancel"></button>
+                </div>
+                <div class="modal-body">
+                    <p class="mb-2">
+                        Update <strong>@CurrentBranch</strong> in <strong>@RepositoryName</strong> with the latest
+                        changes from <strong>@DefaultBranch</strong>
+                        (@CommitsBehind @(CommitsBehind == 1 ? "commit" : "commits") behind).
+                    </p>
+                    <p class="mb-2 text-muted small">The following will happen:</p>
+                    <ol class="mb-2 small">
+                        <li>Fetch the latest <strong>@DefaultBranch</strong> from origin.</li>
+                        <li>Merge <strong>origin/@DefaultBranch</strong> into <strong>@CurrentBranch</strong>.</li>
+                        <li>
+                            If the merge succeeds, your branch will have the latest changes and new outgoing commits ready to push.
+                        </li>
+                        <li>
+                            If there are merge conflicts, you will be notified and can resolve them in your IDE before committing.
+                        </li>
+                    </ol>
+                    <p class="mb-0 text-muted small">No automatic push - you stay in control.</p>
+                </div>
+                <div class="modal-footer">
+                    @if (!string.IsNullOrWhiteSpace(GitHubCompareUrl))
+                    {
+                        <a href="@GitHubCompareUrl" target="_blank" rel="noopener noreferrer"
+                           class="btn btn-outline-secondary me-auto">
+                            @CommitsBehind @(CommitsBehind == 1 ? "commit" : "commits")
+                        </a>
+                    }
+                    <button type="button" class="btn btn-primary" @onclick="OnConfirm">
+                        Update Branch
+                    </button>
+                    <button type="button" class="btn btn-outline-secondary" @onclick="OnCancel">
+                        Cancel
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+}
+
+@code {
+    [Parameter] public bool IsVisible { get; set; }
+    [Parameter] public string? RepositoryName { get; set; }
+    [Parameter] public string? CurrentBranch { get; set; }
+    [Parameter] public string? DefaultBranch { get; set; }
+    [Parameter] public int CommitsBehind { get; set; }
+    [Parameter] public string? GitHubCompareUrl { get; set; }
+    [Parameter] public EventCallback OnConfirm { get; set; }
+    [Parameter] public EventCallback OnCancel { get; set; }
+
+    private ElementReference _modalElement;
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (IsVisible)
+            await _modalElement.FocusAsync();
+    }
+
+    private async Task HandleKeyDown(KeyboardEventArgs e)
+    {
+        if (e.Key == "Escape")
+            await OnCancel.InvokeAsync();
+        else if (e.Key == "Enter")
+            await OnConfirm.InvokeAsync();
+    }
+}

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.Branches.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.Branches.cs
@@ -473,8 +473,8 @@ public sealed partial class WorkspaceRepositories
 
         StartPageJob($"Updating branch in {repoName}...", async (job, ct) =>
         {
-            var result = await ScopedExecutor.ExecuteAsync<WorkspaceBranchHandler, UpdateBranchFromDefaultResult>(
-                svc => svc.UpdateBranchFromDefaultAsync(WorkspaceId, repositoryId, ApiBaseUrl, ct));
+            var result = await ScopedExecutor.ExecuteAsync<WorkspaceBranchUpdateHandler, UpdateBranchFromDefaultResult>(
+                svc => svc.UpdateBranchFromDefaultAsync(WorkspaceId, repositoryId, ct));
 
             if (result.HasConflicts)
             {

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.Branches.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.Branches.cs
@@ -7,6 +7,7 @@ public sealed partial class WorkspaceRepositories
 {
     private SwitchBranchModalState _switchBranchModal = new();
     private BranchModalState _branchModal = new();
+    private UpdateBranchModalState _updateBranchModal = new();
 
     private void ShowSwitchBranchModal(int repositoryId, string? currentBranch, string? cloneUrl)
     {
@@ -400,5 +401,110 @@ public sealed partial class WorkspaceRepositories
         public string? CurrentBranch { get; init; }
         public string? RepositoryUrl { get; init; }
         public string? InitialTab { get; init; }
+    }
+
+    private sealed record UpdateBranchModalState
+    {
+        public bool IsVisible { get; init; }
+        public int RepositoryId { get; init; }
+        public string? RepositoryName { get; init; }
+        public string? CurrentBranch { get; init; }
+        public string? DefaultBranch { get; init; }
+        public int CommitsBehind { get; init; }
+        public string? GitHubCompareUrl { get; init; }
+    }
+
+    private void ShowUpdateBranchModal(int repositoryId)
+    {
+        var wr = TryGetLink(repositoryId);
+        var repo = wr?.Repository;
+        if (wr == null || repo == null || string.IsNullOrWhiteSpace(wr.BranchName) || wr.IsOnTag)
+            return;
+
+        var repoUrl = RepositoryUrlHelper.GetRepositoryUrl(repo.CloneUrl);
+        var currentBranch = wr.BranchName;
+        var defaultBranch = wr.DefaultBranchName ?? "default";
+        string? compareUrl = null;
+        if (!string.IsNullOrWhiteSpace(repoUrl) && !string.IsNullOrWhiteSpace(currentBranch))
+        {
+            var encBranch = Uri.EscapeDataString(currentBranch);
+            var encDefault = Uri.EscapeDataString(defaultBranch);
+            compareUrl = $"{repoUrl}/compare/{encBranch}...{encDefault}";
+        }
+
+        _updateBranchModal = _updateBranchModal with
+        {
+            IsVisible = true,
+            RepositoryId = repositoryId,
+            RepositoryName = repo.RepositoryName,
+            CurrentBranch = currentBranch,
+            DefaultBranch = defaultBranch,
+            CommitsBehind = wr.DefaultBranchBehindCommits ?? 0,
+            GitHubCompareUrl = compareUrl
+        };
+        StateHasChanged();
+    }
+
+    private void CloseUpdateBranchModal()
+    {
+        _updateBranchModal = _updateBranchModal with
+        {
+            IsVisible = false,
+            RepositoryId = 0,
+            RepositoryName = null,
+            CurrentBranch = null,
+            DefaultBranch = null,
+            CommitsBehind = 0,
+            GitHubCompareUrl = null
+        };
+    }
+
+    private Task OnUpdateBranchConfirmedAsync()
+    {
+        var repositoryId = _updateBranchModal.RepositoryId;
+        var repoName = _updateBranchModal.RepositoryName;
+        if (workspace == null || repositoryId <= 0)
+        {
+            CloseUpdateBranchModal();
+            return Task.CompletedTask;
+        }
+
+        CloseUpdateBranchModal();
+
+        StartPageJob($"Updating branch in {repoName}...", async (job, ct) =>
+        {
+            var result = await ScopedExecutor.ExecuteAsync<WorkspaceBranchHandler, UpdateBranchFromDefaultResult>(
+                svc => svc.UpdateBranchFromDefaultAsync(WorkspaceId, repositoryId, ApiBaseUrl, ct));
+
+            if (result.HasConflicts)
+            {
+                var fileList = result.ConflictFiles.Count > 0
+                    ? string.Join(", ", result.ConflictFiles)
+                    : "unknown files";
+                var conflictCount = result.ConflictFiles.Count;
+                SafeInvoke(() => ToastService.ShowError(
+                    $"Merge conflict in {conflictCount} {(conflictCount == 1 ? "file" : "files")}: {fileList}. " +
+                    "Resolve the conflicts in your IDE, then commit."));
+            }
+            else if (!result.Success)
+            {
+                var message = result.ErrorMessage ?? "Failed to update branch. The GrayMoon Agent may be offline.";
+                SafeInvoke(() => ToastService.ShowError(message));
+            }
+            else
+            {
+                SafeInvoke(() => ToastService.Show($"Branch updated successfully."));
+            }
+        }, new PageJobOptions
+        {
+            RefreshOnSuccess = false,
+            OnError = ex =>
+            {
+                Logger.LogError(ex, "Error updating branch from default for repository {RepositoryId}", repositoryId);
+                SafeInvoke(() => ToastService.ShowError("An error occurred while updating branch."));
+            }
+        });
+
+        return Task.CompletedTask;
     }
 }

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor
@@ -167,6 +167,7 @@
                                                                   OnVersionClick="() => CopyVersionToClipboard(wr.GitVersion!)"
                                                                   OnVersionMouseLeave="() => OnVersionMouseLeave(wr.GitVersion!)"
                                                                   OnBranchClick="() => ShowSwitchBranchModal(wr.RepositoryId, wr.BranchName, wr.Repository?.CloneUrl)"
+                                                                  OnUpdateBranchClick="() => ShowUpdateBranchModal(wr.RepositoryId)"
                                                                   OnDependencyBadgeClick="() => OnDependencyBadgeClick(wr.RepositoryId, wr.UnmatchedDeps ?? 0)"
                                                                   OnCustomDependenciesClick="() => ShowCustomDependenciesModalAsync(wr.RepositoryId)"
                                                                   OnFileDependencyBadgeClick="() => OnFileDependencyBadgeClick(wr.RepositoryId)"
@@ -245,6 +246,15 @@
                    OnCheckoutBranch="@CheckoutBranchAsync"
                    OnSyncToDefault="@SyncToDefaultFromModalAsync"
                    OnCreateBranch="@CreateSingleBranchAsync" />
+
+<UpdateBranchModal IsVisible="@_updateBranchModal.IsVisible"
+                  RepositoryName="@_updateBranchModal.RepositoryName"
+                  CurrentBranch="@_updateBranchModal.CurrentBranch"
+                  DefaultBranch="@_updateBranchModal.DefaultBranch"
+                  CommitsBehind="@_updateBranchModal.CommitsBehind"
+                  GitHubCompareUrl="@_updateBranchModal.GitHubCompareUrl"
+                  OnConfirm="@OnUpdateBranchConfirmedAsync"
+                  OnCancel="@CloseUpdateBranchModal" />
 
 <UpdateDependenciesModal IsVisible="@_updateModal.IsVisible"
                          IsBusy="@IsJobRunning"

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositoriesRow.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositoriesRow.razor
@@ -83,7 +83,8 @@
                                     BranchName="@Link.BranchName"
                                     RepositoryUrl="@RepositoryUrlHelper.GetRepositoryUrl(repo.CloneUrl)"
                                     DefaultBranchName="@Link.DefaultBranchName"
-                                    IsOnTag="@Link.IsOnTag" />
+                                    IsOnTag="@Link.IsOnTag"
+                                    OnUpdateBranchClick="@OnUpdateBranchClick" />
                 </span>
                 <span class="metrics-block metrics-pr text-nowrap"
                       @onmouseenter="HandlePrBadgeMouseEnter">
@@ -432,6 +433,7 @@
     [Parameter] public EventCallback OnDependencyBadgeMouseLeave { get; set; }
     [Parameter] public EventCallback OnPushBadgeClick { get; set; }
     [Parameter] public EventCallback OnPullBadgeClick { get; set; }
+    [Parameter] public EventCallback OnUpdateBranchClick { get; set; }
     [Parameter] public EventCallback OnSyncClick { get; set; }
     [Parameter] public EventCallback OnDismissError { get; set; }
     [Parameter] public EventCallback OnPrBadgeMouseEnter { get; set; }

--- a/src/GrayMoon.App/Components/Shared/DivergenceBadge.razor
+++ b/src/GrayMoon.App/Components/Shared/DivergenceBadge.razor
@@ -41,7 +41,11 @@
                     ? "This branch is 1 commit behind the default branch"
                     : $"This branch is {behind} commits behind the default branch");
 
-            if (!string.IsNullOrWhiteSpace(behindUrl))
+            @if (behind > 0 && OnUpdateBranchClick.HasDelegate)
+            {
+                <button type="button" class="divergence-link divergence-link-behind divergence-link-behind--actionable" title="@behindTitle" @onclick="OnUpdateBranchClick">@behind</button>
+            }
+            else if (!string.IsNullOrWhiteSpace(behindUrl))
             {
                 <a href="@behindUrl" target="_blank" rel="noopener noreferrer" class="divergence-link divergence-link-behind" title="@behindTitle">@behind</a>
             }
@@ -70,4 +74,6 @@
     [Parameter] public string? DefaultBranchName { get; set; }
     /// <summary>True when the repository is checked out at a tag (detached HEAD); divergence vs. default branch is not meaningful, render blank.</summary>
     [Parameter] public bool IsOnTag { get; set; }
+    /// <summary>When set, the behind count renders as an actionable red button that invokes this callback instead of opening GitHub.</summary>
+    [Parameter] public EventCallback OnUpdateBranchClick { get; set; }
 }

--- a/src/GrayMoon.App/Program.cs
+++ b/src/GrayMoon.App/Program.cs
@@ -88,6 +88,7 @@ try
     builder.Services.AddScoped<IWorkspaceFileSearchService, WorkspaceFileSearchService>();
     builder.Services.AddScoped<WorkspaceFileVersionService>();
     builder.Services.AddScoped<WorkspaceCommitSyncHandler>();
+    builder.Services.AddScoped<WorkspaceBranchUpdateHandler>();
     builder.Services.AddScoped<WorkspaceSyncHandler>();
     builder.Services.AddScoped<DependencyUpdateOrchestrator>();
     builder.Services.AddScoped<WorkspaceUpdateHandler>();

--- a/src/GrayMoon.App/Services/WorkspaceBranchHandler.cs
+++ b/src/GrayMoon.App/Services/WorkspaceBranchHandler.cs
@@ -315,6 +315,36 @@ public sealed class WorkspaceBranchHandler(
         var failureCount = errors.Count;
         return new WorkspaceBranchBulkResult(total - failureCount, failureCount, new Dictionary<int, string>(errors));
     }
+
+    public async Task<UpdateBranchFromDefaultResult> UpdateBranchFromDefaultAsync(int workspaceId, int repositoryId, string apiBaseUrl, CancellationToken cancellationToken)
+    {
+        var httpClient = httpClientFactory.CreateClient();
+        var request = new { workspaceId, repositoryId };
+        var json = JsonSerializer.Serialize(request);
+        using var content = new StringContent(json, System.Text.Encoding.UTF8, "application/json");
+
+        using var response = await httpClient.PostAsync($"{apiBaseUrl}/api/branches/update-from-default", content, cancellationToken);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            var errorText = await response.Content.ReadAsStringAsync(cancellationToken);
+            var message = ApiErrorHelper.TryGetErrorMessageFromResponseBody(errorText)
+                ?? $"Request failed: {response.StatusCode}";
+            logger.LogWarning("UpdateBranchFromDefault failed for repository {RepositoryId}: {Error}", repositoryId, message);
+            return new UpdateBranchFromDefaultResult(false, false, Array.Empty<string>(), message);
+        }
+
+        var responseContent = await response.Content.ReadAsStringAsync(cancellationToken);
+        var result = JsonSerializer.Deserialize<UpdateBranchFromDefaultApiResult>(responseContent, AgentResponseJson.Options);
+        if (result == null)
+            return new UpdateBranchFromDefaultResult(false, false, Array.Empty<string>(), "Invalid response from server");
+
+        return new UpdateBranchFromDefaultResult(
+            result.Success,
+            result.HasConflicts,
+            result.ConflictFiles ?? Array.Empty<string>(),
+            null);
+    }
 }
 
 public sealed record WorkspaceBranchBulkResult(
@@ -323,5 +353,24 @@ public sealed record WorkspaceBranchBulkResult(
     IReadOnlyDictionary<int, string> ErrorsByRepositoryId)
 {
     public static WorkspaceBranchBulkResult Empty { get; } = new(0, 0, new Dictionary<int, string>());
+}
+
+public sealed record UpdateBranchFromDefaultResult(
+    bool Success,
+    bool HasConflicts,
+    IReadOnlyList<string> ConflictFiles,
+    string? ErrorMessage);
+
+/// <summary>Mirrors the JSON returned by POST /api/branches/update-from-default.</summary>
+internal sealed class UpdateBranchFromDefaultApiResult
+{
+    [System.Text.Json.Serialization.JsonPropertyName("success")]
+    public bool Success { get; set; }
+
+    [System.Text.Json.Serialization.JsonPropertyName("hasConflicts")]
+    public bool HasConflicts { get; set; }
+
+    [System.Text.Json.Serialization.JsonPropertyName("conflictFiles")]
+    public IReadOnlyList<string>? ConflictFiles { get; set; }
 }
 

--- a/src/GrayMoon.App/Services/WorkspaceBranchUpdateHandler.cs
+++ b/src/GrayMoon.App/Services/WorkspaceBranchUpdateHandler.cs
@@ -1,0 +1,112 @@
+using GrayMoon.App.Api.Endpoints;
+using GrayMoon.App.Data;
+using GrayMoon.App.Hubs;
+using GrayMoon.App.Models;
+using GrayMoon.App.Models.Api;
+using GrayMoon.App.Repositories;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.EntityFrameworkCore;
+
+namespace GrayMoon.App.Services;
+
+/// <summary>
+/// Handles the "Update Branch from Default" operation.
+/// Calls the agent directly so CommandOutput streams to TerminalSinkContext when invoked inside a background job.
+/// Stateless; all UI state is provided by the caller via callbacks.
+/// </summary>
+public sealed class WorkspaceBranchUpdateHandler(
+    IAgentBridge agentBridge,
+    WorkspaceRepository workspaceRepository,
+    GitHubRepositoryRepository repoRepository,
+    WorkspaceService workspaceService,
+    ConnectorHealthService connectorHealthService,
+    AppDbContext dbContext,
+    IHubContext<WorkspaceSyncHub> hubContext,
+    ILogger<WorkspaceBranchUpdateHandler> logger)
+{
+    public async Task<UpdateBranchFromDefaultResult> UpdateBranchFromDefaultAsync(
+        int workspaceId,
+        int repositoryId,
+        CancellationToken cancellationToken)
+    {
+        var workspace = await workspaceRepository.GetByIdAsync(workspaceId);
+        if (workspace == null)
+            return new UpdateBranchFromDefaultResult(false, false, Array.Empty<string>(), "Workspace not found.");
+
+        var repo = await repoRepository.GetByIdAsync(repositoryId, cancellationToken);
+        if (repo == null)
+            return new UpdateBranchFromDefaultResult(false, false, Array.Empty<string>(), "Repository not found.");
+
+        var wr = await dbContext.WorkspaceRepositories
+            .FirstOrDefaultAsync(w => w.WorkspaceId == workspaceId && w.RepositoryId == repositoryId, cancellationToken);
+        if (wr == null)
+            return new UpdateBranchFromDefaultResult(false, false, Array.Empty<string>(), "Repository is not in the given workspace.");
+
+        if (!agentBridge.IsAgentConnected)
+            return new UpdateBranchFromDefaultResult(false, false, Array.Empty<string>(), "Agent not connected. Start GrayMoon.Agent and try again.");
+
+        try
+        {
+            await connectorHealthService.EnsureConnectorHealthyForRepositoryAsync(repo.RepositoryId, cancellationToken);
+
+            var workspaceRoot = await workspaceService.GetRootPathForWorkspaceAsync(workspace, cancellationToken);
+            var defaultBranchName = await dbContext.RepositoryBranches
+                .Where(rb => rb.WorkspaceRepositoryId == wr.WorkspaceRepositoryId && rb.IsDefault && !rb.IsTag)
+                .Select(rb => rb.BranchName)
+                .FirstOrDefaultAsync(cancellationToken) ?? "main";
+
+            var args = new
+            {
+                workspaceName = workspace.Name,
+                repositoryName = repo.RepositoryName,
+                currentBranchName = wr.BranchName,
+                defaultBranchName,
+                bearerToken = ConnectorHelpers.UnprotectToken(repo.Connector?.UserToken),
+                workspaceRoot
+            };
+
+            // AgentBridge.SendCommandAsync reads TerminalSinkContext.Current (set by BackgroundJobService.StartJob)
+            // so all git output streams to the loading overlay terminal automatically.
+            var response = await agentBridge.SendCommandAsync("UpdateBranchFromDefault", args, cancellationToken);
+
+            var updateResponse = AgentResponseJson.DeserializeAgentResponse<UpdateBranchFromDefaultResponse>(response.Data);
+            var commandSuccess = updateResponse?.Success ?? response.Success;
+
+            if (!commandSuccess && updateResponse?.HasConflicts != true)
+            {
+                var errorMessage = updateResponse?.ErrorMessage ?? response.Error ?? "Failed to update branch.";
+                logger.LogWarning("UpdateBranchFromDefault failed for repository {RepositoryId}: {Error}", repositoryId, errorMessage);
+                return new UpdateBranchFromDefaultResult(false, false, Array.Empty<string>(), errorMessage);
+            }
+
+            if (commandSuccess && updateResponse != null)
+            {
+                if (updateResponse.OutgoingCommits.HasValue)
+                    wr.OutgoingCommits = updateResponse.OutgoingCommits.Value;
+                if (updateResponse.IncomingCommits.HasValue)
+                    wr.IncomingCommits = updateResponse.IncomingCommits.Value;
+                if (updateResponse.DefaultBranchBehind.HasValue)
+                    wr.DefaultBranchBehindCommits = updateResponse.DefaultBranchBehind.Value;
+                if (updateResponse.DefaultBranchAhead.HasValue)
+                    wr.DefaultBranchAheadCommits = updateResponse.DefaultBranchAhead.Value;
+                await dbContext.SaveChangesAsync(cancellationToken);
+                await hubContext.Clients.All.SendAsync("WorkspaceSynced", workspaceId, cancellationToken);
+            }
+
+            return new UpdateBranchFromDefaultResult(
+                commandSuccess,
+                updateResponse?.HasConflicts ?? false,
+                updateResponse?.ConflictFiles ?? Array.Empty<string>(),
+                null);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error updating branch from default for repository {RepositoryId}", repositoryId);
+            return new UpdateBranchFromDefaultResult(false, false, Array.Empty<string>(), "An unexpected error occurred while updating branch.");
+        }
+    }
+}

--- a/src/GrayMoon.App/wwwroot/app.css
+++ b/src/GrayMoon.App/wwwroot/app.css
@@ -1099,11 +1099,11 @@ table.resizable-columns th:hover .resize-handle::after {
     box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
 }
 
-/* Red actionable style for the behind count when update-branch is available */
+/* Yellow actionable style for the behind count when update-branch is available */
 .repositories-table td.col-divergence .divergence-link-behind--actionable {
-    background-color: #dc3545;
-    color: #fff !important;
-    border-color: #dc3545;
+    background-color: #ffc107;
+    color: #000 !important;
+    border-color: #ffc107;
     font-weight: 500;
     /* Reset button defaults */
     font-size: inherit;
@@ -1112,9 +1112,9 @@ table.resizable-columns th:hover .resize-handle::after {
 }
 
 .repositories-table td.col-divergence .divergence-link-behind--actionable:hover {
-    background-color: #b02a37;
-    color: #fff !important;
-    border-color: #a52834;
+    background-color: #e0a800;
+    color: #000 !important;
+    border-color: #d39e00;
     box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
 }
 

--- a/src/GrayMoon.App/wwwroot/app.css
+++ b/src/GrayMoon.App/wwwroot/app.css
@@ -1100,7 +1100,13 @@ table.resizable-columns th:hover .resize-handle::after {
 }
 
 /* Yellow actionable style for the behind count when update-branch is available */
-.repositories-table td.col-divergence .divergence-link-behind--actionable {
+.repositories-table td.col-divergence .divergence-link.divergence-link-behind--actionable,
+.repositories-table td.col-divergence .divergence-link.divergence-link-behind--actionable:link,
+.repositories-table td.col-divergence .divergence-link.divergence-link-behind--actionable:visited,
+.repositories-table td.col-divergence .divergence-link.divergence-link-behind--actionable:focus,
+.repositories-table td.col-divergence .divergence-link.divergence-link-behind--actionable:focus-visible,
+.repositories-table td.col-divergence .divergence-link.divergence-link-behind--actionable:hover,
+.repositories-table td.col-divergence .divergence-link.divergence-link-behind--actionable:active {
     background-color: #ffc107;
     color: #000 !important;
     border-color: #ffc107;
@@ -1111,9 +1117,9 @@ table.resizable-columns th:hover .resize-handle::after {
     line-height: inherit;
 }
 
-.repositories-table td.col-divergence .divergence-link-behind--actionable:hover {
+.repositories-table td.col-divergence .divergence-link.divergence-link-behind--actionable:hover,
+.repositories-table td.col-divergence .divergence-link.divergence-link-behind--actionable:focus-visible {
     background-color: #e0a800;
-    color: #000 !important;
     border-color: #d39e00;
     box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
 }

--- a/src/GrayMoon.App/wwwroot/app.css
+++ b/src/GrayMoon.App/wwwroot/app.css
@@ -1099,6 +1099,25 @@ table.resizable-columns th:hover .resize-handle::after {
     box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
 }
 
+/* Red actionable style for the behind count when update-branch is available */
+.repositories-table td.col-divergence .divergence-link-behind--actionable {
+    background-color: #dc3545;
+    color: #fff !important;
+    border-color: #dc3545;
+    font-weight: 500;
+    /* Reset button defaults */
+    font-size: inherit;
+    font-family: inherit;
+    line-height: inherit;
+}
+
+.repositories-table td.col-divergence .divergence-link-behind--actionable:hover {
+    background-color: #b02a37;
+    color: #fff !important;
+    border-color: #a52834;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+}
+
 /* PR column badges - white text except create (black on yellow) */
 .repositories-table td.col-pr .pr-badge {
     font-weight: 400;


### PR DESCRIPTION
## Summary

- Add an agent command that fetches the remote default branch and merges it into the current branch, leaving conflicts for IDE resolution instead of auto-aborting
- Wire App UI so the behind-count divergence badge opens a confirmation modal (with GitHub compare link) and runs the merge under the loading overlay with live terminal output
- Style the actionable behind badge as yellow with black text so it reads as attention, not an error; no auto-push after a successful merge
- Some local edits may be uncommitted only - commit and push before opening the PR

## Test plan

- [ ] Click a yellow behind-count badge and confirm the modal explains fetch/merge and the commit-count link opens the GitHub compare view
- [ ] Run Update Branch with no conflicts and verify the loading overlay/terminal shows git output, divergence updates, and outgoing commits appear without an auto-push
- [ ] Run Update Branch into a conflicted merge and confirm conflict notification lists files, MERGE_HEAD remains for IDE resolve, and a second attempt is refused while merge is in progress