### PR TITLE
Fix branch menu overflow expanding actions page scrollbars

### DIFF
--- a/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor
@@ -133,7 +133,7 @@
                         @if (_rerunMenuOpen)
                         {
                             <div class="branch-menu-backdrop" @onclick="CloseRerunMenu"></div>
-                            <ul class="dropdown-menu show shadow branch-menu-list"
+                            <ul class="dropdown-menu show shadow branch-menu-list workspace-repository-actions-menu"
                                 role="menu">
                                 <li>
                                     <button class="dropdown-item" type="button"

--- a/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor.css
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor.css
@@ -1,12 +1,22 @@
-/* Dropdown menu positioning (mirrors WorkspaceRepositoriesHeader.razor.css) */
-.branch-menu-list {
-    position: absolute;
-    top: 100%;
-    left: 0;
+/*
+ * Fixed so the header Re-run menu does not expand article.content scroll overflow
+ * (see workspace-repos-header-menus.js; mirrors WorkspaceRepositoriesHeader.razor.css).
+ */
+.workspace-repository-actions-menu {
+    position: fixed;
+    top: -9999px;
+    left: -9999px;
     right: auto;
-    margin-top: 0.125rem;
+    margin-top: 0;
     z-index: 1051;
-    min-width: 100%;
+    height: auto;
+    max-height: none;
+    overflow: visible;
+    box-sizing: border-box;
+}
+
+.branch-menu-list {
+    min-width: 0;
 }
 
 .branch-menu-backdrop {


### PR DESCRIPTION
## Summary

- Switch the workspace repository branch dropdown to fixed positioning so it no longer expands `article.content` scroll overflow when opened
- Add a dedicated `workspace-repository-actions-menu` class to scope the fix without affecting other dropdown usages

## Test plan

- [ ] Open the Actions page and trigger the repository branch/re-run dropdown menu, confirm no extra scrollbars appear on the page
- [ ] Verify the dropdown menu still positions and renders correctly relative to its trigger button