### PR TITLE
Cut GitHub Actions API volume with metadata caching, shared rate-limit backoff, and bounded refresh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,9 +78,11 @@ Three orchestrators coordinate multi-step workflows across repositories:
 
 ### GHA live feed services
 
-`GhaWorkflowLiveFeedService` polls `GetWorkflowRunJobsAsync` (jobs + steps) on adaptive intervals (2 s active, 3 s waiting, 15 s idle). It tracks step-status transitions and feeds the left pane of `GhaWorkflowLiveTerminal`. Rate limit state (`_rateLimitedUntil`) is shared across all terminals in the same Blazor circuit so one 429 pauses all.
+`GhaWorkflowLiveFeedService` polls `GetWorkflowRunJobsAsync` (jobs + steps) on adaptive intervals (2 s active, 3 s waiting, 15 s idle). It tracks step-status transitions and feeds the left pane of `GhaWorkflowLiveTerminal`. Rate-limit backoff state lives in `IGitHubRateLimitTracker` (singleton, keyed by connector name), not a field on the service itself - this matters because `WorkspacePushService` resolves its own `GhaWorkflowLiveFeedService` from a separate DI scope (via `ScopedExecutor`/`ServiceScopeFactory.CreateAsyncScope()`) during a push, so a per-instance field would not have been shared with the terminals on the page; routing the gate through the tracker singleton means a 429 hit by any poller for a connector pauses every poller for that connector, regardless of scope.
 
-`GhaStepLogFeedService` polls `GetJobLogsAsync` (the full job log text) and supports two modes: incremental group-parsed step output (`PollStepLogsAsync`) and a raw tail (`PollStepLogTailAsync`) that strips timestamps, filters blank lines, and returns the last N lines of the full log without parsing group markers.
+`GhaLogsModal.LoadLogsAsync` fetches logs on demand (not polled) when the modal opens: one `GetWorkflowRunJobsAsync` call to list jobs, then one `GetJobLogsAsync` call per job, each returning the full log text (no incremental/tail fetching).
+
+`GitHubActionsService.GetWorkflowStatusesForBranchAsync` caches its static parts via `IMemoryCache` - the workflow list (5 min TTL) and per-workflow `workflow_dispatch` YAML detection (12 h TTL, keyed by connector+owner+repo+workflow id+path) - since neither changes tick to tick. `GetWorkflowRunsForBranchAsync` (the actual run status) is never cached and is fetched fresh on every call, so grid/terminal responsiveness is unaffected.
 
 ### Filter search expression (GrayMoon.Common)
 

--- a/src/GrayMoon.App.Tests/GitHubRateLimitTrackerTests.cs
+++ b/src/GrayMoon.App.Tests/GitHubRateLimitTrackerTests.cs
@@ -1,0 +1,69 @@
+using GrayMoon.App.Services;
+
+namespace GrayMoon.App.Tests;
+
+public sealed class GitHubRateLimitTrackerTests
+{
+    [Fact]
+    public void Record_ThenGetLatest_ReturnsMostRecentSnapshotForConnector()
+    {
+        var tracker = new GitHubRateLimitTracker();
+        var snapshot = new GitHubRateLimitSnapshot(5000, 4999, 1, 1_700_000_000);
+
+        tracker.Record("GitHub", snapshot);
+
+        Assert.Equal(snapshot, tracker.GetLatest("GitHub"));
+    }
+
+    [Fact]
+    public void GetLatest_ReturnsNullForUnknownConnector()
+    {
+        var tracker = new GitHubRateLimitTracker();
+
+        Assert.Null(tracker.GetLatest("Unknown"));
+    }
+
+    [Fact]
+    public void PauseUntil_ThenGetPausedUntil_ReturnsFutureTimestamp()
+    {
+        var tracker = new GitHubRateLimitTracker();
+        var until = DateTimeOffset.UtcNow.AddMinutes(5);
+
+        tracker.PauseUntil("GitHub", until);
+
+        Assert.Equal(until, tracker.GetPausedUntil("GitHub"));
+    }
+
+    [Fact]
+    public void GetPausedUntil_ReturnsNullOncePauseHasExpired()
+    {
+        var tracker = new GitHubRateLimitTracker();
+        tracker.PauseUntil("GitHub", DateTimeOffset.UtcNow.AddMilliseconds(-1));
+
+        Assert.Null(tracker.GetPausedUntil("GitHub"));
+    }
+
+    [Fact]
+    public void PauseUntil_DoesNotShortenAnExistingLongerPause()
+    {
+        var tracker = new GitHubRateLimitTracker();
+        var longer = DateTimeOffset.UtcNow.AddMinutes(10);
+        var shorter = DateTimeOffset.UtcNow.AddMinutes(1);
+
+        tracker.PauseUntil("GitHub", longer);
+        tracker.PauseUntil("GitHub", shorter);
+
+        Assert.Equal(longer, tracker.GetPausedUntil("GitHub"));
+    }
+
+    [Fact]
+    public void PauseGates_AreIndependentPerConnector()
+    {
+        var tracker = new GitHubRateLimitTracker();
+        var until = DateTimeOffset.UtcNow.AddMinutes(5);
+
+        tracker.PauseUntil("GitHub", until);
+
+        Assert.Null(tracker.GetPausedUntil("OtherConnector"));
+    }
+}

