### PR TITLE
Fix synchronized push version refresh and defer grid reload during jobs

### DIFF
--- a/src/GrayMoon.Agent/Commands/PushRepositoryCommand.cs
+++ b/src/GrayMoon.Agent/Commands/PushRepositoryCommand.cs
@@ -99,13 +99,13 @@ public sealed class PushRepositoryCommand(
     private Task SendPostOperationSyncIfRequestedAsync(PushRepositoryRequest request, string repoPath, string branch)
     {
         if (request.RefreshVersionAfterPush)
-            return SendPostOperationSyncAsync(request.WorkspaceId, request.RepositoryId, repoPath, branch);
+            return SendPostOperationSyncAsync(request.WorkspaceId, request.RepositoryId, repoPath, branch, versionOnly: true);
 
-        _ = SendPostOperationSyncAsync(request.WorkspaceId, request.RepositoryId, repoPath, branch);
+        _ = SendPostOperationSyncAsync(request.WorkspaceId, request.RepositoryId, repoPath, branch, versionOnly: false);
         return Task.CompletedTask;
     }
 
-    private async Task SendPostOperationSyncAsync(int workspaceId, int repositoryId, string repoPath, string branch)
+    private async Task SendPostOperationSyncAsync(int workspaceId, int repositoryId, string repoPath, string branch, bool versionOnly)
     {
         try
         {
@@ -113,8 +113,17 @@ public sealed class PushRepositoryCommand(
             if (connection?.State != HubConnectionState.Connected) return;
 
             var defaultRef = await git.GetDefaultBranchOriginRefAsync(repoPath, CancellationToken.None);
-            var (outgoing, incoming, hasUpstream) = await git.GetCommitCountsAsync(repoPath, branch, defaultRef, CancellationToken.None);
-            var (defaultBehind, defaultAhead, _) = await git.GetCommitCountsVsDefaultAsync(repoPath, defaultRef, CancellationToken.None);
+            int? outgoing = null;
+            int? incoming = null;
+            bool? hasUpstream = null;
+            int? defaultBehind = null;
+            int? defaultAhead = null;
+            if (!versionOnly)
+            {
+                (outgoing, incoming, hasUpstream) = await git.GetCommitCountsAsync(repoPath, branch, defaultRef, CancellationToken.None);
+                (defaultBehind, defaultAhead, _) = await git.GetCommitCountsVsDefaultAsync(repoPath, defaultRef, CancellationToken.None);
+            }
+
             var (versionResult, _) = await git.GetVersionAsync(repoPath, nonNormalize: true, CancellationToken.None);
             var version = versionResult?.InformationalVersion ?? "-";
             var versionBranch = versionResult?.BranchName ?? versionResult?.EscapedBranchName ?? branch;
@@ -132,8 +141,8 @@ public sealed class PushRepositoryCommand(
                 DefaultBranchAhead = defaultAhead,
             };
             await connection.InvokeAsync(AgentHubMethods.SyncCommand, notification, CancellationToken.None);
-            logger.LogInformation("Post-push SyncCommand sent: workspace={WorkspaceId}, repo={RepoId}, outgoing={Outgoing}",
-                workspaceId, repositoryId, outgoing);
+            logger.LogInformation("Post-push SyncCommand sent: workspace={WorkspaceId}, repo={RepoId}, outgoing={Outgoing}, versionOnly={VersionOnly}",
+                workspaceId, repositoryId, outgoing, versionOnly);
         }
         catch (Exception ex)
         {

--- a/src/GrayMoon.Agent/Commands/PushRepositoryCommand.cs
+++ b/src/GrayMoon.Agent/Commands/PushRepositoryCommand.cs
@@ -1,134 +1,143 @@
-using GrayMoon.Abstractions.Agent;
-using GrayMoon.Abstractions.Notifications;
-using GrayMoon.Agent.Abstractions;
-using GrayMoon.Agent.Jobs.Requests;
-using GrayMoon.Agent.Jobs.Response;
-using GrayMoon.Agent.Services;
-using Microsoft.AspNetCore.SignalR.Client;
-using Microsoft.Extensions.Logging;
-
-namespace GrayMoon.Agent.Commands;
-
-/// <summary>Fetches and pulls remote changes, then pushes when outgoing commits exist or upstream is not set.</summary>
-public sealed class PushRepositoryCommand(
-    IGitService git,
-    GitRemoteIntegrateService remoteIntegrate,
-    IHubConnectionProvider hubProvider,
-    ILogger<PushRepositoryCommand> logger) : ICommandHandler<PushRepositoryRequest, PushRepositoryResponse>
-{
-    public async Task<PushRepositoryResponse> ExecuteAsync(PushRepositoryRequest request, CancellationToken cancellationToken = default)
-    {
-        try
-        {
-            return await ExecuteCoreAsync(request, cancellationToken);
-        }
-        catch (Exception ex)
-        {
-            return new PushRepositoryResponse
-            {
-                Success = false,
-                ErrorMessage = ex.Message
-            };
-        }
-    }
-
-    private async Task<PushRepositoryResponse> ExecuteCoreAsync(PushRepositoryRequest request, CancellationToken cancellationToken = default)
-    {
-        var workspaceName = request.WorkspaceName ?? throw new ArgumentException("workspaceName required");
-        var repositoryName = request.RepositoryName ?? throw new ArgumentException("repositoryName required");
-        var bearerToken = request.BearerToken;
-
-        var workspacePath = git.GetWorkspacePath(request.WorkspaceRoot!, workspaceName);
-        var repoPath = Path.Combine(workspacePath, repositoryName);
-
-        if (!git.DirectoryExists(repoPath))
-        {
-            return new PushRepositoryResponse
-            {
-                Success = false,
-                ErrorMessage = "Repository not found"
-            };
-        }
-
-        var integrate = await remoteIntegrate.IntegrateAsync(repoPath, bearerToken, cancellationToken);
-        if (!integrate.Success)
-        {
-            if (integrate.Branch != null)
-                _ = SendPostOperationSyncAsync(request.WorkspaceId, request.RepositoryId, repoPath, integrate.Branch);
-
-            return new PushRepositoryResponse
-            {
-                Success = false,
-                ErrorMessage = integrate.ErrorMessage
-            };
-        }
-
-        var branch = request.BranchName?.Trim();
-        if (string.IsNullOrEmpty(branch))
-            branch = integrate.Branch;
-        if (string.IsNullOrWhiteSpace(branch))
-        {
-            return new PushRepositoryResponse
-            {
-                Success = false,
-                ErrorMessage = "Could not determine branch name"
-            };
-        }
-
-        var outgoing = integrate.Outgoing ?? 0;
-        var hasUpstream = integrate.HasUpstream;
-
-        if (outgoing <= 0 && hasUpstream)
-        {
-            _ = SendPostOperationSyncAsync(request.WorkspaceId, request.RepositoryId, repoPath, branch);
-            return new PushRepositoryResponse { Success = true };
-        }
-
-        var setTracking = !hasUpstream;
-        var (pushSuccess, errorMessage) = await git.PushAsync(repoPath, branch, bearerToken, setTracking: setTracking, ct: cancellationToken);
-
-        _ = SendPostOperationSyncAsync(request.WorkspaceId, request.RepositoryId, repoPath, branch);
-
-        return new PushRepositoryResponse
-        {
-            Success = pushSuccess,
-            ErrorMessage = pushSuccess ? null : errorMessage
-        };
-    }
-
-    private async Task SendPostOperationSyncAsync(int workspaceId, int repositoryId, string repoPath, string branch)
-    {
-        try
-        {
-            var connection = hubProvider.Connection;
-            if (connection?.State != HubConnectionState.Connected) return;
-
-            var defaultRef = await git.GetDefaultBranchOriginRefAsync(repoPath, CancellationToken.None);
-            var (outgoing, incoming, hasUpstream) = await git.GetCommitCountsAsync(repoPath, branch, defaultRef, CancellationToken.None);
-            var (defaultBehind, defaultAhead, _) = await git.GetCommitCountsVsDefaultAsync(repoPath, defaultRef, CancellationToken.None);
-            var (versionResult, _) = await git.GetVersionAsync(repoPath, nonNormalize: true, CancellationToken.None);
-            var version = versionResult?.InformationalVersion ?? "-";
-            var versionBranch = versionResult?.BranchName ?? versionResult?.EscapedBranchName ?? branch;
-
-            var notification = new RepositorySyncNotification
-            {
-                WorkspaceId = workspaceId,
-                RepositoryId = repositoryId,
-                Version = version,
-                Branch = versionBranch,
-                OutgoingCommits = outgoing,
-                IncomingCommits = incoming,
-                HasUpstream = hasUpstream,
-                DefaultBranchBehind = defaultBehind,
-                DefaultBranchAhead = defaultAhead,
-            };
-            await connection.InvokeAsync(AgentHubMethods.SyncCommand, notification, CancellationToken.None);
-            logger.LogInformation("Post-push SyncCommand sent: workspace={WorkspaceId}, repo={RepoId}, outgoing={Outgoing}",
-                workspaceId, repositoryId, outgoing);
-        }
-        catch (Exception ex)
-        {
-            logger.LogWarning(ex, "Post-push SyncCommand failed for repo {RepoId}", repositoryId);
-        }
-    }
-}
+using GrayMoon.Abstractions.Agent;
+using GrayMoon.Abstractions.Notifications;
+using GrayMoon.Agent.Abstractions;
+using GrayMoon.Agent.Jobs.Requests;
+using GrayMoon.Agent.Jobs.Response;
+using GrayMoon.Agent.Services;
+using Microsoft.AspNetCore.SignalR.Client;
+using Microsoft.Extensions.Logging;
+
+namespace GrayMoon.Agent.Commands;
+
+/// <summary>Fetches and pulls remote changes, then pushes when outgoing commits exist or upstream is not set.</summary>
+public sealed class PushRepositoryCommand(
+    IGitService git,
+    GitRemoteIntegrateService remoteIntegrate,
+    IHubConnectionProvider hubProvider,
+    ILogger<PushRepositoryCommand> logger) : ICommandHandler<PushRepositoryRequest, PushRepositoryResponse>
+{
+    public async Task<PushRepositoryResponse> ExecuteAsync(PushRepositoryRequest request, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            return await ExecuteCoreAsync(request, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            return new PushRepositoryResponse
+            {
+                Success = false,
+                ErrorMessage = ex.Message
+            };
+        }
+    }
+
+    private async Task<PushRepositoryResponse> ExecuteCoreAsync(PushRepositoryRequest request, CancellationToken cancellationToken = default)
+    {
+        var workspaceName = request.WorkspaceName ?? throw new ArgumentException("workspaceName required");
+        var repositoryName = request.RepositoryName ?? throw new ArgumentException("repositoryName required");
+        var bearerToken = request.BearerToken;
+
+        var workspacePath = git.GetWorkspacePath(request.WorkspaceRoot!, workspaceName);
+        var repoPath = Path.Combine(workspacePath, repositoryName);
+
+        if (!git.DirectoryExists(repoPath))
+        {
+            return new PushRepositoryResponse
+            {
+                Success = false,
+                ErrorMessage = "Repository not found"
+            };
+        }
+
+        var integrate = await remoteIntegrate.IntegrateAsync(repoPath, bearerToken, cancellationToken);
+        if (!integrate.Success)
+        {
+            if (integrate.Branch != null)
+                await SendPostOperationSyncIfRequestedAsync(request, repoPath, integrate.Branch);
+
+            return new PushRepositoryResponse
+            {
+                Success = false,
+                ErrorMessage = integrate.ErrorMessage
+            };
+        }
+
+        var branch = request.BranchName?.Trim();
+        if (string.IsNullOrEmpty(branch))
+            branch = integrate.Branch;
+        if (string.IsNullOrWhiteSpace(branch))
+        {
+            return new PushRepositoryResponse
+            {
+                Success = false,
+                ErrorMessage = "Could not determine branch name"
+            };
+        }
+
+        var outgoing = integrate.Outgoing ?? 0;
+        var hasUpstream = integrate.HasUpstream;
+
+        if (outgoing <= 0 && hasUpstream)
+        {
+            await SendPostOperationSyncIfRequestedAsync(request, repoPath, branch);
+            return new PushRepositoryResponse { Success = true };
+        }
+
+        var setTracking = !hasUpstream;
+        var (pushSuccess, errorMessage) = await git.PushAsync(repoPath, branch, bearerToken, setTracking: setTracking, ct: cancellationToken);
+
+        await SendPostOperationSyncIfRequestedAsync(request, repoPath, branch);
+
+        return new PushRepositoryResponse
+        {
+            Success = pushSuccess,
+            ErrorMessage = pushSuccess ? null : errorMessage
+        };
+    }
+
+    private Task SendPostOperationSyncIfRequestedAsync(PushRepositoryRequest request, string repoPath, string branch)
+    {
+        if (request.RefreshVersionAfterPush)
+            return SendPostOperationSyncAsync(request.WorkspaceId, request.RepositoryId, repoPath, branch);
+
+        _ = SendPostOperationSyncAsync(request.WorkspaceId, request.RepositoryId, repoPath, branch);
+        return Task.CompletedTask;
+    }
+
+    private async Task SendPostOperationSyncAsync(int workspaceId, int repositoryId, string repoPath, string branch)
+    {
+        try
+        {
+            var connection = hubProvider.Connection;
+            if (connection?.State != HubConnectionState.Connected) return;
+
+            var defaultRef = await git.GetDefaultBranchOriginRefAsync(repoPath, CancellationToken.None);
+            var (outgoing, incoming, hasUpstream) = await git.GetCommitCountsAsync(repoPath, branch, defaultRef, CancellationToken.None);
+            var (defaultBehind, defaultAhead, _) = await git.GetCommitCountsVsDefaultAsync(repoPath, defaultRef, CancellationToken.None);
+            var (versionResult, _) = await git.GetVersionAsync(repoPath, nonNormalize: true, CancellationToken.None);
+            var version = versionResult?.InformationalVersion ?? "-";
+            var versionBranch = versionResult?.BranchName ?? versionResult?.EscapedBranchName ?? branch;
+
+            var notification = new RepositorySyncNotification
+            {
+                WorkspaceId = workspaceId,
+                RepositoryId = repositoryId,
+                Version = version,
+                Branch = versionBranch,
+                OutgoingCommits = outgoing,
+                IncomingCommits = incoming,
+                HasUpstream = hasUpstream,
+                DefaultBranchBehind = defaultBehind,
+                DefaultBranchAhead = defaultAhead,
+            };
+            await connection.InvokeAsync(AgentHubMethods.SyncCommand, notification, CancellationToken.None);
+            logger.LogInformation("Post-push SyncCommand sent: workspace={WorkspaceId}, repo={RepoId}, outgoing={Outgoing}",
+                workspaceId, repositoryId, outgoing);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Post-push SyncCommand failed for repo {RepoId}", repositoryId);
+        }
+    }
+}

--- a/src/GrayMoon.Agent/Jobs/Requests/PushRepositoryRequest.cs
+++ b/src/GrayMoon.Agent/Jobs/Requests/PushRepositoryRequest.cs
@@ -22,4 +22,8 @@ public sealed class PushRepositoryRequest : WorkspaceCommandRequest
     /// <summary>Optional. When set, the agent uses this branch instead of resolving the current branch via git.</summary>
     [JsonPropertyName("branchName")]
     public string? BranchName { get; set; }
+
+    /// <summary>When true, the agent awaits GitVersion and SyncCommand after push before returning (orchestrator synchronized push).</summary>
+    [JsonPropertyName("refreshVersionAfterPush")]
+    public bool RefreshVersionAfterPush { get; set; }
 }

--- a/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor.css
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor.css
@@ -110,10 +110,14 @@
     align-items: center;
     justify-content: center;
     min-width: 1.25rem;
-    padding: 0 0.28rem;
+    min-height: 1.25rem;
+    padding: 0.1rem 0.28rem;
     font-size: 0.72rem;
     font-weight: 600;
-    line-height: 1.35;
+    line-height: 1;
+    font-variant-numeric: tabular-nums;
+    text-align: center;
+    box-sizing: border-box;
     border-radius: var(--gha-status-filter-radius);
 }
 

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.Push.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.Push.cs
@@ -228,6 +228,7 @@ public sealed partial class WorkspaceRepositories
         }
         finally
         {
+            _pendingRefreshAfterJob = false;
             await InvokeAsync(async () =>
             {
                 if (_disposed) return;

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.Realtime.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.Realtime.cs
@@ -23,7 +23,11 @@ public sealed partial class WorkspaceRepositories
             _hubConnection.On<int>("WorkspaceSynced", async (workspaceId) =>
             {
                 if (workspaceId != WorkspaceId) return;
-                if (IsJobRunning) return;
+                if (IsBackgroundJobRunning)
+                {
+                    _pendingRefreshAfterJob = true;
+                    return;
+                }
                 CancellationTokenSource cts;
                 lock (_refreshDebounceLock)
                 {
@@ -68,9 +72,18 @@ public sealed partial class WorkspaceRepositories
     private void OnJobServiceChanged()
     {
         if (_disposed) return;
+        var shouldRefreshAfterJob = _pendingRefreshAfterJob && !IsBackgroundJobRunning;
+        if (shouldRefreshAfterJob)
+            _pendingRefreshAfterJob = false;
         // Overlay / IsJobRunning UI only. Grid refresh runs inside job bodies
         // (RefreshOnSuccess / ReloadWorkspaceDataAfterCancelAsync), not here.
-        _ = InvokeAsync(StateHasChanged);
+        _ = InvokeAsync(async () =>
+        {
+            if (_disposed) return;
+            StateHasChanged();
+            if (shouldRefreshAfterJob)
+                await RefreshFromSync();
+        });
     }
 
     private void SafeInvoke(Action callback)

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.State.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.State.cs
@@ -69,7 +69,11 @@ public sealed partial class WorkspaceRepositories
     private bool _disposed;
     private readonly SemaphoreSlim _reloadGate = new(1, 1);
     private string PageJobKey => new Uri(NavigationManager.Uri).AbsolutePath.ToLowerInvariant();
+    private string WorkspacePanelJobKey => $"/workspaces/{WorkspaceId}";
     private bool IsJobRunning => JobService.IsRunning(PageJobKey);
+    /// <summary>True when either the repos page or the floating notification panel has a job for this workspace.</summary>
+    private bool IsBackgroundJobRunning => IsJobRunning || JobService.IsRunning(WorkspacePanelJobKey);
+    private bool _pendingRefreshAfterJob;
     private int AgentTasksPendingCount => AgentQueueStateService.GetPendingCountForWorkspace(WorkspaceId);
     private const int RefreshDebounceMs = 200;
     private CancellationTokenSource? _refreshDebounceCts;

--- a/src/GrayMoon.App/Models/WorkspaceOptions.cs
+++ b/src/GrayMoon.App/Models/WorkspaceOptions.cs
@@ -11,6 +11,6 @@ public class WorkspaceOptions
     /// <summary>Port only for post-commit hook URL. When set (and PostCommitHookBaseUrl is empty), hooks use http://127.0.0.1:{port}. Typical value: 8384.</summary>
     public int? PostCommitHookPort { get; set; }
 
-    /// <summary>Expected time per dependency build in minutes, used to compute push wait timeout. Timeout = (number of dependencies) × this value. Default 2.</summary>
-    public double PushWaitDependencyTimeoutMinutesPerDependency { get; set; } = 2.0;
+    /// <summary>Expected time per dependency build in minutes, used to compute push wait timeout. Timeout = (number of dependencies) × this value. Default 3.</summary>
+    public double PushWaitDependencyTimeoutMinutesPerDependency { get; set; } = 3.0;
 }

--- a/src/GrayMoon.App/Services/WorkspacePushService.cs
+++ b/src/GrayMoon.App/Services/WorkspacePushService.cs
@@ -144,7 +144,7 @@ public sealed class WorkspacePushService(
         if (!synchronizedPushPossible || _nuGetService == null || _connectorRepository == null)
         {
             onProgressMessage?.Invoke("Pushing all repositories...");
-            await PushReposAsync(workspace, payload, bearerByRepoId, onProgressMessage, onRepoError, onAppSideComplete, cancellationToken);
+            await PushReposAsync(workspace, payload, bearerByRepoId, onProgressMessage, onRepoError, onAppSideComplete, cancellationToken: cancellationToken);
             await UpdateCommitCountsAndUpstreamAfterPushAsync(workspaceId, payload, cancellationToken);
             return;
         }
@@ -308,6 +308,7 @@ public sealed class WorkspacePushService(
                 levelProgress,
                 onRepoError,
                 onAppSideComplete: level == lastLevel ? null : onAppSideComplete,
+                refreshVersionAfterPush: true,
                 cancellationToken);
             await UpdateCommitCountsAndUpstreamAfterPushAsync(workspaceId, reposAtLevel, cancellationToken);
             pushedRepos.AddRange(reposAtLevel);
@@ -433,7 +434,7 @@ public sealed class WorkspacePushService(
             if (reposAtLevel.Count == 0) continue;
             var levelProgress = onProgressMessage == null ? (Action<string>?)null : msg => onProgressMessage($"{msg}\nLevel {level}");
             levelProgress?.Invoke($"Pushing {reposAtLevel.Count} {(reposAtLevel.Count == 1 ? "repository" : "repositories")}...");
-            await PushReposAsync(workspace, reposAtLevel, bearerByRepoId, levelProgress, onRepoError, onAppSideComplete: null, cancellationToken);
+            await PushReposAsync(workspace, reposAtLevel, bearerByRepoId, levelProgress, onRepoError, onAppSideComplete: null, cancellationToken: cancellationToken);
             await UpdateCommitCountsAndUpstreamAfterPushAsync(workspaceId, reposAtLevel, cancellationToken);
         }
 
@@ -491,7 +492,7 @@ public sealed class WorkspacePushService(
         }
 
         onProgressMessage?.Invoke($"Pushing {payload.Count} {(payload.Count == 1 ? "repository" : "repositories")}...");
-        await PushReposAsync(workspace, payload, bearerByRepoId, onProgressMessage, onRepoError, onAppSideComplete, cancellationToken);
+        await PushReposAsync(workspace, payload, bearerByRepoId, onProgressMessage, onRepoError, onAppSideComplete, cancellationToken: cancellationToken);
         await UpdateCommitCountsAndUpstreamAfterPushAsync(workspaceId, payload, cancellationToken);
     }
 
@@ -718,6 +719,7 @@ public sealed class WorkspacePushService(
         Action<string>? onProgressMessage,
         Action<int, string>? onRepoError,
         Action? onAppSideComplete = null,
+        bool refreshVersionAfterPush = false,
         CancellationToken cancellationToken = default)
     {
         var completed = 0;
@@ -740,7 +742,8 @@ public sealed class WorkspacePushService(
                     repositoryName = repo.RepoName,
                     bearerToken = bearerByRepoId.GetValueOrDefault(repo.RepoId),
                     workspaceId = workspace.WorkspaceId,
-                    workspaceRoot
+                    workspaceRoot,
+                    refreshVersionAfterPush
                 };
                 var response = await _agentBridge.SendCommandAsync("PushRepository", args, cancellationToken);
                 var success = response.Success && response.Data != null && AgentResponseJson.DeserializeAgentResponse<PushRepositoryResponse>(response.Data) is { Success: true };

--- a/src/GrayMoon.App/wwwroot/app.css
+++ b/src/GrayMoon.App/wwwroot/app.css
@@ -1072,7 +1072,11 @@ table.resizable-columns th:hover .resize-handle::after {
 .repositories-table td.col-divergence .divergence-link {
     display: inline-flex;
     align-items: center;
+    justify-content: center;
+    height: calc(1.5em + 2px);
+    line-height: 1;
     padding: 0 0.25rem;
+    box-sizing: border-box;
     border: 1px solid transparent;
     border-radius: 0.25rem;
     cursor: pointer;
@@ -1114,7 +1118,8 @@ table.resizable-columns th:hover .resize-handle::after {
     /* Reset button defaults */
     font-size: inherit;
     font-family: inherit;
-    line-height: inherit;
+    line-height: 1;
+    padding: 0 0.25rem;
 }
 
 .repositories-table td.col-divergence .divergence-link.divergence-link-behind--actionable:hover,


### PR DESCRIPTION
## Summary

- Await post-push GitVersion SyncCommand during orchestrated push so NuGet wait sees the new package version
- Raise per-dependency push wait timeout from 2 to 3 minutes
- Defer workspace grid refresh while a background job is running, then reload once it finishes
- Tighten vertical centering for count badges in the actions and repositories UI
- Working tree has uncommitted changes that may not be included in the branch diff

## Test plan

- [ ] Run synchronized push across multi-level repos and confirm each level waits on the refreshed version before proceeding
- [ ] Confirm a slow NuGet publish still succeeds within the 3-minute-per-dependency timeout
- [ ] Trigger a workspace sync event while a push/update job is running and verify the grid refreshes only after the job completes
- [ ] Spot-check badge/count alignment on Workspace Actions and repository table headers