### PR TITLE
Fix dependency level walk and pending-action detection for file version updates

### DIFF
--- a/src/GrayMoon.App/Repositories/WorkspaceProjectRepository.cs
+++ b/src/GrayMoon.App/Repositories/WorkspaceProjectRepository.cs
@@ -132,7 +132,7 @@ public sealed class WorkspaceProjectRepository(
             workspaceId, repositoryId, toRemove.Count, byName.Count);
     }
 
-    /// <summary>Replaces project dependencies for workspace projects from sync results. Only dependencies where the referenced package is a workspace project are persisted. When <paramref name="persistDependencyLevel"/> is false, this method does not persist levels (avoids partial uniqueEdges); callers such as <c>WorkspaceGitService.PersistVersionsAsync</c> follow with <c>RecomputeAndPersistRepositoryDependencyStatsAsync</c> so levels are recomputed from the full DB graph.</summary>
+    /// <summary>Replaces project dependencies for workspace projects from sync results. Only dependencies where the referenced package is a workspace project are persisted. When <paramref name="persistDependencyLevel"/> is true, levels are recomputed from the full DB graph (not the partial merge batch). When false, callers such as <c>WorkspaceGitService.PersistVersionsAsync</c> follow with <c>RecomputeAndPersistRepositoryDependencyStatsAsync</c>.</summary>
     public async Task MergeWorkspaceProjectDependenciesAsync(
         int workspaceId,
         IReadOnlyList<(int RepoId, IReadOnlyList<SyncProjectInfo>? ProjectsDetail)> syncResults,
@@ -207,7 +207,7 @@ public sealed class WorkspaceProjectRepository(
             workspaceId, dependentProjectIds.Count, uniqueEdges.Count);
 
         if (persistDependencyLevel)
-            await PersistRepositoryDependencyLevelAndDependenciesAsync(workspaceId, workspaceProjects, uniqueEdges, cancellationToken);
+            await RecomputeAndPersistRepositoryDependencyStatsAsync(workspaceId, cancellationToken);
     }
 
     /// <summary>Recomputes DependencyLevel, Dependencies, and UnmatchedDeps from current DB state (workspace projects, project dependencies, and file version configs) and persists to WorkspaceRepositoryLink. Use after a repository version change (e.g. notify job) so the grid can refresh without re-reading .csproj files.</summary>

