### PR TITLE
Fix sync-to-default refresh by skipping pull hooks in orchestrated flows

### DIFF
--- a/src/GrayMoon.Agent/Abstractions/IGitService.cs
+++ b/src/GrayMoon.Agent/Abstractions/IGitService.cs
@@ -28,8 +28,8 @@ public interface IGitService
     Task<(int? Outgoing, int? Incoming, bool HasUpstream)> GetCommitCountsAsync(string repoPath, string branchName, string? defaultBranchOriginRef, CancellationToken ct, bool skipUpstreamCheck = false);
     /// <summary>Returns (behind, ahead, defaultBranchName) for the current branch vs the default branch. DefaultBranchName is without "origin/" prefix. When <paramref name="defaultBranchOriginRef"/> is provided, uses it instead of resolving.</summary>
     Task<(int? DefaultBehind, int? DefaultAhead, string? DefaultBranchName)> GetCommitCountsVsDefaultAsync(string repoPath, string? defaultBranchOriginRef, CancellationToken ct);
-    /// <summary>Pulls from origin. Returns (success, mergeConflict, errorMessage).</summary>
-    Task<(bool Success, bool MergeConflict, string? ErrorMessage)> PullAsync(string repoPath, string branchName, string? bearerToken, CancellationToken ct);
+    /// <summary>Pulls from origin. Returns (success, mergeConflict, errorMessage). When <paramref name="skipHooks"/> is true, hooks are disabled for the pull (orchestrated flows that already recompute and persist commit counts themselves).</summary>
+    Task<(bool Success, bool MergeConflict, string? ErrorMessage)> PullAsync(string repoPath, string branchName, string? bearerToken, CancellationToken ct, bool skipHooks = false);
     /// <summary>Pushes to origin. When setTracking is true, uses -u so the branch is upstreamed even when there are no commits to push. Returns (success, errorMessage).</summary>
     Task<(bool Success, string? ErrorMessage)> PushAsync(string repoPath, string branchName, string? bearerToken, bool setTracking = false, CancellationToken ct = default);
     /// <summary>Aborts a merge in progress.</summary>

--- a/src/GrayMoon.Agent/Commands/SyncToDefaultBranchCommand.cs
+++ b/src/GrayMoon.Agent/Commands/SyncToDefaultBranchCommand.cs
@@ -75,8 +75,11 @@ public sealed class SyncToDefaultBranchCommand(IGitService git, ICsProjFileServi
                 logger.LogWarning("Local branch delete failed for {Branch} in {RepoPath}: {Error}", currentBranchName, repoPath, localDeleteErr);
         }
 
