### PR TITLE
Decouple GitVersion from push integrate and improve Blazor reconnect UX

### DIFF
--- a/src/GrayMoon.Agent/Commands/CommitSyncRepositoryCommand.cs
+++ b/src/GrayMoon.Agent/Commands/CommitSyncRepositoryCommand.cs
@@ -44,11 +44,12 @@ public sealed class CommitSyncRepositoryCommand(IGitService git, GitRemoteIntegr
         var integrate = await remoteIntegrate.IntegrateAsync(repoPath, bearerToken, cancellationToken);
         if (!integrate.Success)
         {
+            var failVersion = await ResolveVersionAsync(repoPath, cancellationToken);
             return new CommitSyncRepositoryResponse
             {
                 Success = false,
                 MergeConflict = integrate.MergeConflict,
-                Version = integrate.Version,
+                Version = failVersion,
                 Branch = integrate.Branch,
                 OutgoingCommits = integrate.Outgoing,
                 IncomingCommits = integrate.Incoming,
@@ -57,7 +58,7 @@ public sealed class CommitSyncRepositoryCommand(IGitService git, GitRemoteIntegr
         }
 
         var branch = integrate.Branch!;
-        var version = integrate.Version ?? "-";
+        var version = await ResolveVersionAsync(repoPath, cancellationToken);
         var outgoing = integrate.Outgoing;
         var incoming = integrate.Incoming;
 
@@ -98,4 +99,11 @@ public sealed class CommitSyncRepositoryCommand(IGitService git, GitRemoteIntegr
             IncomingCommits = incoming
         };
     }
+
+    private async Task<string> ResolveVersionAsync(string repoPath, CancellationToken cancellationToken)
+    {
+        var (versionResult, _) = await git.GetVersionAsync(repoPath, cancellationToken);
+        return versionResult?.InformationalVersion ?? "-";
+    }
 }
+

--- a/src/GrayMoon.Agent/Jobs/Requests/PushRepositoryRequest.cs
+++ b/src/GrayMoon.Agent/Jobs/Requests/PushRepositoryRequest.cs
@@ -19,7 +19,7 @@ public sealed class PushRepositoryRequest : WorkspaceCommandRequest
     [JsonPropertyName("workspaceId")]
     public int WorkspaceId { get; set; }
 
-    /// <summary>Optional. When set, the agent uses this branch instead of resolving via GitVersion.</summary>
+    /// <summary>Optional. When set, the agent uses this branch instead of resolving the current branch via git.</summary>
     [JsonPropertyName("branchName")]
     public string? BranchName { get; set; }
 }

--- a/src/GrayMoon.Agent/Services/GitRemoteIntegrateService.cs
+++ b/src/GrayMoon.Agent/Services/GitRemoteIntegrateService.cs
@@ -15,6 +15,7 @@ public sealed record GitRemoteIntegrateResult(
 /// <summary>
 /// Fetches from origin and pulls incoming commits before push or commit-sync workflows.
 /// Single source of truth for remote integration (fetch + conditional pull).
+/// Resolves branch via git only; Version is always null - callers that need SemVer run GitVersion themselves.
 /// </summary>
 public sealed class GitRemoteIntegrateService(IGitService git)
 {
@@ -37,21 +38,7 @@ public sealed class GitRemoteIntegrateService(IGitService git)
                 ErrorMessage: fetchError ?? "Fetch failed");
         }
 
-        var (versionResult, versionError) = await git.GetVersionAsync(repoPath, cancellationToken);
-        if (versionResult == null)
-        {
-            return new GitRemoteIntegrateResult(
-                Success: false,
-                Branch: null,
-                Version: null,
-                Outgoing: null,
-                Incoming: null,
-                HasUpstream: false,
-                MergeConflict: false,
-                ErrorMessage: versionError ?? "Could not determine repository version");
-        }
-
-        var branch = versionResult.BranchName ?? versionResult.EscapedBranchName;
+        var branch = await git.GetCurrentBranchNameAsync(repoPath, cancellationToken);
         if (string.IsNullOrWhiteSpace(branch))
         {
             return new GitRemoteIntegrateResult(
@@ -65,7 +52,6 @@ public sealed class GitRemoteIntegrateService(IGitService git)
                 ErrorMessage: "Could not determine branch name");
         }
 
