### PR TITLE
Fix workspace repository dropdown menus expanding page scroll

### DIFF
--- a/src/GrayMoon.App/Components/App.razor
+++ b/src/GrayMoon.App/Components/App.razor
@@ -28,6 +28,7 @@
     <script src="js/cytoscape-graph.js"></script>
     <script src="js/resizable-columns.js"></script>
     <script src="js/dependency-badge-tooltip.js"></script>
+    <script src="js/workspace-repos-header-menus.js"></script>
     <script src="js/matrixOverlay.js"></script>
     <script src="js/loadingOverlayTerminal.js"></script>
     <script src="js/versionPatternEditor.js"></script>

--- a/src/GrayMoon.App/Components/Shared/WorkspaceRepositoriesHeader.razor
+++ b/src/GrayMoon.App/Components/Shared/WorkspaceRepositoriesHeader.razor
@@ -63,7 +63,7 @@
             @if (_branchMenuOpen)
             {
                 <div class="branch-menu-backdrop" @onclick="CloseBranchMenu"></div>
-                <ul class="dropdown-menu show shadow branch-menu-list"
+                <ul class="dropdown-menu show shadow branch-menu-list workspace-repository-actions-menu"
                     role="menu">
                     <li>
                         <button class="dropdown-item" type="button"
@@ -132,7 +132,7 @@
                 @if (_pushUpdatedMenuOpen)
                 {
                     <div class="branch-menu-backdrop" @onclick="ClosePushUpdatedMenu"></div>
-                    <ul class="dropdown-menu show shadow branch-menu-list"
+                    <ul class="dropdown-menu show shadow branch-menu-list workspace-repository-actions-menu"
                         role="menu">
                         @if (LowestLevelNeedingWork.HasValue)
                         {
@@ -209,7 +209,7 @@
                 @if (_updateMenuOpen)
                 {
                     <div class="branch-menu-backdrop" @onclick="CloseUpdateMenu"></div>
-                    <ul class="dropdown-menu show shadow branch-menu-list"
+                    <ul class="dropdown-menu show shadow branch-menu-list workspace-repository-actions-menu"
                         role="menu">
                         <li>
                             <button class="dropdown-item" type="button"
@@ -269,7 +269,7 @@
                     @if (_pushMenuOpen)
                     {
                         <div class="branch-menu-backdrop" @onclick="ClosePushMenu"></div>
-                        <ul class="dropdown-menu show shadow branch-menu-list" role="menu">
+                        <ul class="dropdown-menu show shadow branch-menu-list workspace-repository-actions-menu" role="menu">
                             <li>
                                 <button class="dropdown-item" type="button" role="menuitem"
                                         disabled="@(WorkspaceName == null || RepositoriesCount == 0 || IsSyncing || IsUpdating || IsPushing || AgentTasksPendingCount > 0)"
@@ -309,7 +309,7 @@
             @if (_syncMenuOpen)
             {
                 <div class="branch-menu-backdrop" @onclick="CloseSyncMenu"></div>
-                <ul class="dropdown-menu show shadow branch-menu-list branch-menu-list-end"
+                <ul class="dropdown-menu show shadow branch-menu-list branch-menu-list-end workspace-repository-actions-menu"
                     role="menu">
                     <li>
                         <button class="dropdown-item" type="button"

--- a/src/GrayMoon.App/Components/Shared/WorkspaceRepositoriesHeader.razor.css
+++ b/src/GrayMoon.App/Components/Shared/WorkspaceRepositoriesHeader.razor.css
@@ -1,11 +1,19 @@
-.branch-menu-list {
-    position: absolute;
-    top: 100%;
-    left: 0;
+/* Fixed so menus do not expand article.content scroll overflow (see workspace-repos-header-menus.js). */
+.workspace-repository-actions-menu {
+    position: fixed;
+    top: -9999px;
+    left: -9999px;
     right: auto;
-    margin-top: 0.125rem;
+    margin-top: 0;
     z-index: 1051;
-    min-width: 100%;
+    height: auto;
+    max-height: none;
+    overflow: visible;
+    box-sizing: border-box;
+}
+
+.branch-menu-list {
+    min-width: 0;
 }
 
 .branch-menu-backdrop {
@@ -40,11 +48,6 @@
 
 .btn-group > .btn-warning + .btn-warning.dropdown-toggle-split {
     border-left-color: #000;
-}
-
-.branch-menu-list-end {
-    right: 0;
-    left: auto;
 }
 
 .dropdown-item--level-only,

--- a/src/GrayMoon.App/wwwroot/js/workspace-repos-header-menus.js
+++ b/src/GrayMoon.App/wwwroot/js/workspace-repos-header-menus.js
@@ -1,0 +1,65 @@
+/**
+ * Positions WorkspaceRepositories header action menus with position:fixed so they
+ * do not expand article.content scrollable overflow (overflow-x:hidden forces
+ * overflow-y:auto on that scrollport). Scoped to .workspace-repository-actions-menu only.
+ */
+(function () {
+    const HEADER_SEL = '.workspace-repos-header';
+    const MENU_SEL = '.workspace-repository-actions-menu';
+    const GAP = 2;
+    const MARGIN = 8;
+
+    function positionMenu(menu) {
+        const group = menu.closest('.btn-group');
+        if (!group) return;
+
+        const anchor = group.getBoundingClientRect();
+        const menuHeight = menu.offsetHeight || 0;
+        const minWidth = Math.max(menu.offsetWidth || 0, anchor.width);
+        menu.style.minWidth = minWidth + 'px';
+
+        let top = anchor.bottom + GAP;
+        if (top + menuHeight > window.innerHeight - MARGIN && anchor.top - menuHeight - GAP >= MARGIN) {
+            top = anchor.top - menuHeight - GAP;
+        }
+        menu.style.top = top + 'px';
+
+        if (menu.classList.contains('branch-menu-list-end')) {
+            menu.style.left = 'auto';
+            menu.style.right = (window.innerWidth - anchor.right) + 'px';
+            return;
+        }
+
+        menu.style.right = 'auto';
+        let left = anchor.left;
+        const maxLeft = window.innerWidth - minWidth - MARGIN;
+        if (left > maxLeft) left = Math.max(MARGIN, maxLeft);
+        if (left < MARGIN) left = MARGIN;
+        menu.style.left = left + 'px';
+    }
+
+    function positionOpenMenus() {
+        document.querySelectorAll(HEADER_SEL + ' ' + MENU_SEL).forEach(positionMenu);
+    }
+
+    let observedHeader = null;
+    const observer = new MutationObserver(function () {
+        requestAnimationFrame(positionOpenMenus);
+    });
+
+    function ensureObserver() {
+        const header = document.querySelector(HEADER_SEL);
+        if (!header) return;
+        if (observedHeader === header) return;
+        if (observedHeader) observer.disconnect();
+        observedHeader = header;
+        observer.observe(header, { childList: true, subtree: true });
+    }
+
+    document.addEventListener('click', function () {
+        ensureObserver();
+        requestAnimationFrame(positionOpenMenus);
+    }, true);
+
+    window.addEventListener('resize', positionOpenMenus);
+})();


### PR DESCRIPTION
## Summary

- Position workspace repository header action menus (branch switcher, actions dropdowns) with `position: fixed` and JS-computed coordinates instead of `position: absolute`, so open menus no longer expand `article.content`'s scrollable overflow
- Add `workspace-repos-header-menus.js` to compute and update menu placement (clamped to viewport, flips above the anchor when there isn't room below) on click and window resize

## Test plan

- [ ] Open each dropdown (branch switcher, row actions, end-aligned actions) on `WorkspaceRepositoriesHeader` and confirm no extra vertical/horizontal scrollbar appears on the page
- [ ] Verify menus stay anchored correctly when scrolling and resizing the window, including near viewport edges
- [ ] Confirm right-aligned (`branch-menu-list-end`) menus still align to the right edge of their trigger