### PR TITLE
Fix workspace reload races and polish switch-branch Create flow

### DIFF
--- a/src/GrayMoon.App.Tests/ListQueryTestContext.cs
+++ b/src/GrayMoon.App.Tests/ListQueryTestContext.cs
@@ -15,13 +15,13 @@ public sealed class ListQueryTestContext : IAsyncDisposable
     public WorkspaceProjectListQueryService ProjectQuery { get; }
     public WorkspaceRepositoryLinkListQueryService WorkspaceRepoLinkQuery { get; }
 
-    private ListQueryTestContext(SqliteConnection connection, AppDbContext dbContext)
+    private ListQueryTestContext(SqliteConnection connection, AppDbContext dbContext, DbContextOptions<AppDbContext> options)
     {
         _connection = connection;
         DbContext = dbContext;
         RepositoryQuery = new RepositoryListQueryService(dbContext);
         ProjectQuery = new WorkspaceProjectListQueryService(dbContext);
-        WorkspaceRepoLinkQuery = new WorkspaceRepositoryLinkListQueryService(dbContext);
+        WorkspaceRepoLinkQuery = new WorkspaceRepositoryLinkListQueryService(new TestDbContextFactory(options));
     }
 
     public static async Task<ListQueryTestContext> CreateAsync(int repositoryCount = 120)
@@ -105,7 +105,7 @@ public sealed class ListQueryTestContext : IAsyncDisposable
         }
 
         await dbContext.SaveChangesAsync();
-        return new ListQueryTestContext(connection, dbContext);
+        return new ListQueryTestContext(connection, dbContext, options);
     }
 
     public static async Task<(ListQueryTestContext Context, int WorkspaceId)> CreateWithWorkspaceLinksAsync(int repositoryCount = 120)
@@ -119,5 +119,10 @@ public sealed class ListQueryTestContext : IAsyncDisposable
     {
         await DbContext.DisposeAsync();
         await _connection.DisposeAsync();
+    }
+
+    private sealed class TestDbContextFactory(DbContextOptions<AppDbContext> options) : IDbContextFactory<AppDbContext>
+    {
+        public AppDbContext CreateDbContext() => new(options);
     }
 }

--- a/src/GrayMoon.App/Components/Modals/SwitchBranchModal.razor
+++ b/src/GrayMoon.App/Components/Modals/SwitchBranchModal.razor
@@ -127,13 +127,7 @@
                                 {
                                     @if (GetFilteredLocalBranches().Count() == 0)
                                     {
-                                        <div class="d-flex align-items-center justify-content-between px-3 py-3 text-muted">
-                                            <span>@(localBranches.Count == 0 ? "No local branches found." : "No branches match the filter.")</span>
-                                            @if (localBranches.Count > 0 && !string.IsNullOrWhiteSpace(branchFilter))
-                                            {
-                                                <button type="button" class="btn btn-secondary btn-sm" @onclick="CreateFromFilter" @onclick:stopPropagation="true">Create</button>
-                                            }
-                                        </div>
+                                        <div class="text-muted p-3">@(localBranches.Count == 0 ? "No local branches found." : "No branches match the filter.")</div>
                                     }
                                     else
                                     {
@@ -441,6 +435,15 @@
                                     Create
                                 </button>
                             }
+                        }
+                        else if (CanCreateFromFilter())
+                        {
+                            <button type="button"
+                                    class="btn btn-primary"
+                                    @onclick="CreateFromFilter"
+                                    disabled="@isRefreshing">
+                                Create
+                            </button>
                         }
                         else
                         {
@@ -773,6 +776,13 @@
             selectedBranch = null;
         StateHasChanged();
     }
+
+    /// <summary>True when Locals filter matched no branches so the footer can offer Create instead of Check out.</summary>
+    private bool CanCreateFromFilter() =>
+        activeTab == "local"
+        && localBranches.Count > 0
+        && !string.IsNullOrWhiteSpace(branchFilter)
+        && GetFilteredLocalBranches().Count() == 0;
 
     /// <summary>Copy filter text to New branch name and switch to New Branch tab (when Locals filter matched no branches).</summary>
     private void CreateFromFilter()
@@ -1143,7 +1153,7 @@
         if (activeTab == "newbranch" || isRefreshing)
             return;
         // Locals tab: when filter matched no branches, Enter opens New Branch with filter text as name
-        if (activeTab == "local" && localBranches.Count > 0 && GetFilteredLocalBranches().Count() == 0)
+        if (CanCreateFromFilter())
         {
             _suppressNextEnterForNewBranch = true;
             CreateFromFilter();

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.Branches.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.Branches.cs
@@ -497,7 +497,6 @@ public sealed partial class WorkspaceRepositories
             }
         }, new PageJobOptions
         {
-            RefreshOnSuccess = false,
             OnError = ex =>
             {
                 Logger.LogError(ex, "Error updating branch from default for repository {RepositoryId}", repositoryId);

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.Loading.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.Loading.cs
@@ -51,50 +51,64 @@ public sealed partial class WorkspaceRepositories
             isInitialLoading = false;
             return;
         }
-        var token = _queryLoader.BeginQueryCycle(out var generation);
-        ClearGridState();
-        isInitialLoading = true;
-        _virtualScrollAttached = false;
+
+        await _reloadGate.WaitAsync();
+        var generation = 0;
         try
         {
-            var filter = new WorkspaceRepositoryLinkListFilter(WorkspaceId, _effectiveSearch);
-            await LoadHeaderStateAsync(token);
-            totalCount = await LinkListQueryService.CountAsync(filter, token);
-            var index = await LinkListQueryService.GetIndexAsync(filter, token);
-            if (generation != _queryLoader.Generation || _disposed)
+            if (_disposed)
             {
                 return;
             }
-            BuildSlots(index);
-            hasLoadedOnce = true;
-            _loadedWorkspaceId = WorkspaceId;
-            var initialEnd = Math.Min(_slots.Count - 1, VirtualInitialViewportSlots - 1);
-            UpdateVisibleRange(0, Math.Max(-1, initialEnd));
-            await EnsureSlotsHydratedAsync(0, initialEnd, token);
-            if (generation != _queryLoader.Generation || _disposed)
+            var token = _queryLoader.BeginQueryCycle(out generation);
+            ClearGridState();
+            isInitialLoading = true;
+            _virtualScrollAttached = false;
+            try
             {
-                return;
+                var filter = new WorkspaceRepositoryLinkListFilter(WorkspaceId, _effectiveSearch);
+                await LoadHeaderStateAsync(token);
+                totalCount = await LinkListQueryService.CountAsync(filter, token);
+                var index = await LinkListQueryService.GetIndexAsync(filter, token);
+                if (generation != _queryLoader.Generation || _disposed)
+                {
+                    return;
+                }
+                BuildSlots(index);
+                hasLoadedOnce = true;
+                _loadedWorkspaceId = WorkspaceId;
+                var initialEnd = Math.Min(_slots.Count - 1, VirtualInitialViewportSlots - 1);
+                UpdateVisibleRange(0, Math.Max(-1, initialEnd));
+                await EnsureSlotsHydratedAsync(0, initialEnd, token);
+                if (generation != _queryLoader.Generation || _disposed)
+                {
+                    return;
+                }
+                ApplySyncStateFromLoadedItems();
             }
-            ApplySyncStateFromLoadedItems();
-        }
-        catch (OperationCanceledException)
-        {
-        }
-        catch (Exception ex)
-        {
-            if (generation == _queryLoader.Generation && !_disposed)
+            catch (OperationCanceledException)
             {
-                Logger.LogError(ex, "Error loading repositories for workspace {WorkspaceId}", WorkspaceId);
-                errorMessage = "Failed to load workspace. Please try again later.";
-                ClearGridState();
+            }
+            catch (Exception ex)
+            {
+                if (generation == _queryLoader.Generation && !_disposed)
+                {
+                    Logger.LogError(ex, "Error loading repositories for workspace {WorkspaceId}", WorkspaceId);
+                    errorMessage = "Failed to load workspace. Please try again later.";
+                    ClearGridState();
+                }
+            }
+            finally
+            {
+                if (generation == _queryLoader.Generation && !_disposed)
+                {
+                    isInitialLoading = false;
+                }
             }
         }
         finally
         {
-            if (generation == _queryLoader.Generation && !_disposed)
-            {
-                isInitialLoading = false;
-            }
+            _reloadGate.Release();
         }
     }
     private async Task<bool> EnsureSlotsHydratedAsync(int start, int end, CancellationToken cancellationToken)
