### PR TITLE
Add Run again for failed GitHub Actions workflows

### DIFF
--- a/.claude/skills/add-agent-command/SKILL.md
+++ b/.claude/skills/add-agent-command/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: add-agent-command
+description: Step-by-step recipe for adding a new GrayMoon.Agent command (ICommandHandler) end-to-end, from request/response DTOs through hub registration.
+---
+
+# Adding a new Agent command
+
+The Agent uses `System.CommandLine`. Each agent operation implements `ICommandHandler<TRequest, TResponse>` in `src/GrayMoon.Agent/Commands/`.
+
+To add a new command:
+
+1. Define request/response DTOs.
+2. Create the handler class.
+3. Register it via `AddSingleton<ICommandHandler<TRequest, TResponse>, YourCommand>()` in `RunCommandHandler.cs`.
+4. Add it to the dispatcher dictionary in `CommandDispatcher.cs`.
+5. Add the hub method constant to `AgentHubMethods.cs`.
+6. Call via `AgentBridge.SendCommandAsync` on the App side.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,8 +42,6 @@ dotnet tool restore
 docker build --build-arg VERSION=1.0.0 -t graymoon .
 ```
 
-CI pushes to Docker Hub on commits to `main`, on tag pushes, or on any branch commit whose message contains `prerelease`.
-
 ## Architecture
 
 GrayMoon is a **two-process** system — never combine them:
@@ -63,16 +61,7 @@ Git hooks (`post-commit`, `post-checkout`, `post-merge`, `pre-push`) POST JSON t
 
 ### Agent command structure
 
-The Agent uses `System.CommandLine`. Each agent operation implements `ICommandHandler<TRequest, TResponse>` in `src/GrayMoon.Agent/Commands/`. To add a new command: (1) define request/response DTOs, (2) create the handler class, (3) register it via `AddSingleton<ICommandHandler<TRequest, TResponse>, YourCommand>()` in `RunCommandHandler.cs`, (4) add it to the dispatcher dictionary in `CommandDispatcher.cs`, (5) add the hub method constant to `AgentHubMethods.cs`, (6) call via `AgentBridge.SendCommandAsync` on the App side.
-
-### App layer structure
-
-The App is organized into:
-- `Components/Pages/` — Blazor Server pages and interactive components
-- `Components/Shared/` and `Components/Modals/` — reusable UI components
-- `Services/` — 60+ domain services (GitHub API, workspace operations, push orchestration, dependency update, etc.)
-- `Data/` — EF Core `DbContext`, entity models, and repository classes
-- `Api/Endpoints/` — REST API endpoints grouped by domain (About, Agent, Branch, Connector, Settings, Sync, Workspace)
+The Agent uses `System.CommandLine`. Each agent operation implements `ICommandHandler<TRequest, TResponse>` in `src/GrayMoon.Agent/Commands/`. See the `add-agent-command` skill for the step-by-step recipe to add a new one.
 
 ### Orchestrators
 
@@ -131,7 +120,7 @@ Connector tokens are AES-256-GCM encrypted at rest via `AesGcmTokenProtector` (b
 
 ### Database schema
 
-Schema is owned by EF Core but applied via `EnsureCreated()`. Core tables: `Connectors`, `Repositories`, `Workspaces`, `WorkspaceRepositories` (join with live state), `WorkspaceRepositoryPullRequest` (1:1 with link), `WorkspaceRepositoryActions` (CI status per link), `WorkspaceProject`, `ProjectDependency`, `WorkspaceFile`, `WorkspaceFileVersionConfig`, `WorkspaceFileLineStatuses`, `WorkspaceRepositoryCustomDependencies`, `RepositoryBranch`, `Settings`.
+Schema is owned by EF Core but applied via `EnsureCreated()`.
 
 After `EnsureCreated()`, startup calls `Migrations.RunAllAsync(dbContext)` (`src/GrayMoon.App/Migrations.cs`). Each migration is an idempotent `ALTER TABLE` guarded by `pragma_table_info()`. To add a new column: add a `public static async Task MigrateXxxAsync(AppDbContext dbContext)` method to `Migrations.cs` (check `pragma_table_info('TableName') WHERE name='ColumnName'` before executing the `ALTER TABLE`), then call it at the end of `RunAllAsync`. No EF Core migration assembly is used.
 

--- a/src/GrayMoon.App.Tests/GitHubServiceWorkflowRunTests.cs
+++ b/src/GrayMoon.App.Tests/GitHubServiceWorkflowRunTests.cs
@@ -1,0 +1,93 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using GrayMoon.App.Models;
+using GrayMoon.App.Services;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace GrayMoon.App.Tests;
+
+public sealed class GitHubServiceWorkflowRunTests
+{
+    private sealed class RecordingHandler : HttpMessageHandler
+    {
+        public HttpRequestMessage? LastRequest { get; private set; }
+        public string? LastRequestBody { get; private set; }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            LastRequest = request;
+            LastRequestBody = request.Content == null ? null : await request.Content.ReadAsStringAsync(cancellationToken);
+            return new HttpResponseMessage(HttpStatusCode.NoContent);
+        }
+    }
+
+    private static (GitHubService Service, RecordingHandler Handler) CreateService()
+    {
+        var handler = new RecordingHandler();
+        var httpClient = new HttpClient(handler);
+        var configuration = new ConfigurationBuilder().Build();
+        var service = new GitHubService(httpClient, configuration, NullLogger<GitHubService>.Instance);
+        return (service, handler);
+    }
+
+    private static Connector CreateConnector() => new()
+    {
+        ConnectorName = "GitHub",
+        ConnectorType = ConnectorType.GitHub,
+        ApiBaseUrl = "https://api.github.com/",
+        UserToken = "test-token"
+    };
+
+    [Fact]
+    public async Task DispatchWorkflowAsync_PostsToDispatchesEndpoint_WithBranchAsRef()
+    {
+        var (service, handler) = CreateService();
+
+        await service.DispatchWorkflowAsync(CreateConnector(), "acme", "widgets", 123, "feature/my-branch");
+
+        Assert.NotNull(handler.LastRequest);
+        Assert.Equal(HttpMethod.Post, handler.LastRequest!.Method);
+        Assert.Equal(
+            "https://api.github.com/repos/acme/widgets/actions/workflows/123/dispatches",
+            handler.LastRequest.RequestUri!.ToString());
+
+        Assert.NotNull(handler.LastRequestBody);
+        using var json = JsonDocument.Parse(handler.LastRequestBody!);
+        Assert.Equal("feature/my-branch", json.RootElement.GetProperty("ref").GetString());
+    }
+
+    [Fact]
+    public async Task RerunWorkflowRunAsync_PostsToRerunEndpoint_ForTheExistingRunId()
+    {
+        var (service, handler) = CreateService();
+
+        await service.RerunWorkflowRunAsync(CreateConnector(), "acme", "widgets", 456);
+
+        Assert.NotNull(handler.LastRequest);
+        Assert.Equal(HttpMethod.Post, handler.LastRequest!.Method);
+        Assert.Equal(
+            "https://api.github.com/repos/acme/widgets/actions/runs/456/rerun",
+            handler.LastRequest.RequestUri!.ToString());
+    }
+
+    [Fact]
+    public async Task DispatchAndRerun_HitDifferentEndpoints()
+    {
+        var (service, handler) = CreateService();
+        var connector = CreateConnector();
+
+        await service.DispatchWorkflowAsync(connector, "acme", "widgets", 123, "main");
+        var dispatchUri = handler.LastRequest!.RequestUri!.ToString();
+
+        await service.RerunWorkflowRunAsync(connector, "acme", "widgets", 456);
+        var rerunUri = handler.LastRequest!.RequestUri!.ToString();
+
+        Assert.NotEqual(dispatchUri, rerunUri);
+        Assert.Contains("/dispatches", dispatchUri);
+        Assert.Contains("/rerun", rerunUri);
+        Assert.DoesNotContain("/rerun", dispatchUri);
+        Assert.DoesNotContain("/dispatches", rerunUri);
+    }
+}

--- a/src/GrayMoon.App.Tests/WorkspaceActionsGatingTests.cs
+++ b/src/GrayMoon.App.Tests/WorkspaceActionsGatingTests.cs
@@ -1,0 +1,72 @@
+using GrayMoon.App.Components.Pages;
+using GrayMoon.App.Models;
+
+namespace GrayMoon.App.Tests;
+
+public sealed class WorkspaceActionsGatingTests
+{
+    private static WorkspaceActions.WorkspaceActionRow CreateRow(string? branchName) => new()
+    {
+        Link = new WorkspaceRepositoryLink { BranchName = branchName },
+        Repo = new GitHubRepositoryEntry { RepositoryName = "widgets", OrgName = "acme", ConnectorName = "GitHub" }
+    };
+
+    private static WorkspaceActions.WorkflowActionLine CreateLine(
+        string status,
+        string? branchName,
+        long? runId,
+        long? workflowId,
+        bool supportsWorkflowDispatch) => new()
+    {
+        Action = new ActionStatusInfo
+        {
+            Status = status,
+            BranchName = branchName,
+            RunId = runId,
+            WorkflowId = workflowId,
+            SupportsWorkflowDispatch = supportsWorkflowDispatch
+        }
+    };
+
+    [Fact]
+    public void CanRunAgain_TrueWhenFailedRunAlsoSupportsWorkflowDispatch()
+    {
+        var row = CreateRow("main");
+        var line = CreateLine("failed", "main", runId: 1, workflowId: 10, supportsWorkflowDispatch: true);
+
+        Assert.True(WorkspaceActions.CanRerun(row, line));
+        Assert.True(WorkspaceActions.CanRun(row, line));
+        Assert.True(WorkspaceActions.CanRunAgain(row, line));
+    }
+
+    [Fact]
+    public void CanRunAgain_FalseWhenFailedRunDoesNotSupportWorkflowDispatch()
+    {
+        var row = CreateRow("main");
+        var line = CreateLine("failed", "main", runId: 1, workflowId: 10, supportsWorkflowDispatch: false);
+
+        Assert.True(WorkspaceActions.CanRerun(row, line));
+        Assert.False(WorkspaceActions.CanRun(row, line));
+        Assert.False(WorkspaceActions.CanRunAgain(row, line));
+    }
+
+    [Fact]
+    public void CanRunAgain_FalseWhenRunHasNotFailed()
+    {
+        var row = CreateRow("main");
+        var line = CreateLine("success", "main", runId: 1, workflowId: 10, supportsWorkflowDispatch: true);
+
+        Assert.False(WorkspaceActions.CanRerun(row, line));
+        Assert.False(WorkspaceActions.CanRunAgain(row, line));
+    }
+
+    [Fact]
+    public void CanRunAgain_FalseWhenNoBranchIsSelected()
+    {
+        var row = CreateRow(null);
+        var line = CreateLine("failed", null, runId: 1, workflowId: 10, supportsWorkflowDispatch: true);
+
+        Assert.False(WorkspaceActions.CanRun(row, line));
+        Assert.False(WorkspaceActions.CanRunAgain(row, line));
+    }
+}

--- a/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor
@@ -152,6 +152,18 @@
                                         Re-run Failed Jobs Only
                                     </button>
                                 </li>
+                                @if (HasFailedRowsSupportingRunAgain)
+                                {
+                                    <li><hr class="dropdown-divider branch-menu-divider" /></li>
+                                    <li>
+                                        <button class="dropdown-item" type="button"
+                                                role="menuitem"
+                                                @onclick="HandleRunAgainAllClick"
+                                                disabled="@(isRerunningAll || isRefreshing || isLoading)">
+                                            Run again
+                                        </button>
+                                    </li>
+                                }
                             </ul>
                         }
                     </div>
@@ -192,7 +204,7 @@
                                     <th class="col-actions">Actions</th>
                                 </tr>
                             </thead>
-                            <tbody>
+                            <tbody @onscroll="CloseRerunLineMenu">
                                 @if (isLoading)
                                 {
                                     <tr>
@@ -349,7 +361,7 @@
                                                                             class="btn btn-outline-primary dropdown-toggle dropdown-toggle-split action-run-btn-split-toggle"
                                                                             aria-label="Toggle Re-run menu"
                                                                             aria-expanded="@(IsRerunLineMenuOpen(line) ? "true" : "false")"
-                                                                            @onclick="() => ToggleRerunLineMenu(line)"
+                                                                            @onclick="(MouseEventArgs args) => ToggleRerunLineMenu(line, args)"
                                                                             @onclick:stopPropagation
                                                                             disabled="@line.RunInProgress">
                                                                         <span class="visually-hidden">Toggle Dropdown</span>
@@ -357,7 +369,8 @@
                                                                     @if (IsRerunLineMenuOpen(line))
                                                                     {
                                                                         <div class="branch-menu-backdrop" @onclick="CloseRerunLineMenu"></div>
-                                                                        <ul class="dropdown-menu show shadow branch-menu-list" role="menu">
+                                                                        <ul class="dropdown-menu show shadow action-run-menu-fixed" role="menu"
+                                                                            style="@($"top:{_rerunLineMenuTop.ToString(System.Globalization.CultureInfo.InvariantCulture)}px; left:{_rerunLineMenuLeft.ToString(System.Globalization.CultureInfo.InvariantCulture)}px;")">
                                                                             <li>
                                                                                 <button class="dropdown-item" type="button" role="menuitem"
                                                                                         @onclick="() => HandleRunAgainClick(row, line)"

--- a/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor
@@ -329,7 +329,48 @@
                                                     @if (string.IsNullOrWhiteSpace(row.ErrorMessage))
                                                     {
                                                         <div class="d-flex gap-2 align-items-center">
-                                                            @if (CanRerun(row, line))
+                                                            @if (CanRunAgain(row, line))
+                                                            {
+                                                                <div class="btn-group position-relative">
+                                                                    <button class="btn btn-outline-primary action-run-btn"
+                                                                            @onclick="() => RerunWorkflowAsync(row, line)"
+                                                                            disabled="@line.RunInProgress"
+                                                                            title="Re-run failed workflow: @line.Action?.WorkflowName">
+                                                                        @if (line.RunInProgress)
+                                                                        {
+                                                                            <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
+                                                                        }
+                                                                        else
+                                                                        {
+                                                                            @:Re-run
+                                                                        }
+                                                                    </button>
+                                                                    <button type="button"
+                                                                            class="btn btn-outline-primary dropdown-toggle dropdown-toggle-split action-run-btn-split-toggle"
+                                                                            aria-label="Toggle Re-run menu"
+                                                                            aria-expanded="@(IsRerunLineMenuOpen(line) ? "true" : "false")"
+                                                                            @onclick="() => ToggleRerunLineMenu(line)"
+                                                                            @onclick:stopPropagation
+                                                                            disabled="@line.RunInProgress">
+                                                                        <span class="visually-hidden">Toggle Dropdown</span>
+                                                                    </button>
+                                                                    @if (IsRerunLineMenuOpen(line))
+                                                                    {
+                                                                        <div class="branch-menu-backdrop" @onclick="CloseRerunLineMenu"></div>
+                                                                        <ul class="dropdown-menu show shadow branch-menu-list" role="menu">
+                                                                            <li>
+                                                                                <button class="dropdown-item" type="button" role="menuitem"
+                                                                                        @onclick="() => HandleRunAgainClick(row, line)"
+                                                                                        disabled="@line.RunInProgress"
+                                                                                        title="@($"Run a new workflow on branch {row.Link.BranchName}")">
+                                                                                    Run again
+                                                                                </button>
+                                                                            </li>
+                                                                        </ul>
+                                                                    }
+                                                                </div>
+                                                            }
+                                                            else if (CanRerun(row, line))
                                                             {
                                                                 <button class="btn btn-outline-primary action-run-btn"
                                                                         @onclick="() => RerunWorkflowAsync(row, line)"

--- a/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor.cs
@@ -92,6 +92,7 @@ public sealed partial class WorkspaceActions : IDisposable
     private string? _logsWorkflowName;
 
     private bool _rerunMenuOpen;
+    private WorkflowActionLine? _openRerunMenuLine;
 
     private enum ActionLineFilterBucket
     {
@@ -232,6 +233,26 @@ public sealed partial class WorkspaceActions : IDisposable
     {
         CloseRerunMenu();
         await RerunAllFailedJobsOnlyAsync();
+    }
+
+    internal bool IsRerunLineMenuOpen(WorkflowActionLine line) => ReferenceEquals(_openRerunMenuLine, line);
+
+    internal void ToggleRerunLineMenu(WorkflowActionLine line)
+    {
+        _openRerunMenuLine = ReferenceEquals(_openRerunMenuLine, line) ? null : line;
+        StateHasChanged();
+    }
+
+    internal void CloseRerunLineMenu()
+    {
+        _openRerunMenuLine = null;
+        StateHasChanged();
+    }
+
+    internal async Task HandleRunAgainClick(WorkspaceActionRow row, WorkflowActionLine line)
+    {
+        CloseRerunLineMenu();
+        await RunWorkflowAsync(row, line);
     }
 
     internal void ToggleShowErrors()
@@ -1341,6 +1362,10 @@ public sealed partial class WorkspaceActions : IDisposable
         (line.Action?.SupportsWorkflowDispatch ?? false) &&
         (line.Action?.WorkflowId ?? 0) > 0 &&
         !string.IsNullOrWhiteSpace(row.Link.BranchName);
+
+    /// <summary>Failed run that also supports workflow_dispatch: show Re-run as a split button with a "Run again" (new dispatch) option.</summary>
+    internal static bool CanRunAgain(WorkspaceActionRow row, WorkflowActionLine line) =>
+        CanRerun(row, line) && CanRun(row, line);
 
     internal static bool CanAbort(WorkspaceActionRow row, WorkflowActionLine line) =>
         IsLineRunningForBranch(row, line) && (line.Action?.RunId ?? 0) > 0;

--- a/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor.cs
@@ -61,6 +61,9 @@ public sealed partial class WorkspaceActions : IDisposable
     private bool isRerunningAll;
     private int _rerunTotal;
     private volatile int _rerunCompleted;
+
+    /// <summary>Verb shown in <see cref="RerunAllOverlayMessage"/> for whichever bulk operation is in flight ("Re-running" vs "Starting").</summary>
+    private string _bulkOperationVerb = "Re-running";
     private CancellationTokenSource _cts = new();
     private HubConnection? _hubConnection;
     private CancellationTokenSource? _syncDebounceCts;
@@ -92,7 +95,17 @@ public sealed partial class WorkspaceActions : IDisposable
     private string? _logsWorkflowName;
 
     private bool _rerunMenuOpen;
-    private WorkflowActionLine? _openRerunMenuLine;
+
+    /// <summary>
+    /// Latch key (see <see cref="GetLineLatchKey"/>) of the per-row Run-again menu currently open, or null when none is.
+    /// The menu itself is rendered with <c>position: fixed</c> at <see cref="_rerunLineMenuTop"/>/<see cref="_rerunLineMenuLeft"/>
+    /// (captured from the click event) rather than anchored via CSS to its trigger button, because the actions grid's
+    /// scrollable <c>tbody</c> (and its ancestors) clip absolutely-positioned overflow - see WorkspaceActions.razor.css.
+    /// </summary>
+    private long? _openRerunLineMenuKey;
+
+    private double _rerunLineMenuTop;
+    private double _rerunLineMenuLeft;
 
     private enum ActionLineFilterBucket
     {
@@ -106,6 +119,10 @@ public sealed partial class WorkspaceActions : IDisposable
     internal bool HasFailedRows => rows.Any(row =>
         row.WorkflowLines.Any(line =>
             IsLineFailedForBranch(row, line)));
+
+    /// <summary>True when at least one failed workflow (anywhere in the grid) also supports workflow_dispatch, so the bulk "Run again" option has something to act on.</summary>
+    internal bool HasFailedRowsSupportingRunAgain => rows.Any(row =>
+        row.WorkflowLines.Any(line => CanRunAgain(row, line)));
 
     internal int ErrorCount => rows.Count(r => !string.IsNullOrWhiteSpace(r.ErrorMessage));
 
@@ -126,8 +143,8 @@ public sealed partial class WorkspaceActions : IDisposable
 
     internal string RerunAllOverlayMessage =>
         _rerunCompleted == 0
-            ? "Re-running actions..."
-            : $"Re-running {_rerunCompleted} of {_rerunTotal}";
+            ? $"{_bulkOperationVerb} actions..."
+            : $"{_bulkOperationVerb} {_rerunCompleted} of {_rerunTotal}";
 
     internal bool HasSearchFilter => !string.IsNullOrWhiteSpace(searchTerm);
 
@@ -235,17 +252,40 @@ public sealed partial class WorkspaceActions : IDisposable
         await RerunAllFailedJobsOnlyAsync();
     }
 
-    internal bool IsRerunLineMenuOpen(WorkflowActionLine line) => ReferenceEquals(_openRerunMenuLine, line);
-
-    internal void ToggleRerunLineMenu(WorkflowActionLine line)
+    internal async Task HandleRunAgainAllClick()
     {
-        _openRerunMenuLine = ReferenceEquals(_openRerunMenuLine, line) ? null : line;
+        CloseRerunMenu();
+        await RunAgainAllFailedAsync();
+    }
+
+    internal bool IsRerunLineMenuOpen(WorkflowActionLine line)
+    {
+        var key = GetLineLatchKey(line);
+        return key > 0 && _openRerunLineMenuKey == key;
+    }
+
+    /// <summary>Uses the click's viewport coordinates (rather than the trigger button's position) so the fixed-position menu renders correctly regardless of the grid's scroll offset.</summary>
+    internal void ToggleRerunLineMenu(WorkflowActionLine line, MouseEventArgs args)
+    {
+        var key = GetLineLatchKey(line);
+        if (key <= 0) return;
+
+        if (_openRerunLineMenuKey == key)
+        {
+            _openRerunLineMenuKey = null;
+            StateHasChanged();
+            return;
+        }
+
+        _rerunLineMenuTop = args.ClientY + 4;
+        _rerunLineMenuLeft = args.ClientX;
+        _openRerunLineMenuKey = key;
         StateHasChanged();
     }
 
     internal void CloseRerunLineMenu()
     {
-        _openRerunMenuLine = null;
+        _openRerunLineMenuKey = null;
         StateHasChanged();
     }
 
@@ -1145,6 +1185,7 @@ public sealed partial class WorkspaceActions : IDisposable
             WorkspaceId,
             failedPairs.Count);
 
+        _bulkOperationVerb = "Re-running";
         _rerunTotal = failedPairs.Count;
         _rerunCompleted = 0;
         isRerunningAll = true;
@@ -1222,6 +1263,7 @@ public sealed partial class WorkspaceActions : IDisposable
             WorkspaceId,
             failedPairs.Count);
 
+        _bulkOperationVerb = "Re-running";
         _rerunTotal = failedPairs.Count;
         _rerunCompleted = 0;
         isRerunningAll = true;
@@ -1271,6 +1313,86 @@ public sealed partial class WorkspaceActions : IDisposable
                 "GHA Re-run failed jobs only finished (API phase): WorkspaceId={WorkspaceId} attempted={Count}",
                 WorkspaceId,
                 failedPairs.Count);
+        }
+        finally
+        {
+            isRerunningAll = false;
+            await InvokeAsync(StateHasChanged);
+            _ = RefreshAllAsync();
+        }
+    }
+
+    /// <summary>Bulk "Run again": dispatches a new run (latest commit on the selected branch) for every failed workflow that supports workflow_dispatch, skipping any that don't.</summary>
+    internal async Task RunAgainAllFailedAsync()
+    {
+        var eligiblePairs = new List<(WorkspaceActionRow Row, WorkflowActionLine Line)>();
+        foreach (var row in rows)
+        {
+            foreach (var line in row.WorkflowLines)
+            {
+                if (CanRunAgain(row, line))
+                    eligiblePairs.Add((row, line));
+            }
+        }
+
+        if (eligiblePairs.Count == 0) return;
+
+        Logger.LogInformation(
+            "GHA Run again all failed requested: WorkspaceId={WorkspaceId} count={Count}",
+            WorkspaceId,
+            eligiblePairs.Count);
+
+        _bulkOperationVerb = "Starting";
+        _rerunTotal = eligiblePairs.Count;
+        _rerunCompleted = 0;
+        isRerunningAll = true;
+        await InvokeAsync(StateHasChanged);
+
+        try
+        {
+            using var semaphore = new SemaphoreSlim(MaxConcurrency, MaxConcurrency);
+            var tasks = eligiblePairs.Select(async pair =>
+            {
+                await semaphore.WaitAsync(_cts.Token);
+                try
+                {
+                    var actionEntry = BuildActionEntry(pair.Row, pair.Line);
+                    Logger.LogInformation(
+                        "GHA Run again all: invoking {Owner}/{Repo} branch={Branch} workflow={WorkflowName} WorkflowId={WorkflowId}",
+                        actionEntry.Owner,
+                        actionEntry.RepositoryName,
+                        actionEntry.HeadBranch,
+                        actionEntry.WorkflowName,
+                        actionEntry.WorkflowId);
+                    await GitHubActionsService.RunWorkflowAsync(actionEntry);
+                    Logger.LogInformation(
+                        "GHA Run again all: API ok {Owner}/{Repo} workflow={WorkflowName} WorkflowId={WorkflowId}",
+                        actionEntry.Owner,
+                        actionEntry.RepositoryName,
+                        actionEntry.WorkflowName,
+                        actionEntry.WorkflowId);
+                }
+                catch (Exception ex)
+                {
+                    Logger.LogError(ex,
+                        "GHA Run again all item failed: WorkspaceId={WorkspaceId} {Owner}/{Repo} WorkflowId={WorkflowId}",
+                        WorkspaceId,
+                        pair.Row.Repo.OrgName,
+                        pair.Row.Repo.RepositoryName,
+                        pair.Line.Action?.WorkflowId);
+                }
+                finally
+                {
+                    semaphore.Release();
+                    Interlocked.Increment(ref _rerunCompleted);
+                    await InvokeAsync(StateHasChanged);
+                }
+            });
+            await Task.WhenAll(tasks);
+            Logger.LogInformation(
+                "GHA Run again all finished (API phase): WorkspaceId={WorkspaceId} attempted={Count}",
+                WorkspaceId,
+                eligiblePairs.Count);
         }
         finally
         {

--- a/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor.css
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor.css
@@ -45,6 +45,21 @@
 }
 
 /*
+ * Per-row Run-again menu: positioned with `position: fixed` at the click's viewport
+ * coordinates (set inline via style="top:...px; left:...px;") instead of anchored
+ * via CSS to its trigger button. The actions grid confines scrolling to `tbody`
+ * (grid-page-body, table-responsive, and tbody all clip overflow in app.css), which
+ * would clip a `position: absolute` dropdown almost universally; `position: fixed`
+ * escapes that clipping the same way `.gm-gh-dropdown` does elsewhere in app.css.
+ */
+.action-run-menu-fixed {
+    position: fixed;
+    transform: translateX(-90%);
+    z-index: 2000;
+    min-width: 9rem;
+}
+
+/*
  * Title row: use same baseline alignment as app.css .workspace-repos-header .workspace-repos-title-row
  * (do not override with flex-end - that sat the subtitle lower than the h2 text).
  * Workflow count stays in <p> like WorkspaceRepositories; status chips are siblings so they don't stretch the subtitle.

--- a/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor.css
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor.css
@@ -37,6 +37,13 @@
     border-left-color: rgba(255, 255, 255, 0.4);
 }
 
+.action-run-btn-split-toggle {
+    height: 1.5rem;
+    min-width: 1.25rem;
+    padding-left: 0.35rem;
+    padding-right: 0.35rem;
+}
+
 /*
  * Title row: use same baseline alignment as app.css .workspace-repos-header .workspace-repos-title-row
  * (do not override with flex-end - that sat the subtitle lower than the h2 text).

--- a/src/GrayMoon.App/GrayMoon.App.csproj
+++ b/src/GrayMoon.App/GrayMoon.App.csproj
@@ -19,6 +19,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="GrayMoon.App.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <EmbeddedResource Include="Resources\install-agent.ps1" />
     <EmbeddedResource Include="Resources\uninstall-agent.ps1" />
   </ItemGroup>


### PR DESCRIPTION
## Summary

- Add a per-row and bulk "Run again" path on Workspace Actions that dispatches a new workflow_dispatch run on the selected branch, distinct from re-running the existing failed run
- Show Run again only when a failed workflow also supports workflow_dispatch, using a split-button menu with fixed positioning so it is not clipped by the scrollable actions grid
- Cover dispatch vs rerun API endpoints and CanRunAgain gating with unit tests; InternalsVisibleTo App.Tests for page helpers
- Extract the add-agent-command skill and trim CLAUDE.md to point at it

## Test plan

- [ ] On a failed workflow that supports workflow_dispatch, open the split menu and confirm "Run again" starts a new run on the branch (not a rerun of the same run id)
- [ ] Confirm Re-run still reuses the existing failed run, and that Run again is hidden when workflow_dispatch is unsupported
- [ ] Use bulk "Run again" and verify only eligible failed rows are dispatched, with progress overlay wording ("Starting")
- [ ] Scroll the actions grid and confirm the per-row Run again menu is not clipped
- [ ] Run `dotnet test src/GrayMoon.App.Tests/GrayMoon.App.Tests.csproj --filter "FullyQualifiedName~GitHubServiceWorkflowRunTests|FullyQualifiedName~WorkspaceActionsGatingTests"`