### PR TITLE
Add desktop top bar toggle, workspace sync, and layout polish

### DIFF
--- a/src/GrayMoon.App.Tests/WorkspaceTopBarServiceTests.cs
+++ b/src/GrayMoon.App.Tests/WorkspaceTopBarServiceTests.cs
@@ -1,0 +1,134 @@
+using GrayMoon.Abstractions.Agent;
+using GrayMoon.App.Data;
+using GrayMoon.App.Hubs;
+using GrayMoon.App.Models;
+using GrayMoon.App.Repositories;
+using GrayMoon.App.Services;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace GrayMoon.App.Tests;
+
+public sealed class WorkspaceTopBarServiceTests
+{
+    private sealed class TestNavigationManager : NavigationManager
+    {
+        public TestNavigationManager(string uri) => Initialize("http://localhost/", uri);
+
+        public void SetUri(string uri)
+        {
+            Uri = ToAbsoluteUri(uri).ToString();
+            NotifyLocationChanged(false);
+        }
+
+        protected override void NavigateToCore(string uri, NavigationOptions options) => SetUri(uri);
+    }
+
+    private sealed class NoOpAgentBridge : IAgentBridge
+    {
+        public bool IsAgentConnected => false;
+
+        public Task<AgentCommandResponse> SendCommandAsync(string command, object args, CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException("Not used by these tests.");
+    }
+
+    private static async Task<(SqliteConnection Connection, AppDbContext DbContext, int WorkspaceId)> CreateSeededDbAsync()
+    {
+        var connection = new SqliteConnection("Data Source=:memory:");
+        await connection.OpenAsync();
+
+        var options = new DbContextOptionsBuilder<AppDbContext>().UseSqlite(connection).Options;
+        var dbContext = new AppDbContext(options);
+        await dbContext.Database.EnsureCreatedAsync();
+
+        var workspace = new Workspace { Name = "Acme Workspace" };
+        dbContext.Workspaces.Add(workspace);
+        await dbContext.SaveChangesAsync();
+
+        return (connection, dbContext, workspace.WorkspaceId);
+    }
+
+    private static WorkspaceRepository CreateWorkspaceRepository(AppDbContext dbContext)
+    {
+        var workspaceService = new WorkspaceService(
+            new NoOpAgentBridge(),
+            NullLogger<WorkspaceService>.Instance,
+            new AppSettingRepository(dbContext),
+            Options.Create(new WorkspaceOptions()));
+
+        return new WorkspaceRepository(dbContext, workspaceService, NullLogger<WorkspaceRepository>.Instance);
+    }
+
+    [Fact]
+    public async Task Navigating_into_a_workspace_pushes_WorkspaceChanged_with_its_name()
+    {
+        var (connection, dbContext, workspaceId) = await CreateSeededDbAsync();
+        await using var _ = connection;
+        await using var __ = dbContext;
+
+        var navigationManager = new TestNavigationManager($"http://localhost/workspaces/{workspaceId}/repositories");
+        var hubContext = new FakeHubContext<DesktopNotificationHub>();
+        var tracker = new DesktopWorkspaceContextTracker();
+        var service = new WorkspaceTopBarService(navigationManager, CreateWorkspaceRepository(dbContext), hubContext, tracker);
+
+        await service.EnsureSynchronizedAsync();
+
+        Assert.Equal("Acme Workspace", service.WorkspaceDisplayName);
+
+        var sent = Assert.Single(hubContext.ClientsImpl.AllProxy.Sent, s => s.Method == "WorkspaceChanged");
+        var context = Assert.IsType<WorkspaceContext>(sent.Args[0]);
+        Assert.Equal(workspaceId, context.WorkspaceId);
+        Assert.Equal("Acme Workspace", context.WorkspaceName);
+        Assert.Same(context, tracker.Current);
+    }
+
+    [Fact]
+    public async Task Navigating_away_from_a_workspace_pushes_WorkspaceChanged_with_null_name()
+    {
+        var (connection, dbContext, workspaceId) = await CreateSeededDbAsync();
+        await using var _ = connection;
+        await using var __ = dbContext;
+
+        var navigationManager = new TestNavigationManager($"http://localhost/workspaces/{workspaceId}/repositories");
+        var hubContext = new FakeHubContext<DesktopNotificationHub>();
+        var tracker = new DesktopWorkspaceContextTracker();
+        var service = new WorkspaceTopBarService(navigationManager, CreateWorkspaceRepository(dbContext), hubContext, tracker);
+
+        await service.EnsureSynchronizedAsync();
+        hubContext.ClientsImpl.AllProxy.Sent.Clear();
+
+        navigationManager.SetUri("http://localhost/dashboard");
+        // LocationChanged handler fires fire-and-forget; EnsureSynchronizedAsync is the same code path
+        // and is awaitable, so drive it directly to avoid a race on the background task in the test.
+        await service.EnsureSynchronizedAsync();
+
+        Assert.Null(service.WorkspaceDisplayName);
+
+        var sent = Assert.Single(hubContext.ClientsImpl.AllProxy.Sent, s => s.Method == "WorkspaceChanged");
+        var context = Assert.IsType<WorkspaceContext>(sent.Args[0]);
+        Assert.Null(context.WorkspaceId);
+        Assert.Null(context.WorkspaceName);
+    }
+
+    [Fact]
+    public async Task Non_workspace_route_never_pushes_when_nothing_was_ever_selected()
+    {
+        var (connection, dbContext, _) = await CreateSeededDbAsync();
+        await using var _1 = connection;
+        await using var _2 = dbContext;
+
+        var navigationManager = new TestNavigationManager("http://localhost/dashboard");
+        var hubContext = new FakeHubContext<DesktopNotificationHub>();
+        var tracker = new DesktopWorkspaceContextTracker();
+        var service = new WorkspaceTopBarService(navigationManager, CreateWorkspaceRepository(dbContext), hubContext, tracker);
+
+        await service.EnsureSynchronizedAsync();
+
+        Assert.Null(service.WorkspaceDisplayName);
+        Assert.Empty(hubContext.ClientsImpl.AllProxy.Sent);
+        Assert.Null(tracker.Current);
+    }
+}

--- a/src/GrayMoon.App.Tests/WorkspaceTopBarServiceTests.cs
+++ b/src/GrayMoon.App.Tests/WorkspaceTopBarServiceTests.cs
@@ -114,6 +114,36 @@ public sealed class WorkspaceTopBarServiceTests
     }
 
     [Fact]