@@ -303,13 +317,19 @@ public sealed partial class WorkspaceRepositories
             Logger.LogDebug(ex, "Branch refresh after PR merge failed for RepositoryId={RepositoryId}", repositoryId);
         }
     }
-    /// <summary>Reload workspace after abort/cancel using a fresh scope. Safe to call from background job bodies. Swallows disposal exceptions so abort does not cascade errors when the circuit or context is already disposed.</summary>
+    /// <summary>Reload workspace after abort/cancel using a fresh scope. Safe to call from background job bodies. Marshals the reload onto the Blazor dispatcher so it does not race circuit-scoped DbContext use. Swallows disposal exceptions so abort does not cascade errors when the circuit or context is already disposed.</summary>
     private async Task ReloadWorkspaceDataAfterCancelAsync()
     {
         if (_disposed) return;
         try
         {
-            await ReloadWorkspaceDataFromFreshScopeAsync();
+            await InvokeAsync(async () =>
+            {
+                if (_disposed) return;
+                await ReloadWorkspaceDataFromFreshScopeAsync();
+                ApplySyncStateFromLoadedItems();
+                StateHasChanged();
+            });
         }
         catch (ObjectDisposedException ex)
         {
@@ -319,12 +339,6 @@ public sealed partial class WorkspaceRepositories
         {
             Logger.LogDebug(ex, "Reload after cancel skipped (invalid operation, e.g. circuit disposed) for workspace {WorkspaceId}", WorkspaceId);
         }
-        try
-        {
-            await InvokeAsync(() => { if (!_disposed) { ApplySyncStateFromLoadedItems(); StateHasChanged(); } });
-        }
-        catch (ObjectDisposedException) { }
-        catch (InvalidOperationException) { }
     }
     /// <summary>Loads workspace using a new scope (fresh DbContext) so we get current DB values and avoid EF cache. Used by RefreshFromSync so the grid shows updated UnmatchedDeps after notify or Update.</summary>
     private async Task ReloadWorkspaceDataFromFreshScopeAsync()
@@ -344,60 +358,69 @@ public sealed partial class WorkspaceRepositories
     private async Task RefreshFromSync()
     {
         if (_disposed) return;
+        await _reloadGate.WaitAsync();
         try
         {
-            var token = _queryLoader.GetQueryToken();
-            var w = await ScopedExecutor.ExecuteAsync<WorkspaceRepository, Workspace?>(
-                repo => repo.GetHeaderAsync(WorkspaceId));
-            if (w == null)
-            {
-                errorMessage = "Workspace not found.";
-                ClearGridState();
-                await InvokeAsync(StateHasChanged);
-                return;
-            }
-            workspace = w;
-            // Rebuild index when levels/order may have changed; keep scroll position via virtual scroll.
-            var filter = new WorkspaceRepositoryLinkListFilter(WorkspaceId, _effectiveSearch);
-            var index = await LinkListQueryService.GetIndexAsync(filter, token);
             if (_disposed) return;
-            BuildSlots(index);
-            totalCount = index.Count;
-            await LoadHeaderStateAsync(token);
-            _linkByRepoId.Clear();
-            _linkByWrlId.Clear();
-            prByRepositoryId = new Dictionary<int, PullRequestInfo?>();
-            repoSyncStatus = new();
-            _tooltipLoadedRepoIds.Clear();
-            _tooltipLoadInFlight.Clear();
-            if (_visibleEnd < 0 || _visibleStart >= _slots.Count)
+            try
             {
-                var initialEnd = Math.Min(_slots.Count - 1, VirtualInitialViewportSlots - 1);
-                UpdateVisibleRange(0, Math.Max(-1, initialEnd));
-            }
-            else
-            {
-                UpdateVisibleRange(_visibleStart, Math.Min(_visibleEnd, _slots.Count - 1));
-            }
-            await EnsureSlotsHydratedAsync(_visibleStart, _visibleEnd, token);
-            if (_virtualScrollAttached)
-            {
-                try
+                var token = _queryLoader.GetQueryToken();
+                var w = await ScopedExecutor.ExecuteAsync<WorkspaceRepository, Workspace?>(
+                    repo => repo.GetHeaderAsync(WorkspaceId));
+                if (w == null)
                 {
-                    await JSRuntime.InvokeVoidAsync("grayMoonVirtualScroll.setTotalHeight", _tbodyRef, TotalScrollHeightPx());
+                    errorMessage = "Workspace not found.";
+                    ClearGridState();
+                    await InvokeAsync(StateHasChanged);
+                    return;
                 }
-                catch (JSDisconnectedException) { }
-                catch (InvalidOperationException) { }
+                workspace = w;
+                // Rebuild index when levels/order may have changed; keep scroll position via virtual scroll.
+                var filter = new WorkspaceRepositoryLinkListFilter(WorkspaceId, _effectiveSearch);
+                var index = await LinkListQueryService.GetIndexAsync(filter, token);
+                if (_disposed) return;
+                BuildSlots(index);
+                totalCount = index.Count;
+                await LoadHeaderStateAsync(token);
+                _linkByRepoId.Clear();
+                _linkByWrlId.Clear();
+                prByRepositoryId = new Dictionary<int, PullRequestInfo?>();
+                repoSyncStatus = new();
+                _tooltipLoadedRepoIds.Clear();
+                _tooltipLoadInFlight.Clear();
+                if (_visibleEnd < 0 || _visibleStart >= _slots.Count)
+                {
+                    var initialEnd = Math.Min(_slots.Count - 1, VirtualInitialViewportSlots - 1);
+                    UpdateVisibleRange(0, Math.Max(-1, initialEnd));
+                }
+                else
+                {
+                    UpdateVisibleRange(_visibleStart, Math.Min(_visibleEnd, _slots.Count - 1));
+                }
+                await EnsureSlotsHydratedAsync(_visibleStart, _visibleEnd, token);
+                if (_virtualScrollAttached)
+                {
+                    try
+                    {
+                        await JSRuntime.InvokeVoidAsync("grayMoonVirtualScroll.setTotalHeight", _tbodyRef, TotalScrollHeightPx());
+                    }
+                    catch (JSDisconnectedException) { }
+                    catch (InvalidOperationException) { }
+                }
+                ApplySyncStateFromLoadedItems();
+                await InvokeAsync(StateHasChanged);
             }
-            ApplySyncStateFromLoadedItems();
-            await InvokeAsync(StateHasChanged);
+            catch (OperationCanceledException) { }
+            catch (ObjectDisposedException) { }
+            catch (InvalidOperationException) { }
+            catch (Exception ex)
+            {
+                Logger.LogDebug(ex, "RefreshFromSync failed for workspace {WorkspaceId}", WorkspaceId);
+            }
         }
-        catch (OperationCanceledException) { }
-        catch (ObjectDisposedException) { }
-        catch (InvalidOperationException) { }
-        catch (Exception ex)
+        finally
         {
-            Logger.LogDebug(ex, "RefreshFromSync failed for workspace {WorkspaceId}", WorkspaceId);
+            _reloadGate.Release();
         }
     }
     private void CancelBackgroundWork()

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.Loading.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.Loading.cs
@@ -452,7 +452,8 @@ public sealed partial class WorkspaceRepositories
             var allDeps = await projectRepo.GetPackageDependencyLinesForRepoAsync(WorkspaceId, repositoryId);
             var mismatchedFiles = await fileVersionService.GetMismatchedFileVersionLinesForRepoAsync(WorkspaceId, repositoryId);
             var fileStatuses = await fileVersionService.GetFileLineStatusForRepoAsync(WorkspaceId, repositoryId);
-            var repoVersionMap = await LinkListQueryService.GetGitVersionNameMapAsync(WorkspaceId);
+            var linkListQuery = scope.ServiceProvider.GetRequiredService<IWorkspaceRepositoryLinkListQueryService>();
+            var repoVersionMap = await linkListQuery.GetGitVersionNameMapAsync(WorkspaceId);
             var allFileLines = await fileVersionService.GetAllFileVersionLinesForRepoAsync(WorkspaceId, repositoryId, repoVersionMap);
             var custom = await customDepRepo.GetCustomDependencyNamesForRepoAsync(WorkspaceId, repositoryId);
             var mismatchDict = _mismatchedDependencyLinesByRepo as Dictionary<int, IReadOnlyList<DependencyMismatchLine>>

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.PullRequests.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.PullRequests.cs
@@ -234,6 +234,12 @@ public sealed partial class WorkspaceRepositories
                     Logger.LogDebug(ex, "Failed to refresh pull requests after creation");
                 }
             }
