### PR TITLE
Add git process timeouts, raise Git Changes refresh workers, and improve orchestration error handling

### DIFF
--- a/src/GrayMoon.Agent.Tests/GitCliRepositoryGitChangesServiceTests.cs
+++ b/src/GrayMoon.Agent.Tests/GitCliRepositoryGitChangesServiceTests.cs
@@ -4,6 +4,7 @@ using GrayMoon.Agent.Services.GitChanges;
 using GrayMoon.Common;
 using GrayMoon.Common.Git;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 
 namespace GrayMoon.Agent.Tests;
 
@@ -14,8 +15,8 @@ public sealed class GitCliRepositoryGitChangesServiceTests : IDisposable
 
     public GitCliRepositoryGitChangesServiceTests()
     {
-        var commandLine = new CommandLineService(NullLogger<CommandLineService>.Instance);
-        var runner = new GitProcessRunner(commandLine, NullLogger<GitProcessRunner>.Instance);
+        var commandLine = new CommandLineService(NullLogger<CommandLineService>.Instance, Options.Create(new ProcessExecutionOptions()));
+        var runner = new GitProcessRunner(commandLine, Options.Create(new GitProcessOptions()), NullLogger<GitProcessRunner>.Instance);
         _service = new GitCliRepositoryGitChangesService(runner, NullLogger<GitCliRepositoryGitChangesService>.Instance);
     }
 

--- a/src/GrayMoon.Agent.Tests/GitProcessRunnerTests.cs
+++ b/src/GrayMoon.Agent.Tests/GitProcessRunnerTests.cs
@@ -1,0 +1,134 @@
+using System.Threading;
+using GrayMoon.Agent.Services;
+using GrayMoon.Common;
+using GrayMoon.Common.Git;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace GrayMoon.Agent.Tests;
+
+public sealed class GitProcessRunnerTests
+{
+    private static GitProcessRunner CreateRunner(int defaultSeconds = 60, int networkSeconds = 180, int gitVersionSeconds = 90, int cloneSeconds = 0)
+    {
+        var commandLine = new CommandLineService(NullLogger<CommandLineService>.Instance, Options.Create(new ProcessExecutionOptions()));
+        return new GitProcessRunner(
+            commandLine,
+            Options.Create(new GitProcessOptions
+            {
+                DefaultTimeoutSeconds = defaultSeconds,
+                NetworkTimeoutSeconds = networkSeconds,
+                GitVersionTimeoutSeconds = gitVersionSeconds,
+                CloneTimeoutSeconds = cloneSeconds,
+            }),
+            NullLogger<GitProcessRunner>.Instance);
+    }
+
+    [Theory]
+    [InlineData("fetch origin --prune")]
+    [InlineData("pull origin main")]
+    [InlineData("push origin main")]
+    [InlineData("ls-remote --heads origin")]
+    public void ResolveTimeout_StringOverload_UsesNetworkTier_ForNetworkSubcommands(string arguments)
+    {
+        var runner = CreateRunner(defaultSeconds: 60, networkSeconds: 180);
+
+        var timeout = runner.ResolveTimeout("git", arguments);
+
+        Assert.Equal(TimeSpan.FromSeconds(180), timeout);
+    }
+
+    [Fact]
+    public void ResolveTimeout_StringOverload_UsesInfiniteTimeout_ForClone_WhenCloneTimeoutSecondsIsDefault()
+    {
+        var runner = CreateRunner(defaultSeconds: 60, networkSeconds: 180, cloneSeconds: 0);
+
+        var timeout = runner.ResolveTimeout("git", "clone https://example.com/repo.git dest");
+
+        Assert.Equal(Timeout.InfiniteTimeSpan, timeout);
+    }
+
+    [Fact]
+    public void ResolveTimeout_StringOverload_UsesConfiguredCloneTimeout_WhenCloneTimeoutSecondsIsSet()
+    {
+        var runner = CreateRunner(cloneSeconds: 600);
+
+        var timeout = runner.ResolveTimeout("git", "clone https://example.com/repo.git dest");
+
+        Assert.Equal(TimeSpan.FromSeconds(600), timeout);
+    }
+
+    [Fact]
+    public void ResolveTimeout_ArgumentListOverload_UsesInfiniteTimeout_ForClone_WhenCloneTimeoutSecondsIsDefault()
+    {
+        var runner = CreateRunner(cloneSeconds: 0);
+
+        var timeout = runner.ResolveTimeout("git", ["clone", "https://example.com/repo.git", "dest"]);
+
+        Assert.Equal(Timeout.InfiniteTimeSpan, timeout);
+    }
+
+    [Theory]
+    [InlineData("status --porcelain=v2 -z --branch")]
+    [InlineData("rev-parse --verify HEAD")]
+    [InlineData("commit -F -")]
+    [InlineData("config --global --add safe.directory /repo")]
+    public void ResolveTimeout_StringOverload_UsesDefaultTier_ForLocalSubcommands(string arguments)
+    {
+        var runner = CreateRunner(defaultSeconds: 60, networkSeconds: 180);
+
+        var timeout = runner.ResolveTimeout("git", arguments);
+
+        Assert.Equal(TimeSpan.FromSeconds(60), timeout);
+    }
+
+    [Fact]
+    public void ResolveTimeout_StringOverload_UsesGitVersionTier_ForDotnetGitVersionInvocation()
+    {
+        var runner = CreateRunner(defaultSeconds: 60, gitVersionSeconds: 90);
+
+        var timeout = runner.ResolveTimeout("dotnet", "gitversion /output json");
+
+        Assert.Equal(TimeSpan.FromSeconds(90), timeout);
+    }
+
+    [Fact]
+    public void ResolveTimeout_StringOverload_UsesGitVersionTier_ForDotnetGitVersionExecutable()
+    {
+        var runner = CreateRunner(gitVersionSeconds: 90);
+
+        var timeout = runner.ResolveTimeout("dotnet-gitversion", "/output json");
+
+        Assert.Equal(TimeSpan.FromSeconds(90), timeout);
+    }
+
+    [Fact]
+    public void ResolveTimeout_ArgumentListOverload_UsesNetworkTier_ForPush()
+    {
+        var runner = CreateRunner(defaultSeconds: 60, networkSeconds: 180);
+
+        var timeout = runner.ResolveTimeout("git", ["push", "origin", "main"]);
+
+        Assert.Equal(TimeSpan.FromSeconds(180), timeout);
+    }
+
+    [Fact]
+    public void ResolveTimeout_ArgumentListOverload_UsesDefaultTier_ForStatus()
+    {
+        var runner = CreateRunner(defaultSeconds: 60, networkSeconds: 180);
+
+        var timeout = runner.ResolveTimeout("git", ["status", "--porcelain=v2"]);
+
+        Assert.Equal(TimeSpan.FromSeconds(60), timeout);
+    }
+
+    [Fact]
+    public void ResolveTimeout_NonGitExecutable_UsesDefaultTier()
+    {
+        var runner = CreateRunner(defaultSeconds: 60, networkSeconds: 180);
+
+        var timeout = runner.ResolveTimeout("dotnet", "restore --force --no-cache");
+
+        Assert.Equal(TimeSpan.FromSeconds(60), timeout);
+    }
+}

--- a/src/GrayMoon.Agent/AgentOptions.cs
+++ b/src/GrayMoon.Agent/AgentOptions.cs
@@ -15,7 +15,7 @@ public class AgentOptions
     /// small and separate from <see cref="MaxConcurrentCommands"/> so reads stay responsive even when the
     /// main pool is fully occupied by long-running writes (push/update/sync).
     /// </summary>
-    public int MaxConcurrentReadCommands { get; set; } = 4;
+    public int MaxConcurrentReadCommands { get; set; } = 8;
 
     /// <summary>
     /// Worker count for the dedicated diff command pool (GetGitFileDiff). Kept separate from both

--- a/src/GrayMoon.Agent/Cli/Handlers/RunCommandHandler.cs
+++ b/src/GrayMoon.Agent/Cli/Handlers/RunCommandHandler.cs
@@ -68,6 +68,11 @@ internal static class RunCommandHandler
 
         builder.Services.Configure<AgentOptions>(builder.Configuration.GetSection(AgentOptions.SectionName));
         builder.Services.Configure<GitChangesOptions>(builder.Configuration.GetSection($"{AgentOptions.SectionName}:GitChanges"));
+        builder.Services.Configure<GitProcessOptions>(builder.Configuration.GetSection($"{AgentOptions.SectionName}:GitProcess"));
+        // ProcessExecutionOptions.DefaultTimeoutSeconds mirrors GitProcessOptions.DefaultTimeoutSeconds -
+        // same "GitProcess" section, so CommandLineService's own fallback timeout stays in sync with the
+        // tier GitProcessRunner resolves for local/fast git operations.
+        builder.Services.Configure<ProcessExecutionOptions>(builder.Configuration.GetSection($"{AgentOptions.SectionName}:GitProcess"));
 
         var logDirectory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), "GrayMoon", "logs");
         Directory.CreateDirectory(logDirectory);

--- a/src/GrayMoon.Agent/GrayMoon.Agent.csproj
+++ b/src/GrayMoon.Agent/GrayMoon.Agent.csproj
@@ -24,6 +24,9 @@
 		<Compile Remove="Example\**\*" />
 	</ItemGroup>
 	<ItemGroup>
+		<InternalsVisibleTo Include="GrayMoon.Agent.Tests" />
+	</ItemGroup>
+	<ItemGroup>
 		<Content Include="appsettings.json">
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</Content>

--- a/src/GrayMoon.Agent/Services/GitProcessRunner.cs
+++ b/src/GrayMoon.Agent/Services/GitProcessRunner.cs
@@ -1,7 +1,10 @@
 using System.Collections.Concurrent;
+using System.Threading;
 using GrayMoon.Abstractions.Agent;
 using GrayMoon.Common;
+using GrayMoon.Common.Git;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Polly;
 
 namespace GrayMoon.Agent.Services;
@@ -20,31 +23,47 @@ public enum GitLockIntent
     Read,
 }
 