--- a/src/GrayMoon.App.Tests/GitHubServiceWorkflowRunTests.cs
+++ b/src/GrayMoon.App.Tests/GitHubServiceWorkflowRunTests.cs
@@ -28,7 +28,7 @@ public sealed class GitHubServiceWorkflowRunTests
         var handler = new RecordingHandler();
         var httpClient = new HttpClient(handler);
         var configuration = new ConfigurationBuilder().Build();
-        var service = new GitHubService(httpClient, configuration, NullLogger<GitHubService>.Instance);
+        var service = new GitHubService(httpClient, configuration, new GitHubRateLimitTracker(), NullLogger<GitHubService>.Instance);
         return (service, handler);
     }
 

--- a/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor.cs
@@ -630,9 +630,33 @@ public sealed partial class WorkspaceActions : IDisposable
 
     private void StartBackgroundRefresh()
     {
+        var token = _cts.Token;
+        var semaphore = new SemaphoreSlim(MaxConcurrency, MaxConcurrency);
         foreach (var row in rows.Where(r => !string.IsNullOrWhiteSpace(r.Link.BranchName)))
         {
-            _ = RefreshRowAsync(row, _cts.Token);
+            _ = RefreshRowThrottledAsync(row, semaphore, token);
+        }
+    }
+
+    /// <summary>Bounds full-grid refresh fan-out to <see cref="MaxConcurrency"/> concurrent GitHub calls, avoiding secondary rate-limit ("abuse") bursts on large workspaces.</summary>
+    private async Task RefreshRowThrottledAsync(WorkspaceActionRow row, SemaphoreSlim semaphore, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await semaphore.WaitAsync(cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            return;
+        }
+
+        try
+        {
+            await RefreshRowAsync(row, cancellationToken);
+        }
+        finally
+        {
+            semaphore.Release();
         }
     }
 
@@ -957,9 +981,10 @@ public sealed partial class WorkspaceActions : IDisposable
             _cts = new CancellationTokenSource();
 
             var token = _cts.Token;
+            using var semaphore = new SemaphoreSlim(MaxConcurrency, MaxConcurrency);
             var tasks = rows
                 .Where(r => !string.IsNullOrWhiteSpace(r.Link.BranchName))
-                .Select(row => RefreshRowAsync(row, token))
+                .Select(row => RefreshRowThrottledAsync(row, semaphore, token))
                 .ToList();
 
             await Task.WhenAll(tasks);