+
+            await InvokeAsync(async () =>
+            {
+                if (_disposed) return;
+                await RefreshFromSync();
+            });
         });
 
         return Task.CompletedTask;

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.Realtime.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.Realtime.cs
@@ -1,3 +1,4 @@
+using GrayMoon.App.Services;
 using Microsoft.AspNetCore.SignalR.Client;
 using Microsoft.JSInterop;
 
@@ -72,7 +73,11 @@ public sealed partial class WorkspaceRepositories
         {
             if (_disposed) return;
             var isRunning = IsJobRunning;
-            if (_wasJobRunning && !isRunning && !_disposed)
+            // Abort already reloads via ReloadWorkspaceDataAfterCancelAsync; skip duplicate RefreshFromSync
+            // so we do not race the circuit-scoped DbContext against the cancel-path reload.
+            var finishedJobWasAborted = !isRunning
+                && JobService.GetJob(PageJobKey)?.State == BackgroundJobState.Aborted;
+            if (_wasJobRunning && !isRunning && !_disposed && !finishedJobWasAborted)
                 _ = InvokeAsync(RefreshFromSync);
             _wasJobRunning = isRunning;
             StateHasChanged();

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.Realtime.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.Realtime.cs
@@ -68,15 +68,9 @@ public sealed partial class WorkspaceRepositories
     private void OnJobServiceChanged()
     {
         if (_disposed) return;
-        _ = InvokeAsync(() =>
-        {
-            if (_disposed) return;
-            var isRunning = IsJobRunning;
-            // Success and abort paths refresh inside the job body (RefreshOnSuccess / ReloadWorkspaceDataAfterCancelAsync).
-            // Skipping here avoids a redundant second RefreshFromSync and abort/success races on completion.
-            _wasJobRunning = isRunning;
-            StateHasChanged();
-        });
+        // Overlay / IsJobRunning UI only. Grid refresh runs inside job bodies
+        // (RefreshOnSuccess / ReloadWorkspaceDataAfterCancelAsync), not here.
+        _ = InvokeAsync(StateHasChanged);
     }
 
     private void SafeInvoke(Action callback)

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.Realtime.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.Realtime.cs
@@ -1,4 +1,3 @@
-using GrayMoon.App.Services;
 using Microsoft.AspNetCore.SignalR.Client;
 using Microsoft.JSInterop;
 
@@ -73,12 +72,8 @@ public sealed partial class WorkspaceRepositories
         {
             if (_disposed) return;
             var isRunning = IsJobRunning;
-            // Abort already reloads via ReloadWorkspaceDataAfterCancelAsync; skip duplicate RefreshFromSync
-            // so we do not race the circuit-scoped DbContext against the cancel-path reload.
-            var finishedJobWasAborted = !isRunning
-                && JobService.GetJob(PageJobKey)?.State == BackgroundJobState.Aborted;
-            if (_wasJobRunning && !isRunning && !_disposed && !finishedJobWasAborted)
-                _ = InvokeAsync(RefreshFromSync);
+            // Success and abort paths refresh inside the job body (RefreshOnSuccess / ReloadWorkspaceDataAfterCancelAsync).
+            // Skipping here avoids a redundant second RefreshFromSync and abort/success races on completion.
             _wasJobRunning = isRunning;
             StateHasChanged();
         });

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.State.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.State.cs
@@ -67,7 +67,6 @@ public sealed partial class WorkspaceRepositories
     private HashSet<int> clickedDependencyBadges = new();
     private string searchTerm = string.Empty;
     private bool _disposed;