-        // Always pull after switching to default so local is up to date
-        var (pullSuccess, mergeConflict, pullError) = await git.PullAsync(repoPath, defaultBranch, request.BearerToken, cancellationToken);
+        // Always pull after switching to default so local is up to date. Skip hooks: this orchestrated
+        // flow recomputes and returns commit counts/version itself below, so a hook-triggered NotifyJob
+        // racing (and, under multi-repo sync, queuing well behind) this authoritative write would just
+        // clobber it later with a redundant recompute.
+        var (pullSuccess, mergeConflict, pullError) = await git.PullAsync(repoPath, defaultBranch, request.BearerToken, cancellationToken, skipHooks: true);
         if (!pullSuccess)
         {
             return new SyncToDefaultBranchResponse

--- a/src/GrayMoon.Agent/Services/GitRemoteIntegrateService.cs
+++ b/src/GrayMoon.Agent/Services/GitRemoteIntegrateService.cs
@@ -1,115 +1,117 @@
-using GrayMoon.Agent.Abstractions;
-
-namespace GrayMoon.Agent.Services;
-
-public sealed record GitRemoteIntegrateResult(
-    bool Success,
-    string? Branch,
-    string? Version,
-    int? Outgoing,
-    int? Incoming,
-    bool HasUpstream,
-    bool MergeConflict,
-    string? ErrorMessage);
-
-/// <summary>
-/// Fetches from origin and pulls incoming commits before push or commit-sync workflows.
-/// Single source of truth for remote integration (fetch + conditional pull).
-/// Resolves branch via git only; Version is always null - callers that need SemVer run GitVersion themselves.
-/// </summary>
-public sealed class GitRemoteIntegrateService(IGitService git)
-{
-    public async Task<GitRemoteIntegrateResult> IntegrateAsync(
-        string repoPath,
-        string? bearerToken,
-        CancellationToken cancellationToken = default)
-    {
-        var (fetchSuccess, fetchError) = await git.FetchAsync(repoPath, includeTags: true, bearerToken, cancellationToken);
-        if (!fetchSuccess)
-        {
-            return new GitRemoteIntegrateResult(
-                Success: false,
-                Branch: null,
-                Version: null,
-                Outgoing: null,
-                Incoming: null,
-                HasUpstream: false,
-                MergeConflict: false,
-                ErrorMessage: fetchError ?? "Fetch failed");
-        }
-
-        var branch = await git.GetCurrentBranchNameAsync(repoPath, cancellationToken);
-        if (string.IsNullOrWhiteSpace(branch))
-        {
-            return new GitRemoteIntegrateResult(
-                Success: false,
-                Branch: null,
-                Version: null,
-                Outgoing: null,
-                Incoming: null,
-                HasUpstream: false,
-                MergeConflict: false,
-                ErrorMessage: "Could not determine branch name");
-        }
-
-        var (outgoing, incoming, hasUpstream) = await git.GetCommitCountsAsync(repoPath, branch, null, cancellationToken);
-
-        if (!incoming.HasValue || incoming.Value <= 0)
-        {
-            return new GitRemoteIntegrateResult(
-                Success: true,
-                Branch: branch,
-                Version: null,
-                Outgoing: outgoing,
-                Incoming: incoming,
-                HasUpstream: hasUpstream,
-                MergeConflict: false,
-                ErrorMessage: null);
-        }
-
-        var (pullSuccess, mergeConflict, pullError) = await git.PullAsync(repoPath, branch, bearerToken, cancellationToken);
-
-        if (mergeConflict)
-        {
-            await git.AbortMergeAsync(repoPath, cancellationToken);
-            await git.FetchAsync(repoPath, includeTags: true, bearerToken, cancellationToken);
-            (outgoing, incoming, hasUpstream) = await git.GetCommitCountsAsync(repoPath, branch, null, cancellationToken);
-
-            return new GitRemoteIntegrateResult(
-                Success: false,
-                Branch: branch,
-                Version: null,
-                Outgoing: outgoing,
-                Incoming: incoming,
-                HasUpstream: hasUpstream,
-                MergeConflict: true,
-                ErrorMessage: pullError ?? "Merge conflict detected. Merge aborted.");
-        }
-
-        if (!pullSuccess)
-        {
-            return new GitRemoteIntegrateResult(
-                Success: false,
-                Branch: branch,
-                Version: null,
-                Outgoing: outgoing,
-                Incoming: incoming,
-                HasUpstream: hasUpstream,
-                MergeConflict: false,
-                ErrorMessage: pullError ?? "Pull failed");
-        }
-
-        (outgoing, incoming, hasUpstream) = await git.GetCommitCountsAsync(repoPath, branch, null, cancellationToken);
-
-        return new GitRemoteIntegrateResult(
-            Success: true,
-            Branch: branch,
-            Version: null,
-            Outgoing: outgoing,
-            Incoming: incoming,
-            HasUpstream: hasUpstream,
-            MergeConflict: false,
-            ErrorMessage: null);
-    }
-}
+using GrayMoon.Agent.Abstractions;
+
+namespace GrayMoon.Agent.Services;
+
+public sealed record GitRemoteIntegrateResult(
+    bool Success,
+    string? Branch,
+    string? Version,
+    int? Outgoing,
+    int? Incoming,
+    bool HasUpstream,
+    bool MergeConflict,
+    string? ErrorMessage);
+
+/// <summary>
+/// Fetches from origin and pulls incoming commits before push or commit-sync workflows.
+/// Single source of truth for remote integration (fetch + conditional pull).
+/// Resolves branch via git only; Version is always null - callers that need SemVer run GitVersion themselves.
+/// </summary>
+public sealed class GitRemoteIntegrateService(IGitService git)
+{
+    public async Task<GitRemoteIntegrateResult> IntegrateAsync(
+        string repoPath,
+        string? bearerToken,
+        CancellationToken cancellationToken = default)
+    {
+        var (fetchSuccess, fetchError) = await git.FetchAsync(repoPath, includeTags: true, bearerToken, cancellationToken);
+        if (!fetchSuccess)
+        {
+            return new GitRemoteIntegrateResult(
+                Success: false,
+                Branch: null,
+                Version: null,
+                Outgoing: null,
+                Incoming: null,
+                HasUpstream: false,
+                MergeConflict: false,
+                ErrorMessage: fetchError ?? "Fetch failed");
+        }
+
+        var branch = await git.GetCurrentBranchNameAsync(repoPath, cancellationToken);
+        if (string.IsNullOrWhiteSpace(branch))
+        {
+            return new GitRemoteIntegrateResult(
+                Success: false,
+                Branch: null,
+                Version: null,
+                Outgoing: null,
+                Incoming: null,
+                HasUpstream: false,
+                MergeConflict: false,
+                ErrorMessage: "Could not determine branch name");
+        }
+
+        var (outgoing, incoming, hasUpstream) = await git.GetCommitCountsAsync(repoPath, branch, null, cancellationToken);
+
+        if (!incoming.HasValue || incoming.Value <= 0)
+        {
+            return new GitRemoteIntegrateResult(
+                Success: true,
+                Branch: branch,
+                Version: null,
+                Outgoing: outgoing,
+                Incoming: incoming,
+                HasUpstream: hasUpstream,
+                MergeConflict: false,
+                ErrorMessage: null);
+        }
+
+        // Skip hooks: this service recomputes commit counts itself right after the pull (below), so a
+        // hook-triggered NotifyJob racing this authoritative recompute would just clobber it later.
+        var (pullSuccess, mergeConflict, pullError) = await git.PullAsync(repoPath, branch, bearerToken, cancellationToken, skipHooks: true);
+
+        if (mergeConflict)
+        {
+            await git.AbortMergeAsync(repoPath, cancellationToken);
+            await git.FetchAsync(repoPath, includeTags: true, bearerToken, cancellationToken);
+            (outgoing, incoming, hasUpstream) = await git.GetCommitCountsAsync(repoPath, branch, null, cancellationToken);
+
+            return new GitRemoteIntegrateResult(
+                Success: false,
+                Branch: branch,
+                Version: null,
+                Outgoing: outgoing,
+                Incoming: incoming,
+                HasUpstream: hasUpstream,
+                MergeConflict: true,
+                ErrorMessage: pullError ?? "Merge conflict detected. Merge aborted.");
+        }
+
+        if (!pullSuccess)
+        {
+            return new GitRemoteIntegrateResult(
+                Success: false,
+                Branch: branch,
+                Version: null,
+                Outgoing: outgoing,
+                Incoming: incoming,
+                HasUpstream: hasUpstream,
+                MergeConflict: false,
+                ErrorMessage: pullError ?? "Pull failed");
+        }
+
+        (outgoing, incoming, hasUpstream) = await git.GetCommitCountsAsync(repoPath, branch, null, cancellationToken);
+
+        return new GitRemoteIntegrateResult(
+            Success: true,
+            Branch: branch,
+            Version: null,
+            Outgoing: outgoing,
+            Incoming: incoming,
+            HasUpstream: hasUpstream,
+            MergeConflict: false,
+            ErrorMessage: null);
+    }
+}
 

--- a/src/GrayMoon.Agent/Services/GitService.cs
+++ b/src/GrayMoon.Agent/Services/GitService.cs
@@ -408,21 +408,23 @@ public sealed class GitService(IOptions<AgentOptions> options, ILogger<GitServic
         return (behind, ahead, defaultBranchName);
     }
 
-    public async Task<(bool Success, bool MergeConflict, string? ErrorMessage)> PullAsync(string repoPath, string branchName, string? bearerToken, CancellationToken ct)
+    public async Task<(bool Success, bool MergeConflict, string? ErrorMessage)> PullAsync(string repoPath, string branchName, string? bearerToken, CancellationToken ct, bool skipHooks = false)
     {
         if (string.IsNullOrWhiteSpace(repoPath) || !Directory.Exists(repoPath) || string.IsNullOrWhiteSpace(branchName))
             return (false, false, "Invalid repository path or branch name");
+
+        var hooksPrefix = GetHooksConfigPrefix(skipHooks);
 
         string args;
         var logArgs = "";
         if (string.IsNullOrWhiteSpace(bearerToken))
         {
-            args = $"pull origin {branchName}";
+            args = $"{hooksPrefix}pull origin {branchName}";
             logArgs = args;
         }
         else
         {
-            args = $"{BuildAuthHeaderArgs(bearerToken)} pull origin {branchName}";
+            args = $"{BuildAuthHeaderArgs(bearerToken)} {hooksPrefix}pull origin {branchName}";
             logArgs = "***";
         }
 

--- a/src/GrayMoon.App/Components/Layout/MainLayout.razor.css
+++ b/src/GrayMoon.App/Components/Layout/MainLayout.razor.css
@@ -66,7 +66,7 @@ article.content {
     padding-inline: 0.35rem;
 }
 
-/* Same family/weight/line-height as page h2 (.h2); ~72% scale for top bar */
+/* Same family/weight/line-height as page h2 (.h2); original ~72% scale, kept independent of page-title font size */
 .top-row-workspace-title__text {
     pointer-events: auto;
     display: inline-block;
@@ -322,7 +322,7 @@ article.content {
 @media (min-width: 1200px) {
     main .top-row-workspace-title__text,
     main .top-row-workspace-title ::deep a.top-row-workspace-title__link {
-        font-size: calc(1.44rem * 0.7);
+        font-size: 1.44rem;
     }
 }
 

--- a/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.SyncToDefault.cs
+++ b/src/GrayMoon.App/Components/Pages/WorkspaceRepositories.SyncToDefault.cs
@@ -328,6 +328,11 @@ public sealed partial class WorkspaceRepositories
 
                     return (repositoryId, success, errMsg);
                 }
+                catch (Exception ex) when (ex is not OperationCanceledException)
+                {
+                    Logger.LogError(ex, "Error syncing to default branch for repository {RepositoryId}", repositoryId);
+                    return (repositoryId, false, (string?)"Sync to default branch failed. The GrayMoon Agent may be offline.");
+                }
                 finally
                 {
                     semaphore.Release();
@@ -533,6 +538,11 @@ public sealed partial class WorkspaceRepositories
                             deleteRemoteBranch && item.HasRemote, allowForceDeleteLocalBranch: true, ct));
 
                     return (RepoId: repoId, Success: success, ErrorMsg: errMsg);
+                }
+                catch (Exception ex) when (ex is not OperationCanceledException)
+                {
+                    Logger.LogError(ex, "Error syncing to default branch for repository {RepositoryId}", repoId);
+                    return (RepoId: repoId, Success: false, ErrorMsg: (string?)"Sync to default branch failed. The GrayMoon Agent may be offline.");
                 }
                 finally
                 {

--- a/src/GrayMoon.App/wwwroot/app.css
+++ b/src/GrayMoon.App/wwwroot/app.css
@@ -63,7 +63,8 @@
 
     /* Bootstrap h2 base is calc(1.325rem + 0.9vw); page titles use 70% of that */
     --page-title-font-size: calc((1.325rem + 0.9vw) * 0.7);
-    --topbar-workspace-title-font-size: calc(var(--page-title-font-size) * 0.72);
+    /* Kept at original (pre page-title-reduction) scale; intentionally not derived from --page-title-font-size */
+    --topbar-workspace-title-font-size: calc((1.325rem + 0.9vw) * 0.72);
 }
 
 @media (min-width: 641px) {


### PR DESCRIPTION
## Summary

- Add optional `skipHooks` to agent `PullAsync` and use it in sync-to-default and remote-integrate flows so hook-triggered NotifyJobs do not race and overwrite authoritative commit-count recomputes
- Harden sync-to-default UI with per-repository exception handling and a clear failure message when the agent is unreachable
- Decouple topbar workspace title font size from `--page-title-font-size` so it stays at the original scale after page title sizing changes

## Test plan

- [ ] Sync a workspace repository to its default branch and confirm outgoing/incoming counts and version refresh correctly without stale values
- [ ] Run push or commit-sync flows that pull incoming commits and verify commit counts remain accurate after integration
- [ ] Trigger sync-to-default with the agent offline and confirm the operation fails gracefully with the expected error message
- [ ] Resize the viewport and confirm the topbar workspace title keeps the intended size independent of page title styling