--- a/src/GrayMoon.App/Program.cs
+++ b/src/GrayMoon.App/Program.cs
@@ -76,6 +76,7 @@ try
     builder.Services.AddSingleton<MatrixOverlayPreferenceService>();
     builder.Services.AddSingleton<CommandTerminalOverlayPreferenceService>();
     builder.Services.AddSingleton<LoadingOverlayUiSettingsService>();
+    builder.Services.AddSingleton<IGitHubRateLimitTracker, GitHubRateLimitTracker>();
     builder.Services.AddScoped<SyncCommandHandler>();
     builder.Services.AddScoped<IAgentBridge, AgentBridge>();
     builder.Services.AddScoped<WorkspaceService>();
@@ -85,6 +86,7 @@ try
     builder.Services.AddScoped<IRepositoryListQueryService, RepositoryListQueryService>();
     builder.Services.AddScoped<IWorkspaceProjectListQueryService, WorkspaceProjectListQueryService>();
     builder.Services.AddScoped<IWorkspaceRepositoryLinkListQueryService, WorkspaceRepositoryLinkListQueryService>();
+    builder.Services.AddMemoryCache();
     builder.Services.AddScoped<GitHubActionsService>();
     builder.Services.AddScoped<GhaWorkflowLiveFeedService>();
     builder.Services.AddScoped<GitHubPullRequestService>();

