### PR TITLE
Improve Git Changes refresh UX and cut loading-overlay CPU use

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,14 @@ Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManage
 
 ## What's new
 
+### Git Changes refresh keeps running when you leave the page
+
+Workspace **Changes** refresh now uses the same circuit-scoped background job pipeline as **Repositories**, so a scan is not cancelled when you navigate away.
+
+- **Empty workspace ("No changes"):** Refresh (and the automatic warm-up scan when you first open Changes for an inactive workspace) runs as a non-overlay background job. The page shows an inline spinner with progress (`Refreshing x of y repositories...`) and an **Abort** button. Leave the page and the scan continues; come back while it is still running and the spinner returns.
+- **When there are already changes:** Refresh still uses the standard LoadingOverlay / terminal job for that Changes URL, so you can navigate away and see the overlay again when you return.
+- **No header subtitle status:** the old warm-up-only subtitle next to the Changes title is gone - progress for empty/warm-up scans lives in the empty-state UI (or updates the tree silently when changes are already showing).
+
 ### Fixed: navigating to Changes no longer aborts running jobs or breaks the diff viewer
 
 Two related navigation bugs in the Git Changes page are fixed.

--- a/src/GrayMoon.Agent/Services/GitChanges/GitStatusRefreshCoordinator.cs
+++ b/src/GrayMoon.Agent/Services/GitChanges/GitStatusRefreshCoordinator.cs
@@ -18,7 +18,7 @@ public enum RepositoryRefreshState
 
 /// <summary>
 /// Per-repository debounce coordinator, backed by a global bounded semaphore shared across all
-/// repositories (<see cref="GitChangesOptions.MaxParallelRepositoryOperations"/>, default 16). A watcher
+/// repositories (<see cref="GitChangesOptions.MaxParallelRepositoryOperations"/>, default 8). A watcher
 /// event marks a repository dirty; after a debounce window, exactly one authoritative git status scan
 /// runs. A dirty event that arrives while a scan is already in flight is coalesced into a single
 /// follow-up scan - a repository never has more than one active and one pending refresh.

--- a/src/GrayMoon.App/Components/GitChanges/GitChangesHeader.razor
+++ b/src/GrayMoon.App/Components/GitChanges/GitChangesHeader.razor
@@ -31,13 +31,6 @@
                 </span>
             }
         </div>
-        @if (!string.IsNullOrEmpty(StatusText))
-        {
-            <span class="text-muted small git-changes-header__status">
-                <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
-                @StatusText
-            </span>
-        }
         <span class="workspace-repos-title-spacer"></span>
     </div>
     @if (HasChanges)
@@ -80,10 +73,6 @@
 
 @code {
     [Parameter] public WorkspaceGitChangesView? View { get; set; }
-
-    /// <summary>Non-blocking status text (e.g. an automatic warm-up scan in progress). Never used for
-    /// user-triggered operations - those get the full LoadingOverlay via BackgroundJobService instead.</summary>
-    [Parameter] public string? StatusText { get; set; }
 
     /// <summary>Gates the entire actions row (filter, change nav, refresh) - hidden while there are no
     /// changes anywhere in the workspace, so the empty state is a clean "No changes" message instead.</summary>

--- a/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor.cs
@@ -723,7 +723,14 @@ public sealed partial class WorkspaceActions : IDisposable
                     EnsureAutoPollRunning();
             }
         }