-public sealed class GitProcessRunner(ICommandLineService commandLine, ILogger<GitProcessRunner> logger)
+public sealed class GitProcessRunner(ICommandLineService commandLine, IOptions<GitProcessOptions> gitProcessOptions, ILogger<GitProcessRunner> logger)
 {
+    private static readonly string[] NetworkSubcommands = ["fetch", "pull", "push", "ls-remote"];
+
+    private readonly TimeSpan _defaultTimeout = TimeSpan.FromSeconds(Math.Max(1, gitProcessOptions.Value.DefaultTimeoutSeconds));
+    private readonly TimeSpan _networkTimeout = TimeSpan.FromSeconds(Math.Max(1, gitProcessOptions.Value.NetworkTimeoutSeconds));
+    private readonly TimeSpan _gitVersionTimeout = TimeSpan.FromSeconds(Math.Max(1, gitProcessOptions.Value.GitVersionTimeoutSeconds));
+
+    /// <summary>
+    /// <see cref="Timeout.InfiniteTimeSpan"/> when <see cref="GitProcessOptions.CloneTimeoutSeconds"/> is
+    /// 0 (the default) - both <see cref="CommandLineService"/>'s <c>CancellationTokenSource(TimeSpan)</c>
+    /// constructor and Polly's <c>AddTimeout</c> understand that sentinel as "never time out" (the former
+    /// natively; the latter is special-cased in <see cref="GitResiliencePipelines.CreateClonePipeline"/>
+    /// since Polly rejects a non-positive duration), so a long-running clone is never killed or retried
+    /// away just for taking a while.
+    /// </summary>
+    private readonly TimeSpan _cloneTimeout = ResolveCloneTimeout(gitProcessOptions.Value);
+
     internal static readonly ConcurrentDictionary<string, SemaphoreSlim> RepoLocks =
         new(StringComparer.OrdinalIgnoreCase);
 
     internal readonly ResiliencePipeline<(int ExitCode, string? Stdout, string? Stderr)> SafeDirectoryPipeline =
-        GitResiliencePipelines.CreateSafeDirectoryPipeline(logger);
+        GitResiliencePipelines.CreateSafeDirectoryPipeline(logger, TimeSpan.FromSeconds(Math.Max(1, gitProcessOptions.Value.NetworkTimeoutSeconds)));
 
     internal readonly ResiliencePipeline<(int ExitCode, string? Stdout, string? Stderr)> ClonePipeline =
-        GitResiliencePipelines.CreateClonePipeline(logger);
+        GitResiliencePipelines.CreateClonePipeline(logger, ResolveCloneTimeout(gitProcessOptions.Value));
 
     internal readonly ResiliencePipeline<(int ExitCode, string? Stdout, string? Stderr)> FetchPipeline =
-        GitResiliencePipelines.CreateFetchPipeline(logger);
+        GitResiliencePipelines.CreateFetchPipeline(logger, TimeSpan.FromSeconds(Math.Max(1, gitProcessOptions.Value.NetworkTimeoutSeconds)));
 
     internal readonly ResiliencePipeline<(int ExitCode, string? Stdout, string? Stderr)> PullPipeline =
-        GitResiliencePipelines.CreatePullPipeline(logger);
+        GitResiliencePipelines.CreatePullPipeline(logger, TimeSpan.FromSeconds(Math.Max(1, gitProcessOptions.Value.NetworkTimeoutSeconds)));
 
     internal readonly ResiliencePipeline<(int ExitCode, string? Stdout, string? Stderr)> PushPipeline =
-        GitResiliencePipelines.CreatePushPipeline(logger);
+        GitResiliencePipelines.CreatePushPipeline(logger, TimeSpan.FromSeconds(Math.Max(1, gitProcessOptions.Value.NetworkTimeoutSeconds)));
 
     internal readonly ResiliencePipeline<(int ExitCode, string? Stdout, string? Stderr)> LsRemotePipeline =
-        GitResiliencePipelines.CreateLsRemotePipeline(logger);
+        GitResiliencePipelines.CreateLsRemotePipeline(logger, TimeSpan.FromSeconds(Math.Max(1, gitProcessOptions.Value.NetworkTimeoutSeconds)));
 
     internal readonly ResiliencePipeline<(int ExitCode, string? Stdout, string? Stderr)> MinimalFetchPipeline =
-        GitResiliencePipelines.CreateMinimalFetchPipeline(logger);
+        GitResiliencePipelines.CreateMinimalFetchPipeline(logger, TimeSpan.FromSeconds(Math.Max(1, gitProcessOptions.Value.NetworkTimeoutSeconds)));
 
     internal async Task<(int ExitCode, string? Stdout, string? Stderr)> RunAsync(
         string fileName,
@@ -82,7 +101,8 @@ public sealed class GitProcessRunner(ICommandLineService commandLine, ILogger<Gi
         var gitLike = IsGitLikeProgressStreaming(fileName, arguments);
         var stderrAsOut = streamStderrAsStdout ?? gitLike;
         var mirror = mirrorFailureOutputAsStderr ?? gitLike;
-        var r = await commandLine.RunAsync(fileName, arguments, workingDirectory, null, ct, stderrAsOut, mirror);
+        var timeout = ResolveTimeout(fileName, arguments);
+        var r = await commandLine.RunAsync(fileName, arguments, workingDirectory, null, ct, stderrAsOut, mirror, timeout);
         return (r.ExitCode, r.Stdout, r.Stderr);
     }
 
@@ -118,7 +138,8 @@ public sealed class GitProcessRunner(ICommandLineService commandLine, ILogger<Gi
         CancellationToken ct)
     {
         var gitLike = IsGitLikeProgressStreaming(fileName, arguments);
-        var r = await commandLine.RunAsync(fileName, arguments, workingDirectory, stdinContent, ct, gitLike, gitLike);
+        var timeout = ResolveTimeout(fileName, arguments);
+        var r = await commandLine.RunAsync(fileName, arguments, workingDirectory, stdinContent, ct, gitLike, gitLike, timeout);
         return (r.ExitCode, r.Stdout, r.Stderr);
     }
 
@@ -163,7 +184,8 @@ public sealed class GitProcessRunner(ICommandLineService commandLine, ILogger<Gi
         CancellationToken ct)
     {
         var gitLike = string.Equals(fileName, "git", StringComparison.OrdinalIgnoreCase);
-        var r = await commandLine.RunAsync(fileName, arguments, workingDirectory, stdinBytes, ct, gitLike, gitLike);
+        var timeout = ResolveTimeout(fileName, arguments);
+        var r = await commandLine.RunAsync(fileName, arguments, workingDirectory, stdinBytes, ct, gitLike, gitLike, timeout);
         return (r.ExitCode, r.Stdout, r.Stderr);
     }
 
@@ -208,5 +230,105 @@ public sealed class GitProcessRunner(ICommandLineService commandLine, ILogger<Gi
             return true;
         return string.Equals(fileName, "dotnet", StringComparison.OrdinalIgnoreCase)
                && arguments.Contains("gitversion", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Picks the timeout tier for one invocation: GitVersion (scans full history, can be slower than a
+    /// plain git call), clone (its own unbounded-by-default tier - see <see cref="_cloneTimeout"/>),
+    /// network (fetch/pull/push/ls-remote - can legitimately take longer on large repos/slow networks),
+    /// or the default (everything else - status, diff/show, rev-parse, cat-file, add, restore, reset,
+    /// commit, branch/tag queries, config, etc.).
+    /// </summary>
+    internal TimeSpan ResolveTimeout(string fileName, string arguments)
+    {
+        if (IsGitVersionInvocation(fileName, arguments))
+            return _gitVersionTimeout;
+
+        if (string.Equals(fileName, "git", StringComparison.OrdinalIgnoreCase))
+        {
+            if (StartsWithSubcommand(arguments, "clone"))
+                return _cloneTimeout;
+
+            if (StartsWithNetworkSubcommand(arguments))
+                return _networkTimeout;
+        }
+
+        return _defaultTimeout;
+    }
+
+    internal TimeSpan ResolveTimeout(string fileName, IReadOnlyList<string> arguments)
+    {
+        if (string.Equals(fileName, "git", StringComparison.OrdinalIgnoreCase))
+        {
+            if (StartsWithSubcommand(arguments, "clone"))
+                return _cloneTimeout;
+
+            if (StartsWithNetworkSubcommand(arguments))
+                return _networkTimeout;
+        }
+
+        return _defaultTimeout;
+    }
+
+    private static bool IsGitVersionInvocation(string fileName, string arguments)
+        => string.Equals(fileName, "dotnet-gitversion", StringComparison.OrdinalIgnoreCase)
+        || (string.Equals(fileName, "dotnet", StringComparison.OrdinalIgnoreCase)
+            && arguments.Contains("gitversion", StringComparison.OrdinalIgnoreCase));
+
+    /// <summary>
+    /// 0 (or negative) means "no timeout" per <see cref="GitProcessOptions.CloneTimeoutSeconds"/>'s doc -
+    /// <see cref="Timeout.InfiniteTimeSpan"/> is the sentinel both <c>CancellationTokenSource(TimeSpan)</c>
+    /// and (with explicit handling) Polly's <c>AddTimeout</c> treat as "never fires".
+    /// </summary>
+    private static TimeSpan ResolveCloneTimeout(GitProcessOptions options)
+        => options.CloneTimeoutSeconds <= 0 ? Timeout.InfiniteTimeSpan : TimeSpan.FromSeconds(options.CloneTimeoutSeconds);
+
+    /// <summary>
+    /// Every fetch/pull/push/ls-remote invocation in this codebase passes the subcommand as the first
+    /// token with no leading global options (see <c>GitService.cs</c>), so a simple leading-token check
+    /// is sufficient here - this is not a general-purpose git argument parser.
+    /// </summary>
+    private static bool StartsWithNetworkSubcommand(string arguments)
+    {
+        foreach (var sub in NetworkSubcommands)
+        {
+            if (StartsWithSubcommand(arguments, sub))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static bool StartsWithNetworkSubcommand(IReadOnlyList<string> arguments)
+    {
+        foreach (var arg in arguments)
+        {
+            if (arg.Length == 0)
+                continue;
+
+            return Array.IndexOf(NetworkSubcommands, arg) >= 0;
+        }
+
+        return false;
+    }
+
+    private static bool StartsWithSubcommand(string arguments, string subcommand)
+    {
+        var trimmed = arguments.TrimStart();
+        return trimmed.StartsWith(subcommand, StringComparison.Ordinal)
+            && (trimmed.Length == subcommand.Length || trimmed[subcommand.Length] == ' ');
+    }
+
+    private static bool StartsWithSubcommand(IReadOnlyList<string> arguments, string subcommand)
+    {
+        foreach (var arg in arguments)
+        {
+            if (arg.Length == 0)
+                continue;
+
+            return string.Equals(arg, subcommand, StringComparison.Ordinal);
+        }
+
+        return false;
     }
 }

--- a/src/GrayMoon.Agent/Services/GitResiliencePipelines.cs
+++ b/src/GrayMoon.Agent/Services/GitResiliencePipelines.cs
@@ -1,16 +1,35 @@
+using System.Threading;
+using GrayMoon.Common.Git;
 using Microsoft.Extensions.Logging;
 using Polly;
+using Polly.Fallback;
 using Polly.Retry;
+using Polly.Timeout;
 
 namespace GrayMoon.Agent.Services;
 
 internal static class GitResiliencePipelines
 {
-    public static ResiliencePipeline<(int ExitCode, string? Stdout, string? Stderr)> CreateSafeDirectoryPipeline(ILogger logger)
+    /// <summary>
+    /// Bounds a single retry attempt so a hung process cannot consume the pipeline's entire retry budget
+    /// stuck on one attempt. <see cref="GitProcessRunner"/> already passes the same
+    /// <paramref name="attemptTimeout"/> down to <c>CommandLineService</c> for these commands, so in
+    /// practice the process itself is killed and returns a normal failed result before this Polly-level
+    /// timeout would ever fire - this is a defense-in-depth backstop, not the primary timeout mechanism.
+    /// The fallback strategy converts a <see cref="TimeoutRejectedException"/> (raised only if this
+    /// backstop itself trips) into the same synthetic failed-result shape <c>CommandLineService</c> uses,
+    /// and the retry's <c>ShouldHandle</c> also treats that exception like a normal non-zero exit so the
+    /// existing retry-on-bad-exit-code behavior is preserved rather than an unhandled exception reaching
+    /// callers that only expect a result tuple back from <c>ExecuteAsync</c>.
+    /// </summary>
+    public static ResiliencePipeline<(int ExitCode, string? Stdout, string? Stderr)> CreateSafeDirectoryPipeline(ILogger logger, TimeSpan attemptTimeout)
         => new ResiliencePipelineBuilder<(int ExitCode, string? Stdout, string? Stderr)>()
+            .AddFallback(CreateTimeoutFallbackOptions(attemptTimeout))
             .AddRetry(new RetryStrategyOptions<(int ExitCode, string? Stdout, string? Stderr)>
             {
-                ShouldHandle = new PredicateBuilder<(int ExitCode, string? Stdout, string? Stderr)>().HandleResult(r => r.ExitCode != 0),
+                ShouldHandle = new PredicateBuilder<(int ExitCode, string? Stdout, string? Stderr)>()
+                    .HandleResult(r => r.ExitCode != 0)
+                    .Handle<TimeoutRejectedException>(),
                 MaxRetryAttempts = 3,
                 Delay = TimeSpan.FromMilliseconds(100),
                 BackoffType = DelayBackoffType.Exponential,
@@ -22,32 +41,58 @@ internal static class GitResiliencePipelines
                     return ValueTask.CompletedTask;
                 }
             })
+            .AddTimeout(attemptTimeout)
             .Build();
 
-    public static ResiliencePipeline<(int ExitCode, string? Stdout, string? Stderr)> CreateClonePipeline(ILogger logger)
-        => new ResiliencePipelineBuilder<(int ExitCode, string? Stdout, string? Stderr)>()
-            .AddRetry(new RetryStrategyOptions<(int ExitCode, string? Stdout, string? Stderr)>
+    /// <summary>
+    /// Clone is the one pipeline where <paramref name="attemptTimeout"/> may legitimately be
+    /// <see cref="Timeout.InfiniteTimeSpan"/> (<see cref="GitProcessOptions.CloneTimeoutSeconds"/> = 0,
+    /// the default) - an initial clone can take far longer than any other git operation, and killing it
+    /// partway through wastes all the work done so far. Polly's <c>AddTimeout</c> rejects a non-positive
+    /// duration, so the fallback/timeout strategies are only added when a finite timeout was configured;
+    /// with no timeout strategy in the pipeline, a <see cref="TimeoutRejectedException"/> can never occur,
+    /// so retry's extra <c>Handle&lt;TimeoutRejectedException&gt;()</c> clause is simply inert in that case.
+    /// </summary>
+    public static ResiliencePipeline<(int ExitCode, string? Stdout, string? Stderr)> CreateClonePipeline(ILogger logger, TimeSpan attemptTimeout)
+    {
+        var builder = new ResiliencePipelineBuilder<(int ExitCode, string? Stdout, string? Stderr)>();
+        var hasTimeout = attemptTimeout != Timeout.InfiniteTimeSpan;
+
+        if (hasTimeout)
+            builder.AddFallback(CreateTimeoutFallbackOptions(attemptTimeout));
+
+        builder.AddRetry(new RetryStrategyOptions<(int ExitCode, string? Stdout, string? Stderr)>
+        {
+            ShouldHandle = new PredicateBuilder<(int ExitCode, string? Stdout, string? Stderr)>()
+                .HandleResult(r => r.ExitCode != 0)
+                .Handle<TimeoutRejectedException>(),
+            MaxRetryAttempts = 3,
+            Delay = TimeSpan.FromMilliseconds(200),
+            BackoffType = DelayBackoffType.Exponential,
+            UseJitter = true,
+            OnRetry = args =>
             {
-                ShouldHandle = new PredicateBuilder<(int ExitCode, string? Stdout, string? Stderr)>().HandleResult(r => r.ExitCode != 0),
-                MaxRetryAttempts = 3,
-                Delay = TimeSpan.FromMilliseconds(200),
-                BackoffType = DelayBackoffType.Exponential,
-                UseJitter = true,
-                OnRetry = args =>
-                {
-                    var exitCode = args.Outcome.Result.ExitCode;
-                    logger.LogWarning("Git clone retry {Attempt} (ExitCode={ExitCode})", args.AttemptNumber, exitCode);
-                    return ValueTask.CompletedTask;
-                }
-            })
-            .Build();
+                var exitCode = args.Outcome.Result.ExitCode;
+                logger.LogWarning("Git clone retry {Attempt} (ExitCode={ExitCode})", args.AttemptNumber, exitCode);
+                return ValueTask.CompletedTask;
+            }
+        });
 
-    public static ResiliencePipeline<(int ExitCode, string? Stdout, string? Stderr)> CreateFetchPipeline(ILogger logger)
+        if (hasTimeout)
+            builder.AddTimeout(attemptTimeout);
+
+        return builder.Build();
+    }
+
+    public static ResiliencePipeline<(int ExitCode, string? Stdout, string? Stderr)> CreateFetchPipeline(ILogger logger, TimeSpan attemptTimeout)
         => new ResiliencePipelineBuilder<(int ExitCode, string? Stdout, string? Stderr)>()
+            .AddFallback(CreateTimeoutFallbackOptions(attemptTimeout))
             .AddRetry(new RetryStrategyOptions<(int ExitCode, string? Stdout, string? Stderr)>
             {
                 // Retry any non-zero exit code from git fetch (e.g., transient network failures).
-                ShouldHandle = new PredicateBuilder<(int ExitCode, string? Stdout, string? Stderr)>().HandleResult(r => r.ExitCode != 0),
+                ShouldHandle = new PredicateBuilder<(int ExitCode, string? Stdout, string? Stderr)>()
+                    .HandleResult(r => r.ExitCode != 0)
+                    .Handle<TimeoutRejectedException>(),
                 MaxRetryAttempts = 3,
                 Delay = TimeSpan.FromMilliseconds(200),
                 BackoffType = DelayBackoffType.Exponential,
@@ -59,15 +104,18 @@ internal static class GitResiliencePipelines
                     return ValueTask.CompletedTask;
                 }
             })
+            .AddTimeout(attemptTimeout)
             .Build();
 
-    public static ResiliencePipeline<(int ExitCode, string? Stdout, string? Stderr)> CreatePullPipeline(ILogger logger)
+    public static ResiliencePipeline<(int ExitCode, string? Stdout, string? Stderr)> CreatePullPipeline(ILogger logger, TimeSpan attemptTimeout)
         => new ResiliencePipelineBuilder<(int ExitCode, string? Stdout, string? Stderr)>()
+            .AddFallback(CreateTimeoutFallbackOptions(attemptTimeout))
             .AddRetry(new RetryStrategyOptions<(int ExitCode, string? Stdout, string? Stderr)>
             {
                 // Retry transient failures (non-zero exit) but not merge conflicts which are deterministic.
                 ShouldHandle = new PredicateBuilder<(int ExitCode, string? Stdout, string? Stderr)>()
-                    .HandleResult(r => r.ExitCode != 0 && !IsMergeConflict(r.Stdout, r.Stderr)),
+                    .HandleResult(r => r.ExitCode != 0 && !IsMergeConflict(r.Stdout, r.Stderr))
+                    .Handle<TimeoutRejectedException>(),
                 MaxRetryAttempts = 3,
                 Delay = TimeSpan.FromMilliseconds(200),
                 BackoffType = DelayBackoffType.Exponential,
@@ -79,14 +127,18 @@ internal static class GitResiliencePipelines
                     return ValueTask.CompletedTask;
                 }
             })
+            .AddTimeout(attemptTimeout)
             .Build();
 
-    public static ResiliencePipeline<(int ExitCode, string? Stdout, string? Stderr)> CreatePushPipeline(ILogger logger)
+    public static ResiliencePipeline<(int ExitCode, string? Stdout, string? Stderr)> CreatePushPipeline(ILogger logger, TimeSpan attemptTimeout)
         => new ResiliencePipelineBuilder<(int ExitCode, string? Stdout, string? Stderr)>()
+            .AddFallback(CreateTimeoutFallbackOptions(attemptTimeout))
             .AddRetry(new RetryStrategyOptions<(int ExitCode, string? Stdout, string? Stderr)>
             {
                 // Retry any non-zero exit code from git push (e.g., transient network failures).
-                ShouldHandle = new PredicateBuilder<(int ExitCode, string? Stdout, string? Stderr)>().HandleResult(r => r.ExitCode != 0),
+                ShouldHandle = new PredicateBuilder<(int ExitCode, string? Stdout, string? Stderr)>()
+                    .HandleResult(r => r.ExitCode != 0)
+                    .Handle<TimeoutRejectedException>(),
                 MaxRetryAttempts = 3,
                 Delay = TimeSpan.FromMilliseconds(200),
                 BackoffType = DelayBackoffType.Exponential,
@@ -98,14 +150,18 @@ internal static class GitResiliencePipelines
                     return ValueTask.CompletedTask;
                 }
             })
+            .AddTimeout(attemptTimeout)
             .Build();
 
-    public static ResiliencePipeline<(int ExitCode, string? Stdout, string? Stderr)> CreateLsRemotePipeline(ILogger logger)
+    public static ResiliencePipeline<(int ExitCode, string? Stdout, string? Stderr)> CreateLsRemotePipeline(ILogger logger, TimeSpan attemptTimeout)
         => new ResiliencePipelineBuilder<(int ExitCode, string? Stdout, string? Stderr)>()
+            .AddFallback(CreateTimeoutFallbackOptions(attemptTimeout))
             .AddRetry(new RetryStrategyOptions<(int ExitCode, string? Stdout, string? Stderr)>
             {
                 // Retry any non-zero exit code from git ls-remote (e.g., transient network failures).
-                ShouldHandle = new PredicateBuilder<(int ExitCode, string? Stdout, string? Stderr)>().HandleResult(r => r.ExitCode != 0),
+                ShouldHandle = new PredicateBuilder<(int ExitCode, string? Stdout, string? Stderr)>()
+                    .HandleResult(r => r.ExitCode != 0)
+                    .Handle<TimeoutRejectedException>(),
                 MaxRetryAttempts = 3,
                 Delay = TimeSpan.FromMilliseconds(200),
                 BackoffType = DelayBackoffType.Exponential,
@@ -117,14 +173,18 @@ internal static class GitResiliencePipelines
                     return ValueTask.CompletedTask;
                 }
             })
+            .AddTimeout(attemptTimeout)
             .Build();
 
-    public static ResiliencePipeline<(int ExitCode, string? Stdout, string? Stderr)> CreateMinimalFetchPipeline(ILogger logger)
+    public static ResiliencePipeline<(int ExitCode, string? Stdout, string? Stderr)> CreateMinimalFetchPipeline(ILogger logger, TimeSpan attemptTimeout)
         => new ResiliencePipelineBuilder<(int ExitCode, string? Stdout, string? Stderr)>()
+            .AddFallback(CreateTimeoutFallbackOptions(attemptTimeout))
             .AddRetry(new RetryStrategyOptions<(int ExitCode, string? Stdout, string? Stderr)>
             {
                 // Retry any non-zero exit code from minimal git fetch (e.g., transient network failures).
-                ShouldHandle = new PredicateBuilder<(int ExitCode, string? Stdout, string? Stderr)>().HandleResult(r => r.ExitCode != 0),
+                ShouldHandle = new PredicateBuilder<(int ExitCode, string? Stdout, string? Stderr)>()
+                    .HandleResult(r => r.ExitCode != 0)
+                    .Handle<TimeoutRejectedException>(),
                 MaxRetryAttempts = 3,
                 Delay = TimeSpan.FromMilliseconds(200),
                 BackoffType = DelayBackoffType.Exponential,
@@ -136,7 +196,22 @@ internal static class GitResiliencePipelines
                     return ValueTask.CompletedTask;
                 }
             })
