### PR TITLE
Refresh PR status after sync to default branch

### DIFF
--- a/src/GrayMoon.App/Services/WorkspaceGitService.cs
+++ b/src/GrayMoon.App/Services/WorkspaceGitService.cs
@@ -1026,6 +1026,12 @@ public class WorkspaceGitService(
             await _dbContext.SaveChangesAsync(cancellationToken);
         }
 
+        // The PR refresh above (before the sync) looked up the PR for the OLD branch, purely to decide
+        // forceDeleteLocalBranch. Now that BranchName has switched to the default branch, refresh again so the
+        // persisted PR row reflects the branch actually checked out (GitHub has no PR for the default branch
+        // against itself, so this clears any stale merged/closed PR badge instead of leaving it stuck).
+        await _workspacePullRequestService.RefreshPullRequestsAsync(workspaceId, [repositoryId], force: true, cancellationToken);
+
         // Persist fresh csproj data from the default branch so dependency stats reflect the new branch content.
         var projectsDetail = GetProjectsDetail(syncResponse?.Projects);
         if (projectsDetail is { Count: > 0 })


### PR DESCRIPTION
## Summary

- Refresh the persisted pull-request status again after a repository is synced to its default branch, using the branch actually checked out
- Fixes stale "merged"/"closed" PR badges that previously stayed stuck on the old feature branch's PR after sync-to-default completed, since the only PR refresh ran before the branch switch

## Test plan

- [ ] Sync a repository with a merged PR to its default branch and confirm the PR badge clears/updates instead of still showing "merged"
- [ ] Sync a level of multiple repositories to default and confirm each repo's PR status updates independently
- [ ] Confirm ahead/behind and incoming/outgoing commit counts remain correct after sync to default