-        catch (Exception ex) when (!cancellationToken.IsCancellationRequested)
+        catch (OperationCanceledException)
+        {
+            // Expected: either this call's own token was cancelled, or this call coalesced onto an
+            // in-flight fetch (WorkspaceActionService.FetchAndPersistAsync) that got cancelled by a
+            // newer refresh superseding it (e.g. clicking Refresh while a background poll is in flight).
+            // Not a genuine failure, so no error badge should be shown.
+        }
+        catch (Exception ex)
         {
             Logger.LogError(ex, "Error refreshing action for {Repo}/{Branch}", row.Repo.RepositoryName, row.Link.BranchName);
             row.ErrorMessage = GetFriendlyErrorMessage(ex);

--- a/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor.css
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceActions.razor.css
@@ -66,7 +66,16 @@
     position: fixed;
     transform: translateX(-90%);
     z-index: 2000;
-    min-width: 9rem;
+    min-width: 0;
+    width: max-content;
+    padding: 0.2rem 0;
+    font-size: 0.75rem;
+}
+
+.action-run-menu-fixed .dropdown-item {
+    font-size: 0.75rem;
+    line-height: 1.2;
+    padding: 0.2rem 0.55rem;
 }
 
 /*

--- a/src/GrayMoon.App/Components/Pages/WorkspaceGitChanges.Activity.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceGitChanges.Activity.cs
@@ -1,74 +1,49 @@
-using GrayMoon.App.Services.GitChanges;
-using Microsoft.AspNetCore.Components;
-
-namespace GrayMoon.App.Components.Pages;
-
-public sealed partial class WorkspaceGitChanges
-{
-    [Inject] private IWorkspaceGitChangesActivityTracker ActivityTracker { get; set; } = default!;
-    [Inject] private IGitChangesWorkspaceScanner Scanner { get; set; } = default!;
-
-    private IDisposable? _activityLease;
-    private int? _activityLeaseWorkspaceId;
-    private bool _isWarmingUp;
-    private string? _warmUpStatus;
-
-    /// <summary>
-    /// Leases workspace activity for as long as this page is open (mirrors the Agent's watcher-lease
-    /// pattern, just App-side and keyed by workspace). If the workspace was not already active - meaning
-    /// background monitoring has not been sweeping it and its Agent-side watchers may be idle or never
-    /// started - kicks off a one-time warm-up scan instead of waiting for the next periodic sweep.
-    /// </summary>
-    private void EnsureActivitySubscription()
-    {
-        if (_activityLeaseWorkspaceId == WorkspaceId)
-        {
-            return;
-        }
-
-        _activityLease?.Dispose();
-        _activityLease = null;
-        _activityLeaseWorkspaceId = WorkspaceId;
-
-        var wasActive = ActivityTracker.IsActive(WorkspaceId);
-        _activityLease = ActivityTracker.Subscribe(WorkspaceId);
-
-        if (!wasActive)
-        {
-            _isWarmingUp = true;
-            _warmUpStatus = "Refreshing repositories...";
-            _ = RunWarmUpScanAsync(WorkspaceId);
-        }
-    }
-
-    // Silent-but-visible: no LoadingOverlay for this one - it runs automatically, not from a user click,
-    // so it only surfaces as a small header status text. Tree updates arrive incrementally the same way
-    // periodic sweep results already do, via GitChangesUpdated -> LoadAsync.
-    private async Task RunWarmUpScanAsync(int workspaceId)
-    {
-        try
-        {
-            await Scanner.ScanWorkspaceAsync(workspaceId, CancellationToken.None, progress =>
-                SafeInvoke(() => _warmUpStatus = $"Refreshing {progress.Completed} of {progress.Total} repositories..."));
-        }
-        catch (Exception ex)
-        {
-            Logger.LogWarning(ex, "Git Changes warm-up scan failed for workspace {WorkspaceId}", workspaceId);
-        }
-        finally
-        {
-            SafeInvoke(() =>
-            {
-                _isWarmingUp = false;
-                _warmUpStatus = null;
-            });
-        }
-    }
-
-    private void ReleaseActivitySubscription()
-    {
-        _activityLease?.Dispose();
-        _activityLease = null;
-        _activityLeaseWorkspaceId = null;
-    }
-}
+using GrayMoon.App.Services.GitChanges;
+using Microsoft.AspNetCore.Components;
+
+namespace GrayMoon.App.Components.Pages;
+
+public sealed partial class WorkspaceGitChanges
+{
+    [Inject] private IWorkspaceGitChangesActivityTracker ActivityTracker { get; set; } = default!;
+    [Inject] private IGitChangesWorkspaceScanner Scanner { get; set; } = default!;
+
+    private IDisposable? _activityLease;
+    private int? _activityLeaseWorkspaceId;
+
+    /// <summary>
+    /// Leases workspace activity for as long as this page is open (mirrors the Agent's watcher-lease
+    /// pattern, just App-side and keyed by workspace). If the workspace was not already active - meaning
+    /// background monitoring has not been sweeping it and its Agent-side watchers may be idle or never
+    /// started - kicks off a one-time warm-up scan via EmptyScanJobKey instead of waiting for the next
+    /// periodic sweep. That job survives navigation; when the page is empty the inline spinner binds to
+    /// it, and when the tree is showing updates arrive via GitChangesUpdated -> LoadAsync.
+    /// </summary>
+    private void EnsureActivitySubscription()
+    {
+        if (_activityLeaseWorkspaceId == WorkspaceId)
+        {
+            return;
+        }
+
+        _activityLease?.Dispose();
+        _activityLease = null;
+        _activityLeaseWorkspaceId = WorkspaceId;
+
+        var wasActive = ActivityTracker.IsActive(WorkspaceId);
+        _activityLease = ActivityTracker.Subscribe(WorkspaceId);
+
+        if (!wasActive && AgentBridge.IsAgentConnected && !IsAnyScanRunning)
+        {
+            StartEmptyScanJob("Refreshing repositories...");
+        }
+    }
+
+    private void ReleaseActivitySubscription()
+    {
+        _activityLease?.Dispose();
+        _activityLease = null;
+        _activityLeaseWorkspaceId = null;
+    }
+}
+

--- a/src/GrayMoon.App/Components/Pages/WorkspaceGitChanges.JobHelper.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceGitChanges.JobHelper.cs
@@ -1,85 +1,140 @@
-using GrayMoon.App.Services;
-
-namespace GrayMoon.App.Components.Pages;
-
-public sealed partial class WorkspaceGitChanges
-{
-    private sealed record PageJobOptions
-    {
-        /// <summary>When true (default), calls LoadAsync inside InvokeAsync after work completes without exception.</summary>
-        public bool ReloadOnSuccess { get; init; } = true;
-        /// <summary>Toast message shown via ToastService.Show on OperationCanceledException. Null means no toast.</summary>
-        public string? CancelToast { get; init; }
-        /// <summary>Called with the exception on a general Exception catch. Null means no callback.</summary>
-        public Action<Exception>? OnError { get; init; }
-    }
-
-    private string PageJobKey => new Uri(NavigationManager.Uri).AbsolutePath.ToLowerInvariant();
-    private bool IsJobRunning => JobService.IsRunning(PageJobKey);
-
-    /// <summary>
-    /// Starts a background job under PageJobKey - the globally-mounted BackgroundJobOverlay (keyed by the
-    /// same URL path) picks it up automatically and renders LoadingOverlay with the job's terminal, the
-    /// same pattern Workspace Repositories uses for push/update. Reserved for operations that touch many
-    /// files or repositories (commit, whole-repository/section/multi-repository stage-unstage, manual
-    /// refresh) - single-file/folder stage/unstage stay on the lightweight inline indicator instead.
-    /// </summary>
-    private void StartPageJob(
-        string label,
-        Func<BackgroundJobHandle, CancellationToken, Task> work,
-        PageJobOptions? options = null)
-    {
-        options ??= new PageJobOptions();
-        JobService.StartJob(PageJobKey, label, async (job, ct) =>
-        {
-            try
-            {
-                await work(job, ct);
-                if (options.ReloadOnSuccess)
-                {
-                    await InvokeAsync(async () =>
-                    {
-                        if (_disposed)
-                        {
-                            return;
-                        }
-
-                        await LoadAsync();
-                    });
-                }
-            }
-            catch (OperationCanceledException)
-            {
-                if (options.CancelToast != null)
-                {
-                    SafeInvoke(() => ToastService.Show(options.CancelToast));
-                }
-
-                throw;
-            }
-            catch (Exception ex)
-            {
-                Logger.LogError(ex, "Git Changes background job failed");
-                options.OnError?.Invoke(ex);
-                throw;
-            }
-        });
-    }
-
-    private void SafeInvoke(Action callback)
-    {
-        if (_disposed)
-        {
-            return;
-        }
-
-        _ = InvokeAsync(() =>
-        {
-            if (!_disposed)
-            {
-                callback();
-                StateHasChanged();
-            }
-        });
-    }
-}
+using GrayMoon.App.Services;
+
+namespace GrayMoon.App.Components.Pages;
+
+public sealed partial class WorkspaceGitChanges
+{
+    private sealed record PageJobOptions
+    {
+        /// <summary>When true (default), calls LoadAsync inside InvokeAsync after work completes without exception.</summary>
+        public bool ReloadOnSuccess { get; init; } = true;
+        /// <summary>Toast message shown via ToastService.Show on OperationCanceledException. Null means no toast.</summary>
+        public string? CancelToast { get; init; }
+        /// <summary>Called with the exception on a general Exception catch. Null means no callback.</summary>
+        public Action<Exception>? OnError { get; init; }
+    }
+
+    private string PageJobKey => new Uri(NavigationManager.Uri).AbsolutePath.ToLowerInvariant();
+
+    /// <summary>
+    /// Sibling of <see cref="PageJobKey"/> that does not match the URL path, so BackgroundJobOverlay
+    /// never shows LoadingOverlay for empty-state / warm-up scans. Shared by both so StartJob
+    /// idempotency coalesces overlapping requests.
+    /// </summary>
+    private string EmptyScanJobKey => PageJobKey + ":scan";
+
+    private bool IsJobRunning => JobService.IsRunning(PageJobKey);
+    private bool IsEmptyScanRunning => JobService.IsRunning(EmptyScanJobKey);
+    private bool IsAnyScanRunning => IsJobRunning || IsEmptyScanRunning;
+
+    private string? EmptyScanStatus =>
+        JobService.GetJob(EmptyScanJobKey) is { State: BackgroundJobState.Running } job
+            ? job.DisplayMessage
+            : null;
+
+    /// <summary>
+    /// Starts a background job under PageJobKey - the globally-mounted BackgroundJobOverlay (keyed by the
+    /// same URL path) picks it up automatically and renders LoadingOverlay with the job's terminal, the
+    /// same pattern Workspace Repositories uses for push/update. Reserved for operations that touch many
+    /// files or repositories (commit, whole-repository/section/multi-repository stage-unstage, manual
+    /// refresh) - single-file/folder stage/unstage stay on the lightweight inline indicator instead.
+    /// </summary>
+    private void StartPageJob(
+        string label,
+        Func<BackgroundJobHandle, CancellationToken, Task> work,
+        PageJobOptions? options = null)
+    {
+        options ??= new PageJobOptions();
+        JobService.StartJob(PageJobKey, label, async (job, ct) =>
+        {
+            try
+            {
+                await work(job, ct);
+                if (options.ReloadOnSuccess)
+                {
+                    await InvokeAsync(async () =>
+                    {
+                        if (_disposed)
+                        {
+                            return;
+                        }
+
+                        await LoadAsync();
+                    });
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                if (options.CancelToast != null)
+                {
+                    SafeInvoke(() => ToastService.Show(options.CancelToast));
+                }
+
+                throw;
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "Git Changes background job failed");
+                options.OnError?.Invoke(ex);
+                throw;
+            }
+        });
+    }
+
+    /// <summary>
+    /// Non-overlay workspace scan under EmptyScanJobKey - used by empty-state Refresh and warm-up.
+    /// Survives page navigation (circuit-scoped BackgroundJobService); the empty-state UI binds to
+    /// IsEmptyScanRunning / EmptyScanStatus when the page is mounted.
+    /// </summary>
+    private void StartEmptyScanJob(string label)
+    {
+        JobService.StartJob(EmptyScanJobKey, label, async (job, ct) =>
+        {
+            try
+            {
+                await Scanner.ScanWorkspaceAsync(WorkspaceId, ct, progress =>
+                    job.ReportProgress($"Refreshing {progress.Completed} of {progress.Total} repositories..."));
+
+                await InvokeAsync(async () =>
+                {
+                    if (_disposed)
+                    {
+                        return;
+                    }
+
+                    await LoadAsync();
+                });
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "Git Changes empty-state refresh failed for workspace {WorkspaceId}", WorkspaceId);
+                SafeInvoke(() => ToastService.ShowError("Refresh failed. See logs for details."));
+                throw;
+            }
+        });
+    }
+
+    private void AbortEmptyStateRefresh() => JobService.GetJob(EmptyScanJobKey)?.Abort();
+
+    private void SafeInvoke(Action callback)
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _ = InvokeAsync(() =>
+        {
+            if (!_disposed)
+            {
+                callback();
+                StateHasChanged();
+            }
+        });
+    }
+}
+

--- a/src/GrayMoon.App/Components/Pages/WorkspaceGitChanges.MultiRepo.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceGitChanges.MultiRepo.cs
@@ -8,7 +8,7 @@ namespace GrayMoon.App.Components.Pages;
 
 public sealed partial class WorkspaceGitChanges
 {
-    [Inject] private IOptions<WorkspaceOptions> WorkspaceOptions { get; set; } = default!;
+    [Inject] private IOptions<GitChangesOptions> GitChangesOptions { get; set; } = default!;
 
     private string _workspaceCommitMessage = string.Empty;
     private bool _workspaceCommitMessageHasContent;
@@ -46,7 +46,9 @@ public sealed partial class WorkspaceGitChanges
     /// Commits with one shared message across every applicable repository. Not atomic: each repository
     /// commits independently through the bounded fan-out below, one repository's failure never blocks
     /// or rolls back another's success. Mirrors the existing SemaphoreSlim + Task.WhenAll idiom used by
-    /// PushOrchestrator/DependencyUpdateOrchestrator rather than introducing a new scheduler abstraction.
+    /// PushOrchestrator/DependencyUpdateOrchestrator rather than introducing a new scheduler abstraction,
+    /// bounded by the shared <see cref="GitChangesOptions.MaxParallelRepositoryOperations"/> - the same
+    /// limit used by the workspace status scan - rather than a separately hard-coded value.
     /// Runs behind the page's LoadingOverlay/terminal job - this can touch many files across many
     /// repositories and run commit hooks, unlike the fast single-file/folder stage/unstage actions.
     /// </summary>
@@ -120,7 +122,7 @@ public sealed partial class WorkspaceGitChanges
             var failed = new List<(string Repository, string Error)>();
             var completed = 0;
 
-            using var semaphore = new SemaphoreSlim(Math.Max(1, WorkspaceOptions.Value.MaxParallelOperations));
+            using var semaphore = new SemaphoreSlim(Math.Max(1, GitChangesOptions.Value.MaxParallelRepositoryOperations));
 
             var tasks = targets.Select(async repo =>
             {
@@ -208,7 +210,8 @@ public sealed partial class WorkspaceGitChanges
 
     /// <summary>Stage all items in the Changed section, or unstage all items in the Staged section, across
     /// every repository represented in that section. Same bounded fan-out idiom as <see cref="CommitWorkspaceAsync"/>,
-    /// also behind the page's LoadingOverlay/terminal job since it spans every repository in the section.</summary>
+    /// sharing the same <see cref="GitChangesOptions.MaxParallelRepositoryOperations"/> limit, also behind
+    /// the page's LoadingOverlay/terminal job since it spans every repository in the section.</summary>
     private void BulkSectionActionAsync(bool unstageStagedSection)
     {
         if (!AgentBridge.IsAgentConnected)
@@ -233,7 +236,7 @@ public sealed partial class WorkspaceGitChanges
         StartPageJob(label, async (job, ct) =>
         {
             var completed = 0;
-            using var semaphore = new SemaphoreSlim(Math.Max(1, WorkspaceOptions.Value.MaxParallelOperations));
+            using var semaphore = new SemaphoreSlim(Math.Max(1, GitChangesOptions.Value.MaxParallelRepositoryOperations));
 
             var tasks = targets.Select(async repo =>
             {

--- a/src/GrayMoon.App/Components/Pages/WorkspaceGitChanges.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceGitChanges.razor
@@ -46,7 +46,7 @@
                     Abort
                 </button>
             }
-            else
+            else if (!_isWarmingUp)
             {
                 <div class="git-changes-empty__label">No changes</div>
                 <button type="button"

--- a/src/GrayMoon.App/Components/Pages/WorkspaceGitChanges.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceGitChanges.razor
@@ -10,7 +10,6 @@
 <div class="container-fluid page-container grid-page git-changes-page">
     <div class="grid-page-header">
         <GitChangesHeader View="_view"
-                           StatusText="@(_isWarmingUp ? _warmUpStatus : null)"
                            HasChanges="@(ChangedRepositoryCount > 0)"
                            FilterQuery="@_filterQuery"
                            FilterQueryChanged="OnFilterChanged"
@@ -34,19 +33,19 @@
     {
         <div class="git-changes-empty text-muted">
             <i class="bi bi-git git-changes-empty__bg-icon" aria-hidden="true"></i>
-            @if (_isEmptyStateRefreshing)
+            @if (IsEmptyScanRunning)
             {
                 <div class="spinner-border" role="status">
                     <span class="visually-hidden">Loading...</span>
                 </div>
-                <div class="git-changes-empty__label">@_emptyStateRefreshStatus</div>
+                <div class="git-changes-empty__label">@(EmptyScanStatus ?? "Refreshing repositories...")</div>
                 <button type="button"
                         class="btn btn-outline-secondary btn-sm git-changes-empty__refresh"
                         @onclick="AbortEmptyStateRefresh">
                     Abort
                 </button>
             }
-            else if (!_isWarmingUp)
+            else
             {
                 <div class="git-changes-empty__label">No changes</div>
                 <button type="button"

--- a/src/GrayMoon.App/Components/Pages/WorkspaceGitChanges.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceGitChanges.razor
@@ -33,6 +33,7 @@
     else if (ChangedRepositoryCount == 0)
     {
         <div class="git-changes-empty text-muted">
+            <i class="bi bi-git git-changes-empty__bg-icon" aria-hidden="true"></i>
             @if (_isEmptyStateRefreshing)
             {
                 <div class="spinner-border" role="status">
@@ -47,7 +48,6 @@
             }
             else
             {
-                <i class="bi bi-git git-changes-empty__bg-icon" aria-hidden="true"></i>
                 <div class="git-changes-empty__label">No changes</div>
                 <button type="button"
                         class="btn btn-outline-secondary git-changes-empty__refresh"

--- a/src/GrayMoon.App/Components/Pages/WorkspaceGitChanges.razor
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceGitChanges.razor
@@ -33,13 +33,28 @@
     else if (ChangedRepositoryCount == 0)
     {
         <div class="git-changes-empty text-muted">
-            <i class="bi bi-git git-changes-empty__bg-icon" aria-hidden="true"></i>
-            <div class="git-changes-empty__label">No changes</div>
-            <button type="button"
-                    class="btn btn-outline-secondary git-changes-empty__refresh"
-                    @onclick="ManualRefreshAsync">
-                Refresh
-            </button>
+            @if (_isEmptyStateRefreshing)
+            {
+                <div class="spinner-border" role="status">
+                    <span class="visually-hidden">Loading...</span>
+                </div>
+                <div class="git-changes-empty__label">@_emptyStateRefreshStatus</div>
+                <button type="button"
+                        class="btn btn-outline-secondary btn-sm git-changes-empty__refresh"
+                        @onclick="AbortEmptyStateRefresh">
+                    Abort
+                </button>
+            }
+            else
+            {
+                <i class="bi bi-git git-changes-empty__bg-icon" aria-hidden="true"></i>
+                <div class="git-changes-empty__label">No changes</div>
+                <button type="button"
+                        class="btn btn-outline-secondary git-changes-empty__refresh"
+                        @onclick="ManualRefreshAsync">
+                    Refresh
+                </button>
+            }
         </div>
     }
     else

--- a/src/GrayMoon.App/Components/Pages/WorkspaceGitChanges.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceGitChanges.razor.cs
@@ -38,14 +38,6 @@ public sealed partial class WorkspaceGitChanges : IAsyncDisposable
     private bool _disposed;
     private bool _scrollSelectionIntoViewPending;
 
-    // Empty-state ("No changes") refresh: a non-overlay refresh path. Unlike ManualRefreshAsync's
-    // StartPageJob branch (used once there are already persisted changed repositories), this never
-    // touches the JobService/BackgroundJobOverlay - the empty state's own "No changes"/Refresh UI is
-    // swapped inline for a centred spinner + progress text + Abort button for the duration of the scan.
-    private bool _isEmptyStateRefreshing;
-    private string? _emptyStateRefreshStatus;
-    private CancellationTokenSource? _emptyStateRefreshCts;
-
     // Selection: the currently chosen file row (diff panel wiring lands in Stage 6 - Monaco).
     private GitChangesTreeRow? _selectedRow;
 
@@ -58,10 +50,21 @@ public sealed partial class WorkspaceGitChanges : IAsyncDisposable
 
     protected override Task OnInitializedAsync()
     {
+        JobService.Changed += OnJobServiceChanged;
         EnsureActivitySubscription();
         RestoreWorkspaceCommitMessage();
         StartInitialLoadJob();
         return Task.CompletedTask;
+    }
+
+    private void OnJobServiceChanged()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _ = InvokeAsync(StateHasChanged);
     }
 
     protected override Task OnParametersSetAsync()
@@ -140,9 +143,9 @@ public sealed partial class WorkspaceGitChanges : IAsyncDisposable
     /// tree/splitter is showing), this runs behind the standard LoadingOverlay/terminal job so it's
     /// visibly a real operation - unchanged from before. When the page is showing the empty "No changes"
     /// state, the overlay would otherwise cover that same message/button, so it instead runs via the
-    /// non-overlay inline refresh (see StartEmptyStateRefreshAsync). Both rely on the same
-    /// GitChangesUpdated -> LoadAsync pipeline used everywhere else for incremental per-repository
-    /// updates as results stream in.
+    /// non-overlay EmptyScanJobKey job (inline spinner + Abort). Both survive navigation via
+    /// BackgroundJobService and rely on the same GitChangesUpdated -> LoadAsync pipeline for
+    /// incremental per-repository updates as results stream in.
     /// </summary>
     private void ManualRefreshAsync()
     {
@@ -152,7 +155,7 @@ public sealed partial class WorkspaceGitChanges : IAsyncDisposable
             return;
         }
 
-        if (IsJobRunning || _isEmptyStateRefreshing)
+        if (IsAnyScanRunning)
         {
             ToastService.Show("Another Git Changes operation is already running.");
             return;
@@ -160,7 +163,7 @@ public sealed partial class WorkspaceGitChanges : IAsyncDisposable
 
         if (ChangedRepositoryCount == 0)
         {
-            StartEmptyStateRefreshAsync();
+            StartEmptyScanJob("Refreshing repositories...");
             return;
         }
 
@@ -168,65 +171,6 @@ public sealed partial class WorkspaceGitChanges : IAsyncDisposable
             Scanner.ScanWorkspaceAsync(WorkspaceId, ct, progress =>
                 job.ReportProgress($"Refreshed {progress.Completed} of {progress.Total} repositories")));
     }
-
-    /// <summary>
-    /// Non-overlay refresh for the empty "No changes" state - swaps the "No changes"/Refresh UI for a
-    /// centred spinner + progress text + Abort button, using the same progress text format the
-    /// LoadingOverlay path uses ("Refreshing x of y repositories..."). Restores the normal empty-state
-    /// UI once the scan completes, is aborted, or fails.
-    /// </summary>
-    private void StartEmptyStateRefreshAsync()
-    {
-        _isEmptyStateRefreshing = true;
-        _emptyStateRefreshStatus = "Refreshing repositories...";
-        _emptyStateRefreshCts = new CancellationTokenSource();
-        var ct = _emptyStateRefreshCts.Token;
-
-        _ = RunEmptyStateRefreshAsync(ct);
-    }
-
-    private async Task RunEmptyStateRefreshAsync(CancellationToken ct)
-    {
-        try
-        {
-            await Scanner.ScanWorkspaceAsync(WorkspaceId, ct, progress =>
-                SafeInvoke(() => _emptyStateRefreshStatus = $"Refreshing {progress.Completed} of {progress.Total} repositories..."));
-
-            if (_disposed)
-            {
-                return;
-            }
-
-            await InvokeAsync(async () =>
-            {
-                if (!_disposed)
-                {
-                    await LoadAsync();
-                }
-            });
-        }
-        catch (OperationCanceledException)
-        {
-            // Aborted by the user - fall through to restore the normal empty-state UI below.
-        }
-        catch (Exception ex)
-        {
-            Logger.LogError(ex, "Git Changes empty-state refresh failed for workspace {WorkspaceId}", WorkspaceId);
-            SafeInvoke(() => ToastService.ShowError("Refresh failed. See logs for details."));
-        }
-        finally
-        {
-            SafeInvoke(() =>
-            {
-                _isEmptyStateRefreshing = false;
-                _emptyStateRefreshStatus = null;
-            });
-            _emptyStateRefreshCts?.Dispose();
-            _emptyStateRefreshCts = null;
-        }
-    }
-
-    private void AbortEmptyStateRefresh() => _emptyStateRefreshCts?.Cancel();
 
     private string MostRecentPersistedLabel()
     {
@@ -618,11 +562,8 @@ public sealed partial class WorkspaceGitChanges : IAsyncDisposable
         }
 
         _disposed = true;
+        JobService.Changed -= OnJobServiceChanged;
         ReleaseActivitySubscription();
-
-        _emptyStateRefreshCts?.Cancel();
-        _emptyStateRefreshCts?.Dispose();
-        _emptyStateRefreshCts = null;
 
         if (_hubConnection != null)
         {

--- a/src/GrayMoon.App/Components/Pages/WorkspaceGitChanges.razor.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceGitChanges.razor.cs
@@ -38,6 +38,14 @@ public sealed partial class WorkspaceGitChanges : IAsyncDisposable
     private bool _disposed;
     private bool _scrollSelectionIntoViewPending;
 
+    // Empty-state ("No changes") refresh: a non-overlay refresh path. Unlike ManualRefreshAsync's
+    // StartPageJob branch (used once there are already persisted changed repositories), this never
+    // touches the JobService/BackgroundJobOverlay - the empty state's own "No changes"/Refresh UI is
+    // swapped inline for a centred spinner + progress text + Abort button for the duration of the scan.
+    private bool _isEmptyStateRefreshing;
+    private string? _emptyStateRefreshStatus;
+    private CancellationTokenSource? _emptyStateRefreshCts;
+
     // Selection: the currently chosen file row (diff panel wiring lands in Stage 6 - Monaco).
     private GitChangesTreeRow? _selectedRow;
 
@@ -128,9 +136,13 @@ public sealed partial class WorkspaceGitChanges : IAsyncDisposable
 
     /// <summary>
     /// The Refresh button: a real, user-triggered rescan of every repository in the workspace (not just
-    /// the ones currently showing changes), run behind the standard LoadingOverlay/terminal job so it's
-    /// visibly a real operation. Relies on the same GitChangesUpdated -> LoadAsync pipeline used
-    /// everywhere else for incremental per-repository updates as results stream in.
+    /// the ones currently showing changes). When previously changed files are already persisted (the
+    /// tree/splitter is showing), this runs behind the standard LoadingOverlay/terminal job so it's
+    /// visibly a real operation - unchanged from before. When the page is showing the empty "No changes"
+    /// state, the overlay would otherwise cover that same message/button, so it instead runs via the
+    /// non-overlay inline refresh (see StartEmptyStateRefreshAsync). Both rely on the same
+    /// GitChangesUpdated -> LoadAsync pipeline used everywhere else for incremental per-repository
+    /// updates as results stream in.
     /// </summary>
     private void ManualRefreshAsync()
     {
@@ -140,9 +152,15 @@ public sealed partial class WorkspaceGitChanges : IAsyncDisposable
             return;
         }
 
-        if (IsJobRunning)
+        if (IsJobRunning || _isEmptyStateRefreshing)
         {
             ToastService.Show("Another Git Changes operation is already running.");
+            return;
+        }
+
+        if (ChangedRepositoryCount == 0)
+        {
+            StartEmptyStateRefreshAsync();
             return;
         }
 
@@ -150,6 +168,65 @@ public sealed partial class WorkspaceGitChanges : IAsyncDisposable
             Scanner.ScanWorkspaceAsync(WorkspaceId, ct, progress =>
                 job.ReportProgress($"Refreshed {progress.Completed} of {progress.Total} repositories")));
     }
+
+    /// <summary>
+    /// Non-overlay refresh for the empty "No changes" state - swaps the "No changes"/Refresh UI for a
+    /// centred spinner + progress text + Abort button, using the same progress text format the
+    /// LoadingOverlay path uses ("Refreshing x of y repositories..."). Restores the normal empty-state
+    /// UI once the scan completes, is aborted, or fails.
+    /// </summary>
+    private void StartEmptyStateRefreshAsync()
+    {
+        _isEmptyStateRefreshing = true;
+        _emptyStateRefreshStatus = "Refreshing repositories...";
+        _emptyStateRefreshCts = new CancellationTokenSource();
+        var ct = _emptyStateRefreshCts.Token;
+
+        _ = RunEmptyStateRefreshAsync(ct);
+    }
+
+    private async Task RunEmptyStateRefreshAsync(CancellationToken ct)
+    {
+        try
+        {
+            await Scanner.ScanWorkspaceAsync(WorkspaceId, ct, progress =>
+                SafeInvoke(() => _emptyStateRefreshStatus = $"Refreshing {progress.Completed} of {progress.Total} repositories..."));
+
+            if (_disposed)
+            {
+                return;
+            }
+
+            await InvokeAsync(async () =>
+            {
+                if (!_disposed)
+                {
+                    await LoadAsync();
+                }
+            });
+        }
+        catch (OperationCanceledException)
+        {
+            // Aborted by the user - fall through to restore the normal empty-state UI below.
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Git Changes empty-state refresh failed for workspace {WorkspaceId}", WorkspaceId);
+            SafeInvoke(() => ToastService.ShowError("Refresh failed. See logs for details."));
+        }
+        finally
+        {
+            SafeInvoke(() =>
+            {
+                _isEmptyStateRefreshing = false;
+                _emptyStateRefreshStatus = null;
+            });
+            _emptyStateRefreshCts?.Dispose();
+            _emptyStateRefreshCts = null;
+        }
+    }
+
+    private void AbortEmptyStateRefresh() => _emptyStateRefreshCts?.Cancel();
 
     private string MostRecentPersistedLabel()
     {
@@ -542,6 +619,10 @@ public sealed partial class WorkspaceGitChanges : IAsyncDisposable
 
         _disposed = true;
         ReleaseActivitySubscription();
+
+        _emptyStateRefreshCts?.Cancel();
+        _emptyStateRefreshCts?.Dispose();
+        _emptyStateRefreshCts = null;
 
         if (_hubConnection != null)
         {

--- a/src/GrayMoon.App/Components/Shared/LoadingOverlay.razor
+++ b/src/GrayMoon.App/Components/Shared/LoadingOverlay.razor
@@ -106,8 +106,8 @@
 
     /// <summary>Matrix rain: character size in px.</summary>
     [Parameter] public int FontSize { get; set; } = 16;
-    /// <summary>Matrix rain: frame interval in ms (~20 FPS = 50).</summary>
-    [Parameter] public int FrameIntervalMs { get; set; } = 50;
+    /// <summary>Matrix rain: frame interval in ms (~15 FPS = 66; lighter than the old 20 FPS default).</summary>
+    [Parameter] public int FrameIntervalMs { get; set; } = 66;
     /// <summary>Matrix rain: trail length (e.g. 0.08).</summary>
     [Parameter] public double FadeAlpha { get; set; } = 0.08;
     /// <summary>Matrix rain: character opacity (e.g. 0.65).</summary>

--- a/src/GrayMoon.App/Components/Shared/WorkspaceActionNotificationPanel.razor.css
+++ b/src/GrayMoon.App/Components/Shared/WorkspaceActionNotificationPanel.razor.css
@@ -99,7 +99,7 @@
 }
 
 .notif-dep-badge {
-    background-color: #a50c1b;
+    background-color: #dc3545;
     color: #fff;
     font-size: 0.7rem;
     font-weight: 400;

--- a/src/GrayMoon.App/wwwroot/js/matrixOverlay.js
+++ b/src/GrayMoon.App/wwwroot/js/matrixOverlay.js
@@ -19,14 +19,31 @@
     return { w, h };
   }
 
+  // Flattened once at module load instead of rebuilt (3 array + string
+  // allocations) on every single glyph draw - this ran once per column per
+  // frame (~100+ times/frame), so hoisting it is a real allocation-count win.
+  const CHAR_POOL = Array.from(
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789" +
+    "!@#$%^&*()-_=+[]{};:,.<>/?\\|" +
+    "ｱｲｳｴｵｶｷｸｹｺｻｼｽｾｿﾀﾁﾂﾃﾄﾅﾆﾇﾈﾉﾊﾋﾌﾍﾎﾏﾐﾑﾒﾓﾔﾕﾖﾗﾘﾙﾚﾛﾜﾝ"
+  );
+
   function randomChar() {
-    const pools = [
-      "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789",
-      "!@#$%^&*()-_=+[]{};:,.<>/?\\|",
-      "ｱｲｳｴｵｶｷｸｹｺｻｼｽｾｿﾀﾁﾂﾃﾄﾅﾆﾇﾈﾉﾊﾋﾌﾍﾎﾏﾐﾑﾒﾓﾔﾕﾖﾗﾘﾙﾚﾛﾜﾝ"
-    ];
-    const p = pools[(Math.random() * pools.length) | 0];
-    return p[(Math.random() * p.length) | 0];
+    return CHAR_POOL[(Math.random() * CHAR_POOL.length) | 0];
+  }
+
+  // Quantized grayscale palette instead of formatting a new "rgba(...)"
+  // string per glyph per frame (the intensity variation only needs a handful
+  // of visually distinct steps, not a continuous 0-255 range).
+  const COLOR_STEPS = 12;
+
+  function buildColorPalette(characterOpacity) {
+    const palette = new Array(COLOR_STEPS);
+    for (let i = 0; i < COLOR_STEPS; i++) {
+      const intensity = 180 + Math.round((i / (COLOR_STEPS - 1)) * 75);
+      palette[i] = `rgba(${intensity}, ${intensity}, ${intensity}, ${characterOpacity})`;
+    }
+    return palette;
   }
 
   function start(canvasId, options) {
@@ -51,6 +68,9 @@
 
     ctx.font = `${fontSize}px ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace`;
     ctx.textBaseline = "top";
+
+    const fadeFillStyle = `rgba(0, 0, 0, ${fadeAlpha})`;
+    const colorPalette = buildColorPalette(characterOpacity);
 
     const onResize = () => {
       ({ w, h } = resize(canvas, ctx));
@@ -84,7 +104,7 @@
       if (!s.running) return;
 
       // translucent black fill = trail
-      ctx.fillStyle = `rgba(0, 0, 0, ${fadeAlpha})`;
+      ctx.fillStyle = fadeFillStyle;
       ctx.fillRect(0, 0, w, h);
 
       for (let i = 0; i < drops.length; i++) {
@@ -94,8 +114,7 @@
         const c = randomChar();
 
         // Grayscale intensity range (brighter + dimmer variation)
-        const intensity = 180 + ((Math.random() * 75) | 0);
-        ctx.fillStyle = `rgba(${intensity}, ${intensity}, ${intensity}, ${characterOpacity})`;
+        ctx.fillStyle = colorPalette[(Math.random() * COLOR_STEPS) | 0];
         ctx.fillText(c, x, y);
 
         // reset occasionally for randomness

--- a/src/GrayMoon.App/wwwroot/js/matrixOverlay.js
+++ b/src/GrayMoon.App/wwwroot/js/matrixOverlay.js
@@ -1,8 +1,13 @@
 (function () {
   const state = new Map(); // canvasId -> state object
 
+  // Cap the backing-store resolution: full devicePixelRatio (2-3x on modern
+  // displays) multiplies fill/text work by dpr^2 for a purely decorative
+  // effect, so we clamp it well below native sharpness.
+  const MAX_DPR = 1.25;
+
   function resize(canvas, ctx) {
-    const dpr = window.devicePixelRatio || 1;
+    const dpr = Math.min(window.devicePixelRatio || 1, MAX_DPR);
     const rect = canvas.getBoundingClientRect();
     const w = Math.max(1, Math.floor(rect.width));
     const h = Math.max(1, Math.floor(rect.height));
@@ -34,7 +39,7 @@
     if (!ctx) return;
 
     const fontSize = Math.max(10, (options?.fontSize ?? 16) | 0);
-    const frameIntervalMs = Math.max(16, (options?.frameIntervalMs ?? 50) | 0);
+    const frameIntervalMs = Math.max(33, (options?.frameIntervalMs ?? 66) | 0);
     const fadeAlpha = Math.min(1, Math.max(0, options?.fadeAlpha ?? 0.08)); // trail length
     const characterOpacity = Math.min(1, Math.max(0, options?.characterOpacity ?? 0.65));
     const dropSpeed = Math.min(2, Math.max(0.1, options?.dropSpeed ?? 0.6)); // fall speed (lower = slower)
@@ -71,11 +76,11 @@
       fadeAlpha,
       characterOpacity,
       onResize,
-      timerId: null
+      timerId: null,
+      onVisibilityChange: null
     };
 
-    // Throttled loop (stable FPS, less battery use than full raf)
-    s.timerId = window.setInterval(() => {
+    const tick = () => {
       if (!s.running) return;
 
       // translucent black fill = trail
@@ -97,7 +102,30 @@
         if (y > h && Math.random() > 0.975) drops[i] = 0;
         else drops[i] += dropSpeed;
       }
-    }, frameIntervalMs);
+    };
+
+    const startTimer = () => {
+      if (s.timerId) return;
+      // Throttled loop (stable FPS, less battery use than full raf)
+      s.timerId = window.setInterval(tick, frameIntervalMs);
+    };
+
+    const stopTimer = () => {
+      if (!s.timerId) return;
+      window.clearInterval(s.timerId);
+      s.timerId = null;
+    };
+
+    // Backgrounded tabs still tick this timer (browsers only throttle to
+    // ~1/s), so fully stop drawing while the overlay isn't visible on
+    // screen to avoid burning CPU on a hidden tab.
+    s.onVisibilityChange = () => {
+      if (document.hidden) stopTimer();
+      else startTimer();
+    };
+    document.addEventListener("visibilitychange", s.onVisibilityChange);
+
+    if (!document.hidden) startTimer();
 
     state.set(canvasId, s);
   }
@@ -109,6 +137,7 @@
     s.running = false;
     if (s.timerId) window.clearInterval(s.timerId);
     window.removeEventListener("resize", s.onResize);
+    if (s.onVisibilityChange) document.removeEventListener("visibilitychange", s.onVisibilityChange);
 
     // clear canvas
     try {

--- a/src/GrayMoon.Common/CommandLineService.cs
+++ b/src/GrayMoon.Common/CommandLineService.cs
@@ -337,32 +337,41 @@ public sealed class CommandLineService(ILogger<CommandLineService> logger) : ICo
         if (!string.Equals(fileName, "git", StringComparison.OrdinalIgnoreCase))
             return false;
 
-        var trimmed = arguments.TrimStart();
-        if (trimmed.StartsWith("diff", StringComparison.Ordinal)
-            && (trimmed.Length == 4 || trimmed[4] == ' '))
-            return true;
-
-        if (IsGitStatusCommand(fileName, arguments))
-            return true;
-
-        if (!trimmed.StartsWith("show ", StringComparison.Ordinal))
+        if (!TryGetGitSubcommand(arguments, out var subcommandAndRest))
             return false;
 
-        return trimmed.AsSpan(5).IndexOf(':') >= 0;
+        if (subcommandAndRest.StartsWith("diff", StringComparison.Ordinal)
+            && (subcommandAndRest.Length == 4 || subcommandAndRest[4] == ' '))
+            return true;
+
+        if (subcommandAndRest.StartsWith("status", StringComparison.Ordinal)
+            && (subcommandAndRest.Length == 6 || subcommandAndRest[6] == ' '))
+            return true;
+
+        if (!subcommandAndRest.StartsWith("show ", StringComparison.Ordinal))
+            return false;
+
+        return subcommandAndRest.AsSpan(5).IndexOf(':') >= 0;
     }
 
     private static bool ShouldSuppressStreamLogging(string fileName, IReadOnlyList<string> arguments)
     {
-        if (!string.Equals(fileName, "git", StringComparison.OrdinalIgnoreCase) || arguments.Count == 0)
+        if (!string.Equals(fileName, "git", StringComparison.OrdinalIgnoreCase))
             return false;
 
-        if (string.Equals(arguments[0], "diff", StringComparison.Ordinal) || string.Equals(arguments[0], "status", StringComparison.Ordinal))
+        var subIdx = FindGitSubcommandIndex(arguments);
+        if (subIdx < 0)
+            return false;
+
+        var subcommand = arguments[subIdx];
+        if (string.Equals(subcommand, "diff", StringComparison.Ordinal)
+            || string.Equals(subcommand, "status", StringComparison.Ordinal))
             return true;
 
-        if (!string.Equals(arguments[0], "show", StringComparison.Ordinal))
+        if (!string.Equals(subcommand, "show", StringComparison.Ordinal))
             return false;
 
-        for (var i = 1; i < arguments.Count; i++)
+        for (var i = subIdx + 1; i < arguments.Count; i++)
         {
             if (arguments[i].Contains(':', StringComparison.Ordinal))
                 return true;
@@ -383,14 +392,82 @@ public sealed class CommandLineService(ILogger<CommandLineService> logger) : ICo
         if (!string.Equals(fileName, "git", StringComparison.OrdinalIgnoreCase))
             return false;
 
-        var trimmed = arguments.TrimStart();
-        return trimmed.StartsWith("status", StringComparison.Ordinal) && (trimmed.Length == 6 || trimmed[6] == ' ');
+        if (!TryGetGitSubcommand(arguments, out var subcommandAndRest))
+            return false;
+
+        return subcommandAndRest.StartsWith("status", StringComparison.Ordinal)
+            && (subcommandAndRest.Length == 6 || subcommandAndRest[6] == ' ');
     }
 
-    private static bool IsGitStatusCommand(string fileName, IReadOnlyList<string> arguments) =>
-        string.Equals(fileName, "git", StringComparison.OrdinalIgnoreCase)
-        && arguments.Count > 0
-        && string.Equals(arguments[0], "status", StringComparison.Ordinal);
+    private static bool IsGitStatusCommand(string fileName, IReadOnlyList<string> arguments)
+    {
+        if (!string.Equals(fileName, "git", StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        var subIdx = FindGitSubcommandIndex(arguments);
+        return subIdx >= 0 && string.Equals(arguments[subIdx], "status", StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Skips leading global git options (e.g. <c>--no-optional-locks</c>, <c>-C path</c>, <c>-c key=value</c>)
+    /// so callers that prepend them still match subcommand-based suppress rules.
+    /// </summary>
+    private static int FindGitSubcommandIndex(IReadOnlyList<string> arguments)
+    {
+        for (var i = 0; i < arguments.Count; i++)
+        {
+            var arg = arguments[i];
+            if (arg.Length == 0 || arg[0] != '-')
+                return i;
+
+            // Global options that take the next argv as their value.
+            if (arg is "-C" or "-c")
+                i++;
+        }
+
+        return -1;
+    }
+
+    /// <summary>
+    /// Same as <see cref="FindGitSubcommandIndex"/> for the joined-arguments overload.
+    /// </summary>
+    private static bool TryGetGitSubcommand(string arguments, out string subcommandAndRest)
+    {
+        var trimmed = arguments.TrimStart();
+        while (trimmed.Length > 0 && trimmed[0] == '-')
+        {
+            var space = trimmed.IndexOf(' ');
+            if (space < 0)
+            {
+                subcommandAndRest = "";
+                return false;
+            }
+
+            var option = trimmed[..space];
+            trimmed = trimmed[(space + 1)..].TrimStart();
+
+            if (option is "-C" or "-c")
+            {
+                space = trimmed.IndexOf(' ');
+                if (space < 0)
+                {
+                    subcommandAndRest = "";
+                    return false;
+                }
+
+                trimmed = trimmed[(space + 1)..].TrimStart();
+            }
+        }
+
+        if (trimmed.Length == 0)
+        {
+            subcommandAndRest = "";
+            return false;
+        }
+
+        subcommandAndRest = trimmed;
+        return true;
+    }
 
     private void OnStreamSegment(string fileName, bool suppressStreamLogging, bool suppressOverlay, AgentCommandStreamKind kind, string segment)
     {

--- a/src/GrayMoon.Common/Git/GitChangesOptions.cs
+++ b/src/GrayMoon.Common/Git/GitChangesOptions.cs
@@ -3,14 +3,13 @@ namespace GrayMoon.Common.Git;
 /// <summary>Bounded-concurrency and debounce tuning for the Git Changes feature. Configurable, benchmark-driven.</summary>
 public sealed class GitChangesOptions
 {
-    /// <summary>Max repositories with a concurrent status scan in flight. Default 16.</summary>
-    public int MaxParallelRepositoryOperations { get; init; } = 16;
-
-    /// <summary>Max repositories with a concurrent mutation (stage/unstage/commit) in flight. Default 4.</summary>
-    public int MaxParallelRepositoryMutations { get; init; } = 4;
-
-    /// <summary>Max concurrent diff content loads. Default 4.</summary>
-    public int MaxParallelDiffLoads { get; init; } = 4;
+    /// <summary>
+    /// Single shared concurrency bound for every repository-level batch operation in the Git Changes
+    /// feature - status scans (background sweep, on-open warm-up, manual Refresh), stage/unstage/commit
+    /// fan-out, and diff loads all gate on this one value rather than each carrying its own hard-coded
+    /// limit. Default 8.
+    /// </summary>
+    public int MaxParallelRepositoryOperations { get; init; } = 8;
 
     /// <summary>Debounce window after a watcher event before running an authoritative status scan.</summary>
     public int WatcherDebounceMilliseconds { get; init; } = 400;


### PR DESCRIPTION
## Summary

- Run empty-state and warm-up Git Changes scans as abortable BackgroundJobService jobs so they keep going after you leave the page; keep LoadingOverlay only when Refresh runs with existing changes
- Hide "No changes"/Refresh while a scan is in progress, drop the header warm-up subtitle, and document the behavior in the README
- Cap Git Changes parallelism at 8 shared workers and keep notification dependency badges on the classic danger red
- Lower matrix-overlay CPU (slower default frame rate and JS tweaks) and stop cancelled GHA refreshes from showing as failures
- Keep file pathspecs out of CommandLineService stdout so large path lists do not flood the terminal log

## Test plan

- [ ] On Changes with no local changes, start Refresh, navigate away and back - scan continues and the inline spinner/Abort returns until finished
- [ ] Open Changes for an inactive workspace (warm-up) and confirm empty-state progress (or silent tree updates) with no header subtitle
- [ ] With changes present, Refresh still uses LoadingOverlay and survives navigation like Repositories jobs
- [ ] Abort an empty-state scan and confirm it stops cleanly; Abort is available during warm-up/empty refresh
- [ ] On Actions, cancel/supersede a refresh and confirm no error badge for OperationCanceledException
- [ ] Confirm matrix overlay feels lighter under load and notification dependency badges use `#dc3545`