--- a/src/GrayMoon.App/Services/GhaWorkflowLiveFeedService.cs
+++ b/src/GrayMoon.App/Services/GhaWorkflowLiveFeedService.cs
@@ -9,33 +9,31 @@ namespace GrayMoon.App.Services;
 public sealed class GhaWorkflowLiveFeedService(
     GitHubService gitHubService,
     ConnectorRepository connectorRepository,
+    IGitHubRateLimitTracker rateLimitTracker,
     ILogger<GhaWorkflowLiveFeedService> logger)
 {
     public const int PollIntervalActiveMs = 2_000;
     public const int PollIntervalWaitingJobsMs = 3_000;
     public const int PollIntervalIdleMs = 15_000;
 
-    // Shared across all terminals in the same circuit — one 429 pauses all of them.
-    private DateTimeOffset? _rateLimitedUntil;
-
     public async Task<GhaWorkflowLiveFeedUpdate> PollOnceAsync(
         GhaWorkflowLiveFeedState state,
         CancellationToken cancellationToken)
     {
-        // Gate: skip the API call while rate-limited; stagger per-RunId so terminals don't all resume simultaneously.
-        if (_rateLimitedUntil.HasValue)
+        // Gate: skip the API call while rate-limited. Shared per connector via IGitHubRateLimitTracker (not a
+        // per-instance field) so a 429 hit by one poller (this terminal, another terminal, or push discovery -
+        // which resolves its own GhaWorkflowLiveFeedService in a separate DI scope) pauses every poller for
+        // that connector. Stagger per-RunId so terminals don't all resume simultaneously.
+        var pausedUntil = rateLimitTracker.GetPausedUntil(state.ConnectorName);
+        if (pausedUntil.HasValue)
         {
-            var remaining = (int)(_rateLimitedUntil.Value - DateTimeOffset.UtcNow).TotalMilliseconds;
-            if (remaining > 0)
-            {
-                var jitter = (int)(state.RunId % 2_000);
-                return new GhaWorkflowLiveFeedUpdate(
-                    Caption: state.LastCaption,
-                    StepProgress: state.LastStepProgress,
-                    NewLines: [],
-                    DelayMs: Math.Min(remaining + jitter, 60_000));
-            }
-            _rateLimitedUntil = null;
+            var remaining = (int)(pausedUntil.Value - DateTimeOffset.UtcNow).TotalMilliseconds;
+            var jitter = (int)(state.RunId % 2_000);
+            return new GhaWorkflowLiveFeedUpdate(
+                Caption: state.LastCaption,
+                StepProgress: state.LastStepProgress,
+                NewLines: [],
+                DelayMs: Math.Min(Math.Max(remaining, 0) + jitter, 60_000));
         }
 
         try
@@ -118,7 +116,7 @@ public sealed class GhaWorkflowLiveFeedService(
                 var resumeAt = resetEpoch.HasValue
                     ? DateTimeOffset.FromUnixTimeSeconds(resetEpoch.Value).AddSeconds(5)
                     : DateTimeOffset.UtcNow.AddSeconds(60);
-                _rateLimitedUntil = resumeAt;
+                rateLimitTracker.PauseUntil(state.ConnectorName, resumeAt);
                 var waitMs = (int)Math.Clamp((resumeAt - DateTimeOffset.UtcNow).TotalMilliseconds, 60_000, 600_000);
                 var jitter = (int)(state.RunId % 2_000);
                 var label = resetEpoch.HasValue

--- a/src/GrayMoon.App/Services/GitHubActionsService.cs
+++ b/src/GrayMoon.App/Services/GitHubActionsService.cs
@@ -1,6 +1,7 @@
 using System.Text.RegularExpressions;
 using GrayMoon.App.Models;
 using GrayMoon.App.Repositories;
+using Microsoft.Extensions.Caching.Memory;
 
 namespace GrayMoon.App.Services;
 
@@ -8,8 +9,14 @@ public class GitHubActionsService(
     ConnectorRepository connectorRepository,
     GitHubRepositoryService repositoryService,
     GitHubService gitHubService,
+    IMemoryCache memoryCache,
     ILogger<GitHubActionsService> logger)
 {
+    /// <summary>Workflow list rarely changes; short TTL so new/removed workflows still show up promptly.</summary>
+    private static readonly TimeSpan WorkflowListCacheTtl = TimeSpan.FromMinutes(5);
+
+    /// <summary>Whether a workflow file supports <c>workflow_dispatch</c> essentially never changes for a given workflow id/path, so this is cached far longer than the run status itself.</summary>
+    private static readonly TimeSpan WorkflowDispatchSupportCacheTtl = TimeSpan.FromHours(12);
     public async Task<List<GitHubActionEntry>> GetLatestActionsAsync()
     {
         var results = new List<GitHubActionEntry>();
@@ -150,11 +157,12 @@ public class GitHubActionsService(
         var owner = repository.OrgName!;
         var repoName = repository.RepositoryName;
 
-        var workflows = (await gitHubService.GetWorkflowsAsync(connector, owner, repoName, cancellationToken))
+        var workflows = (await GetCachedWorkflowsAsync(connector, owner, repoName, cancellationToken))
             .Where(w => string.Equals(w.State, "active", StringComparison.OrdinalIgnoreCase))
             .OrderBy(w => w.Name, StringComparer.OrdinalIgnoreCase)
             .ToList();
 
+        // Live/dynamic - always fetched fresh, never cached.
         var runs = await gitHubService.GetWorkflowRunsForBranchAsync(
             connector, owner, repoName, branch, perPage: 100);
         var latestByWorkflowId = runs
@@ -166,8 +174,8 @@ public class GitHubActionsService(
         {
             var dispatchPairs = await Task.WhenAll(workflows.Select(async wf =>
             {
-                var yaml = await gitHubService.GetRepositoryFileUtf8TextAsync(connector, owner, repoName, wf.Path, cancellationToken);
-                return (wf.Id, Supports: YamlAppearsToHaveWorkflowDispatch(yaml));
+                var supports = await GetCachedDispatchSupportAsync(connector, owner, repoName, wf.Id, wf.Path, cancellationToken);
+                return (wf.Id, Supports: supports);
             }));
             var dispatchById = dispatchPairs.ToDictionary(x => x.Id, x => x.Supports);
 
@@ -202,10 +210,9 @@ public class GitHubActionsService(
             foreach (var run in latestByWorkflowId.Values.OrderBy(r => r.Name, StringComparer.OrdinalIgnoreCase))
             {
                 var meta = await gitHubService.GetWorkflowByIdAsync(connector, owner, repoName, run.WorkflowId, cancellationToken);
-                var yaml = string.IsNullOrWhiteSpace(meta?.Path)
-                    ? null
-                    : await gitHubService.GetRepositoryFileUtf8TextAsync(connector, owner, repoName, meta.Path, cancellationToken);
-                var supportsDispatch = YamlAppearsToHaveWorkflowDispatch(yaml);
+                var supportsDispatch = string.IsNullOrWhiteSpace(meta?.Path)
+                    ? false
+                    : await GetCachedDispatchSupportAsync(connector, owner, repoName, run.WorkflowId, meta.Path, cancellationToken);
                 var workflowPageUrl = RepositoryUrlHelper.BuildWorkflowPageUrl(
                     meta?.HtmlUrl,
                     repository.CloneUrl,
@@ -230,6 +237,32 @@ public class GitHubActionsService(
         }
 
         return result;
+    }
+
+    /// <summary>Cached workflow list - this rarely changes, unlike run status, which must stay live.</summary>
+    private Task<List<GitHubWorkflowDto>> GetCachedWorkflowsAsync(Connector connector, string owner, string repoName, CancellationToken cancellationToken)
+    {
+        var cacheKey = $"gha:workflows:{connector.ConnectorName}:{owner}/{repoName}";
+        return memoryCache.GetOrCreateAsync(cacheKey, entry =>
+        {
+            entry.AbsoluteExpirationRelativeToNow = WorkflowListCacheTtl;
+            return gitHubService.GetWorkflowsAsync(connector, owner, repoName, cancellationToken);
+        })!;
+    }
+
+    /// <summary>Cached <c>workflow_dispatch</c> support for a workflow file - fetches and parses the YAML at most once per TTL per workflow id/path, since this essentially never changes.</summary>
+    private Task<bool> GetCachedDispatchSupportAsync(Connector connector, string owner, string repoName, long workflowId, string? workflowPath, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(workflowPath))
+            return Task.FromResult(false);
+
+        var cacheKey = $"gha:dispatch:{connector.ConnectorName}:{owner}/{repoName}:{workflowId}:{workflowPath}";
+        return memoryCache.GetOrCreateAsync(cacheKey, async entry =>
+        {
+            entry.AbsoluteExpirationRelativeToNow = WorkflowDispatchSupportCacheTtl;
+            var yaml = await gitHubService.GetRepositoryFileUtf8TextAsync(connector, owner, repoName, workflowPath, cancellationToken);
+            return YamlAppearsToHaveWorkflowDispatch(yaml);
+        });
     }
 
     /// <summary>Detects a <c>workflow_dispatch</c> trigger in workflow YAML without a full parser.</summary>

--- a/src/GrayMoon.App/Services/GitHubRateLimitTracker.cs
+++ b/src/GrayMoon.App/Services/GitHubRateLimitTracker.cs
@@ -1,0 +1,61 @@
+using System.Collections.Concurrent;
+
+namespace GrayMoon.App.Services;
+
+/// <summary>
+/// Tracks the most recently observed GitHub rate-limit snapshot per connector (recorded from every response,
+/// not just failures), and a shared "paused until" backoff gate per connector so a 429 hit by any poller
+/// (grid, live-feed terminal, push discovery) pauses every other poller for that connector too - regardless
+/// of which DI scope resolved them.
+/// </summary>
+public interface IGitHubRateLimitTracker
+{
+    void Record(string connectorName, GitHubRateLimitSnapshot snapshot);
+
+    GitHubRateLimitSnapshot? GetLatest(string connectorName);
+
+    void PauseUntil(string connectorName, DateTimeOffset until);
+
+    DateTimeOffset? GetPausedUntil(string connectorName);
+}
+
+public sealed class GitHubRateLimitTracker : IGitHubRateLimitTracker
+{
+    private readonly ConcurrentDictionary<string, GitHubRateLimitSnapshot> _snapshots = new();
+    private readonly ConcurrentDictionary<string, DateTimeOffset> _pausedUntil = new();
+
+    public void Record(string connectorName, GitHubRateLimitSnapshot snapshot)
+    {
+        if (string.IsNullOrWhiteSpace(connectorName))
+            return;
+
+        _snapshots[connectorName] = snapshot;
+    }
+
+    public GitHubRateLimitSnapshot? GetLatest(string connectorName)
+    {
+        return _snapshots.TryGetValue(connectorName, out var snapshot) ? snapshot : null;
+    }
+
+    public void PauseUntil(string connectorName, DateTimeOffset until)
+    {
+        if (string.IsNullOrWhiteSpace(connectorName))
+            return;
+
+        _pausedUntil.AddOrUpdate(connectorName, until, (_, existing) => until > existing ? until : existing);
+    }
+
+    public DateTimeOffset? GetPausedUntil(string connectorName)
+    {
+        if (!_pausedUntil.TryGetValue(connectorName, out var until))
+            return null;
+
+        if (until <= DateTimeOffset.UtcNow)
+        {
+            _pausedUntil.TryRemove(connectorName, out _);
+            return null;
+        }
+
+        return until;
+    }
+}

--- a/src/GrayMoon.App/Services/GitHubService.cs
+++ b/src/GrayMoon.App/Services/GitHubService.cs
@@ -14,6 +14,7 @@ public class GitHubService : IConnectorService
     private readonly HttpClient _httpClient;
     private readonly ILogger<GitHubService> _logger;
     private readonly GitHubOptions _options;
+    private readonly IGitHubRateLimitTracker _rateLimitTracker;
     private readonly JsonSerializerOptions _jsonOptions = new()
     {
         PropertyNameCaseInsensitive = true
@@ -21,10 +22,11 @@ public class GitHubService : IConnectorService
 
     public ConnectorType ConnectorType => ConnectorType.GitHub;
 
-    public GitHubService(HttpClient httpClient, IConfiguration configuration, ILogger<GitHubService> logger)
+    public GitHubService(HttpClient httpClient, IConfiguration configuration, IGitHubRateLimitTracker rateLimitTracker, ILogger<GitHubService> logger)
     {
         _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _rateLimitTracker = rateLimitTracker ?? throw new ArgumentNullException(nameof(rateLimitTracker));
         _options = configuration.GetSection("GitHub").Get<GitHubOptions>() ?? new GitHubOptions();
 
         var baseUrl = string.IsNullOrWhiteSpace(_options.ApiBaseUrl)
@@ -730,11 +732,22 @@ public class GitHubService : IConnectorService
     private async Task<HttpResponseMessage> GetResponseAsync(Connector connector, string requestUri, CancellationToken cancellationToken, bool skipRateLimitRetry = false)
     {
         var pipeline = skipRateLimitRetry ? GitHubLiveFeedRetryPipeline : GitHubGetRetryPipeline;
-        return await pipeline.ExecuteAsync(async (ct) =>
+        var response = await pipeline.ExecuteAsync(async (ct) =>
         {
             using var request = CreateGetRequest(connector, requestUri);
             return await _httpClient.SendAsync(request, ct);
         }, cancellationToken);
+
+        RecordRateLimit(connector, response);
+        return response;
+    }
+
+    /// <summary>Records rate-limit headers from every response, not only failures, so remaining quota is visible before a call ever fails.</summary>
+    private void RecordRateLimit(Connector connector, HttpResponseMessage response)
+    {
+        var snapshot = GitHubApiErrorHelper.TryParseRateLimitHeaders(response);
+        if (snapshot.HasValue)
+            _rateLimitTracker.Record(connector.ConnectorName, snapshot.Value);
     }
 
     private async Task<T?> GetAsync<T>(string requestUri)

--- a/src/GrayMoon.App/Services/WorkspaceActionService.cs
+++ b/src/GrayMoon.App/Services/WorkspaceActionService.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using GrayMoon.App.Models;
 using GrayMoon.App.Repositories;
 
@@ -8,6 +9,9 @@ public sealed class WorkspaceActionService(
     WorkspaceActionRepository actionRepository,
     GitHubActionsService gitHubActionsService)
 {
+    /// <summary>Coalesces concurrent <see cref="FetchAndPersistAsync"/> callers for the same row (multiple open tabs, grid auto-poll overlapping push discovery) onto one in-flight GitHub fetch.</summary>
+    private static readonly ConcurrentDictionary<int, Task<IReadOnlyList<ActionStatusInfo>?>> InFlightFetches = new();
+
     /// <summary>Returns persisted action state for the workspace keyed by RepositoryId. Used when building the grid from cache.</summary>
     public async Task<IReadOnlyDictionary<int, RepositoryActionsPersistedState>> GetPersistedActionsForWorkspaceAsync(int workspaceId, CancellationToken cancellationToken = default)
     {
@@ -18,12 +22,41 @@ public sealed class WorkspaceActionService(
     /// Fetches CI status per workflow for <paramref name="branch"/> from GitHub and persists it.
     /// Returns null if the repository has no valid connector/org (nothing persisted).
     /// Throws on GitHub API errors (e.g. HTTP 401/403) so the caller can surface them as error badges.
+    /// Concurrent callers for the same <paramref name="workspaceRepositoryId"/> coalesce onto one in-flight fetch.
     /// </summary>
-    public async Task<IReadOnlyList<ActionStatusInfo>?> FetchAndPersistAsync(
+    public Task<IReadOnlyList<ActionStatusInfo>?> FetchAndPersistAsync(
         int workspaceRepositoryId,
         GitHubRepositoryEntry repository,
         string branch,
         CancellationToken cancellationToken = default)
+    {
+        if (InFlightFetches.TryGetValue(workspaceRepositoryId, out var existing) && !existing.IsCompleted)
+            return existing;
+
+        var fetchTask = FetchAndPersistCoreAsync(workspaceRepositoryId, repository, branch, cancellationToken);
+        InFlightFetches[workspaceRepositoryId] = fetchTask;
+        return AwaitAndClearInFlightAsync(workspaceRepositoryId, fetchTask);
+    }
+
+    private static async Task<IReadOnlyList<ActionStatusInfo>?> AwaitAndClearInFlightAsync(
+        int workspaceRepositoryId,
+        Task<IReadOnlyList<ActionStatusInfo>?> fetchTask)
+    {
+        try
+        {
+            return await fetchTask.ConfigureAwait(false);
+        }
+        finally
+        {
+            InFlightFetches.TryRemove(new KeyValuePair<int, Task<IReadOnlyList<ActionStatusInfo>?>>(workspaceRepositoryId, fetchTask));
+        }
+    }
+
+    private async Task<IReadOnlyList<ActionStatusInfo>?> FetchAndPersistCoreAsync(
+        int workspaceRepositoryId,
+        GitHubRepositoryEntry repository,
+        string branch,
+        CancellationToken cancellationToken)
     {
         var workflows = await gitHubActionsService.GetWorkflowStatusesForBranchAsync(repository, branch, cancellationToken);
         if (workflows == null)


### PR DESCRIPTION
## Summary

- Cache static GHA workflow lists (5 min) and `workflow_dispatch` YAML detection (12 h) while keeping run status fetches live
- Share connector-scoped 429 backoff via a singleton `IGitHubRateLimitTracker` so grid, live-feed, and push-discovery pollers pause together across DI scopes
- Bound Actions grid refresh fan-out and coalesce concurrent status fetches for the same row to avoid secondary rate-limit bursts on large workspaces

## Test plan

- [ ] Open Workspace Actions on a multi-repo workspace and confirm grid refresh stays responsive without hammering GitHub (no abuse/secondary rate-limit spikes)
- [ ] Trigger a 429 (or simulate pause) and confirm live-feed terminals and push discovery stop polling that connector until the backoff expires
- [ ] Reopen Actions / refresh repeatedly and verify workflow list / dispatch support stay correct while run statuses continue to update
- [ ] Run `GitHubRateLimitTrackerTests` and `GitHubServiceWorkflowRunTests`