-        var version = versionResult.InformationalVersion ?? "-";
         var (outgoing, incoming, hasUpstream) = await git.GetCommitCountsAsync(repoPath, branch, null, cancellationToken);
 
         if (!incoming.HasValue || incoming.Value <= 0)
@@ -73,7 +59,7 @@ public sealed class GitRemoteIntegrateService(IGitService git)
             return new GitRemoteIntegrateResult(
                 Success: true,
                 Branch: branch,
-                Version: version,
+                Version: null,
                 Outgoing: outgoing,
                 Incoming: incoming,
                 HasUpstream: hasUpstream,
@@ -92,7 +78,7 @@ public sealed class GitRemoteIntegrateService(IGitService git)
             return new GitRemoteIntegrateResult(
                 Success: false,
                 Branch: branch,
-                Version: version,
+                Version: null,
                 Outgoing: outgoing,
                 Incoming: incoming,
                 HasUpstream: hasUpstream,
@@ -105,7 +91,7 @@ public sealed class GitRemoteIntegrateService(IGitService git)
             return new GitRemoteIntegrateResult(
                 Success: false,
                 Branch: branch,
-                Version: version,
+                Version: null,
                 Outgoing: outgoing,
                 Incoming: incoming,
                 HasUpstream: hasUpstream,
@@ -118,7 +104,7 @@ public sealed class GitRemoteIntegrateService(IGitService git)
         return new GitRemoteIntegrateResult(
             Success: true,
             Branch: branch,
-            Version: version,
+            Version: null,
             Outgoing: outgoing,
             Incoming: incoming,
             HasUpstream: hasUpstream,
@@ -126,3 +112,4 @@ public sealed class GitRemoteIntegrateService(IGitService git)
             ErrorMessage: null);
     }
 }
+

--- a/src/GrayMoon.App/Components/App.razor
+++ b/src/GrayMoon.App/Components/App.razor
@@ -16,8 +16,10 @@
 </head>
 
 <body>
+    <ReconnectModal />
     <Routes />
     <script src="_framework/blazor.web.js"></script>
+    <script src="js/reconnectModal.js" type="module"></script>
     <script src="js/cytoscape.min.js"></script>
     <script src="js/dagre.min.js"></script>
     <script src="js/cytoscape-dagre.js"></script>

--- a/src/GrayMoon.App/Components/App.razor
+++ b/src/GrayMoon.App/Components/App.razor
@@ -5,12 +5,13 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <base href="/" />
-    <link rel="stylesheet" href="bootstrap/bootstrap.min.css" />
-    <link rel="stylesheet" href="bootstrap-icons/bootstrap-icons.css" />
-    <link rel="stylesheet" href="app.css" />
-    <link rel="stylesheet" href="css/workspace-grid-search.css" />
-    <link rel="stylesheet" href="css/loading-overlay.css" />
-    <link rel="stylesheet" href="GrayMoon.App.styles.css" />
+    <link rel="stylesheet" href="@Assets["bootstrap/bootstrap.min.css"]" />
+    <link rel="stylesheet" href="@Assets["bootstrap-icons/bootstrap-icons.css"]" />
+    <link rel="stylesheet" href="@Assets["app.css"]" />
+    <link rel="stylesheet" href="@Assets["css/workspace-grid-search.css"]" />
+    <link rel="stylesheet" href="@Assets["css/loading-overlay.css"]" />
+    <link rel="stylesheet" href="@Assets["GrayMoon.App.styles.css"]" />
+    <ImportMap />
     <link rel="icon" type="image/svg+xml" href="moon.svg" />
     <HeadOutlet />
 </head>

--- a/src/GrayMoon.App/Components/Layout/ReconnectModal.razor
+++ b/src/GrayMoon.App/Components/Layout/ReconnectModal.razor
@@ -1,0 +1,29 @@
+<dialog id="components-reconnect-modal" data-nosnippet>
+    <div class="components-reconnect-container">
+        <div class="components-rejoining-animation" aria-hidden="true">
+            <div></div>
+            <div></div>
+        </div>
+        <p class="components-reconnect-first-attempt-visible">
+            Rejoining the server...
+        </p>
+        <p class="components-reconnect-repeated-attempt-visible">
+            Rejoin failed... trying again in <span id="components-seconds-to-next-attempt"></span> seconds.
+        </p>
+        <p class="components-reconnect-failed-visible">
+            Failed to rejoin.<br />Please retry or reload the page.
+        </p>
+        <button id="components-reconnect-button" type="button" class="components-reconnect-failed-visible">
+            Retry
+        </button>
+        <p class="components-pause-visible">
+            The session has been paused by the server.
+        </p>
+        <p class="components-resume-failed-visible">
+            Failed to resume the session.<br />Please retry or reload the page.
+        </p>
+        <button id="components-resume-button" type="button" class="components-pause-visible components-resume-failed-visible">
+            Resume
+        </button>
+    </div>
+</dialog>

--- a/src/GrayMoon.App/Components/Layout/ReconnectModal.razor.css
+++ b/src/GrayMoon.App/Components/Layout/ReconnectModal.razor.css
@@ -19,6 +19,11 @@
     display: block;
 }
 