--- a/src/GrayMoon.App/Services/DependencyUpdateOrchestrator.cs
+++ b/src/GrayMoon.App/Services/DependencyUpdateOrchestrator.cs
@@ -21,6 +21,8 @@ public sealed class DependencyUpdateOrchestrator(
     /// <summary>
     /// Runs the full update flow per dependency level:
     /// refresh projects, update+commit version files, sync+commit csproj deps, refresh repo versions.
+    /// Walks all dependency levels (up to <paramref name="maxLevel"/>) so version-file work that appears
+    /// after a lower-level commit is not skipped. Csproj sync is scoped to <paramref name="repoIdsToUpdate"/>.
     /// Stops on first error and reports it via <paramref name="onRepoError"/>.
     /// </summary>
     /// <param name="repoIdsToUpdate">Optional. When set, only these repositories are considered for the update plan and all steps.</param>
@@ -61,8 +63,10 @@ public sealed class DependencyUpdateOrchestrator(
         if (hadError)
             return new HashSet<int>();
 
-        // Step 2+: Process repositories by dependency level.
-        var levelRepoIds = await GetRepositoryIdsByDependencyLevelAsync(workspaceId, repoIdsToUpdate, OnRepoError);
+        // Step 2+: Walk every dependency level (up to maxLevel). Do not limit the level walk to the
+        // initial reposNeedingWork set - a lower-level csproj commit refreshes GitVersion and can mark
+        // higher-level version files out of date; those repos must still be visited for file updates.
+        var levelRepoIds = await GetRepositoryIdsByDependencyLevelAsync(workspaceId, selectedRepositoryIds: null, OnRepoError);
         if (maxLevel.HasValue)
             levelRepoIds = levelRepoIds.Where(x => x.Level <= maxLevel.Value).ToList();
         if (levelRepoIds.Count == 0)
@@ -76,7 +80,7 @@ public sealed class DependencyUpdateOrchestrator(
                 break;
 
             if (repoIds.Count == 0)
-                break;
+                continue;
 
             // Re-fetch per level: RefreshRepositoryVersionsAsync updates OutOfDateFileRepos in the DB
             // after each level commits, so re-reading here ensures newly out-of-date files at higher
@@ -86,6 +90,15 @@ public sealed class DependencyUpdateOrchestrator(
                 .Where(l => (l.OutOfDateFileRepos ?? 0) > 0)
                 .Select(l => l.RepositoryId)
                 .ToHashSet();
+
+            // Csproj sync stays scoped to the caller's selection (or all repos at this level when null).
+            var csprojScope = repoIdsToUpdate != null
+                ? (IReadOnlySet<int>)repoIds.Where(repoIdsToUpdate.Contains).ToHashSet()
+                : repoIds;
+
+            var hasFileWork = repoIds.Any(outOfDateFileRepoIds.Contains);
+            if (!hasFileWork && csprojScope.Count == 0)
+                continue;
 
             Action<string> levelProgress = msg => setProgress($"{msg}\nLevel {level}");
 
@@ -107,9 +120,19 @@ public sealed class DependencyUpdateOrchestrator(
                 break;
             }
 
-            var (payload, _) = await workspaceGitService.GetUpdatePlanAsync(workspaceId, repoIds, cancellationToken);
+            if (csprojScope.Count == 0)
+            {
+                if (vfCommittedRepoIds.Count > 0
+                    && !await RefreshRepositoryVersionsAsync(vfCommittedRepoIds, workspaceId, cancellationToken, levelProgress, onAppSideComplete, OnRepoError))
+                {
+                    hadError = true;
+                }
+                continue;
+            }
+
+            var (payload, _) = await workspaceGitService.GetUpdatePlanAsync(workspaceId, csprojScope, cancellationToken);
             var reposAtLevel = payload
-                .Where(p => repoIds.Contains(p.RepoId))
+                .Where(p => csprojScope.Contains(p.RepoId))
                 .ToList();
             if (reposAtLevel.Count == 0)
             {
@@ -127,7 +150,7 @@ public sealed class DependencyUpdateOrchestrator(
                 workspaceId,
                 onProgress: (c, t, _) => levelProgress($"Syncing {c} of {t}"),
                 onRepoError: OnRepoError,
-                repoIdsToSync: repoIds,
+                repoIdsToSync: csprojScope,
                 cancellationToken);
             allSyncedRepoIds.UnionWith(syncedRepoIds);
             if (hadError)

--- a/src/GrayMoon.App/Services/WorkspacePendingActionsService.cs
+++ b/src/GrayMoon.App/Services/WorkspacePendingActionsService.cs
@@ -48,7 +48,7 @@ public sealed class WorkspacePendingActionsService
         IReadOnlyList<WorkspaceRepositoryLink> links,
         IReadOnlyDictionary<int, IReadOnlyList<(string PackageId, string CurrentVersion, string NewVersion)>>? mismatchedDeps = null)
     {
-        bool hasUnmatched = links.Any(wr => !wr.IsOnTag && (wr.UnmatchedDeps ?? 0) > 0);
+        bool hasUnmatched = links.Any(wr => !wr.IsOnTag && ((wr.UnmatchedDeps ?? 0) > 0 || (wr.OutOfDateFileRepos ?? 0) > 0));
         bool isPushRecommended = links.Any(wr => !wr.IsOnTag && ((wr.OutgoingCommits ?? 0) > 0 || wr.BranchHasUpstream == false));
         bool hasIncoming = links.Any(wr =>
             !wr.IsOnTag
@@ -58,6 +58,7 @@ public sealed class WorkspacePendingActionsService
         var actionLinks = links
             .Where(wr => !wr.IsOnTag && (
                 (wr.UnmatchedDeps ?? 0) > 0 ||
+                (wr.OutOfDateFileRepos ?? 0) > 0 ||
                 (wr.OutgoingCommits ?? 0) > 0 ||
                 wr.BranchHasUpstream == false ||
                 (wr.IncomingCommits ?? 0) > 0))
@@ -86,7 +87,7 @@ public sealed class WorkspacePendingActionsService
             })
             .ToList();
         var lowestLevel = links
-            .Where(wr => !wr.IsOnTag && (wr.UnmatchedDeps ?? 0) > 0)
+            .Where(wr => !wr.IsOnTag && ((wr.UnmatchedDeps ?? 0) > 0 || (wr.OutOfDateFileRepos ?? 0) > 0))
             .Min(wr => (int?)wr.DependencyLevel);
         return new WorkspaceNotification(
             workspaceId,


### PR DESCRIPTION
## Summary

- Walk all dependency levels during updates (not just the initial repo set) so a lower-level csproj commit that refreshes GitVersion still triggers file-version updates on higher-level repos
- Scope csproj sync to the caller's selection while still visiting every level for file-only work, skipping levels only when there is neither file work nor csproj work to do
- Include out-of-date file repos (not just unmatched dependencies) when computing pending-action notifications and outgoing-change badges
- Some changes are uncommitted only - commit and push before opening the PR

## Test plan

- [ ] Run a dependency update where a lower-level repo's csproj change should cascade a version-file update to a higher-level repo; confirm it is no longer skipped
- [ ] Run a dependency update scoped to a subset of repos and confirm csproj sync stays limited to that selection while file updates still propagate across levels
- [ ] Verify the workspace pending-actions panel and outgoing-change badge now surface repos with out-of-date file versions, not only unmatched dependencies