-    private bool _wasJobRunning;
     private readonly SemaphoreSlim _reloadGate = new(1, 1);
     private string PageJobKey => new Uri(NavigationManager.Uri).AbsolutePath.ToLowerInvariant();
     private bool IsJobRunning => JobService.IsRunning(PageJobKey);

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.State.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.State.cs
@@ -68,6 +68,7 @@ public sealed partial class WorkspaceRepositories
     private string searchTerm = string.Empty;
     private bool _disposed;
     private bool _wasJobRunning;
+    private readonly SemaphoreSlim _reloadGate = new(1, 1);
     private string PageJobKey => new Uri(NavigationManager.Uri).AbsolutePath.ToLowerInvariant();
     private bool IsJobRunning => JobService.IsRunning(PageJobKey);
     private int AgentTasksPendingCount => AgentQueueStateService.GetPendingCountForWorkspace(WorkspaceId);

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
@@ -32,7 +32,6 @@ public sealed partial class WorkspaceRepositories : IAsyncDisposable, IDisposabl
     {
         AgentQueueStateService.OnQueueStateChanged(OnQueueStateChanged);
         JobService.Changed += OnJobServiceChanged;
-        _wasJobRunning = IsJobRunning;
         _loadedWorkspaceId = WorkspaceId;
         await LoadWorkspaceAsync();
         ApplySyncStateFromLoadedItems();

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.razor.cs
@@ -82,6 +82,7 @@ public sealed partial class WorkspaceRepositories : IAsyncDisposable, IDisposabl
         _fetchRepositoriesCts?.Cancel();
         _fetchRepositoriesCts?.Dispose();
         _queryLoader.Dispose();
+        _reloadGate.Dispose();
         _virtualScrollDotNetRef?.Dispose();
         _virtualScrollDotNetRef = null;
     }

--- a/src/GrayMoon.App/Components/Shared/WorkspaceActionNotificationPanel.razor
+++ b/src/GrayMoon.App/Components/Shared/WorkspaceActionNotificationPanel.razor
@@ -9,7 +9,6 @@
 @inject IBackgroundJobService JobService
 @inject IToastService ToastService
 @inject ILogger<WorkspaceActionNotificationPanel> Logger