+/* Blazor adds this when the circuit is restored; hide immediately even if close() is delayed. */
+#components-reconnect-modal.components-reconnect-hide {
+    display: none !important;
+}
+
 #components-reconnect-modal {
     background-color: #252526;
     color: #e8e8e8;

--- a/src/GrayMoon.App/Components/Layout/ReconnectModal.razor.css
+++ b/src/GrayMoon.App/Components/Layout/ReconnectModal.razor.css
@@ -1,0 +1,164 @@
+.components-reconnect-first-attempt-visible,
+.components-reconnect-repeated-attempt-visible,
+.components-reconnect-failed-visible,
+.components-pause-visible,
+.components-resume-failed-visible,
+.components-rejoining-animation {
+    display: none;
+}
+
+#components-reconnect-modal.components-reconnect-show .components-reconnect-first-attempt-visible,
+#components-reconnect-modal.components-reconnect-show .components-rejoining-animation,
+#components-reconnect-modal.components-reconnect-paused .components-pause-visible,
+#components-reconnect-modal.components-reconnect-resume-failed .components-resume-failed-visible,
+#components-reconnect-modal.components-reconnect-retrying,
+#components-reconnect-modal.components-reconnect-retrying .components-reconnect-repeated-attempt-visible,
+#components-reconnect-modal.components-reconnect-retrying .components-rejoining-animation,
+#components-reconnect-modal.components-reconnect-failed,
+#components-reconnect-modal.components-reconnect-failed .components-reconnect-failed-visible {
+    display: block;
+}
+
+#components-reconnect-modal {
+    background-color: #252526;
+    color: #e8e8e8;
+    width: 20rem;
+    margin: 20vh auto;
+    padding: 2rem;
+    border: 1px solid #3e3e42;
+    border-radius: 0.5rem;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.55);
+    opacity: 0;
+    transition: display 0.5s allow-discrete, overlay 0.5s allow-discrete;
+    animation: components-reconnect-modal-fadeOutOpacity 0.5s both;
+}
+
+#components-reconnect-modal[open] {
+    animation: components-reconnect-modal-slideUp 1.5s cubic-bezier(.05, .89, .25, 1.02) 0.3s, components-reconnect-modal-fadeInOpacity 0.5s ease-in-out 0.3s;
+    animation-fill-mode: both;
+}
+
+#components-reconnect-modal::backdrop {
+    background-color: rgba(0, 0, 0, 0.65);
+    animation: components-reconnect-modal-fadeInOpacity 0.5s ease-in-out;
+    opacity: 1;
+}
+
+@keyframes components-reconnect-modal-slideUp {
+    0% {
+        transform: translateY(30px) scale(0.95);
+    }
+
+    100% {
+        transform: translateY(0);
+    }
+}
+
+@keyframes components-reconnect-modal-fadeInOpacity {
+    0% {
+        opacity: 0;
+    }
+
+    100% {
+        opacity: 1;
+    }
+}
+
+@keyframes components-reconnect-modal-fadeOutOpacity {
+    0% {
+        opacity: 1;
+    }
+
+    100% {
+        opacity: 0;
+    }
+}
+
+.components-reconnect-container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1rem;
+}
+
+#components-reconnect-modal p {
+    margin: 0;
+    text-align: center;
+    color: #e8e8e8;
+    font-size: 1.05rem;
+    line-height: 1.45;
+    font-weight: 500;
+}
+
+#components-reconnect-modal button {
+    border: 1px solid #5a5a5a;
+    background-color: #3c3c3c;
+    color: #f0f0f0;
+    padding: 0.35rem 1.5rem;
+    border-radius: 0.25rem;
+    font-size: 0.95rem;
+    font-weight: 500;
+    cursor: pointer;
+}
+
+#components-reconnect-modal button:hover {
+    background-color: #4a4a4a;
+    border-color: #6a6a6a;
+    color: #ffffff;
+}
+
+#components-reconnect-modal button:active {
+    background-color: #353535;
+}
+
+.components-rejoining-animation {
+    position: relative;
+    width: 80px;
+    height: 80px;
+}
+
+.components-rejoining-animation div {
+    position: absolute;
+    border: 3px solid #909090;
+    opacity: 1;
+    border-radius: 50%;
+    animation: components-rejoining-animation 1.5s cubic-bezier(0, 0.2, 0.8, 1) infinite;
+}
+
+.components-rejoining-animation div:nth-child(2) {
+    animation-delay: -0.5s;
+}
+
+@keyframes components-rejoining-animation {
+    0% {
+        top: 40px;
+        left: 40px;
+        width: 0;
+        height: 0;
+        opacity: 0;
+    }
+
+    4.9% {
+        top: 40px;
+        left: 40px;
+        width: 0;
+        height: 0;
+        opacity: 0;
+    }
+
+    5% {
+        top: 40px;
+        left: 40px;
+        width: 0;
+        height: 0;
+        opacity: 1;
+    }
+
+    100% {
+        top: 0px;
+        left: 0px;
+        width: 80px;
+        height: 80px;
+        opacity: 0;
+    }
+}