+            .AddTimeout(attemptTimeout)
             .Build();
+
+    /// <summary>
+    /// Converts a <see cref="TimeoutRejectedException"/> that survives all retry attempts into the same
+    /// synthetic failed-result shape <c>CommandLineService</c> returns on its own timeout, so
+    /// <c>ExecuteAsync</c> callers always get back a result tuple - never an exception - regardless of
+    /// which layer's timeout ultimately fired.
+    /// </summary>
+    private static FallbackStrategyOptions<(int ExitCode, string? Stdout, string? Stderr)> CreateTimeoutFallbackOptions(TimeSpan attemptTimeout)
+        => new()
+        {
+            ShouldHandle = new PredicateBuilder<(int ExitCode, string? Stdout, string? Stderr)>().Handle<TimeoutRejectedException>(),
+            FallbackAction = _ => Outcome.FromResultAsValueTask<(int ExitCode, string? Stdout, string? Stderr)>(
+                (-1, null, $"Operation timed out after {attemptTimeout.TotalSeconds:0}s."))
+        };
 
     internal static bool IsMergeConflict(string? stdout, string? stderr)
     {
@@ -146,4 +221,3 @@ internal static class GitResiliencePipelines
             || combined.Contains("Automatic merge failed", StringComparison.OrdinalIgnoreCase);
     }
 }
-

--- a/src/GrayMoon.Agent/appsettings.json
+++ b/src/GrayMoon.Agent/appsettings.json
@@ -3,7 +3,7 @@
     "AppHubUrl": "http://localhost:8384/hub/agent",
     "ListenPort": 9191,
     "MaxConcurrentCommands": 16,
-    "MaxConcurrentReadCommands": 4,
+    "MaxConcurrentReadCommands": 8,
     "MaxConcurrentDiffCommands": 4,
     "GitProcess": {
       "DefaultTimeoutSeconds": 60,

--- a/src/GrayMoon.Agent/appsettings.json
+++ b/src/GrayMoon.Agent/appsettings.json
@@ -4,7 +4,13 @@
     "ListenPort": 9191,
     "MaxConcurrentCommands": 16,
     "MaxConcurrentReadCommands": 4,
-    "MaxConcurrentDiffCommands": 4
+    "MaxConcurrentDiffCommands": 4,
+    "GitProcess": {
+      "DefaultTimeoutSeconds": 60,
+      "NetworkTimeoutSeconds": 180,
+      "GitVersionTimeoutSeconds": 90,
+      "CloneTimeoutSeconds": 0
+    }
   },
   "Logging": {
     "LogLevel": {

--- a/src/GrayMoon.App/Components/Layout/MainLayout.razor
+++ b/src/GrayMoon.App/Components/Layout/MainLayout.razor
@@ -54,10 +54,15 @@
     </main>
 </div>
 
-<div id="blazor-error-ui">
-    An unhandled error has occurred.
-    <a href="" class="reload">Reload</a>
-    <a class="dismiss">🗙</a>
+<div id="blazor-error-ui" role="alertdialog" aria-modal="true" aria-labelledby="blazor-error-title">
+    <div class="blazor-error-card">
+        <i class="bi bi-arrow-clockwise blazor-error-icon" aria-hidden="true"></i>
+        <div class="blazor-error-copy">
+            <h2 id="blazor-error-title">GrayMoon needs to reload</h2>
+            <p>The current session can no longer continue. Reload the page to reconnect and restore the latest state.</p>
+        </div>
+        <a href="" class="reload">Reload page</a>
+    </div>
 </div>
 
 @code {

--- a/src/GrayMoon.App/Components/Layout/MainLayout.razor.css
+++ b/src/GrayMoon.App/Components/Layout/MainLayout.razor.css
@@ -310,22 +310,79 @@ article.content {
 }
 
 #blazor-error-ui {
-    background: rgba(244, 135, 113, 0.2);
-    border-top: 1px solid var(--error);
-    bottom: 0;
-    box-shadow: 0 -1px 2px rgba(0, 0, 0, 0.3);
+    background-color: rgba(0, 0, 0, 0.65);
     display: none;
+    inset: 0;
     left: 0;
-    padding: 0.6rem 1.25rem 0.7rem 1.25rem;
+    padding: max(1rem, env(safe-area-inset-top)) 1rem max(1rem, env(safe-area-inset-bottom));
     position: fixed;
-    width: 100%;
-    z-index: 1000;
-    color: var(--error);
+    z-index: 1100;
 }
 
-    #blazor-error-ui .dismiss {
-        cursor: pointer;
-        position: absolute;
-        right: 0.75rem;
-        top: 0.5rem;
-    }
+#blazor-error-ui .blazor-error-card {
+    align-items: center;
+    background-color: var(--bg-secondary);
+    border: 1px solid var(--border-color);
+    border-radius: 0.5rem;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.55);
+    color: var(--text-primary);
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    margin: 20vh auto 0;
+    max-width: 24rem;
+    padding: 2rem;
+    text-align: center;
+}
+
+#blazor-error-ui .blazor-error-icon {
+    align-items: center;
+    border: 2px solid var(--text-secondary);
+    border-radius: 50%;
+    color: var(--text-primary);
+    display: flex;
+    font-size: 1.75rem;
+    height: 4rem;
+    justify-content: center;
+    width: 4rem;
+}
+
+#blazor-error-ui .blazor-error-copy h2 {
+    color: #e8e8e8;
+    font-size: 1.15rem;
+    font-weight: 600;
+    margin: 0 0 0.5rem;
+}
+
+#blazor-error-ui .blazor-error-copy p {
+    color: var(--text-secondary);
+    font-size: 0.95rem;
+    line-height: 1.45;
+    margin: 0;
+}
+
+#blazor-error-ui .reload {
+    background-color: #3c3c3c;
+    border: 1px solid #5a5a5a;
+    border-radius: 0.25rem;
+    color: #f0f0f0;
+    font-size: 0.95rem;
+    font-weight: 500;
+    padding: 0.4rem 1.5rem;
+    text-decoration: none;
+}
+
+#blazor-error-ui .reload:hover {
+    background-color: #4a4a4a;
+    border-color: #6a6a6a;
+    color: #ffffff;
+}
+
+#blazor-error-ui .reload:active {
+    background-color: #353535;
+}
+
+#blazor-error-ui .reload:focus-visible {
+    box-shadow: 0 0 0 1px var(--focus-ring-outer);
+    outline: none;
+}

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.Push.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.Push.cs
@@ -206,7 +206,8 @@ public sealed partial class WorkspaceRepositories
         IReadOnlySet<int> repoIds,
         bool synchronizedPush,
         IReadOnlySet<string> requiredPackageIds,