-@inject WorkspaceFileVersionService FileVersionService
 @inject WorkspaceUndoPushHandler UndoPushHandler
 
 @{

--- a/src/GrayMoon.App/Program.cs
+++ b/src/GrayMoon.App/Program.cs
@@ -51,6 +51,7 @@ try
     var connectionString = builder.Configuration.GetConnectionString("DefaultConnection") ?? "Data Source=db/graymoon.db";
     if (!connectionString.Contains("Cache=", StringComparison.OrdinalIgnoreCase))
         connectionString += connectionString.EndsWith(';') ? "Cache=Shared;" : ";Cache=Shared;";
+    builder.Services.AddDbContextFactory<AppDbContext>(options => options.UseSqlite(connectionString));
     builder.Services.AddDbContext<AppDbContext>(options => options.UseSqlite(connectionString));
     builder.Services.AddScoped<ConnectorRepository>();
     builder.Services.AddScoped<GitHubRepositoryRepository>();

--- a/src/GrayMoon.App/Services/Queries/WorkspaceRepositoryLinkListQueryService.cs
+++ b/src/GrayMoon.App/Services/Queries/WorkspaceRepositoryLinkListQueryService.cs
@@ -1,282 +1,300 @@
-using GrayMoon.App.Data;
-using GrayMoon.App.Models;
-using GrayMoon.Common.Search;
-using Microsoft.EntityFrameworkCore;
-
-namespace GrayMoon.App.Services.Queries;
-
-public sealed class WorkspaceRepositoryLinkListQueryService(AppDbContext dbContext) : IWorkspaceRepositoryLinkListQueryService
-{
-    private readonly AppDbContext _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
-
-    public Task<int> CountAsync(WorkspaceRepositoryLinkListFilter filter, CancellationToken cancellationToken = default) =>
-        ApplyFilters(_dbContext.WorkspaceRepositories.AsNoTracking(), filter).CountAsync(cancellationToken);
-
-    public async Task<WorkspaceRepositoryLinkListPageResult> GetPageAsync(
-        WorkspaceRepositoryLinkListRequest request,
-        CancellationToken cancellationToken = default)
-    {
-        var filter = new WorkspaceRepositoryLinkListFilter(request.WorkspaceId, request.Search);
-        var query = ApplyFilters(_dbContext.WorkspaceRepositories.AsNoTracking(), filter);
-        query = ApplySort(query);
-        query = ApplyKeyset(query, request.Cursor);
-
-        var take = Math.Max(1, request.PageSize) + 1;
-        var rows = await Project(query).Take(take).ToListAsync(cancellationToken);
-
-        var hasMore = rows.Count > request.PageSize;
-        if (hasMore)
-        {
-            rows.RemoveAt(rows.Count - 1);
-        }
-
-        WorkspaceRepositoryLinkListCursor? nextCursor = null;
-        if (hasMore && rows.Count > 0)
-        {
-            var last = rows[^1];
-            nextCursor = ToCursor(last);
-        }
-
-        return new WorkspaceRepositoryLinkListPageResult(rows, nextCursor, hasMore);
-    }
-
-    public async Task<WorkspaceRepositoryHeaderStateDto> GetHeaderStateAsync(
-        int workspaceId,
-        CancellationToken cancellationToken = default)
-    {
-        var baseQuery = _dbContext.WorkspaceRepositories.AsNoTracking()
-            .Where(wr => wr.WorkspaceId == workspaceId);
-
-        var totalCount = await baseQuery.CountAsync(cancellationToken);
-
-        var hasUnmatchedDependencies = await baseQuery.AnyAsync(
-            wr => (wr.CheckedOutTag == null || wr.CheckedOutTag == string.Empty)
-                && ((wr.UnmatchedDeps ?? 0) > 0 || (wr.OutOfDateFileRepos ?? 0) > 0),
-            cancellationToken);
-
-        var isPushRecommended = await baseQuery.AnyAsync(
-            wr => (wr.CheckedOutTag == null || wr.CheckedOutTag == string.Empty)
-                && ((wr.OutgoingCommits ?? 0) > 0 || wr.BranchHasUpstream == false),
-            cancellationToken);
-
-        var hasIncomingCommits = await baseQuery.AnyAsync(
-            wr => (wr.CheckedOutTag == null || wr.CheckedOutTag == string.Empty)
-                && (wr.IncomingCommits ?? 0) > 0
-                && wr.BranchName != null && wr.BranchName != string.Empty
-                && wr.DefaultBranchName != null && wr.DefaultBranchName != string.Empty
-                && wr.BranchName == wr.DefaultBranchName,
-            cancellationToken);
-
-        var hasTaggedRepos = await baseQuery.AnyAsync(
-            wr => wr.CheckedOutTag != null && wr.CheckedOutTag != string.Empty,
-            cancellationToken);
-
-        var isOutOfSync = await baseQuery.AnyAsync(
-            wr => wr.SyncStatus != RepoSyncStatus.InSync,
-            cancellationToken);
-
-        var lowestLevels = await baseQuery
-            .Where(wr => (wr.CheckedOutTag == null || wr.CheckedOutTag == string.Empty)
-                && ((wr.UnmatchedDeps ?? 0) > 0 || (wr.OutOfDateFileRepos ?? 0) > 0)
-                && wr.DependencyLevel != null)
-            .Select(wr => wr.DependencyLevel!.Value)
-            .OrderBy(level => level)
-            .Take(1)
-            .ToListAsync(cancellationToken);
-        int? lowestLevelNeedingWork = lowestLevels.Count > 0 ? lowestLevels[0] : null;
-
-        return new WorkspaceRepositoryHeaderStateDto(
-            totalCount,
-            hasUnmatchedDependencies,
-            isPushRecommended,
-            hasIncomingCommits,
-            hasTaggedRepos,
-            isOutOfSync,
-            lowestLevelNeedingWork);
-    }
-
-    public async Task<IReadOnlyList<WorkspaceRepositoryLinkIndexEntry>> GetIndexAsync(
-        WorkspaceRepositoryLinkListFilter filter,
-        CancellationToken cancellationToken = default)
-    {
-        var query = ApplyFilters(_dbContext.WorkspaceRepositories.AsNoTracking(), filter);
-        query = ApplySort(query);
-        return await query
-            .Select(wr => new WorkspaceRepositoryLinkIndexEntry(
-                wr.WorkspaceRepositoryId,
-                wr.RepositoryId,
-                wr.DependencyLevel))
-            .ToListAsync(cancellationToken);
-    }
-
-    public async Task<IReadOnlyList<WorkspaceRepositoryLinkListItemDto>> GetByIdsAsync(
-        int workspaceId,
-        IReadOnlyList<int> workspaceRepositoryIds,
-        CancellationToken cancellationToken = default)
-    {
-        if (workspaceRepositoryIds.Count == 0)
-        {
-            return Array.Empty<WorkspaceRepositoryLinkListItemDto>();
-        }
-
-        var idSet = workspaceRepositoryIds.ToHashSet();
-        var rows = await Project(_dbContext.WorkspaceRepositories.AsNoTracking()
-                .Where(wr => wr.WorkspaceId == workspaceId && idSet.Contains(wr.WorkspaceRepositoryId)))
-            .ToListAsync(cancellationToken);
-
-        var order = workspaceRepositoryIds
-            .Select((id, index) => (id, index))
-            .ToDictionary(x => x.id, x => x.index);
-        return rows
-            .OrderBy(r => order.GetValueOrDefault(r.WorkspaceRepositoryId, int.MaxValue))
-            .ToList();
-    }
-
-    public async Task<IReadOnlyList<int>> GetRepositoryIdsAtLevelAsync(
-        int workspaceId,
-        int? levelKey,
-        string? search,
-        CancellationToken cancellationToken = default)
-    {
-        var filter = new WorkspaceRepositoryLinkListFilter(workspaceId, search);
-        var query = ApplyFilters(_dbContext.WorkspaceRepositories.AsNoTracking(), filter)
-            .Where(wr => wr.DependencyLevel == levelKey);
-
-        return await query
-            .OrderBy(wr => wr.WorkspaceRepositoryId)
-            .Select(wr => wr.RepositoryId)
-            .ToListAsync(cancellationToken);
-    }
-
-    public async Task<IReadOnlyList<WorkspaceRepositoryLinkListItemDto>> GetAllSnapshotsAsync(
-        int workspaceId,
-        CancellationToken cancellationToken = default)
-    {
-        var query = _dbContext.WorkspaceRepositories.AsNoTracking()
-            .Where(wr => wr.WorkspaceId == workspaceId);
-        query = ApplySort(query);
-        return await Project(query).ToListAsync(cancellationToken);
-    }
-
-    public async Task<IReadOnlyDictionary<string, string>> GetGitVersionNameMapAsync(
-        int workspaceId,
-        CancellationToken cancellationToken = default)
-    {
-        var rows = await _dbContext.WorkspaceRepositories.AsNoTracking()
-            .Where(wr => wr.WorkspaceId == workspaceId
-                && wr.Repository != null
-                && wr.GitVersion != null
-                && wr.GitVersion != string.Empty)
-            .Select(wr => new { wr.Repository!.RepositoryName, wr.GitVersion })
-            .ToListAsync(cancellationToken);
-
-        return rows
-            .Where(r => !string.IsNullOrWhiteSpace(r.RepositoryName) && !string.IsNullOrEmpty(r.GitVersion))
-            .ToDictionary(r => r.RepositoryName!, r => r.GitVersion!, StringComparer.OrdinalIgnoreCase);
-    }
-
-    public async Task<WorkspaceRepositoryLinkListItemDto?> GetSnapshotAsync(
-        int workspaceId,
-        int repositoryId,
-        CancellationToken cancellationToken = default)
-    {
-        return await Project(_dbContext.WorkspaceRepositories.AsNoTracking()
-                .Where(wr => wr.WorkspaceId == workspaceId && wr.RepositoryId == repositoryId))
-            .FirstOrDefaultAsync(cancellationToken);
-    }
-
-    private static IQueryable<WorkspaceRepositoryLink> ApplyFilters(
-        IQueryable<WorkspaceRepositoryLink> query,
-        WorkspaceRepositoryLinkListFilter filter)
-    {
-        query = query.Where(wr => wr.WorkspaceId == filter.WorkspaceId);
-        return query.ApplySearch(filter.Search, WorkspaceRepositoryLinkSearchExpressions.BuildTermPredicate);
-    }
-
-    private static IQueryable<WorkspaceRepositoryLink> ApplySort(IQueryable<WorkspaceRepositoryLink> query) =>
-        query
-            .OrderByDescending(wr => wr.DependencyLevel ?? int.MinValue)
-            .ThenBy(wr => wr.RepositoryType == ProjectType.Service ? 0
-                : wr.RepositoryType == ProjectType.Package ? 1
-                : wr.RepositoryType == ProjectType.Executable ? 2
-                : wr.RepositoryType == ProjectType.Library ? 3
-                : wr.RepositoryType == ProjectType.Test ? 4
-                : 5)
-            .ThenByDescending(wr => wr.Dependencies ?? int.MinValue)
-            .ThenBy(wr => wr.WorkspaceRepositoryId);
-
-    private static IQueryable<WorkspaceRepositoryLink> ApplyKeyset(
-        IQueryable<WorkspaceRepositoryLink> query,
-        WorkspaceRepositoryLinkListCursor? cursor)
-    {
-        if (cursor is null)
-        {
-            return query;
-        }
-
-        return query.Where(wr =>
-            (wr.DependencyLevel ?? int.MinValue) < cursor.DependencyLevelSortKey
-            || ((wr.DependencyLevel ?? int.MinValue) == cursor.DependencyLevelSortKey
-                && (wr.RepositoryType == ProjectType.Service ? 0
-                    : wr.RepositoryType == ProjectType.Package ? 1
-                    : wr.RepositoryType == ProjectType.Executable ? 2
-                    : wr.RepositoryType == ProjectType.Library ? 3
-                    : wr.RepositoryType == ProjectType.Test ? 4
-                    : 5) > cursor.RepositoryTypeSortKey)
-            || ((wr.DependencyLevel ?? int.MinValue) == cursor.DependencyLevelSortKey
-                && (wr.RepositoryType == ProjectType.Service ? 0
-                    : wr.RepositoryType == ProjectType.Package ? 1
-                    : wr.RepositoryType == ProjectType.Executable ? 2
-                    : wr.RepositoryType == ProjectType.Library ? 3
-                    : wr.RepositoryType == ProjectType.Test ? 4
-                    : 5) == cursor.RepositoryTypeSortKey
-                && (wr.Dependencies ?? int.MinValue) < cursor.DependenciesSortKey)
-            || ((wr.DependencyLevel ?? int.MinValue) == cursor.DependencyLevelSortKey
-                && (wr.RepositoryType == ProjectType.Service ? 0
-                    : wr.RepositoryType == ProjectType.Package ? 1
-                    : wr.RepositoryType == ProjectType.Executable ? 2
-                    : wr.RepositoryType == ProjectType.Library ? 3
-                    : wr.RepositoryType == ProjectType.Test ? 4
-                    : 5) == cursor.RepositoryTypeSortKey
-                && (wr.Dependencies ?? int.MinValue) == cursor.DependenciesSortKey
-                && wr.WorkspaceRepositoryId > cursor.WorkspaceRepositoryId));
-    }
-
-    private static IQueryable<WorkspaceRepositoryLinkListItemDto> Project(IQueryable<WorkspaceRepositoryLink> query) =>
-        query.Select(wr => new WorkspaceRepositoryLinkListItemDto(
-            wr.WorkspaceRepositoryId,
-            wr.WorkspaceId,
-            wr.RepositoryId,
-            wr.Repository != null ? wr.Repository.RepositoryName : string.Empty,
-            wr.Repository != null ? wr.Repository.CloneUrl : string.Empty,
-            wr.GitVersion,
-            wr.BranchName,
-            wr.CheckedOutTag,
-            wr.DefaultBranchName,
-            wr.OutgoingCommits,
-            wr.IncomingCommits,
-            wr.DefaultBranchBehindCommits,
-            wr.DefaultBranchAheadCommits,
-            wr.BranchHasUpstream,
-            wr.SyncStatus,
-            wr.DependencyLevel,
-            wr.Dependencies,
-            wr.UnmatchedDeps,
-            wr.OutOfDateFileRepos,
-            wr.RepositoryType,
-            wr.HasNewerTag,
-            wr.PullRequest != null ? wr.PullRequest.State : null,
-            wr.PullRequest != null ? wr.PullRequest.PullRequestNumber : null,
-            wr.PullRequest != null ? wr.PullRequest.HtmlUrl : null,
-            wr.PullRequest != null ? wr.PullRequest.MergedAt : null,
-            wr.PullRequest != null ? wr.PullRequest.Mergeable : null,
-            wr.PullRequest != null ? wr.PullRequest.MergeableState : null,
-            wr.PullRequest != null ? wr.PullRequest.ChangedFiles : null));
-
-    private static WorkspaceRepositoryLinkListCursor ToCursor(WorkspaceRepositoryLinkListItemDto dto) =>
-        new(
-            dto.DependencyLevel ?? int.MinValue,
-            WorkspaceRepositoryLinkSearchExpressions.GetRepositoryTypeSortKey(dto.RepositoryType),
-            dto.Dependencies ?? int.MinValue,
-            dto.WorkspaceRepositoryId);
-}
+using GrayMoon.App.Data;
+using GrayMoon.App.Models;
+using GrayMoon.Common.Search;
+using Microsoft.EntityFrameworkCore;
+
+namespace GrayMoon.App.Services.Queries;
+
+/// <summary>
+/// Link-list queries use a factory so each call owns a short-lived DbContext.
+/// That avoids concurrent-use races when Blazor circuits share work across Job.Run, scroll, and tooltips.
+/// </summary>
+public sealed class WorkspaceRepositoryLinkListQueryService(IDbContextFactory<AppDbContext> dbContextFactory)
+    : IWorkspaceRepositoryLinkListQueryService
+{
+    private readonly IDbContextFactory<AppDbContext> _dbContextFactory =
+        dbContextFactory ?? throw new ArgumentNullException(nameof(dbContextFactory));
+
+    public async Task<int> CountAsync(WorkspaceRepositoryLinkListFilter filter, CancellationToken cancellationToken = default)
+    {
+        await using var db = await _dbContextFactory.CreateDbContextAsync(cancellationToken);
+        return await ApplyFilters(db.WorkspaceRepositories.AsNoTracking(), filter).CountAsync(cancellationToken);
+    }
+
+    public async Task<WorkspaceRepositoryLinkListPageResult> GetPageAsync(
+        WorkspaceRepositoryLinkListRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        await using var db = await _dbContextFactory.CreateDbContextAsync(cancellationToken);
+        var filter = new WorkspaceRepositoryLinkListFilter(request.WorkspaceId, request.Search);
+        var query = ApplyFilters(db.WorkspaceRepositories.AsNoTracking(), filter);
+        query = ApplySort(query);
+        query = ApplyKeyset(query, request.Cursor);
+
+        var take = Math.Max(1, request.PageSize) + 1;
+        var rows = await Project(query).Take(take).ToListAsync(cancellationToken);
+
+        var hasMore = rows.Count > request.PageSize;
+        if (hasMore)
+        {
+            rows.RemoveAt(rows.Count - 1);
+        }
+
+        WorkspaceRepositoryLinkListCursor? nextCursor = null;
+        if (hasMore && rows.Count > 0)
+        {
+            var last = rows[^1];
+            nextCursor = ToCursor(last);
+        }
+
+        return new WorkspaceRepositoryLinkListPageResult(rows, nextCursor, hasMore);
+    }
+
+    public async Task<WorkspaceRepositoryHeaderStateDto> GetHeaderStateAsync(
+        int workspaceId,
+        CancellationToken cancellationToken = default)
+    {
+        await using var db = await _dbContextFactory.CreateDbContextAsync(cancellationToken);
+        var baseQuery = db.WorkspaceRepositories.AsNoTracking()
+            .Where(wr => wr.WorkspaceId == workspaceId);
+
+        var totalCount = await baseQuery.CountAsync(cancellationToken);
+
+        var hasUnmatchedDependencies = await baseQuery.AnyAsync(
+            wr => (wr.CheckedOutTag == null || wr.CheckedOutTag == string.Empty)
+                && ((wr.UnmatchedDeps ?? 0) > 0 || (wr.OutOfDateFileRepos ?? 0) > 0),
+            cancellationToken);
+
+        var isPushRecommended = await baseQuery.AnyAsync(
+            wr => (wr.CheckedOutTag == null || wr.CheckedOutTag == string.Empty)
+                && ((wr.OutgoingCommits ?? 0) > 0 || wr.BranchHasUpstream == false),
+            cancellationToken);
+
+        var hasIncomingCommits = await baseQuery.AnyAsync(
+            wr => (wr.CheckedOutTag == null || wr.CheckedOutTag == string.Empty)
+                && (wr.IncomingCommits ?? 0) > 0
+                && wr.BranchName != null && wr.BranchName != string.Empty
+                && wr.DefaultBranchName != null && wr.DefaultBranchName != string.Empty
+                && wr.BranchName == wr.DefaultBranchName,
+            cancellationToken);
+
+        var hasTaggedRepos = await baseQuery.AnyAsync(
+            wr => wr.CheckedOutTag != null && wr.CheckedOutTag != string.Empty,
+            cancellationToken);
+
+        var isOutOfSync = await baseQuery.AnyAsync(
+            wr => wr.SyncStatus != RepoSyncStatus.InSync,
+            cancellationToken);
+
+        var lowestLevels = await baseQuery
+            .Where(wr => (wr.CheckedOutTag == null || wr.CheckedOutTag == string.Empty)
+                && ((wr.UnmatchedDeps ?? 0) > 0 || (wr.OutOfDateFileRepos ?? 0) > 0)
+                && wr.DependencyLevel != null)
+            .Select(wr => wr.DependencyLevel!.Value)
+            .OrderBy(level => level)
+            .Take(1)
+            .ToListAsync(cancellationToken);
+        int? lowestLevelNeedingWork = lowestLevels.Count > 0 ? lowestLevels[0] : null;
+
+        return new WorkspaceRepositoryHeaderStateDto(
+            totalCount,
+            hasUnmatchedDependencies,
+            isPushRecommended,
+            hasIncomingCommits,
+            hasTaggedRepos,
+            isOutOfSync,
+            lowestLevelNeedingWork);
+    }
+
+    public async Task<IReadOnlyList<WorkspaceRepositoryLinkIndexEntry>> GetIndexAsync(
+        WorkspaceRepositoryLinkListFilter filter,
+        CancellationToken cancellationToken = default)
+    {
+        await using var db = await _dbContextFactory.CreateDbContextAsync(cancellationToken);
+        var query = ApplyFilters(db.WorkspaceRepositories.AsNoTracking(), filter);
+        query = ApplySort(query);
+        return await query
+            .Select(wr => new WorkspaceRepositoryLinkIndexEntry(
+                wr.WorkspaceRepositoryId,
+                wr.RepositoryId,
+                wr.DependencyLevel))
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<WorkspaceRepositoryLinkListItemDto>> GetByIdsAsync(
+        int workspaceId,
+        IReadOnlyList<int> workspaceRepositoryIds,
+        CancellationToken cancellationToken = default)
+    {
+        if (workspaceRepositoryIds.Count == 0)
+        {
+            return Array.Empty<WorkspaceRepositoryLinkListItemDto>();
+        }
+
+        await using var db = await _dbContextFactory.CreateDbContextAsync(cancellationToken);
+        var idSet = workspaceRepositoryIds.ToHashSet();
+        var rows = await Project(db.WorkspaceRepositories.AsNoTracking()
+                .Where(wr => wr.WorkspaceId == workspaceId && idSet.Contains(wr.WorkspaceRepositoryId)))
+            .ToListAsync(cancellationToken);
+
+        var order = workspaceRepositoryIds
+            .Select((id, index) => (id, index))
+            .ToDictionary(x => x.id, x => x.index);
+        return rows
+            .OrderBy(r => order.GetValueOrDefault(r.WorkspaceRepositoryId, int.MaxValue))
+            .ToList();
+    }
+
+    public async Task<IReadOnlyList<int>> GetRepositoryIdsAtLevelAsync(
+        int workspaceId,
+        int? levelKey,
+        string? search,
+        CancellationToken cancellationToken = default)
+    {
+        await using var db = await _dbContextFactory.CreateDbContextAsync(cancellationToken);
+        var filter = new WorkspaceRepositoryLinkListFilter(workspaceId, search);
+        var query = ApplyFilters(db.WorkspaceRepositories.AsNoTracking(), filter)
+            .Where(wr => wr.DependencyLevel == levelKey);
+
+        return await query
+            .OrderBy(wr => wr.WorkspaceRepositoryId)
+            .Select(wr => wr.RepositoryId)
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<WorkspaceRepositoryLinkListItemDto>> GetAllSnapshotsAsync(
+        int workspaceId,
+        CancellationToken cancellationToken = default)
+    {
+        await using var db = await _dbContextFactory.CreateDbContextAsync(cancellationToken);
+        var query = db.WorkspaceRepositories.AsNoTracking()
+            .Where(wr => wr.WorkspaceId == workspaceId);
+        query = ApplySort(query);
+        return await Project(query).ToListAsync(cancellationToken);
+    }
+
+    public async Task<IReadOnlyDictionary<string, string>> GetGitVersionNameMapAsync(
+        int workspaceId,
+        CancellationToken cancellationToken = default)
+    {
+        await using var db = await _dbContextFactory.CreateDbContextAsync(cancellationToken);
+        var rows = await db.WorkspaceRepositories.AsNoTracking()
+            .Where(wr => wr.WorkspaceId == workspaceId
+                && wr.Repository != null
+                && wr.GitVersion != null
+                && wr.GitVersion != string.Empty)
+            .Select(wr => new { wr.Repository!.RepositoryName, wr.GitVersion })
+            .ToListAsync(cancellationToken);
+
+        return rows
+            .Where(r => !string.IsNullOrWhiteSpace(r.RepositoryName) && !string.IsNullOrEmpty(r.GitVersion))
+            .ToDictionary(r => r.RepositoryName!, r => r.GitVersion!, StringComparer.OrdinalIgnoreCase);
+    }
+
+    public async Task<WorkspaceRepositoryLinkListItemDto?> GetSnapshotAsync(
+        int workspaceId,
+        int repositoryId,
+        CancellationToken cancellationToken = default)
+    {
+        await using var db = await _dbContextFactory.CreateDbContextAsync(cancellationToken);
+        return await Project(db.WorkspaceRepositories.AsNoTracking()
+                .Where(wr => wr.WorkspaceId == workspaceId && wr.RepositoryId == repositoryId))
+            .FirstOrDefaultAsync(cancellationToken);
+    }
+
+    private static IQueryable<WorkspaceRepositoryLink> ApplyFilters(
+        IQueryable<WorkspaceRepositoryLink> query,
+        WorkspaceRepositoryLinkListFilter filter)
+    {
+        query = query.Where(wr => wr.WorkspaceId == filter.WorkspaceId);
+        return query.ApplySearch(filter.Search, WorkspaceRepositoryLinkSearchExpressions.BuildTermPredicate);
+    }
+
+    private static IQueryable<WorkspaceRepositoryLink> ApplySort(IQueryable<WorkspaceRepositoryLink> query) =>
+        query
+            .OrderByDescending(wr => wr.DependencyLevel ?? int.MinValue)
+            .ThenBy(wr => wr.RepositoryType == ProjectType.Service ? 0
+                : wr.RepositoryType == ProjectType.Package ? 1
+                : wr.RepositoryType == ProjectType.Executable ? 2
+                : wr.RepositoryType == ProjectType.Library ? 3
+                : wr.RepositoryType == ProjectType.Test ? 4
+                : 5)
+            .ThenByDescending(wr => wr.Dependencies ?? int.MinValue)
+            .ThenBy(wr => wr.WorkspaceRepositoryId);
+
+    private static IQueryable<WorkspaceRepositoryLink> ApplyKeyset(
+        IQueryable<WorkspaceRepositoryLink> query,
+        WorkspaceRepositoryLinkListCursor? cursor)
+    {
+        if (cursor is null)
+        {
+            return query;
+        }
+
+        return query.Where(wr =>
+            (wr.DependencyLevel ?? int.MinValue) < cursor.DependencyLevelSortKey
+            || ((wr.DependencyLevel ?? int.MinValue) == cursor.DependencyLevelSortKey
+                && (wr.RepositoryType == ProjectType.Service ? 0
+                    : wr.RepositoryType == ProjectType.Package ? 1
+                    : wr.RepositoryType == ProjectType.Executable ? 2
+                    : wr.RepositoryType == ProjectType.Library ? 3
+                    : wr.RepositoryType == ProjectType.Test ? 4
+                    : 5) > cursor.RepositoryTypeSortKey)
+            || ((wr.DependencyLevel ?? int.MinValue) == cursor.DependencyLevelSortKey
+                && (wr.RepositoryType == ProjectType.Service ? 0
+                    : wr.RepositoryType == ProjectType.Package ? 1
+                    : wr.RepositoryType == ProjectType.Executable ? 2
+                    : wr.RepositoryType == ProjectType.Library ? 3
+                    : wr.RepositoryType == ProjectType.Test ? 4
+                    : 5) == cursor.RepositoryTypeSortKey
+                && (wr.Dependencies ?? int.MinValue) < cursor.DependenciesSortKey)
+            || ((wr.DependencyLevel ?? int.MinValue) == cursor.DependencyLevelSortKey
+                && (wr.RepositoryType == ProjectType.Service ? 0
+                    : wr.RepositoryType == ProjectType.Package ? 1
+                    : wr.RepositoryType == ProjectType.Executable ? 2
+                    : wr.RepositoryType == ProjectType.Library ? 3
+                    : wr.RepositoryType == ProjectType.Test ? 4
+                    : 5) == cursor.RepositoryTypeSortKey
+                && (wr.Dependencies ?? int.MinValue) == cursor.DependenciesSortKey
+                && wr.WorkspaceRepositoryId > cursor.WorkspaceRepositoryId));
+    }
+
+    private static IQueryable<WorkspaceRepositoryLinkListItemDto> Project(IQueryable<WorkspaceRepositoryLink> query) =>
+        query.Select(wr => new WorkspaceRepositoryLinkListItemDto(
+            wr.WorkspaceRepositoryId,
+            wr.WorkspaceId,
+            wr.RepositoryId,
+            wr.Repository != null ? wr.Repository.RepositoryName : string.Empty,
+            wr.Repository != null ? wr.Repository.CloneUrl : string.Empty,
+            wr.GitVersion,
+            wr.BranchName,
+            wr.CheckedOutTag,
+            wr.DefaultBranchName,
+            wr.OutgoingCommits,
+            wr.IncomingCommits,
+            wr.DefaultBranchBehindCommits,
+            wr.DefaultBranchAheadCommits,
+            wr.BranchHasUpstream,
+            wr.SyncStatus,
+            wr.DependencyLevel,
+            wr.Dependencies,
+            wr.UnmatchedDeps,
+            wr.OutOfDateFileRepos,
+            wr.RepositoryType,
+            wr.HasNewerTag,
+            wr.PullRequest != null ? wr.PullRequest.State : null,
+            wr.PullRequest != null ? wr.PullRequest.PullRequestNumber : null,
+            wr.PullRequest != null ? wr.PullRequest.HtmlUrl : null,
+            wr.PullRequest != null ? wr.PullRequest.MergedAt : null,
+            wr.PullRequest != null ? wr.PullRequest.Mergeable : null,
+            wr.PullRequest != null ? wr.PullRequest.MergeableState : null,
+            wr.PullRequest != null ? wr.PullRequest.ChangedFiles : null));
+
+    private static WorkspaceRepositoryLinkListCursor ToCursor(WorkspaceRepositoryLinkListItemDto dto) =>
+        new(
+            dto.DependencyLevel ?? int.MinValue,
+            WorkspaceRepositoryLinkSearchExpressions.GetRepositoryTypeSortKey(dto.RepositoryType),
+            dto.Dependencies ?? int.MinValue,
+            dto.WorkspaceRepositoryId);
+}
+


### PR DESCRIPTION
## Summary

- Serialize workspace grid reloads with a reload gate and stop refreshing from job-running edge detection so abort/cancel no longer races concurrent refresh paths
- Move Switch Branch "Create" into the modal footer when the Locals filter matches nothing, instead of an odd inline empty-state button
- Register `IDbContextFactory<AppDbContext>` and use it from workspace link list queries so scoped query work is safer under concurrent reloads
- Some changes are uncommitted only — commit and push before opening the PR (query service diff also truncated in review context)

## Test plan

- [ ] Start a long workspace job, abort it, and confirm the grid does not throw or stick mid-reload
- [ ] Complete a sync/PR/branch action and confirm the repositories grid refreshes once without flicker
- [ ] On Locals tab, filter to a name with no match and confirm Create appears in the footer and creates the branch
- [ ] Smoke-test workspace repositories load, scroll hydration, and search while agent sync events arrive