--- a/src/GrayMoon.App/Components/_Imports.razor
+++ b/src/GrayMoon.App/Components/_Imports.razor
@@ -8,6 +8,7 @@
 @using Microsoft.JSInterop
 @using GrayMoon.App
 @using GrayMoon.App.Components
+@using GrayMoon.App.Components.Layout
 @using GrayMoon.App.Components.Modals
 @using GrayMoon.App.Components.Shared
 @using GrayMoon.App.Models

--- a/src/GrayMoon.App/Program.cs
+++ b/src/GrayMoon.App/Program.cs
@@ -204,6 +204,8 @@ try
     app.UseStaticFiles();
     app.UseAntiforgery();
 
+    app.MapStaticAssets();
+
     app.MapApiEndpoints();
     app.MapHub<WorkspaceSyncHub>("/hubs/workspace-sync");
     app.MapHub<AgentHub>("/hub/agent");

--- a/src/GrayMoon.App/wwwroot/js/reconnectModal.js
+++ b/src/GrayMoon.App/wwwroot/js/reconnectModal.js
@@ -1,6 +1,15 @@
 // Blazor circuit reconnect modal (see Components/Layout/ReconnectModal.razor).
-const reconnectModal = document.getElementById("components-reconnect-modal");
-if (reconnectModal) {
+function getReconnectModal() {
+    return document.getElementById("components-reconnect-modal");
+}
+
+function bindReconnectModal() {
+    const reconnectModal = getReconnectModal();
+    if (!reconnectModal || reconnectModal.dataset.reconnectBound === "true") {
+        return;
+    }
+
+    reconnectModal.dataset.reconnectBound = "true";
     reconnectModal.addEventListener("components-reconnect-state-changed", handleReconnectStateChanged);
 
     const retryButton = document.getElementById("components-reconnect-button");
@@ -14,13 +23,24 @@ if (reconnectModal) {
     }
 }
 
+if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", bindReconnectModal);
+} else {
+    bindReconnectModal();
+}
+
 function handleReconnectStateChanged(event) {
-    if (!reconnectModal) return;
+    const reconnectModal = event.currentTarget;
+    if (!(reconnectModal instanceof HTMLDialogElement)) {
+        return;
+    }
 
     if (event.detail.state === "show") {
         reconnectModal.showModal();
     } else if (event.detail.state === "hide") {
-        reconnectModal.close();
+        if (reconnectModal.open) {
+            reconnectModal.close();
+        }
     } else if (event.detail.state === "failed") {
         document.addEventListener("visibilitychange", retryWhenDocumentBecomesVisible);
     } else if (event.detail.state === "rejected" || event.detail.state === "resume-failed") {
@@ -37,8 +57,8 @@ async function retry() {
             const resumeSuccessful = await Blazor.resumeCircuit();
             if (!resumeSuccessful) {
                 location.reload();
-            } else if (reconnectModal) {
-                reconnectModal.close();
+            } else {
+                getReconnectModal()?.close();
             }
         }
     } catch {
@@ -53,6 +73,7 @@ async function resume() {
             location.reload();
         }
     } catch {
+        const reconnectModal = getReconnectModal();
         if (reconnectModal) {
             reconnectModal.classList.replace("components-reconnect-paused", "components-reconnect-resume-failed");
         }

--- a/src/GrayMoon.App/wwwroot/js/reconnectModal.js
+++ b/src/GrayMoon.App/wwwroot/js/reconnectModal.js
@@ -1,0 +1,66 @@
+// Blazor circuit reconnect modal (see Components/Layout/ReconnectModal.razor).
+const reconnectModal = document.getElementById("components-reconnect-modal");
+if (reconnectModal) {
+    reconnectModal.addEventListener("components-reconnect-state-changed", handleReconnectStateChanged);
+
+    const retryButton = document.getElementById("components-reconnect-button");
+    if (retryButton) {
+        retryButton.addEventListener("click", retry);
+    }
+
+    const resumeButton = document.getElementById("components-resume-button");
+    if (resumeButton) {
+        resumeButton.addEventListener("click", resume);
+    }
+}
+
+function handleReconnectStateChanged(event) {
+    if (!reconnectModal) return;
+
+    if (event.detail.state === "show") {
+        reconnectModal.showModal();
+    } else if (event.detail.state === "hide") {
+        reconnectModal.close();
+    } else if (event.detail.state === "failed") {
+        document.addEventListener("visibilitychange", retryWhenDocumentBecomesVisible);
+    } else if (event.detail.state === "rejected" || event.detail.state === "resume-failed") {
+        location.reload();
+    }
+}
+
+async function retry() {
+    document.removeEventListener("visibilitychange", retryWhenDocumentBecomesVisible);
+
+    try {
+        const successful = await Blazor.reconnect();
+        if (!successful) {
+            const resumeSuccessful = await Blazor.resumeCircuit();
+            if (!resumeSuccessful) {
+                location.reload();
+            } else if (reconnectModal) {
+                reconnectModal.close();
+            }
+        }
+    } catch {
+        document.addEventListener("visibilitychange", retryWhenDocumentBecomesVisible);
+    }
+}
+
+async function resume() {
+    try {
+        const successful = await Blazor.resumeCircuit();
+        if (!successful) {
+            location.reload();
+        }
+    } catch {
+        if (reconnectModal) {
+            reconnectModal.classList.replace("components-reconnect-paused", "components-reconnect-resume-failed");
+        }
+    }
+}
+
+async function retryWhenDocumentBecomesVisible() {
+    if (document.visibilityState === "visible") {
+        await retry();
+    }
+}


### PR DESCRIPTION
## Summary

- Stop running GitVersion during remote integrate and push; resolve branch via git and leave version resolution to callers that need it (e.g. commit sync resolves SemVer separately)
- Add a styled Blazor circuit reconnect modal with retry, resume, and visibility-based recovery
- Version static CSS through `MapStaticAssets`, `ImportMap`, and `@Assets` references so stylesheets cache-bust on deploy
- Some changes are uncommitted only — commit and push before opening the PR

## Test plan

- [ ] Run push on a workspace repo and confirm integrate succeeds without invoking GitVersion for branch/version
- [ ] Run commit sync and confirm informational version is still reported correctly on success and failure paths
- [ ] Disconnect the Blazor circuit (e.g. stop/restart App) and verify the reconnect modal appears, retry works, and the modal hides after rejoin
- [ ] Deploy or rebuild the App and confirm CSS updates apply after refresh (no stale cached stylesheets)