-        IReadOnlySet<int>? syncedRepoIds = null)
+        IReadOnlySet<int>? syncedRepoIds = null,
+        string? runId = null)
     {
         try
         {
@@ -219,7 +220,8 @@ public sealed partial class WorkspaceRepositories
                     job.ReportProgress,
                     ToastService.ShowError,
                     syncedRepoIds: syncedRepoIds,
-                    cancellationToken: ct));
+                    cancellationToken: ct,
+                    runId: runId));
         }
         catch (OperationCanceledException)
         {

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.Update.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.Update.cs
@@ -255,17 +255,18 @@ public sealed partial class WorkspaceRepositories
 
         JobService.StartJob(PageJobKey, $"Updating Level {level}...", async (job, ct) =>
         {
+            var runId = Guid.NewGuid().ToString("N")[..8];
+            Logger.LogInformation("[PushUpdated {RunId}] Level-Only Update & Push starting for workspace {WorkspaceId}, up to level {Level}", runId, WorkspaceId, level);
+
             // Phase 1: update repos needing work up to the target level
             IReadOnlySet<int> syncedRepoIds = new HashSet<int>();
             try
             {
-                var allLinks = await GetAllLinksForOperationAsync();
-                var reposNeedingWork = allLinks
-                    .Where(wr => !wr.IsOnTag && (wr.DependencyLevel ?? 0) <= level)
-                    .Where(wr => (wr.UnmatchedDeps ?? 0) > 0 || (wr.OutOfDateFileRepos ?? 0) > 0)
-                    .Select(wr => wr.RepositoryId)
-                    .ToHashSet();
-
+                // Do not pre-filter by a snapshot of repos already flagged as out of date: a level-1/2
+                // commit made during this run can only mark higher levels (up to and including the
+                // target level) out of date once refreshed, which happens after this snapshot is taken.
+                // The orchestrator already scopes/skips per level live (via maxLevel), so no repo-id
+                // scope is needed here.
                 syncedRepoIds = await ScopedExecutor.ExecuteAsync<WorkspaceUpdateHandler, IReadOnlySet<int>>(
                     svc => svc.RunUpdateAsync(
                         WorkspaceId,
@@ -274,8 +275,9 @@ public sealed partial class WorkspaceRepositories
                         (repoId, msg) => SafeInvoke(() => { repositoryErrors[repoId] = msg; }),
                         commitMessage: commitMessage,
                         includeDepsInCommitMessage: includeDepsInCommitMessage,
-                        repoIdsToUpdate: reposNeedingWork,
-                        maxLevel: level));
+                        repoIdsToUpdate: null,
+                        maxLevel: level,
+                        runId: runId));
 
                 await ReloadWorkspaceDataFromFreshScopeAsync();
                 _ = InvokeAsync(() => { if (!_disposed) { ApplySyncStateFromLoadedItems(); StateHasChanged(); } });
@@ -318,7 +320,7 @@ public sealed partial class WorkspaceRepositories
             // Phase 3: execute push (per-level restore of synced repos handled inside push service)
             try
             {
-                await ExecutePushCoreAsync(job, ct, pushRepoIds, synchronizedPush: true, requiredPackageIds, syncedRepoIds);
+                await ExecutePushCoreAsync(job, ct, pushRepoIds, synchronizedPush: true, requiredPackageIds, syncedRepoIds, runId: runId);
             }
             catch (SynchronizedPushNotPossibleException ex)
             {
@@ -328,7 +330,7 @@ public sealed partial class WorkspaceRepositories
                     {
                         JobService.StartJob(PageJobKey, "Preparing push...", async (j, c) =>
                         {
-                            await ExecutePushCoreAsync(j, c, pushRepoIds, synchronizedPush: false, requiredPackageIds, syncedRepoIds);
+                            await ExecutePushCoreAsync(j, c, pushRepoIds, synchronizedPush: false, requiredPackageIds, syncedRepoIds, runId: runId);
                             await RestoreSyncedPackagesCoreAsync(syncedRepoIds, j, c);
                         });
                         return Task.CompletedTask;
@@ -336,6 +338,8 @@ public sealed partial class WorkspaceRepositories
                     confirmButtonText: "Continue"));
                 return;
             }
+
+            Logger.LogInformation("[PushUpdated {RunId}] Level-Only Update & Push completed for workspace {WorkspaceId}", runId, WorkspaceId);
         });
 
         return Task.CompletedTask;
@@ -350,26 +354,27 @@ public sealed partial class WorkspaceRepositories
 
         JobService.StartJob(PageJobKey, "Updating dependencies...", async (job, ct) =>
         {
-            // Phase 1: update - fresh scope so DbContext does not compete with circuit page loads
+            var runId = Guid.NewGuid().ToString("N")[..8];
+            Logger.LogInformation("[PushUpdated {RunId}] Update & Push starting for workspace {WorkspaceId}", runId, WorkspaceId);
+
+            // Phase 1: update - fresh scope so DbContext does not compete with circuit page loads.
+            // Do not pre-filter by a snapshot of repos already flagged as out of date: a lower-level
+            // commit made during this run only marks higher levels out of date once refreshed, which
+            // happens after this snapshot would be taken. The orchestrator already scopes/skips per
+            // level live, so no repo-id scope is needed here (see plain "Update", which also passes null).
             IReadOnlySet<int> syncedRepoIds = new HashSet<int>();
             try
             {
-                var allLinks = await GetAllLinksForOperationAsync();
-                var reposNeedingWork = allLinks
-                    .Where(wr => !wr.IsOnTag)
-                    .Where(wr => (wr.UnmatchedDeps ?? 0) > 0 || (wr.OutOfDateFileRepos ?? 0) > 0)
-                    .Select(wr => wr.RepositoryId)
-                    .ToHashSet();
-
                 syncedRepoIds = await ScopedExecutor.ExecuteAsync<WorkspaceUpdateHandler, IReadOnlySet<int>>(
                     svc => svc.RunUpdateAsync(
                         WorkspaceId,
                         ct,
                         job.ReportProgress,
                         (repoId, msg) => SafeInvoke(() => { repositoryErrors[repoId] = msg; }),
-                        repoIdsToUpdate: reposNeedingWork,
+                        repoIdsToUpdate: null,
                         commitMessage: commitMessage,
-                        includeDepsInCommitMessage: includeDepsInCommitMessage));
+                        includeDepsInCommitMessage: includeDepsInCommitMessage,
+                        runId: runId));
 
                 await ReloadWorkspaceDataFromFreshScopeAsync();
                 _ = InvokeAsync(() => { if (!_disposed) { ApplySyncStateFromLoadedItems(); StateHasChanged(); } });
@@ -410,7 +415,7 @@ public sealed partial class WorkspaceRepositories
             // Phase 3: execute push (per-level restore of synced repos handled inside push service)
             try
             {
-                await ExecutePushCoreAsync(job, ct, pushRepoIds, synchronizedPush: true, requiredPackageIds, syncedRepoIds);
+                await ExecutePushCoreAsync(job, ct, pushRepoIds, synchronizedPush: true, requiredPackageIds, syncedRepoIds, runId: runId);
             }
             catch (SynchronizedPushNotPossibleException ex)
             {
@@ -420,7 +425,7 @@ public sealed partial class WorkspaceRepositories
                     {
                         JobService.StartJob(PageJobKey, "Preparing push...", async (j, c) =>
                         {
-                            await ExecutePushCoreAsync(j, c, pushRepoIds, synchronizedPush: false, requiredPackageIds, syncedRepoIds);
+                            await ExecutePushCoreAsync(j, c, pushRepoIds, synchronizedPush: false, requiredPackageIds, syncedRepoIds, runId: runId);
                             await RestoreSyncedPackagesCoreAsync(syncedRepoIds, j, c);
                         });
                         return Task.CompletedTask;
@@ -428,6 +433,8 @@ public sealed partial class WorkspaceRepositories
                     confirmButtonText: "Continue"));
                 return;
             }
+
+            Logger.LogInformation("[PushUpdated {RunId}] Update & Push completed for workspace {WorkspaceId}", runId, WorkspaceId);
         });
 
         return Task.CompletedTask;