+    public async Task Non_workspace_route_resets_stale_tracker_from_a_previous_circuit()
+    {
+        // Simulates a fresh circuit (e.g. after an F5 hard refresh or a WebView2 full navigation)
+        // starting on a non-workspace route while the shared singleton tracker still holds the
+        // last workspace selected by a previous circuit.
+        var (connection, dbContext, workspaceId) = await CreateSeededDbAsync();
+        await using var _ = connection;
+        await using var __ = dbContext;
+
+        var navigationManager = new TestNavigationManager("http://localhost/dashboard");
+        var hubContext = new FakeHubContext<DesktopNotificationHub>();
+        var tracker = new DesktopWorkspaceContextTracker
+        {
+            Current = new WorkspaceContext(workspaceId, "Acme Workspace")
+        };
+        var service = new WorkspaceTopBarService(navigationManager, CreateWorkspaceRepository(dbContext), hubContext, tracker);
+
+        await service.EnsureSynchronizedAsync();
+
+        Assert.Null(service.WorkspaceDisplayName);
+
+        var sent = Assert.Single(hubContext.ClientsImpl.AllProxy.Sent, s => s.Method == "WorkspaceChanged");
+        var context = Assert.IsType<WorkspaceContext>(sent.Args[0]);
+        Assert.Null(context.WorkspaceId);
+        Assert.Null(context.WorkspaceName);
+        Assert.NotNull(tracker.Current);
+        Assert.Null(tracker.Current!.WorkspaceName);
+    }
+
+    [Fact]
     public async Task Non_workspace_route_never_pushes_when_nothing_was_ever_selected()
     {
         var (connection, dbContext, _) = await CreateSeededDbAsync();

--- a/src/GrayMoon.App/Components/App.razor
+++ b/src/GrayMoon.App/Components/App.razor
@@ -201,7 +201,8 @@
 
         window.graymoonShowToast = function (message) {
             const el = document.createElement('div');
-            el.style.cssText = 'position:fixed;top:calc(3.5rem + 1rem);left:50%;transform:translateX(-50%);z-index:9999;'
+            const topbarHeight = getComputedStyle(document.documentElement).getPropertyValue('--topbar-height').trim() || '3.5rem';
+            el.style.cssText = `position:fixed;top:calc(${topbarHeight} + 1rem);left:50%;transform:translateX(-50%);z-index:9999;`
                 + 'max-width:min(90vw,420px);padding:0.5rem 1rem;background-color:#252526;color:#cccccc;'
                 + 'border:1px solid #3e3e42;border-radius:0.375rem;box-shadow:0 4px 12px rgba(0,0,0,0.35);'
                 + 'font-size:0.875rem;pointer-events:none;text-align:center;';

--- a/src/GrayMoon.App/Components/Layout/MainLayout.razor
+++ b/src/GrayMoon.App/Components/Layout/MainLayout.razor
@@ -15,6 +15,7 @@
 
 <Toast />
 <WorkspaceActionNotificationPanel />
+<DesktopTopBarSync />
 
 <div class="page @(NavbarCollapse.IsCollapsed ? "page--navbar-collapsed" : "") @(!DesktopTopBar.IsVisible ? "page--topbar-hidden" : "")">
     <div class="sidebar" id="sidebar">
@@ -22,34 +23,31 @@
     </div>
 
     <main>
-        @if (DesktopTopBar.IsVisible)
-        {
-            <div class="top-row px-4 top-row-main">
-                <div class="top-row-workspace-title" role="status" aria-live="polite">
-                    @if (!string.IsNullOrEmpty(WorkspaceTopBarService.WorkspaceDisplayName))
-                    {
-                        <a href="@WorkspacesListHref"
-                           class="h2 workspace-repos-title top-row-workspace-title__text top-row-workspace-title__link my-0"
-                           title="@WorkspaceTopBarService.WorkspaceDisplayName"
-                           aria-label="Go to Workspaces">
-                            @WorkspaceTopBarService.WorkspaceDisplayName
-                        </a>
-                    }
-                </div>
-                <div class="top-row-main-trailing">
-                @if (!string.IsNullOrEmpty(version))
+        <div class="top-row px-4 top-row-main">
+            <div class="top-row-workspace-title" role="status" aria-live="polite">
+                @if (!string.IsNullOrEmpty(WorkspaceTopBarService.WorkspaceDisplayName))
                 {
-                    <span class="header-version">
-                        <a href="https://github.com/Jandini/GrayMoon" target="_blank" rel="noopener noreferrer" class="header-github-link" title="GrayMoon on GitHub" aria-label="GrayMoon on GitHub">
-                            <i class="bi bi-github" aria-hidden="true"></i>
-                        </a>
-                        @version
-                    </span>
+                    <a href="@WorkspacesListHref"
+                       class="h2 workspace-repos-title top-row-workspace-title__text top-row-workspace-title__link my-0"
+                       title="@WorkspaceTopBarService.WorkspaceDisplayName"
+                       aria-label="Go to Workspaces">
+                        @WorkspaceTopBarService.WorkspaceDisplayName
+                    </a>
                 }
-                <AgentStatusBadge />
-                </div>
             </div>
-        }
+            <div class="top-row-main-trailing">
+            @if (!string.IsNullOrEmpty(version))
+            {
+                <span class="header-version">
+                    <a href="https://github.com/Jandini/GrayMoon" target="_blank" rel="noopener noreferrer" class="header-github-link" title="GrayMoon on GitHub" aria-label="GrayMoon on GitHub">
+                        <i class="bi bi-github" aria-hidden="true"></i>
+                    </a>
+                    @version
+                </span>
+            }
+            <AgentStatusBadge />
+            </div>
+        </div>
 
         <article class="content px-4">
             @Body
@@ -71,11 +69,6 @@
 
 @code {
     private string? version;
-
-    protected override void OnInitialized()
-    {
-        DesktopTopBar.Changed += OnDesktopTopBarChanged;
-    }
 
     protected override async Task OnInitializedAsync()
     {
@@ -110,11 +103,8 @@
 
     private void OnWorkspaceTopBarChanged() => _ = InvokeAsync(StateHasChanged);
 
-    private void OnDesktopTopBarChanged(bool visible) => _ = InvokeAsync(StateHasChanged);
-
     void IDisposable.Dispose()
     {
         WorkspaceTopBarService.Changed -= OnWorkspaceTopBarChanged;
-        DesktopTopBar.Changed -= OnDesktopTopBarChanged;
     }
 }

--- a/src/GrayMoon.App/Components/Layout/MainLayout.razor
+++ b/src/GrayMoon.App/Components/Layout/MainLayout.razor
@@ -11,41 +11,45 @@
 @inject IWorkspaceTopBarService WorkspaceTopBarService
 @inject NavigationManager NavigationManager
 @inject NavbarCollapseService NavbarCollapse
+@inject DesktopTopBarState DesktopTopBar
 
 <Toast />
 <WorkspaceActionNotificationPanel />
 
-<div class="page @(NavbarCollapse.IsCollapsed ? "page--navbar-collapsed" : "")">
+<div class="page @(NavbarCollapse.IsCollapsed ? "page--navbar-collapsed" : "") @(!DesktopTopBar.IsVisible ? "page--topbar-hidden" : "")">
     <div class="sidebar" id="sidebar">
         <NavMenu />
     </div>
 
     <main>
-        <div class="top-row px-4 top-row-main">
-            <div class="top-row-workspace-title" role="status" aria-live="polite">
-                @if (!string.IsNullOrEmpty(WorkspaceTopBarService.WorkspaceDisplayName))
+        @if (DesktopTopBar.IsVisible)
+        {
+            <div class="top-row px-4 top-row-main">
+                <div class="top-row-workspace-title" role="status" aria-live="polite">
+                    @if (!string.IsNullOrEmpty(WorkspaceTopBarService.WorkspaceDisplayName))
+                    {
+                        <a href="@WorkspacesListHref"
+                           class="h2 workspace-repos-title top-row-workspace-title__text top-row-workspace-title__link my-0"
+                           title="@WorkspaceTopBarService.WorkspaceDisplayName"
+                           aria-label="Go to Workspaces">
+                            @WorkspaceTopBarService.WorkspaceDisplayName
+                        </a>
+                    }
+                </div>
+                <div class="top-row-main-trailing">
+                @if (!string.IsNullOrEmpty(version))
                 {
-                    <a href="@WorkspacesListHref"
-                       class="h2 workspace-repos-title top-row-workspace-title__text top-row-workspace-title__link my-0"
-                       title="@WorkspaceTopBarService.WorkspaceDisplayName"
-                       aria-label="Go to Workspaces">
-                        @WorkspaceTopBarService.WorkspaceDisplayName
-                    </a>
+                    <span class="header-version">
+                        <a href="https://github.com/Jandini/GrayMoon" target="_blank" rel="noopener noreferrer" class="header-github-link" title="GrayMoon on GitHub" aria-label="GrayMoon on GitHub">
+                            <i class="bi bi-github" aria-hidden="true"></i>
+                        </a>
+                        @version
+                    </span>
                 }
+                <AgentStatusBadge />
+                </div>
             </div>
-            <div class="top-row-main-trailing">
-            @if (!string.IsNullOrEmpty(version))
-            {
-                <span class="header-version">
-                    <a href="https://github.com/Jandini/GrayMoon" target="_blank" rel="noopener noreferrer" class="header-github-link" title="GrayMoon on GitHub" aria-label="GrayMoon on GitHub">
-                        <i class="bi bi-github" aria-hidden="true"></i>
-                    </a>
-                    @version
-                </span>
-            }
-            <AgentStatusBadge />
-            </div>
-        </div>
+        }
 
         <article class="content px-4">
             @Body
@@ -67,6 +71,11 @@
 
 @code {
     private string? version;
+
+    protected override void OnInitialized()
+    {
+        DesktopTopBar.Changed += OnDesktopTopBarChanged;
+    }
 
     protected override async Task OnInitializedAsync()
     {
@@ -101,8 +110,11 @@
 
     private void OnWorkspaceTopBarChanged() => _ = InvokeAsync(StateHasChanged);
 
+    private void OnDesktopTopBarChanged(bool visible) => _ = InvokeAsync(StateHasChanged);
+
     void IDisposable.Dispose()
     {
         WorkspaceTopBarService.Changed -= OnWorkspaceTopBarChanged;
+        DesktopTopBar.Changed -= OnDesktopTopBarChanged;
     }
 }

--- a/src/GrayMoon.App/Components/Layout/MainLayout.razor.css
+++ b/src/GrayMoon.App/Components/Layout/MainLayout.razor.css
@@ -32,6 +32,14 @@ article.content {
     border-top: 1px solid var(--border-color);
 }
 
+/* Markup is always rendered (so the live toggle below can flip visibility with no server
+   round-trip); hidden purely via CSS when the class above is applied. Covers both the main
+   column's top row and the sidebar's GrayMoon brand strip (NavMenu.razor). */
+.page--topbar-hidden .top-row-main,
+.page--topbar-hidden .sidebar ::deep .top-row {
+    display: none;
+}
+
 .top-row {
     background-color: var(--bg-tertiary);
     border-bottom: 1px solid var(--border-color);

--- a/src/GrayMoon.App/Components/Layout/MainLayout.razor.css
+++ b/src/GrayMoon.App/Components/Layout/MainLayout.razor.css
@@ -236,13 +236,14 @@ article.content {
         pointer-events: none;
     }
 
+    /* Collapsed: keep overflow scroll, hide the scrollbar track/thumb */
     .page--navbar-collapsed .sidebar ::deep .nav-scrollable {
-        scrollbar-width: thin;
-        scrollbar-color: #5a5a5a var(--bg-card, #252526);
+        scrollbar-width: none;
+        -ms-overflow-style: none;
     }
 
     .page--navbar-collapsed .sidebar ::deep .nav-scrollable::-webkit-scrollbar {
-        width: 3px;
+        display: none;
     }
 
     .top-row {

--- a/src/GrayMoon.App/Components/Layout/MainLayout.razor.css
+++ b/src/GrayMoon.App/Components/Layout/MainLayout.razor.css
@@ -74,7 +74,7 @@ article.content {
     color: var(--text-primary);
     margin-top: 0;
     margin-bottom: 0;
-    font-size: calc((1.325rem + 0.9vw) * 0.72);
+    font-size: var(--topbar-workspace-title-font-size);
     max-width: calc(100% - 5.75rem);
     overflow: hidden;
     text-overflow: ellipsis;
@@ -88,7 +88,7 @@ article.content {
     cursor: pointer;
     position: relative;
     z-index: 1;
-    font-size: calc((1.325rem + 0.9vw) * 0.72);
+    font-size: var(--topbar-workspace-title-font-size);
 }
 
 /* Override generic .top-row ::deep a:hover (blue + underline); workspace title: white, no underline, pointer only */
@@ -288,7 +288,7 @@ article.content {
     main .top-row-workspace-title__text,
     main .top-row-workspace-title ::deep a.top-row-workspace-title__link {
         max-width: min(38rem, calc(100vw - 360px - 1.5rem), calc(100vw - 24rem));
-        font-size: calc((1.325rem + 0.9vw) * 0.72);
+        font-size: var(--topbar-workspace-title-font-size);
         pointer-events: auto;
     }
 
@@ -322,7 +322,7 @@ article.content {
 @media (min-width: 1200px) {
     main .top-row-workspace-title__text,
     main .top-row-workspace-title ::deep a.top-row-workspace-title__link {
-        font-size: 1.44rem;
+        font-size: calc(1.44rem * 0.7);
     }
 }
 

--- a/src/GrayMoon.App/Components/Layout/MainLayout.razor.css
+++ b/src/GrayMoon.App/Components/Layout/MainLayout.razor.css
@@ -24,6 +24,14 @@ article.content {
     background-color: var(--bg-secondary);
 }
 
+/* Top bar hidden (GrayMoon Desktop preference, persisted in the App's own database and mirrored
+   in-memory - see DesktopTopBarState): the top-row markup is never emitted, so the loading
+   overlay must stop reserving space for it, and the window edge gets a thin divider in its place. */
+.page--topbar-hidden {
+    --topbar-height: 0px;
+    border-top: 1px solid var(--border-color);
+}
+
 .top-row {
     background-color: var(--bg-tertiary);
     border-bottom: 1px solid var(--border-color);
@@ -190,10 +198,10 @@ article.content {
         flex-direction: column;
     }
 
-    /* Collapsed: width = topbar height; update --sidebar-width for loading overlay */
-    .page--navbar-collapsed {
-        --sidebar-width: 3.5rem;
-    }
+/* Collapsed: width = topbar height; update --sidebar-width for loading overlay */
+.page--navbar-collapsed {
+    --sidebar-width: 3.5rem;
+}
 
     .page--navbar-collapsed .sidebar {
         width: 3.5rem;

--- a/src/GrayMoon.App/Components/Layout/NavMenu.razor
+++ b/src/GrayMoon.App/Components/Layout/NavMenu.razor
@@ -1,18 +1,22 @@
 @implements IDisposable
 @inject NavigationManager NavigationManager
 @inject NavbarCollapseService NavbarCollapse
+@inject DesktopTopBarState DesktopTopBar
 @using GrayMoon.App.Services
 
-<div class="top-row navbar navbar-dark">
-    <div class="container-fluid d-flex justify-content-center align-items-center">
-        <a class="navbar-brand" href="">
-            <span class="navbar-brand-content">
-                <img src="moon.svg" alt="GrayMoon" class="navbar-brand-icon" />
-                <span class="navbar-brand-title">GrayMoon</span>
-            </span>
-        </a>
+@if (DesktopTopBar.IsVisible)
+{
+    <div class="top-row navbar navbar-dark">
+        <div class="container-fluid d-flex justify-content-center align-items-center">
+            <a class="navbar-brand" href="">
+                <span class="navbar-brand-content">
+                    <img src="moon.svg" alt="GrayMoon" class="navbar-brand-icon" />
+                    <span class="navbar-brand-title">GrayMoon</span>
+                </span>
+            </a>
+        </div>
     </div>
-</div>
+}
 
 <input type="checkbox" title="Navigation menu" class="navbar-toggler" />
 
@@ -139,6 +143,13 @@
     private bool isWorkspaceView;
     private int? workspaceId;
 
+    protected override void OnInitialized()
+    {
+        // NavMenu is a child component with no parameters, so a StateHasChanged() on MainLayout
+        // alone would not re-render it - it must subscribe independently to react live.
+        DesktopTopBar.Changed += OnDesktopTopBarChanged;
+    }
+
     protected override async Task OnInitializedAsync()
     {
         NavigationManager.LocationChanged += HandleLocationChanged;
@@ -172,8 +183,11 @@
         return InvokeAsync(StateHasChanged);
     }
 
+    private void OnDesktopTopBarChanged(bool visible) => _ = InvokeAsync(StateHasChanged);
+
     public void Dispose()
     {
         NavigationManager.LocationChanged -= HandleLocationChanged;
+        DesktopTopBar.Changed -= OnDesktopTopBarChanged;
     }
 }

--- a/src/GrayMoon.App/Components/Layout/NavMenu.razor
+++ b/src/GrayMoon.App/Components/Layout/NavMenu.razor
@@ -1,22 +1,24 @@
 @implements IDisposable
 @inject NavigationManager NavigationManager
 @inject NavbarCollapseService NavbarCollapse
-@inject DesktopTopBarState DesktopTopBar
 @using GrayMoon.App.Services
 
-@if (DesktopTopBar.IsVisible)
-{
-    <div class="top-row navbar navbar-dark">
-        <div class="container-fluid d-flex justify-content-center align-items-center">
-            <a class="navbar-brand" href="">
-                <span class="navbar-brand-content">
-                    <img src="moon.svg" alt="GrayMoon" class="navbar-brand-icon" />
-                    <span class="navbar-brand-title">GrayMoon</span>
-                </span>
-            </a>
-        </div>
+@* Always rendered - hidden purely via CSS (.page--topbar-hidden .sidebar .top-row in
+   MainLayout.razor.css) so GrayMoon.Desktop's tray toggle can flip it with no server round-trip.
+   A child of MainLayout has no way to react to DesktopTopBarState.Changed live: a Layout cannot
+   declare its own @rendermode (see DesktopTopBarSync.razor for why), so MainLayout - and every
+   component it renders, including this one - is always static/SSR-only and never joins a live
+   circuit. *@
+<div class="top-row navbar navbar-dark">
+    <div class="container-fluid d-flex justify-content-center align-items-center">
+        <a class="navbar-brand" href="">
+            <span class="navbar-brand-content">
+                <img src="moon.svg" alt="GrayMoon" class="navbar-brand-icon" />
+                <span class="navbar-brand-title">GrayMoon</span>
+            </span>
+        </a>
     </div>
-}
+</div>
 
 <input type="checkbox" title="Navigation menu" class="navbar-toggler" />
 
@@ -143,13 +145,6 @@
     private bool isWorkspaceView;
     private int? workspaceId;
 
-    protected override void OnInitialized()
-    {
-        // NavMenu is a child component with no parameters, so a StateHasChanged() on MainLayout
-        // alone would not re-render it - it must subscribe independently to react live.
-        DesktopTopBar.Changed += OnDesktopTopBarChanged;
-    }
-
     protected override async Task OnInitializedAsync()
     {
         NavigationManager.LocationChanged += HandleLocationChanged;
@@ -183,11 +178,8 @@
         return InvokeAsync(StateHasChanged);
     }
 
-    private void OnDesktopTopBarChanged(bool visible) => _ = InvokeAsync(StateHasChanged);
-
     public void Dispose()
     {
         NavigationManager.LocationChanged -= HandleLocationChanged;
-        DesktopTopBar.Changed -= OnDesktopTopBarChanged;
     }
 }

--- a/src/GrayMoon.App/Components/Pages/Settings.razor.css
+++ b/src/GrayMoon.App/Components/Pages/Settings.razor.css
@@ -7,14 +7,16 @@
     border-radius: 0.375rem;
 }
 
-/* Scroll the settings stack; cards keep natural height (no flex stretch). Dark scrollbar. */
+/* Scroll the settings stack; cards keep natural height (no flex stretch). Dark scrollbar.
+   max-height is derived from --topbar-height so the scroll area expands when the desktop top
+   bar is hidden (190px assumes the default 3.5rem/56px top bar; remainder is 134px). */
 .settings-page .settings-page__scroll {
     overflow-y: auto;
     overflow-x: hidden;
     display: block;
     flex: 1 1 auto;
     min-height: 0;
-    max-height: calc(100vh - 190px);
+    max-height: calc(100vh - var(--topbar-height) - 134px);
     scrollbar-width: thin;
     scrollbar-color: rgba(95, 95, 105, 0.95) rgba(22, 22, 28, 0.92);
 }

--- a/src/GrayMoon.App/Components/Pages/WorkspaceDependencies.razor.css
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceDependencies.razor.css
@@ -39,13 +39,20 @@
     min-width: 0;
 }
 
+.workspace-dependencies-header .workspace-grid-search-wrapper {
+    min-width: 0;
+    flex: 1 1 0%;
+}
+
 .dependencies-page .deps-header-actions {
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
+    min-width: 0;
+    width: 100%;
 }
 
 .deps-filter-dropdown {
     flex: 0 1 20rem;
-    min-width: 10rem;
+    min-width: 0;
     max-width: 100%;
     position: relative;
     z-index: 1050;
@@ -142,16 +149,4 @@
     inset: 0;
     z-index: 0;
     background: transparent;
-}
-
-@media (max-width: 900px) {
-    .dependencies-page .deps-header-actions {
-        flex-direction: column;
-        align-items: stretch !important;
-    }
-
-    .deps-filter-dropdown {
-        flex: 1 1 auto;
-        max-width: none;
-    }
 }

--- a/src/GrayMoon.App/Components/Pages/WorkspaceDependencies.razor.css
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceDependencies.razor.css
@@ -1,7 +1,7 @@
 /* Match other grid pages; fit viewport so no vertical scroll */
-/* Height = 100vh - top-row (3.5rem) - article padding-top (2rem) */
+/* Height = 100vh - top-row (--topbar-height) - article padding-top (2rem) */
 .dependencies-page.page-container.grid-page {
-    height: calc(100vh - 5.5rem);
+    height: calc(100vh - var(--topbar-height) - 2rem);
     min-height: 240px;
     overflow: hidden;
 }

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.Display.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.Display.cs
@@ -7,15 +7,20 @@ public sealed partial class WorkspaceRepositories
 {
     private async Task CopyVersionToClipboard(string version)
     {
+        if (string.IsNullOrEmpty(version))
+            return;
+
         try
         {
             await JSRuntime.InvokeVoidAsync("navigator.clipboard.writeText", version);
+            ToastService.Show($"{version} copied to the clipboard");
             clickedVersions.Add(version);
             StateHasChanged();
         }
         catch (Exception ex)
         {
             Logger.LogDebug(ex, "Clipboard copy failed for version {Version}", version);
+            ToastService.Show("Could not copy to clipboard.");
         }
     }
 
@@ -26,10 +31,12 @@ public sealed partial class WorkspaceRepositories
         try
         {
             await JSRuntime.InvokeVoidAsync("navigator.clipboard.writeText", text);
+            ToastService.Show("Dependency list copied to the clipboard");
         }
         catch (Exception ex)
         {
             Logger.LogDebug(ex, "Clipboard copy failed for dependencies");
+            ToastService.Show("Could not copy to clipboard.");
         }
     }
 

--- a/src/GrayMoon.App/Components/Shared/DesktopTopBarSync.razor
+++ b/src/GrayMoon.App/Components/Shared/DesktopTopBarSync.razor
@@ -1,0 +1,27 @@
+@rendermode @(new InteractiveServerRenderMode(prerender: true))
+@implements IDisposable
+@inject DesktopTopBarState DesktopTopBar
+@inject IJSRuntime JsRuntime
+
+@* Renders no markup. A Layout cannot declare its own @rendermode (RouteView passes it the page's
+   Body RenderFragment, which cannot cross the SSR/interactive boundary), so MainLayout - and the
+   top bar markup it renders - is always static/SSR-only and is never part of a live circuit. This
+   tiny component is the live circuit instead: it just outlives the page and flips the CSS class
+   directly via JS the instant GrayMoon.Desktop's tray toggles DesktopTopBarState, with no
+   server-driven re-render and no page reload. See MainLayout.razor.css for the
+   .page--topbar-hidden rule this toggles. *@
+
+@code {
+    protected override void OnInitialized()
+    {
+        DesktopTopBar.Changed += OnDesktopTopBarChanged;
+    }
+
+    private void OnDesktopTopBarChanged(bool visible) =>
+        _ = InvokeAsync(() => JsRuntime.InvokeVoidAsync("graymoonToggleClass", ".page", "page--topbar-hidden", !visible));
+
+    void IDisposable.Dispose()
+    {
+        DesktopTopBar.Changed -= OnDesktopTopBarChanged;
+    }
+}

--- a/src/GrayMoon.App/Components/Shared/Toast.razor.css
+++ b/src/GrayMoon.App/Components/Shared/Toast.razor.css
@@ -1,7 +1,7 @@
 /* Toast bubble - matches app dark theme, non-intrusive */
 .toast-bubble {
     position: fixed;
-    top: calc(3.5rem + 1rem); /* Below top-row (3.5rem) + spacing (1rem) */
+    top: calc(var(--topbar-height) + 1rem); /* Below top-row + spacing (1rem) */
     left: 50%;
     transform: translateX(-50%);
     z-index: 9999;

--- a/src/GrayMoon.App/Hubs/DesktopNotificationHub.cs
+++ b/src/GrayMoon.App/Hubs/DesktopNotificationHub.cs
@@ -11,8 +11,24 @@ namespace GrayMoon.App.Hubs;
 ///
 /// Wire contract: see GrayMoon.Desktop/Models/DesktopNotification.cs
 /// Notification method name: "Notify"
+///
+/// Push the currently selected workspace by calling
+/// Clients.All.SendAsync("WorkspaceChanged", context) with a <see cref="WorkspaceContext"/>.
+/// Wire contract: see GrayMoon.Desktop/Models/WorkspaceContext.cs
+/// Notification method name: "WorkspaceChanged"
 /// </summary>
-public sealed class DesktopNotificationHub : Hub
+public sealed class DesktopNotificationHub(DesktopWorkspaceContextTracker workspaceContextTracker) : Hub
 {
-    // Hub is empty — server pushes notifications; clients only subscribe.
+    public override async Task OnConnectedAsync()
+    {
+        await base.OnConnectedAsync();
+
+        // Catch up a newly-connected (or reconnected) client with the last known workspace
+        // selection, so the window title is never left stale after a connection gap.
+        var current = workspaceContextTracker.Current;
+        if (current is not null)
+        {
+            await Clients.Caller.SendAsync("WorkspaceChanged", current);
+        }
+    }
 }

--- a/src/GrayMoon.App/Hubs/DesktopNotificationHub.cs
+++ b/src/GrayMoon.App/Hubs/DesktopNotificationHub.cs
@@ -1,3 +1,5 @@
+using GrayMoon.App.Repositories;
+using GrayMoon.App.Services;
 using Microsoft.AspNetCore.SignalR;
 
 namespace GrayMoon.App.Hubs;
@@ -16,8 +18,16 @@ namespace GrayMoon.App.Hubs;
 /// Clients.All.SendAsync("WorkspaceChanged", context) with a <see cref="WorkspaceContext"/>.
 /// Wire contract: see GrayMoon.Desktop/Models/WorkspaceContext.cs
 /// Notification method name: "WorkspaceChanged"
+///
+/// Top bar visibility is a bool pushed as "TopBarVisibleChanged" (see DesktopTopBarState). It is
+/// also caught up on every (re)connect, and GrayMoon.Desktop calls the "SetTopBarVisible" hub
+/// method (below) when the user toggles it from the tray menu - the App's database is the single
+/// source of truth, not a file on the Desktop side.
 /// </summary>
-public sealed class DesktopNotificationHub(DesktopWorkspaceContextTracker workspaceContextTracker) : Hub
+public sealed class DesktopNotificationHub(
+    DesktopWorkspaceContextTracker workspaceContextTracker,
+    DesktopTopBarState topBarState,
+    AppSettingRepository appSettingRepository) : Hub
 {
     public override async Task OnConnectedAsync()
     {
@@ -30,5 +40,22 @@ public sealed class DesktopNotificationHub(DesktopWorkspaceContextTracker worksp
         {
             await Clients.Caller.SendAsync("WorkspaceChanged", current);
         }
+
+        // Same idea for the top bar: the tray context menu label must always match reality,
+        // even right after (re)connecting.
+        await Clients.Caller.SendAsync("TopBarVisibleChanged", topBarState.IsVisible);
+    }
+
+    /// <summary>
+    /// Called by GrayMoon.Desktop when the user toggles "Show/Hide Top Bar" from the tray menu.
+    /// Persists the change to the App's database, updates the in-memory state every already-open
+    /// Blazor circuit reads live, and broadcasts the confirmed value back to every connected
+    /// client (including the caller) so the tray label only ever shows what was actually applied.
+    /// </summary>
+    public async Task SetTopBarVisible(bool visible)
+    {
+        await appSettingRepository.SetBoolAsync(AppSettingRepository.TopBarShowKey, visible);
+        topBarState.SetVisible(visible);
+        await Clients.All.SendAsync("TopBarVisibleChanged", visible);
     }
 }

--- a/src/GrayMoon.App/Hubs/DesktopWorkspaceContextTracker.cs
+++ b/src/GrayMoon.App/Hubs/DesktopWorkspaceContextTracker.cs
@@ -1,0 +1,11 @@
+namespace GrayMoon.App.Hubs;
+
+/// <summary>
+/// Holds the last workspace selection pushed to GrayMoon.Desktop, so a client that connects (or
+/// reconnects) to <see cref="DesktopNotificationHub"/> after the selection changed can be caught up
+/// immediately instead of showing a stale window title.
+/// </summary>
+public sealed class DesktopWorkspaceContextTracker
+{
+    public WorkspaceContext? Current { get; set; }
+}

--- a/src/GrayMoon.App/Hubs/WorkspaceContext.cs
+++ b/src/GrayMoon.App/Hubs/WorkspaceContext.cs
@@ -1,0 +1,7 @@
+namespace GrayMoon.App.Hubs;
+
+/// <summary>
+/// Current workspace selection pushed from GrayMoon.App to GrayMoon.Desktop through the SignalR desktop hub.
+/// Wire contract - must remain compatible with GrayMoon.Desktop/Models/WorkspaceContext.cs.
+/// </summary>
+public sealed record WorkspaceContext(int? WorkspaceId, string? WorkspaceName);

--- a/src/GrayMoon.App/Program.cs
+++ b/src/GrayMoon.App/Program.cs
@@ -140,6 +140,7 @@ try
     builder.Services.AddScoped<IBackgroundJobService, BackgroundJobService>();
     builder.Services.AddScoped<IWorkspacePageService, WorkspacePageService>();
     builder.Services.AddScoped<IWorkspaceTopBarService, WorkspaceTopBarService>();
+    builder.Services.AddSingleton<DesktopWorkspaceContextTracker>();
 
     builder.Services.AddScoped<IWorkspaceGitChangesReadService, WorkspaceGitChangesReadService>();
     builder.Services.AddScoped<IGitChangesAgentClient, GitChangesAgentClient>();

--- a/src/GrayMoon.App/Program.cs
+++ b/src/GrayMoon.App/Program.cs
@@ -95,6 +95,7 @@ try
     builder.Services.AddScoped<WorkspaceRepository>();
     builder.Services.AddScoped<AppSettingRepository>();
     builder.Services.AddScoped<NavbarCollapseService>();
+    builder.Services.AddSingleton<DesktopTopBarState>();
     builder.Services.AddSingleton<AgentConnectionTracker>();
     builder.Services.AddSingleton<AgentQueueStateService>();
     builder.Services.AddSingleton<AgentCommandCancelSender>();
@@ -220,6 +221,12 @@ try
         await dbContext.Database.ExecuteSqlRawAsync("PRAGMA journal_mode=WAL;");
         await dbContext.Database.ExecuteSqlRawAsync("PRAGMA busy_timeout=5000;");
         await dbContext.Database.ExecuteSqlRawAsync("PRAGMA synchronous=NORMAL;");
+
+        // Load the persisted top bar visibility before any Blazor circuit or Desktop hub
+        // connection can ask for it - see DesktopTopBarState.
+        var appSettingRepository = services.GetRequiredService<AppSettingRepository>();
+        var topBarVisible = await appSettingRepository.GetBoolAsync(AppSettingRepository.TopBarShowKey, defaultValue: true);
+        services.GetRequiredService<DesktopTopBarState>().LoadSilently(topBarVisible);
     }
 
     static string? GetDatabasePath(string connectionString)

--- a/src/GrayMoon.App/Repositories/AppSettingRepository.cs
+++ b/src/GrayMoon.App/Repositories/AppSettingRepository.cs
@@ -13,6 +13,7 @@ public class AppSettingRepository(AppDbContext db)
     public const string TerminalTransparentBackdropKey = "Terminal.TransparentBackdrop";
     public const string TerminalColorSchemeKey = "Terminal.ColorScheme";
     public const string SidebarCollapsedKey = "Sidebar.Collapsed";
+    public const string TopBarShowKey = "TopBar.Show";
 
     public async Task<string?> GetValueAsync(string key)
     {

--- a/src/GrayMoon.App/Services/DesktopTopBarState.cs
+++ b/src/GrayMoon.App/Services/DesktopTopBarState.cs
@@ -12,7 +12,10 @@ namespace GrayMoon.App.Services;
 /// GrayMoon.Desktop's tray menu toggles this live, without a page reload, by calling
 /// <c>SetTopBarVisible</c> on <c>/hubs/desktop</c> (see DesktopNotificationHub); that handler
 /// persists the change and calls <see cref="SetVisible"/>, which raises <see cref="Changed"/> so
-/// every already-connected circuit re-renders immediately.
+/// every already-connected circuit re-renders immediately. Live re-rendering requires
+/// <c>MainLayout</c> itself to declare an interactive <c>@rendermode</c> - a Layout wrapping an
+/// interactive page is otherwise rendered statically once (SSR only) and never joins the live
+/// circuit, so it would never receive this event.
 /// </summary>
 public sealed class DesktopTopBarState
 {

--- a/src/GrayMoon.App/Services/DesktopTopBarState.cs
+++ b/src/GrayMoon.App/Services/DesktopTopBarState.cs
@@ -1,0 +1,32 @@
+namespace GrayMoon.App.Services;
+
+/// <summary>
+/// Whether GrayMoon Desktop's hosted top bar (sidebar brand strip + main title row) is shown.
+/// This is a singleton, in-memory mirror of the persisted setting
+/// (<see cref="Repositories.AppSettingRepository.TopBarShowKey"/>) - the App's own database is the
+/// single source of truth, not any file on GrayMoon.Desktop. It is loaded once at startup (see
+/// Program.cs) before any Blazor circuit connects, so <see cref="IsVisible"/> is always correct
+/// the instant a component reads it - no per-circuit query parameter, no async DB round trip, and
+/// therefore no flash of the wrong state.
+///
+/// GrayMoon.Desktop's tray menu toggles this live, without a page reload, by calling
+/// <c>SetTopBarVisible</c> on <c>/hubs/desktop</c> (see DesktopNotificationHub); that handler
+/// persists the change and calls <see cref="SetVisible"/>, which raises <see cref="Changed"/> so
+/// every already-connected circuit re-renders immediately.
+/// </summary>
+public sealed class DesktopTopBarState
+{
+    public bool IsVisible { get; private set; } = true;
+
+    public event Action<bool>? Changed;
+
+    /// <summary>Sets the initial value loaded from the database at app startup. Raises no event.</summary>
+    public void LoadSilently(bool visible) => IsVisible = visible;
+
+    public void SetVisible(bool visible)
+    {
+        if (IsVisible == visible) return;
+        IsVisible = visible;
+        Changed?.Invoke(visible);
+    }
+}

--- a/src/GrayMoon.App/Services/WorkspaceTopBarService.cs
+++ b/src/GrayMoon.App/Services/WorkspaceTopBarService.cs
@@ -1,7 +1,9 @@
 using System.Threading;
+using GrayMoon.App.Hubs;
 using GrayMoon.App.Repositories;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Routing;
+using Microsoft.AspNetCore.SignalR;
 
 namespace GrayMoon.App.Services;
 
@@ -21,14 +23,22 @@ public sealed class WorkspaceTopBarService : IWorkspaceTopBarService, IDisposabl
 {
     private readonly NavigationManager _navigationManager;
     private readonly WorkspaceRepository _workspaceRepository;
+    private readonly IHubContext<DesktopNotificationHub> _desktopHub;
+    private readonly DesktopWorkspaceContextTracker _desktopContextTracker;
     private int _refreshGeneration;
     private int? _cachedWorkspaceId;
     private string? _workspaceDisplayName;
 
-    public WorkspaceTopBarService(NavigationManager navigationManager, WorkspaceRepository workspaceRepository)
+    public WorkspaceTopBarService(
+        NavigationManager navigationManager,
+        WorkspaceRepository workspaceRepository,
+        IHubContext<DesktopNotificationHub> desktopHub,
+        DesktopWorkspaceContextTracker desktopContextTracker)
     {
         _navigationManager = navigationManager;
         _workspaceRepository = workspaceRepository;
+        _desktopHub = desktopHub;
+        _desktopContextTracker = desktopContextTracker;
         _navigationManager.LocationChanged += OnLocationChanged;
     }
 
@@ -71,7 +81,10 @@ public sealed class WorkspaceTopBarService : IWorkspaceTopBarService, IDisposabl
                 _cachedWorkspaceId = null;
                 _workspaceDisplayName = null;
                 if (generation == Volatile.Read(ref _refreshGeneration))
+                {
                     Changed?.Invoke();
+                    _ = PushToDesktopAsync(null, null);
+                }
             }
             return;
         }
@@ -86,5 +99,21 @@ public sealed class WorkspaceTopBarService : IWorkspaceTopBarService, IDisposabl
         _cachedWorkspaceId = workspaceId;
         _workspaceDisplayName = workspace?.Name ?? "Workspace";
         Changed?.Invoke();
+        _ = PushToDesktopAsync(workspaceId, _workspaceDisplayName);
+    }
+
+    private async Task PushToDesktopAsync(int? workspaceId, string? workspaceName)
+    {
+        var context = new WorkspaceContext(workspaceId, workspaceName);
+        _desktopContextTracker.Current = context;
+
+        try
+        {
+            await _desktopHub.Clients.All.SendAsync("WorkspaceChanged", context);
+        }
+        catch
+        {
+            // Best-effort - the desktop shell may not be connected (e.g. running in the browser, not desktop mode).
+        }
     }
 }

--- a/src/GrayMoon.App/Services/WorkspaceTopBarService.cs
+++ b/src/GrayMoon.App/Services/WorkspaceTopBarService.cs
@@ -76,7 +76,13 @@ public sealed class WorkspaceTopBarService : IWorkspaceTopBarService, IDisposabl
 
         if (workspaceId is null)
         {
-            if (_workspaceDisplayName is not null || _cachedWorkspaceId is not null)
+            // Compare against the shared desktop tracker too, not just this instance's own cache:
+            // a fresh circuit (e.g. after an F5 hard refresh or a WebView2 full navigation) starts
+            // with both local fields null even though the singleton tracker may still hold a stale
+            // workspace selection pushed by a previous circuit, which would otherwise leave the
+            // desktop window title stuck on the old workspace name.
+            var trackerHasStaleSelection = _desktopContextTracker.Current is { WorkspaceId: not null } or { WorkspaceName: not null };
+            if (_workspaceDisplayName is not null || _cachedWorkspaceId is not null || trackerHasStaleSelection)
             {
                 _cachedWorkspaceId = null;
                 _workspaceDisplayName = null;

--- a/src/GrayMoon.App/wwwroot/app.css
+++ b/src/GrayMoon.App/wwwroot/app.css
@@ -501,10 +501,15 @@ h1:focus {
     min-width: 0;
 }
 
+/* max-height is derived from --topbar-height (see :root / .page--topbar-hidden in
+   MainLayout.razor.css) instead of a hardcoded viewport offset, so grid pages (Repositories,
+   Connectors, Agent, etc.) expand to fill the reclaimed space when the desktop top bar is
+   hidden. 168px assumes the default 3.5rem (56px) top bar; subtracting the variable keeps
+   that same remainder (112px) while letting it shrink when the bar is hidden. */
 .grid-page-body {
     flex: 1 1 auto;
     min-height: 0;
-    max-height: calc(100vh - 168px);
+    max-height: calc(100vh - var(--topbar-height) - 112px);
     overflow: hidden;
     display: flex;
     flex-direction: column;

--- a/src/GrayMoon.App/wwwroot/app.css
+++ b/src/GrayMoon.App/wwwroot/app.css
@@ -60,6 +60,10 @@
     /* Layout dimensions (mobile-first; overridden at >= 641px) */
     --sidebar-width: 0px;
     --topbar-height: 2.75rem;
+
+    /* Bootstrap h2 base is calc(1.325rem + 0.9vw); page titles use 70% of that */
+    --page-title-font-size: calc((1.325rem + 0.9vw) * 0.7);
+    --topbar-workspace-title-font-size: calc(var(--page-title-font-size) * 0.72);
 }
 
 @media (min-width: 641px) {
@@ -460,6 +464,10 @@ h1:focus {
 
 .grid-page-header {
     flex-shrink: 0;
+}
+
+.grid-page-header h2 {
+    font-size: var(--page-title-font-size);
 }
 
 /* Workspace repositories page: header with title row + actions row (search + buttons) */

--- a/src/GrayMoon.App/wwwroot/css/git-changes.css
+++ b/src/GrayMoon.App/wwwroot/css/git-changes.css
@@ -56,11 +56,16 @@
     margin-bottom: 0.75rem;
 }
 
+/* Height is derived from --topbar-height (see app.css / MainLayout.razor.css) instead of a
+   hardcoded viewport offset, so the splitter/Monaco panel expands to fill the reclaimed space
+   when the desktop top bar is hidden (.page--topbar-hidden sets --topbar-height: 0px). The
+   168px/192px offsets below assume the default 3.5rem (56px) top bar; subtracting the variable
+   keeps that same remainder while letting it shrink to 112px/136px when the bar is hidden. */
 .git-changes-page .grid-page-body {
     flex: 1 1 auto;
     min-height: 0;
-    height: calc(100vh - 168px);
-    max-height: calc(100vh - 192px);
+    height: calc(100vh - var(--topbar-height) - 112px);
+    max-height: calc(100vh - var(--topbar-height) - 136px);
     overflow: hidden;
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
## Summary

- Add a persisted show/hide top bar setting synced live to GrayMoon Desktop over SignalR, with layout height and toast positioning driven by `--topbar-height`
- Push workspace context to Desktop on navigation and reconnect so the window title stays current after refresh or connection gaps
- Reduce page title font size and fix grid page heights (including Git Changes) when the top bar is hidden
- Keep the Dependencies page search bar and filter dropdown on one row at narrow widths instead of wrapping
- Restore the clipboard toast when clicking the git version column on Repositories
- Hide the vertical scrollbar on the collapsed navbar and add coverage for workspace top bar sync behavior

## Test plan

- [ ] Toggle show/hide top bar from the Desktop tray; confirm the layout expands or contracts immediately and the setting persists after restart
- [ ] Navigate into and out of a workspace; confirm the Desktop window title updates and stays correct after a hard refresh or reconnect
- [ ] Narrow the Dependencies page; confirm the search bar and filter dropdown stay on one row and shrink with ellipsis
- [ ] Click a git version on Repositories; confirm the version is copied and the toast appears
- [ ] Verify page title sizing and Git Changes page layout with the top bar both shown and hidden
- [ ] Collapse the sidebar; confirm no vertical scrollbar appears on the nav menu