--- a/src/GrayMoon.App/Hubs/AgentHub.cs
+++ b/src/GrayMoon.App/Hubs/AgentHub.cs
@@ -41,6 +41,10 @@ public sealed class AgentHub(
     {
         connectionTracker.OnAgentDisconnected(Context.ConnectionId);
         agentQueueStateService.Clear();
+        // Fail any request still in flight immediately rather than letting it wait out its full
+        // AgentBridge command timeout - there is only ever one agent connection, so no per-connection
+        // filtering is needed here.
+        AgentResponseDelivery.FailAll("Agent disconnected before responding.");
         // Clear cached workspace root when agent disconnects.
         // WorkspaceService is scoped, so resolve it from a fresh scope.
         await using var scope = scopeFactory.CreateAsyncScope();

--- a/src/GrayMoon.App/Program.cs
+++ b/src/GrayMoon.App/Program.cs
@@ -34,6 +34,7 @@ try
 
     builder.Services.Configure<WorkspaceOptions>(builder.Configuration.GetSection("Workspace"));
     builder.Services.Configure<GitChangesOptions>(builder.Configuration.GetSection("GitChanges"));
+    builder.Services.Configure<AgentBridgeOptions>(builder.Configuration.GetSection(AgentBridgeOptions.SectionName));
 
     // Add services to the container.
     builder.Services.AddRazorComponents()

--- a/src/GrayMoon.App/Services/AgentBridge.cs
+++ b/src/GrayMoon.App/Services/AgentBridge.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using GrayMoon.Abstractions.Agent;
 using GrayMoon.App.Hubs;
 using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Options;
 
 namespace GrayMoon.App.Services;
 
@@ -16,8 +17,11 @@ public sealed class AgentBridge(
     IHubContext<AgentHub> hubContext,
     AgentConnectionTracker connectionTracker,
     AgentCommandCancelSender cancelSender,
+    IOptions<AgentBridgeOptions> options,
     ILogger<AgentBridge> logger) : IAgentBridge
 {
+    private readonly TimeSpan _commandTimeout = TimeSpan.FromSeconds(Math.Max(1, options.Value.CommandTimeoutSeconds));
+
     public bool IsAgentConnected => connectionTracker.GetAgentConnectionId() != null;
 
     public async Task<AgentCommandResponse> SendCommandAsync(string command, object args, CancellationToken cancellationToken = default)
@@ -31,13 +35,28 @@ public sealed class AgentBridge(
 
         var sink = TerminalSinkContext.Current;
         Action<AgentCommandStreamLine>? onLine = sink != null ? sink.Append : null;
-        var task = AgentResponseDelivery.WaitAsync(requestId, cancellationToken, onLine);
+
+        using var timeoutCts = new CancellationTokenSource(_commandTimeout);
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
+        var task = AgentResponseDelivery.WaitAsync(requestId, linkedCts.Token, onLine);
 
         try
         {
             await hubContext.Clients.Client(connectionId).SendAsync(AgentHubMethods.RequestCommand, requestId, command, argsJson, cancellationToken);
             logger.LogDebug("Sent RequestCommand: {RequestId}, {Command}", requestId, command);
             return await task;
+        }
+        catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+        {
+            // Overall command timeout, not a caller-initiated cancellation: notify the agent to stop
+            // work on this request, then fail fast with a normal response instead of throwing - callers
+            // across the app already handle a false/error AgentCommandResponse, so no call-site changes
+            // are needed to get this "fail fast, let the user retry" behavior everywhere.
+            cancelSender.NotifyCancel(requestId);
+            logger.LogWarning(
+                "Agent command {Command} ({RequestId}) timed out after {TimeoutSeconds}s waiting for a response",
+                command, requestId, _commandTimeout.TotalSeconds);
+            return new AgentCommandResponse(false, null, $"Agent command timed out after {_commandTimeout.TotalSeconds:0}s.");
         }
         catch (OperationCanceledException)
         {

--- a/src/GrayMoon.App/Services/AgentBridgeOptions.cs
+++ b/src/GrayMoon.App/Services/AgentBridgeOptions.cs
@@ -1,0 +1,21 @@
+namespace GrayMoon.App.Services;
+
+/// <summary>
+/// Bounds how long the App waits for the Agent to respond to a single <see cref="IAgentBridge.SendCommandAsync"/>
+/// call. Without this, <see cref="AgentResponseDelivery.WaitAsync"/> would wait forever if the Agent's
+/// connection dropped mid-request without a clean disconnect, or if an Agent-side bug swallowed a
+/// request. On timeout, <see cref="AgentBridge"/> notifies the Agent to cancel the request and returns a
+/// normal failed <see cref="Abstractions.Agent.AgentCommandResponse"/> - matching the "fail fast, let the
+/// user retry manually" behavior chosen for this feature - rather than throwing or hanging the caller.
+/// </summary>
+public sealed class AgentBridgeOptions
+{
+    public const string SectionName = "AgentBridge";
+
+    /// <summary>
+    /// Seconds to wait for a single Agent command round-trip. Default 240s - comfortably above the
+    /// Agent's <c>NetworkTimeoutSeconds</c> (180s by default) for a single network git attempt, so the
+    /// App does not give up mid-attempt while the Agent is still legitimately working.
+    /// </summary>
+    public int CommandTimeoutSeconds { get; init; } = 240;
+}

--- a/src/GrayMoon.App/Services/AgentResponseDelivery.cs
+++ b/src/GrayMoon.App/Services/AgentResponseDelivery.cs
@@ -1,75 +1,98 @@
-using System.Collections.Concurrent;
-using GrayMoon.Abstractions.Agent;
-
-namespace GrayMoon.App.Services;
-
-/// <summary>Static registry for pending command responses. Agent calls ResponseCommand which completes the TCS.</summary>
-public static class AgentResponseDelivery
-{
-    private sealed record PendingRequest(
-        TaskCompletionSource<AgentCommandResponse> Completion,
-        CancellationTokenRegistration Registration,
-        Action<AgentCommandStreamLine>? OnStreamLine);
-
-    private static readonly ConcurrentDictionary<string, PendingRequest> Pending = new();
-    private static Action<string>? _onRequestCancelled;
-
-    /// <summary>Registers a fire-and-forget notifier invoked when a pending wait is cancelled (e.g. job abort).</summary>
-    public static void SetCancelNotifier(Action<string>? onRequestCancelled) =>
-        _onRequestCancelled = onRequestCancelled;
-
-    /// <summary>Waits until the agent completes the request or <paramref name="cancellationToken"/> is canceled (no time limit).</summary>
-    public static Task<AgentCommandResponse> WaitAsync(
-        string requestId,
-        CancellationToken cancellationToken,
-        Action<AgentCommandStreamLine>? onStreamLine = null)
-    {
-        var completion = new TaskCompletionSource<AgentCommandResponse>(TaskCreationOptions.RunContinuationsAsynchronously);
-
-        var registration = cancellationToken.Register(() =>
-        {
-            if (!Pending.TryRemove(requestId, out var pending))
-                return;
-
-            pending.Registration.Dispose();
-            pending.Completion.TrySetCanceled(cancellationToken);
-            _onRequestCancelled?.Invoke(requestId);
-        });
-
-        if (!Pending.TryAdd(requestId, new PendingRequest(completion, registration, onStreamLine)))
-        {
-            registration.Dispose();
-            throw new InvalidOperationException($"Duplicate pending request ID '{requestId}'.");
-        }
-
-        return completion.Task;
-    }
-
-    /// <summary>Invoked from <see cref="Hubs.AgentHub"/> when the agent pushes a streamed line for a pending request.</summary>
-    public static void ReportStreamLine(string requestId, AgentCommandStreamLine line)
-    {
-        if (!Pending.TryGetValue(requestId, out var pending))
-            return;
-
-        pending.OnStreamLine?.Invoke(line);
-    }
-
-    public static void Complete(string requestId, AgentCommandResponse response)
-    {
-        if (!Pending.TryRemove(requestId, out var pending))
-            return;
-
-        pending.Registration.Dispose();
-        pending.Completion.TrySetResult(response);
-    }
-
-    public static void Fail(string requestId, Exception exception)
-    {
-        if (!Pending.TryRemove(requestId, out var pending))
-            return;
-
-        pending.Registration.Dispose();
-        pending.Completion.TrySetException(exception);
-    }
-}
-
+using System.Collections.Concurrent;
+using GrayMoon.Abstractions.Agent;
+
+namespace GrayMoon.App.Services;
+
+/// <summary>Static registry for pending command responses. Agent calls ResponseCommand which completes the TCS.</summary>
+public static class AgentResponseDelivery
+{
+    private sealed record PendingRequest(
+        TaskCompletionSource<AgentCommandResponse> Completion,
+        CancellationTokenRegistration Registration,
+        Action<AgentCommandStreamLine>? OnStreamLine);
+
+    private static readonly ConcurrentDictionary<string, PendingRequest> Pending = new();
+    private static Action<string>? _onRequestCancelled;
+
+    /// <summary>Registers a fire-and-forget notifier invoked when a pending wait is cancelled (e.g. job abort).</summary>
+    public static void SetCancelNotifier(Action<string>? onRequestCancelled) =>
+        _onRequestCancelled = onRequestCancelled;
+
+    /// <summary>
+    /// Waits until the agent completes the request or <paramref name="cancellationToken"/> is canceled.
+    /// Callers are expected to pass a token that also carries an overall timeout (see
+    /// <see cref="AgentBridge.SendCommandAsync"/>) so this never blocks forever even if the Agent never
+    /// responds.
+    /// </summary>
+    public static Task<AgentCommandResponse> WaitAsync(
+        string requestId,
+        CancellationToken cancellationToken,
+        Action<AgentCommandStreamLine>? onStreamLine = null)
+    {
+        var completion = new TaskCompletionSource<AgentCommandResponse>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var registration = cancellationToken.Register(() =>
+        {
+            if (!Pending.TryRemove(requestId, out var pending))
+                return;
+
+            pending.Registration.Dispose();
+            pending.Completion.TrySetCanceled(cancellationToken);
+            _onRequestCancelled?.Invoke(requestId);
+        });
+
+        if (!Pending.TryAdd(requestId, new PendingRequest(completion, registration, onStreamLine)))
+        {
+            registration.Dispose();
+            throw new InvalidOperationException($"Duplicate pending request ID '{requestId}'.");
+        }
+
+        return completion.Task;
+    }
+
+    /// <summary>Invoked from <see cref="Hubs.AgentHub"/> when the agent pushes a streamed line for a pending request.</summary>
+    public static void ReportStreamLine(string requestId, AgentCommandStreamLine line)
+    {
+        if (!Pending.TryGetValue(requestId, out var pending))
+            return;
+
+        pending.OnStreamLine?.Invoke(line);
+    }
+
+    public static void Complete(string requestId, AgentCommandResponse response)
+    {
+        if (!Pending.TryRemove(requestId, out var pending))
+            return;
+
+        pending.Registration.Dispose();
+        pending.Completion.TrySetResult(response);
+    }
+
+    public static void Fail(string requestId, Exception exception)
+    {
+        if (!Pending.TryRemove(requestId, out var pending))
+            return;
+
+        pending.Registration.Dispose();
+        pending.Completion.TrySetException(exception);
+    }
+
+    /// <summary>
+    /// Fails every currently pending request immediately with <paramref name="reason"/>. Called from
+    /// <see cref="Hubs.AgentHub"/> when the Agent's connection drops so requests in flight at that moment
+    /// don't wait out their full timeout - matches the existing single-agent-connection model, so no
+    /// per-connection filtering is needed here.
+    /// </summary>
+    public static void FailAll(string reason)
+    {
+        foreach (var requestId in Pending.Keys.ToArray())
+        {
+            if (!Pending.TryRemove(requestId, out var pending))
+                continue;
+
+            pending.Registration.Dispose();
+            pending.Completion.TrySetResult(new AgentCommandResponse(false, null, reason));
+        }
+    }
+}
+

--- a/src/GrayMoon.App/Services/DependencyUpdateOrchestrator.cs
+++ b/src/GrayMoon.App/Services/DependencyUpdateOrchestrator.cs
@@ -14,7 +14,8 @@ public sealed class DependencyUpdateOrchestrator(
     WorkspaceFileVersionService fileVersionService,
     WorkspaceRepository workspaceRepository,
     IOptions<WorkspaceOptions> workspaceOptions,
-    IServiceScopeFactory scopeFactory)
+    IServiceScopeFactory scopeFactory,
+    ILogger<DependencyUpdateOrchestrator> logger)
 {
     private readonly int _maxConcurrent = Math.Max(1, workspaceOptions?.Value?.MaxParallelOperations ?? 8);
 
@@ -29,6 +30,7 @@ public sealed class DependencyUpdateOrchestrator(
     /// <param name="commitMessage">Optional user-supplied commit subject line. When provided, replaces the default subject in all commits created during this update.</param>
     /// <param name="includeDepsInCommitMessage">When true, the list of updated packages is appended to the commit message body.</param>
     /// <param name="maxLevel">Optional. When set, only repositories at or below this dependency level are processed; higher levels are skipped.</param>
+    /// <param name="runId">Optional caller-supplied correlation id included in every log line for this run so it can be filtered from application logs.</param>
     public async Task<IReadOnlySet<int>> RunAsync(
         int workspaceId,
         CancellationToken cancellationToken,
@@ -38,17 +40,28 @@ public sealed class DependencyUpdateOrchestrator(
         IReadOnlySet<int>? repoIdsToUpdate = null,
         string? commitMessage = null,
         bool includeDepsInCommitMessage = true,
-        int? maxLevel = null)
+        int? maxLevel = null,
+        string? runId = null)
     {
         // Non-null empty set means the caller determined no repos need work.
         if (repoIdsToUpdate is { Count: 0 })
+        {
+            logger.LogInformation("[UpdateOrchestrator {RunId}] Workspace {WorkspaceId}: caller passed an empty repoIdsToUpdate set; nothing to do.", runId, workspaceId);
             return new HashSet<int>();
+        }
+
+        logger.LogInformation(
+            "[UpdateOrchestrator {RunId}] Workspace {WorkspaceId}: starting update run. Scope={Scope}, MaxLevel={MaxLevel}",
+            runId, workspaceId,
+            repoIdsToUpdate == null ? "all repos (live, per level)" : $"{repoIdsToUpdate.Count} repo(s): [{string.Join(",", repoIdsToUpdate)}]",
+            maxLevel?.ToString() ?? "none");
 
         var hadError = false;
         var allSyncedRepoIds = new HashSet<int>();
         void OnRepoError(int repoId, string msg)
         {
             hadError = true;
+            logger.LogWarning("[UpdateOrchestrator {RunId}] Workspace {WorkspaceId}: repo {RepoId} error: {Message}", runId, workspaceId, repoId, msg);
             onRepoError(repoId, msg);
         }
 
@@ -61,7 +74,10 @@ public sealed class DependencyUpdateOrchestrator(
             repositoryIds: repoIdsToUpdate,
             cancellationToken);
         if (hadError)
+        {
+            logger.LogWarning("[UpdateOrchestrator {RunId}] Workspace {WorkspaceId}: aborting after RefreshWorkspaceProjectsAsync error.", runId, workspaceId);
             return new HashSet<int>();
+        }
 
         // Step 2+: Walk every dependency level (up to maxLevel). Do not limit the level walk to the
         // initial reposNeedingWork set - a lower-level csproj commit refreshes GitVersion and can mark
@@ -73,6 +89,11 @@ public sealed class DependencyUpdateOrchestrator(
             hadError = true;
         if (hadError)
             return new HashSet<int>();
+
+        logger.LogInformation(
+            "[UpdateOrchestrator {RunId}] Workspace {WorkspaceId}: {LevelCount} level(s) to walk: {Levels}",
+            runId, workspaceId, levelRepoIds.Count,
+            string.Join(", ", levelRepoIds.Select(l => $"L{l.Level}={l.RepoIds.Count} repo(s)")));
 
         foreach (var (level, repoIds) in levelRepoIds)
         {
@@ -97,8 +118,27 @@ public sealed class DependencyUpdateOrchestrator(
                 : repoIds;
 
             var hasFileWork = repoIds.Any(outOfDateFileRepoIds.Contains);
+
+            if (repoIdsToUpdate != null)
+            {
+                var excludedByScope = repoIds.Where(id => !repoIdsToUpdate.Contains(id)).ToList();
+                if (excludedByScope.Count > 0)
+                {
+                    logger.LogInformation(
+                        "[UpdateOrchestrator {RunId}] Workspace {WorkspaceId}: Level {Level}: {ExcludedCount} repo(s) excluded from csproj scope by caller's repoIdsToUpdate: [{ExcludedIds}]",
+                        runId, workspaceId, level, excludedByScope.Count, string.Join(",", excludedByScope));
+                }
+            }
+
+            logger.LogInformation(
+                "[UpdateOrchestrator {RunId}] Workspace {WorkspaceId}: Level {Level}: starting. TotalRepos={TotalRepos}, CsprojScope={CsprojScope}, HasFileWork={HasFileWork}",
+                runId, workspaceId, level, repoIds.Count, csprojScope.Count, hasFileWork);
+
             if (!hasFileWork && csprojScope.Count == 0)
+            {
+                logger.LogInformation("[UpdateOrchestrator {RunId}] Workspace {WorkspaceId}: Level {Level}: skipped (no file work, empty csproj scope).", runId, workspaceId, level);
                 continue;
+            }
 
             Action<string> levelProgress = msg => setProgress($"{msg}\nLevel {level}");
 
@@ -113,12 +153,17 @@ public sealed class DependencyUpdateOrchestrator(
                 levelProgress,
                 onAppSideComplete,
                 OnRepoError,
-                commitMessage);
+                commitMessage,
+                runId);
             if (!vfOk)
             {
                 hadError = true;
                 break;
             }
+
+            logger.LogInformation(
+                "[UpdateOrchestrator {RunId}] Workspace {WorkspaceId}: Level {Level}: version-file commit result: {CommittedCount} repo(s) committed: [{CommittedIds}]",
+                runId, workspaceId, level, vfCommittedRepoIds.Count, string.Join(",", vfCommittedRepoIds));
 
             if (csprojScope.Count == 0)
             {
@@ -134,6 +179,11 @@ public sealed class DependencyUpdateOrchestrator(
             var reposAtLevel = payload
                 .Where(p => csprojScope.Contains(p.RepoId))
                 .ToList();
+
+            logger.LogInformation(
+                "[UpdateOrchestrator {RunId}] Workspace {WorkspaceId}: Level {Level}: GetUpdatePlanAsync found {PendingCount} of {ScopeCount} scoped repo(s) with pending csproj changes: [{PendingIds}]",
+                runId, workspaceId, level, reposAtLevel.Count, csprojScope.Count, string.Join(",", reposAtLevel.Select(r => r.RepoId)));
+
             if (reposAtLevel.Count == 0)
             {
                 // No csproj work at this level, but version-file commits may need a version refresh.
@@ -153,6 +203,11 @@ public sealed class DependencyUpdateOrchestrator(
                 repoIdsToSync: csprojScope,
                 cancellationToken);
             allSyncedRepoIds.UnionWith(syncedRepoIds);
+
+            logger.LogInformation(
+                "[UpdateOrchestrator {RunId}] Workspace {WorkspaceId}: Level {Level}: SyncDependenciesAsync synced {SyncedCount} of {AttemptedCount} repo(s): [{SyncedIds}]",
+                runId, workspaceId, level, syncedRepoIds.Count, reposAtLevel.Count, string.Join(",", syncedRepoIds));
+
             if (hadError)
                 break;
 
@@ -192,6 +247,11 @@ public sealed class DependencyUpdateOrchestrator(
                 if (committed)
                     csprojCommittedRepoIds.Add(repoId);
             }
+
+            logger.LogInformation(
+                "[UpdateOrchestrator {RunId}] Workspace {WorkspaceId}: Level {Level}: committed csproj changes for {CommittedCount} repo(s): [{CommittedIds}]",
+                runId, workspaceId, level, csprojCommittedRepoIds.Count, string.Join(",", csprojCommittedRepoIds));
+
             if (hadError)
                 break;
 
@@ -204,6 +264,8 @@ public sealed class DependencyUpdateOrchestrator(
                 hadError = true;
                 break;
             }
+
+            logger.LogInformation("[UpdateOrchestrator {RunId}] Workspace {WorkspaceId}: Level {Level}: completed.", runId, workspaceId, level);
         }
 
         // Finalize: broadcast so grid refreshes, then run one file-version check for the whole update.
@@ -213,6 +275,10 @@ public sealed class DependencyUpdateOrchestrator(
             await workspaceGitService.RecomputeAndBroadcastWorkspaceSyncedAsync(workspaceId, cancellationToken);
             await fileVersionService.CheckAndPersistFileVersionStatusAsync(workspaceId, cancellationToken);
         }
+
+        logger.LogInformation(
+            "[UpdateOrchestrator {RunId}] Workspace {WorkspaceId}: run finished. HadError={HadError}, TotalSyncedRepos={SyncedCount}",
+            runId, workspaceId, hadError, hadError ? 0 : allSyncedRepoIds.Count);
 
         return hadError ? new HashSet<int>() : allSyncedRepoIds;
     }
@@ -319,7 +385,8 @@ public sealed class DependencyUpdateOrchestrator(
         Action<string> setProgress,
         Action? onAppSideComplete,
         Action<int, string> onRepoError,
-        string? commitMessageOverride = null)
+        string? commitMessageOverride = null,
+        string? runId = null)
     {
         // Only call agent for repos that actually have out-of-date version files.
         var fileRepoIds = outOfDateFileRepoIds.Count > 0
@@ -328,6 +395,10 @@ public sealed class DependencyUpdateOrchestrator(
 
         if (fileRepoIds.Count == 0)
             return (true, []);
+
+        logger.LogInformation(
+            "[UpdateOrchestrator {RunId}] Workspace {WorkspaceId}: Level {Level}: {FileRepoCount} repo(s) have out-of-date version files: [{FileRepoIds}]",
+            runId, workspaceId, level, fileRepoIds.Count, string.Join(",", fileRepoIds));
 
         setProgress("Updating version files...");
         var (_, _, fileError, updatedFiles) = await fileVersionService.UpdateAllVersionsAsync(

--- a/src/GrayMoon.App/Services/PushOrchestrator.cs
+++ b/src/GrayMoon.App/Services/PushOrchestrator.cs
@@ -9,7 +9,8 @@ namespace GrayMoon.App.Services;
 /// </summary>
 public sealed class PushOrchestrator(
     WorkspacePushService workspacePushService,
-    IServiceProvider serviceProvider)
+    IServiceProvider serviceProvider,
+    ILogger<PushOrchestrator> logger)
 {
     public async Task RunAsync(
         int workspaceId,
@@ -20,8 +21,13 @@ public sealed class PushOrchestrator(
         Action<string> showToast,
         Action? onAppSideComplete = null,
         IReadOnlySet<int>? syncedRepoIds = null,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default,
+        string? runId = null)
     {
+        logger.LogInformation(
+            "[PushOrchestrator {RunId}] Workspace {WorkspaceId}: starting push. Mode={Mode}, RepoCount={RepoCount}, RequiredPackages={RequiredPackages}",
+            runId, workspaceId, synchronizedPush ? "synchronized" : "parallel", repoIds.Count, requiredPackageIds.Count);
+
         if (synchronizedPush)
         {
             setProgress("Syncing package registries for required packages...");
@@ -37,7 +43,8 @@ public sealed class PushOrchestrator(
                 onAppSideComplete,
                 packageRegistriesAlreadySynced: requiredPackageIds.Count > 0,
                 syncedRepoIds: syncedRepoIds,
-                cancellationToken: cancellationToken);
+                cancellationToken: cancellationToken,
+                runId: runId);
         }
         else
         {
@@ -50,6 +57,8 @@ public sealed class PushOrchestrator(
                 onAppSideComplete: null,
                 cancellationToken: cancellationToken);
         }
+
+        logger.LogInformation("[PushOrchestrator {RunId}] Workspace {WorkspaceId}: push finished.", runId, workspaceId);
     }
 
     public Task<(bool Success, string? ErrorMessage)> PushSingleAsync(

--- a/src/GrayMoon.App/Services/WorkspacePushHandler.cs
+++ b/src/GrayMoon.App/Services/WorkspacePushHandler.cs
@@ -37,7 +37,8 @@ public sealed class WorkspacePushHandler(
         Action<string> showToast,
         Action? onAppSideComplete = null,
         IReadOnlySet<int>? syncedRepoIds = null,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default,
+        string? runId = null)
     {
         try
         {
@@ -50,13 +51,14 @@ public sealed class WorkspacePushHandler(
                 showToast,
                 onAppSideComplete,
                 syncedRepoIds,
-                cancellationToken);
+                cancellationToken,
+                runId);
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
             if (ex is SynchronizedPushNotPossibleException)
                 throw;
-            logger.LogError(ex, "Push with dependencies failed for workspace {WorkspaceId}", workspaceId);
+            logger.LogError(ex, "[PushOrchestrator {RunId}] Push with dependencies failed for workspace {WorkspaceId}", runId, workspaceId);
             showToast(ex.Message);
             throw;
         }

--- a/src/GrayMoon.App/Services/WorkspacePushService.cs
+++ b/src/GrayMoon.App/Services/WorkspacePushService.cs
@@ -76,8 +76,13 @@ public sealed class WorkspacePushService(
         Action? onAppSideComplete = null,
         bool packageRegistriesAlreadySynced = false,
         IReadOnlySet<int>? syncedRepoIds = null,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default,
+        string? runId = null)
     {
+        _logger.LogInformation(
+            "[PushOrchestrator {RunId}] Workspace {WorkspaceId}: RunPushAsync starting. Scope={Scope}",
+            runId, workspaceId, repoIdsToPush == null ? "all repos" : $"{repoIdsToPush.Count} repo(s): [{string.Join(",", repoIdsToPush)}]");
+
         if (!_agentBridge.IsAgentConnected)
             throw new InvalidOperationException("Agent not connected. Start GrayMoon.Agent to push.");
 
@@ -152,12 +157,20 @@ public sealed class WorkspacePushService(
         var levelsAsc = payload.Select(p => p.DependencyLevel ?? 0).Distinct().OrderBy(x => x).ToList();
         var lastLevel = levelsAsc[^1];
         var pushedRepos = new List<PushRepoPayload>();
+        _logger.LogInformation(
+            "[PushOrchestrator {RunId}] Workspace {WorkspaceId}: {LevelCount} level(s) to push: {Levels}",
+            runId, workspaceId, levelsAsc.Count,
+            string.Join(", ", levelsAsc.Select(l => $"L{l}={payload.Count(p => (p.DependencyLevel ?? 0) == l)} repo(s)")));
         foreach (var level in levelsAsc)
         {
             cancellationToken.ThrowIfCancellationRequested();
             var reposAtLevel = payload.Where(p => (p.DependencyLevel ?? 0) == level).ToList();
             if (reposAtLevel.Count == 0) continue;
             var levelProgress = onProgressMessage == null ? (Action<string>?)null : msg => onProgressMessage($"{msg}\nLevel {level}");
+
+            _logger.LogInformation(
+                "[PushOrchestrator {RunId}] Workspace {WorkspaceId}: Level {Level}: starting. RepoIds=[{RepoIds}]",
+                runId, workspaceId, level, string.Join(",", reposAtLevel.Select(r => r.RepoId)));
 
             var requiredForLevel = reposAtLevel
                 .SelectMany(r => r.RequiredPackages)
@@ -168,7 +181,8 @@ public sealed class WorkspacePushService(
 
             if (totalDeps > 0)
             {
-                _logger.LogInformation("Push wait: level {Level}, waiting for {Count} package(s): {Packages}",
+                _logger.LogInformation("[PushOrchestrator {RunId}] Push wait: level {Level}, waiting for {Count} package(s): {Packages}",
+                    runId,
                     level,
                     totalDeps,
                     string.Join(", ", requiredForLevel.Select(r => r.PackageId + "@" + r.Version + " (connector " + r.MatchedConnectorId + ")")));
@@ -205,7 +219,7 @@ public sealed class WorkspacePushService(
                     if (remaining <= TimeSpan.Zero)
                     {
                         levelProgress?.Invoke("Timed out.");
-                        _logger.LogWarning("Push wait: timed out after {TotalMinutes:F1} min. Found {Found} of {Total}.", totalTimeout.TotalMinutes, getFoundCount(), totalDeps);
+                        _logger.LogWarning("[PushOrchestrator {RunId}] Push wait: timed out after {TotalMinutes:F1} min. Found {Found} of {Total}.", runId, totalTimeout.TotalMinutes, getFoundCount(), totalDeps);
                         throw new OperationCanceledException("Push wait for dependencies timed out.");
                     }
                     var found = getFoundCount();
@@ -263,12 +277,12 @@ public sealed class WorkspacePushService(
                                     connectorByIdForLevel.TryGetValue(req.MatchedConnectorId!.Value, out var connector);
                                     if (connector == null)
                                     {
-                                        _logger.LogWarning("Push wait: package {PackageId} {Version} has no connector (MatchedConnectorId={ConnectorId}).", req.PackageId, req.Version, req.MatchedConnectorId);
+                                        _logger.LogWarning("[PushOrchestrator {RunId}] Push wait: package {PackageId} {Version} has no connector (MatchedConnectorId={ConnectorId}).", runId, req.PackageId, req.Version, req.MatchedConnectorId);
                                         return;
                                     }
                                     var exists = await _nuGetService.PackageVersionExistsAsync(connector, req.PackageId, req.Version, linkedToken);
-                                    _logger.LogInformation("Push wait: checking {PackageId} {Version} in registry {ConnectorName} (Id={ConnectorId}) -> {Result}",
-                                        req.PackageId, req.Version, connector.ConnectorName, connector.ConnectorId, exists ? "found" : "not found");
+                                    _logger.LogInformation("[PushOrchestrator {RunId}] Push wait: checking {PackageId} {Version} in registry {ConnectorName} (Id={ConnectorId}) -> {Result}",
+                                        runId, req.PackageId, req.Version, connector.ConnectorName, connector.ConnectorId, exists ? "found" : "not found");
                                     if (exists)
                                     {
                                         lock (foundLock)
@@ -284,7 +298,7 @@ public sealed class WorkspacePushService(
                                     deadline = DateTime.UtcNow + TimeSpan.FromMinutes(stillWaiting * minutesPerDep);
                             }
                             if (nowFound >= totalDeps)
-                                _logger.LogInformation("Push wait: all {Total} package(s) found for level {Level}, proceeding.", totalDeps, level);
+                                _logger.LogInformation("[PushOrchestrator {RunId}] Push wait: all {Total} package(s) found for level {Level}, proceeding.", runId, totalDeps, level);
                         }
                     }
 
@@ -312,9 +326,17 @@ public sealed class WorkspacePushService(
                 cancellationToken);
             await UpdateCommitCountsAndUpstreamAfterPushAsync(workspaceId, reposAtLevel, cancellationToken);
             pushedRepos.AddRange(reposAtLevel);
+
+            _logger.LogInformation(
+                "[PushOrchestrator {RunId}] Workspace {WorkspaceId}: Level {Level}: completed. Pushed {PushedCount} repo(s).",
+                runId, workspaceId, level, reposAtLevel.Count);
         }
 
         await UpdateCommitCountsAndUpstreamAfterPushAsync(workspaceId, payload, cancellationToken);
+
+        _logger.LogInformation(
+            "[PushOrchestrator {RunId}] Workspace {WorkspaceId}: RunPushAsync finished. TotalPushed={TotalPushed}",
+            runId, workspaceId, pushedRepos.Count);
     }
 
     /// <summary>Pushed a single repository's current branch with upstream (-u). Used when the user clicks the "not-upstreamed" badge.</summary>

--- a/src/GrayMoon.App/Services/WorkspaceUpdateHandler.cs
+++ b/src/GrayMoon.App/Services/WorkspaceUpdateHandler.cs
@@ -21,7 +21,8 @@ public sealed class WorkspaceUpdateHandler(
         IReadOnlySet<int>? repoIdsToUpdate = null,
         string? commitMessage = null,
         bool includeDepsInCommitMessage = true,
-        int? maxLevel = null)
+        int? maxLevel = null,
+        string? runId = null)
     {
         try
         {
@@ -34,11 +35,12 @@ public sealed class WorkspaceUpdateHandler(
                 repoIdsToUpdate,
                 commitMessage,
                 includeDepsInCommitMessage,
-                maxLevel);
+                maxLevel,
+                runId);
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
-            logger.LogError(ex, "Error running dependency update for workspace {WorkspaceId}", workspaceId);
+            logger.LogError(ex, "[UpdateOrchestrator {RunId}] Error running dependency update for workspace {WorkspaceId}", runId, workspaceId);
             throw;
         }
     }

--- a/src/GrayMoon.App/appsettings.json
+++ b/src/GrayMoon.App/appsettings.json
@@ -50,5 +50,8 @@
   },
   "AgentBridge": {
     "CommandTimeoutSeconds": 240
+  },
+  "GitChanges": {
+    "MaxParallelRepositoryOperations": 8
   }
 }

--- a/src/GrayMoon.App/appsettings.json
+++ b/src/GrayMoon.App/appsettings.json
@@ -47,5 +47,8 @@
   },
   "Sync": {
     "EnableDeduplication": true
+  },
+  "AgentBridge": {
+    "CommandTimeoutSeconds": 240
   }
 }

--- a/src/GrayMoon.Common.Tests/CommandLineServiceTests.cs
+++ b/src/GrayMoon.Common.Tests/CommandLineServiceTests.cs
@@ -1,0 +1,109 @@
+using System.Diagnostics;
+using System.Threading;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace GrayMoon.Common.Tests;
+
+public sealed class CommandLineServiceTests
+{
+    private static CommandLineService CreateService(int defaultTimeoutSeconds = 60)
+        => new(NullLogger<CommandLineService>.Instance, Options.Create(new ProcessExecutionOptions { DefaultTimeoutSeconds = defaultTimeoutSeconds }));
+
+    [Fact]
+    public async Task RunAsync_CompletesNormally_WhenProcessFinishesBeforeTimeout()
+    {
+        var service = CreateService();
+
+        var result = await service.RunAsync("cmd.exe", "/c echo hello", timeout: TimeSpan.FromSeconds(30));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("hello", result.Stdout);
+    }
+
+    [Fact]
+    public async Task RunAsync_KillsProcessAndReturnsSyntheticFailure_WhenItExceedsTheTimeout()
+    {
+        var service = CreateService();
+        var sw = Stopwatch.StartNew();
+
+        // Sleeps far longer than the 1s timeout below - the test only passes if the process is
+        // actually killed rather than the call hanging until the sleep finishes.
+        var result = await service.RunAsync(
+            "powershell.exe",
+            "-NoProfile -NonInteractive -Command \"Start-Sleep -Seconds 30\"",
+            timeout: TimeSpan.FromSeconds(1));
+
+        sw.Stop();
+
+        Assert.Equal(-1, result.ExitCode);
+        Assert.NotNull(result.Stderr);
+        Assert.Contains("timed out", result.Stderr, StringComparison.OrdinalIgnoreCase);
+        Assert.True(sw.Elapsed < TimeSpan.FromSeconds(15), $"Expected the hung process to be killed quickly, took {sw.Elapsed}.");
+    }
+
+    [Fact]
+    public async Task RunAsync_UsesInjectedDefaultTimeout_WhenCallerPassesNone()
+    {
+        var service = CreateService(defaultTimeoutSeconds: 1);
+        var sw = Stopwatch.StartNew();
+
+        var result = await service.RunAsync(
+            "powershell.exe",
+            "-NoProfile -NonInteractive -Command \"Start-Sleep -Seconds 30\"");
+
+        sw.Stop();
+
+        Assert.Equal(-1, result.ExitCode);
+        Assert.True(sw.Elapsed < TimeSpan.FromSeconds(15), $"Expected the injected default timeout to apply, took {sw.Elapsed}.");
+    }
+
+    [Fact]
+    public async Task RunAsync_ArgumentListOverload_KillsProcessAndReturnsSyntheticFailure_WhenItExceedsTheTimeout()
+    {
+        var service = CreateService();
+        var sw = Stopwatch.StartNew();
+
+        var result = await service.RunAsync(
+            "powershell.exe",
+            ["-NoProfile", "-NonInteractive", "-Command", "Start-Sleep -Seconds 30"],
+            timeout: TimeSpan.FromSeconds(1));
+
+        sw.Stop();
+
+        Assert.Equal(-1, result.ExitCode);
+        Assert.NotNull(result.Stderr);
+        Assert.Contains("timed out", result.Stderr, StringComparison.OrdinalIgnoreCase);
+        Assert.True(sw.Elapsed < TimeSpan.FromSeconds(15), $"Expected the hung process to be killed quickly, took {sw.Elapsed}.");
+    }
+
+    [Fact]
+    public async Task RunAsync_InfiniteTimeout_DoesNotKillProcess_UsedForUnboundedCloneTier()
+    {
+        // Timeout.InfiniteTimeSpan is the sentinel GitProcessRunner passes for "clone" when
+        // GitProcessOptions.CloneTimeoutSeconds is 0 (the default) - CancellationTokenSource(TimeSpan)
+        // never schedules cancellation for it, so a long-running command completes normally.
+        var service = CreateService();
+
+        var result = await service.RunAsync(
+            "powershell.exe",
+            "-NoProfile -NonInteractive -Command \"Start-Sleep -Milliseconds 500; exit 0\"",
+            timeout: Timeout.InfiniteTimeSpan);
+
+        Assert.Equal(0, result.ExitCode);
+    }
+
+    [Fact]
+    public async Task RunAsync_CallerCancellation_StillThrowsOperationCanceledException_NotSyntheticFailure()
+    {
+        var service = CreateService();
+        using var cts = new CancellationTokenSource();
+        cts.CancelAfter(TimeSpan.FromMilliseconds(200));
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => service.RunAsync(
+            "powershell.exe",
+            "-NoProfile -NonInteractive -Command \"Start-Sleep -Seconds 30\"",
+            cancellationToken: cts.Token,
+            timeout: TimeSpan.FromSeconds(30)));
+    }
+}

--- a/src/GrayMoon.Common/CommandLineService.cs
+++ b/src/GrayMoon.Common/CommandLineService.cs
@@ -2,17 +2,20 @@ using System.Diagnostics;
 using System.Text;
 using GrayMoon.Abstractions.Agent;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace GrayMoon.Common;
 
 /// <summary>
 /// Single place for process execution and DEBUG logging (safe parameters, elapsed ms, exit code).
 /// </summary>
-public sealed class CommandLineService(ILogger<CommandLineService> logger) : ICommandLineService
+public sealed class CommandLineService(ILogger<CommandLineService> logger, IOptions<ProcessExecutionOptions> options) : ICommandLineService
 {
     private const int MaxLoggedStreamLength = 8_000;
 
     private const int MaxMirrorLineLength = 4096;
+
+    private readonly TimeSpan _defaultTimeout = TimeSpan.FromSeconds(Math.Max(1, options.Value.DefaultTimeoutSeconds));
 
     public async Task<CommandLineResult> RunAsync(
         string fileName,
@@ -21,11 +24,13 @@ public sealed class CommandLineService(ILogger<CommandLineService> logger) : ICo
         string? stdin = null,
         CancellationToken cancellationToken = default,
         bool streamStderrAsStdout = false,
-        bool mirrorFailureOutputAsStderr = false)
+        bool mirrorFailureOutputAsStderr = false,
+        TimeSpan? timeout = null)
     {
         arguments ??= "";
         var sw = Stopwatch.StartNew();
         var cwd = string.IsNullOrEmpty(workingDirectory) ? "." : workingDirectory;
+        var effectiveTimeout = timeout ?? _defaultTimeout;
         logger.LogDebug(
             "Command starting {Executable} {Parameters} cwd={WorkingDirectory}",
             fileName,
@@ -69,17 +74,35 @@ public sealed class CommandLineService(ILogger<CommandLineService> logger) : ICo
             process.StandardInput.Close();
         }
 
+        using var timeoutCts = new CancellationTokenSource(effectiveTimeout);
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
+        var runToken = linkedCts.Token;
+
         var stdoutTask = ConsumeStreamAsync(
             process.StandardOutput,
             segment => OnStreamSegment(fileName, suppressStreamLogging, suppressOverlayStdout, AgentCommandStreamKind.Stdout, segment),
-            cancellationToken);
+            runToken);
         var stderrTask = ConsumeStreamAsync(
             process.StandardError,
             segment => OnStreamSegment(fileName, suppressStreamLogging, suppressOverlay: false, stderrStreamKind, segment),
-            cancellationToken);
-        await process.WaitForExitAsync(cancellationToken);
-        var stdout = await stdoutTask;
-        var stderr = await stderrTask;
+            runToken);
+
+        try
+        {
+            await process.WaitForExitAsync(runToken);
+        }
+        catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+        {
+            return await HandleTimeoutAsync(process, stdoutTask, stderrTask, sw, fileName, LogSafe.ForLog(arguments), effectiveTimeout);
+        }
+        catch (OperationCanceledException)
+        {
+            KillProcessTreeSafely(process);
+            throw;
+        }
+
+        var stdout = await AwaitStreamSafelyAsync(stdoutTask);
+        var stderr = await AwaitStreamSafelyAsync(stderrTask);
         sw.Stop();
 
         logger.LogDebug("Command {Executable} {Parameters} completed in {ElapsedMs}ms (ExitCode={ExitCode})", fileName, LogSafe.ForLog(arguments), sw.ElapsedMilliseconds, process.ExitCode);
@@ -97,11 +120,13 @@ public sealed class CommandLineService(ILogger<CommandLineService> logger) : ICo
         byte[]? stdinBytes = null,
         CancellationToken cancellationToken = default,
         bool streamStderrAsStdout = false,
-        bool mirrorFailureOutputAsStderr = false)
+        bool mirrorFailureOutputAsStderr = false,
+        TimeSpan? timeout = null)
     {
         arguments ??= [];
         var sw = Stopwatch.StartNew();
         var cwd = string.IsNullOrEmpty(workingDirectory) ? "." : workingDirectory;
+        var effectiveTimeout = timeout ?? _defaultTimeout;
         var loggedArguments = LogSafe.ForLog(string.Join(' ', arguments));
         logger.LogDebug(
             "Command starting {Executable} {Parameters} cwd={WorkingDirectory}",
@@ -152,17 +177,35 @@ public sealed class CommandLineService(ILogger<CommandLineService> logger) : ICo
             process.StandardInput.Close();
         }
 
+        using var timeoutCts = new CancellationTokenSource(effectiveTimeout);
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
+        var runToken = linkedCts.Token;
+
         var stdoutTask = ConsumeStreamPreservingLineEndingsAsync(
             process.StandardOutput,
             segment => OnStreamSegment(fileName, suppressStreamLogging, suppressOverlayStdout, AgentCommandStreamKind.Stdout, segment),
-            cancellationToken);
+            runToken);
         var stderrTask = ConsumeStreamPreservingLineEndingsAsync(
             process.StandardError,
             segment => OnStreamSegment(fileName, suppressStreamLogging, suppressOverlay: false, stderrStreamKind, segment),
-            cancellationToken);
-        await process.WaitForExitAsync(cancellationToken);
-        var stdout = await stdoutTask;
-        var stderr = await stderrTask;
+            runToken);
+
+        try
+        {
+            await process.WaitForExitAsync(runToken);
+        }
+        catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+        {
+            return await HandleTimeoutAsync(process, stdoutTask, stderrTask, sw, fileName, loggedArguments, effectiveTimeout);
+        }
+        catch (OperationCanceledException)
+        {
+            KillProcessTreeSafely(process);
+            throw;
+        }
+
+        var stdout = await AwaitStreamSafelyAsync(stdoutTask);
+        var stderr = await AwaitStreamSafelyAsync(stderrTask);
         sw.Stop();
 
         logger.LogDebug("Command {Executable} {Parameters} completed in {ElapsedMs}ms (ExitCode={ExitCode})", fileName, loggedArguments, sw.ElapsedMilliseconds, process.ExitCode);
@@ -171,6 +214,71 @@ public sealed class CommandLineService(ILogger<CommandLineService> logger) : ICo
             MirrorCombinedOutputAsStderr(stdout, stderr);
 
         return new CommandLineResult(process.ExitCode, stdout, stderr);
+    }
+
+    /// <summary>
+    /// Called when a process's timeout elapsed without the process itself observing cancellation
+    /// (e.g. no interactive prompt, stuck credential manager, or a lock file it never lets go of). Kills
+    /// the process tree so the OS process/handles are actually reaped (not just abandoned), drains the
+    /// already-buffered stream output for diagnostics, and returns a synthetic failed result shaped
+    /// exactly like a normal non-zero-exit failure so every existing caller's <c>if (exitCode != 0)</c>
+    /// handling picks it up with no changes required.
+    /// </summary>
+    private async Task<CommandLineResult> HandleTimeoutAsync(
+        Process process,
+        Task<string> stdoutTask,
+        Task<string> stderrTask,
+        Stopwatch sw,
+        string fileName,
+        string loggedArguments,
+        TimeSpan timeout)
+    {
+        KillProcessTreeSafely(process);
+        var stdout = await AwaitStreamSafelyAsync(stdoutTask);
+        await AwaitStreamSafelyAsync(stderrTask);
+        sw.Stop();
+
+        var message = $"Operation timed out after {timeout.TotalSeconds:0}s.";
+        logger.LogWarning(
+            "Command {Executable} {Parameters} timed out after {ElapsedMs}ms (limit {TimeoutSeconds}s) and was killed",
+            fileName, loggedArguments, sw.ElapsedMilliseconds, timeout.TotalSeconds);
+        ReportAmbient(new CommandLineStreamEvent(AgentCommandStreamKind.Stderr, message));
+
+        return new CommandLineResult(-1, stdout, message);
+    }
+
+    private static void KillProcessTreeSafely(Process process)
+    {
+        try
+        {
+            if (!process.HasExited)
+            {
+                process.Kill(entireProcessTree: true);
+            }
+        }
+        catch
+        {
+            // Best-effort: the process may have exited between the check and the kill call, or the OS
+            // may refuse the kill (already exiting) - either way there is nothing further to clean up.
+        }
+    }
+
+    /// <summary>
+    /// Awaits a stream-consuming task that was cancelled alongside the process (its <see cref="StreamReader.ReadAsync"/>
+    /// may throw <see cref="OperationCanceledException"/> or simply return once the killed process's pipe
+    /// closes) - either way the caller only needs whatever partial output was captured before cancellation,
+    /// never an exception bubbling out of a diagnostic-only read.
+    /// </summary>
+    private static async Task<string?> AwaitStreamSafelyAsync(Task<string> streamTask)
+    {
+        try
+        {
+            return await streamTask;
+        }
+        catch
+        {
+            return null;
+        }
     }
 
     private static void MirrorCombinedOutputAsStderr(string? stdout, string? stderr)

--- a/src/GrayMoon.Common/Git/GitProcessOptions.cs
+++ b/src/GrayMoon.Common/Git/GitProcessOptions.cs
@@ -1,0 +1,31 @@
+namespace GrayMoon.Common.Git;
+
+/// <summary>
+/// Per-operation-kind timeouts for every git (and dotnet-gitversion) process the Agent launches through
+/// <c>GitProcessRunner</c>. Every invocation is bounded by one of these tiers - there is no "no timeout"
+/// option - so a hung process (stuck credential prompt, cloud-sync/antivirus file lock, unresponsive
+/// network share) is killed and reported as a normal failure instead of hanging its caller's
+/// worker/semaphore slot forever. No automatic retry is triggered by a timeout; existing retry-on-bad-exit-code
+/// behavior for clone/fetch/pull/push/ls-remote is unchanged, just now bounded per attempt.
+/// </summary>
+public sealed class GitProcessOptions
+{
+    /// <summary>Local/fast operations: status, diff/show, rev-parse, cat-file, add, restore, reset, commit,
+    /// branch/tag queries, commit counts, Git Changes stage/unstage/commit. Default 60.</summary>
+    public int DefaultTimeoutSeconds { get; init; } = 60;
+
+    /// <summary>Network operations: fetch, pull, push, ls-remote. Default 180.</summary>
+    public int NetworkTimeoutSeconds { get; init; } = 180;
+
+    /// <summary>dotnet-gitversion invocations, which scan full repository history. Default 90.</summary>
+    public int GitVersionTimeoutSeconds { get; init; } = 90;
+
+    /// <summary>
+    /// Clone is intentionally its own tier, separate from <see cref="NetworkTimeoutSeconds"/>: an initial
+    /// clone can legitimately take far longer than any other git operation (large repository, slow/first
+    /// connection, no local objects to reuse), and killing it partway through wastes all the work done so
+    /// far instead of just failing fast on a truly transient error. Default 0, meaning **no timeout** -
+    /// a clone runs to completion (or failure) with no time bound. Set to a positive value to bound it.
+    /// </summary>
+    public int CloneTimeoutSeconds { get; init; } = 0;
+}

--- a/src/GrayMoon.Common/GrayMoon.Common.csproj
+++ b/src/GrayMoon.Common/GrayMoon.Common.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <ProjectReference Include="..\GrayMoon.Abstractions\GrayMoon.Abstractions.csproj" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.*" />
   </ItemGroup>
 
 </Project>

--- a/src/GrayMoon.Common/ICommandLineService.cs
+++ b/src/GrayMoon.Common/ICommandLineService.cs
@@ -22,7 +22,13 @@ public interface ICommandLineService
     /// <param name="mirrorFailureOutputAsStderr">
     /// When true and exit code is non-zero, combined stdout+stderr is sent to the overlay again as stderr lines (red).
     /// </param>
-    /// <returns>Exit code (or -1 if process failed to start), stdout, and stderr.</returns>
+    /// <param name="timeout">
+    /// Maximum time the process may run before it is killed (including its full process tree) and the
+    /// call returns a synthetic failed result (ExitCode -1, Stderr describing the timeout) instead of
+    /// waiting forever. Defaults to <see cref="ProcessExecutionOptions.DefaultTimeoutSeconds"/> when not
+    /// specified - there is always a bound, even if the caller passes nothing.
+    /// </param>
+    /// <returns>Exit code (or -1 if process failed to start, or timed out), stdout, and stderr.</returns>
     Task<CommandLineResult> RunAsync(
         string fileName,
         string arguments,
@@ -30,7 +36,8 @@ public interface ICommandLineService
         string? stdin = null,
         CancellationToken cancellationToken = default,
         bool streamStderrAsStdout = false,
-        bool mirrorFailureOutputAsStderr = false);
+        bool mirrorFailureOutputAsStderr = false,
+        TimeSpan? timeout = null);
 
     /// <summary>
     /// Runs the executable with an explicit argument list instead of a single argument string - no shell
@@ -39,6 +46,7 @@ public interface ICommandLineService
     /// raw stdin stream verbatim (not re-encoded), so callers control the exact bytes sent - required for
     /// NUL-delimited UTF-8 pathspec input.
     /// </summary>
+    /// <param name="timeout">See the other overload's <c>timeout</c> parameter.</param>
     Task<CommandLineResult> RunAsync(
         string fileName,
         IReadOnlyList<string> arguments,
@@ -46,5 +54,6 @@ public interface ICommandLineService
         byte[]? stdinBytes = null,
         CancellationToken cancellationToken = default,
         bool streamStderrAsStdout = false,
-        bool mirrorFailureOutputAsStderr = false);
+        bool mirrorFailureOutputAsStderr = false,
+        TimeSpan? timeout = null);
 }

--- a/src/GrayMoon.Common/ProcessExecutionOptions.cs
+++ b/src/GrayMoon.Common/ProcessExecutionOptions.cs
@@ -1,0 +1,20 @@
+namespace GrayMoon.Common;
+
+/// <summary>
+/// Default timeout applied to every process <see cref="ICommandLineService"/> launches when the caller
+/// does not pass an explicit <c>timeout</c>. Callers that know more about a specific command's expected
+/// duration (e.g. <c>GitProcessRunner</c> distinguishing network vs local git operations) should pass
+/// their own value instead of relying on this default.
+/// </summary>
+public sealed class ProcessExecutionOptions
+{
+    public const string SectionName = "ProcessExecution";
+
+    /// <summary>
+    /// Seconds a process may run before it is killed (including its full process tree) and the call
+    /// returns a synthetic failed result (ExitCode -1, Stderr describing the timeout) instead of hanging
+    /// forever. A process that never exits (credential prompt, stuck file lock, unresponsive network
+    /// share) previously blocked its caller's worker/semaphore slot indefinitely.
+    /// </summary>
+    public int DefaultTimeoutSeconds { get; init; } = 60;
+}


### PR DESCRIPTION
## Summary

- Add tiered git and process execution timeouts (default, network, GitVersion, clone) via `GitProcessOptions` and `ProcessExecutionOptions` so hung git calls release agent workers instead of exhausting the worker pool
- Extend `CommandLineService`, `GitProcessRunner`, and `GitResiliencePipelines` with timeout-aware execution and Polly pipeline timeouts, configurable in Agent and App `appsettings.json`
- Raise Git Changes refresh parallelism to 8 workers in `AgentOptions` to improve snapshot throughput under load
- Fix push and dependency-update orchestrator edge cases and add trace logging across `DependencyUpdateOrchestrator`, `PushOrchestrator`, and workspace push/update handlers
- Improve unhandled error presentation in `MainLayout` and tighten `AgentBridge`/`AgentResponseDelivery` command timeout and response delivery behavior
- Add unit tests for `GitProcessRunner` timeout resolution and `CommandLineService` timeout behavior

## Test plan

- [ ] Run `dotnet test src/GrayMoon.Common.Tests/GrayMoon.Common.Tests.csproj` and `dotnet test src/GrayMoon.Agent.Tests/GrayMoon.Agent.Tests.csproj`
- [ ] Open Git Changes on a multi-repo workspace and confirm refreshes complete faster with 8 parallel workers
- [ ] Run a workspace update and push; confirm orchestration completes and trace logging appears in the job terminal
- [ ] Verify agent git operations (status, fetch, push) honor configured timeout values and fail cleanly when exceeded
- [ ] Trigger an unhandled error in the App and confirm the improved error UI renders in the main layout